### PR TITLE
Add /paywall slash command for paywall bypass link generation

### DIFF
--- a/assets/paywall.yaml
+++ b/assets/paywall.yaml
@@ -1,0 +1,188 @@
+---
+# === German news sites — services work ===
+- name: spiegel
+  domains: ["spiegel.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: zeit
+  domains: ["zeit.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: faz
+  domains: ["faz.net"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: sueddeutsche
+  domains: ["sueddeutsche.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: welt
+  domains: ["welt.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: bild
+  domains: ["bild.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: tagesspiegel
+  domains: ["tagesspiegel.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: wiwo
+  domains: ["wiwo.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: cicero
+  domains: ["cicero.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: berliner-zeitung
+  domains: ["berliner-zeitung.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: deraktionaer
+  domains: ["deraktionaer.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: funke
+  domains: ["abendblatt.de", "morgenpost.de", "waz.de", "nrz.de", "wp.de", "wr.de", "braunschweiger-zeitung.de", "otz.de", "thueringer-allgemeine.de", "tlz.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: madsack
+  domains: ["haz.de", "kn-online.de", "ln-online.de", "lvz.de", "maz-online.de", "neuepresse.de", "ostsee-zeitung.de", "rnd.de"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+# === German news sites — NO known web service fix ===
+- name: handelsblatt
+  domains: ["handelsblatt.com"]
+  nofix: true
+
+- name: manager-magazin
+  domains: ["manager-magazin.de"]
+  nofix: true
+
+- name: stern
+  domains: ["stern.de"]
+  nofix: true
+
+- name: heise
+  domains: ["heise.de"]
+  nofix: true
+
+- name: golem
+  domains: ["golem.de"]
+  nofix: true
+
+- name: businessinsider-de
+  domains: ["businessinsider.de"]
+  nofix: true
+
+# === Swiss/Austrian German-language ===
+- name: nzz
+  domains: ["nzz.ch"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: diepresse
+  domains: ["diepresse.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+# === US news sites — services work ===
+- name: nytimes
+  domains: ["nytimes.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: washingtonpost
+  domains: ["washingtonpost.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: wsj
+  domains: ["wsj.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: bloomberg
+  domains: ["bloomberg.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: theatlantic
+  domains: ["theatlantic.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: newyorker
+  domains: ["newyorker.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: economist
+  domains: ["economist.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: ft
+  domains: ["ft.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: wired
+  domains: ["wired.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: businessinsider
+  domains: ["businessinsider.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: forbes
+  domains: ["forbes.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: fortune
+  domains: ["fortune.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: latimes
+  domains: ["latimes.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: reuters
+  domains: ["reuters.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: theathletic
+  domains: ["theathletic.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: seekingalpha
+  domains: ["seekingalpha.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: barrons
+  domains: ["barrons.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: gannett
+  domains: ["usatoday.com", "azcentral.com", "freep.com", "indystar.com", "jsonline.com", "cincinnati.com", "dispatch.com", "tennessean.com", "knoxnews.com", "democratandchronicle.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: mcclatchy
+  domains: ["miamiherald.com", "kansascity.com", "sacbee.com", "charlotteobserver.com", "newsobserver.com", "star-telegram.com", "fresnobee.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+- name: tribune
+  domains: ["chicagotribune.com", "baltimoresun.com", "nydailynews.com", "orlandosentinel.com", "sun-sentinel.com"]
+  services: ["archive.today", "1ft.io", "google-webcache"]
+
+# === US sites — NO known web service fix ===
+- name: theinformation
+  domains: ["theinformation.com"]
+  nofix: true
+
+- name: puck
+  domains: ["puck.news"]
+  nofix: true
+
+# === Platform-specific ===
+- name: medium
+  domains: ["medium.com"]
+  subdomainWildcard: true
+  services: ["freedium"]
+
+# === Default fallback for unknown domains ===
+- name: default
+  domains: ["*"]
+  services: ["archive.today", "1ft.io", "google-webcache"]

--- a/modules/assets.ts
+++ b/modules/assets.ts
@@ -430,6 +430,54 @@ export class EmojiAsset extends BaseAsset {
   }
 }
 
+export class PaywallAsset {
+  private _name: string;
+  private _domains: string[];
+  private _services: string[];
+  private _nofix: boolean;
+  private _subdomainWildcard: boolean;
+
+  public get name() {
+    return this._name;
+  }
+
+  public set name(name: string) {
+    this._name = name;
+  }
+
+  public get domains() {
+    return this._domains;
+  }
+
+  public set domains(domains: string[]) {
+    this._domains = domains;
+  }
+
+  public get services() {
+    return this._services;
+  }
+
+  public set services(services: string[]) {
+    this._services = services;
+  }
+
+  public get nofix() {
+    return this._nofix;
+  }
+
+  public set nofix(nofix: boolean) {
+    this._nofix = nofix;
+  }
+
+  public get subdomainWildcard() {
+    return this._subdomainWildcard;
+  }
+
+  public set subdomainWildcard(subdomainWildcard: boolean) {
+    this._subdomainWildcard = subdomainWildcard;
+  }
+}
+
 async function populateDracoonAsset(type: string, asset: ImageAsset | UserQuoteAsset): Promise<void> {
   if (false === asset.hasOwnProperty("_location") || "dracoon" !== asset.location) {
     return;
@@ -531,6 +579,12 @@ export async function getAssets(type: string): Promise<any[]> {
         case "earningsreminder": {
           const newAsset = plainToClass(EarningsReminderAsset, jsonObject);
           newAsset.roleId = readSecret(newAsset.roleIdReference);
+          newAssets.push(newAsset);
+          break;
+        }
+
+        case "paywall": {
+          const newAsset = plainToClass(PaywallAsset, jsonObject);
           newAssets.push(newAsset);
           break;
         }

--- a/modules/paywall.test.ts
+++ b/modules/paywall.test.ts
@@ -1,0 +1,285 @@
+import axios from "axios";
+import {PaywallAsset} from "./assets.js";
+import {
+  extractHostname,
+  matchPaywallAsset,
+  buildServiceUrl,
+  extractHeadline,
+  checkService,
+  getPaywallLinks,
+  getServiceSuccessRate,
+  getInflightCount,
+} from "./paywall.js";
+
+jest.mock("axios");
+jest.mock("./logging.js", () => ({
+  getLogger: () => ({
+    log: jest.fn(),
+  }),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+function createPaywallAsset(overrides: Partial<{name: string; domains: string[]; services: string[]; nofix: boolean; subdomainWildcard: boolean}>): PaywallAsset {
+  const asset = new PaywallAsset();
+  asset.name = overrides.name ?? "test";
+  asset.domains = overrides.domains ?? [];
+  asset.services = overrides.services ?? [];
+  asset.nofix = overrides.nofix ?? false;
+  asset.subdomainWildcard = overrides.subdomainWildcard ?? false;
+  return asset;
+}
+
+describe("extractHostname", () => {
+  test("extracts hostname from URL", () => {
+    expect(extractHostname("https://www.nytimes.com/2024/article")).toBe("nytimes.com");
+  });
+
+  test("strips www prefix", () => {
+    expect(extractHostname("https://www.spiegel.de/article")).toBe("spiegel.de");
+  });
+
+  test("keeps subdomains other than www", () => {
+    expect(extractHostname("https://tech.medium.com/article")).toBe("tech.medium.com");
+  });
+
+  test("returns empty string for invalid URL", () => {
+    expect(extractHostname("not-a-url")).toBe("");
+  });
+});
+
+describe("matchPaywallAsset", () => {
+  const assets = [
+    createPaywallAsset({name: "nytimes", domains: ["nytimes.com"], services: ["archive.today"]}),
+    createPaywallAsset({name: "medium", domains: ["medium.com"], services: ["freedium"], subdomainWildcard: true}),
+    createPaywallAsset({name: "handelsblatt", domains: ["handelsblatt.com"], nofix: true}),
+    createPaywallAsset({name: "default", domains: ["*"], services: ["archive.today", "1ft.io"]}),
+  ];
+
+  test("matches exact domain", () => {
+    const result = matchPaywallAsset("https://www.nytimes.com/article", assets);
+    expect(result?.name).toBe("nytimes");
+  });
+
+  test("matches subdomain wildcard", () => {
+    const result = matchPaywallAsset("https://tech.medium.com/article", assets);
+    expect(result?.name).toBe("medium");
+  });
+
+  test("matches base domain for subdomain wildcard entry", () => {
+    const result = matchPaywallAsset("https://medium.com/article", assets);
+    expect(result?.name).toBe("medium");
+  });
+
+  test("matches nofix domain", () => {
+    const result = matchPaywallAsset("https://www.handelsblatt.com/article", assets);
+    expect(result?.name).toBe("handelsblatt");
+  });
+
+  test("falls back to default for unknown domain", () => {
+    const result = matchPaywallAsset("https://www.unknown-site.com/article", assets);
+    expect(result?.name).toBe("default");
+  });
+
+  test("returns undefined for invalid URL", () => {
+    const result = matchPaywallAsset("not-a-url", assets);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("buildServiceUrl", () => {
+  test("builds archive.today URL", () => {
+    expect(buildServiceUrl("archive.today", "https://example.com/article"))
+      .toBe("https://archive.ph/newest/https://example.com/article");
+  });
+
+  test("builds 1ft.io URL", () => {
+    expect(buildServiceUrl("1ft.io", "https://example.com/article"))
+      .toBe("https://1ft.io/https://example.com/article");
+  });
+
+  test("builds freedium URL", () => {
+    expect(buildServiceUrl("freedium", "https://medium.com/article"))
+      .toBe("https://freedium.cfd/https://medium.com/article");
+  });
+
+  test("builds google-webcache URL", () => {
+    expect(buildServiceUrl("google-webcache", "https://example.com/article"))
+      .toBe("https://webcache.googleusercontent.com/search?q=cache:https://example.com/article");
+  });
+
+  test("returns undefined for unknown service", () => {
+    expect(buildServiceUrl("nonexistent", "https://example.com")).toBeUndefined();
+  });
+});
+
+describe("extractHeadline", () => {
+  test("extracts og:title", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: '<html><head><meta property="og:title" content="Breaking News Article"></head></html>',
+    });
+
+    const result = await extractHeadline("https://example.com/article");
+    expect(result).toBe("Breaking News Article");
+  });
+
+  test("extracts og:title with reversed attribute order", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: '<html><head><meta content="Reversed Order Title" property="og:title"></head></html>',
+    });
+
+    const result = await extractHeadline("https://example.com/article");
+    expect(result).toBe("Reversed Order Title");
+  });
+
+  test("falls back to title tag", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: "<html><head><title>Page Title Here</title></head></html>",
+    });
+
+    const result = await extractHeadline("https://example.com/article");
+    expect(result).toBe("Page Title Here");
+  });
+
+  test("returns null when no title found", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: "<html><head></head><body>No title</body></html>",
+    });
+
+    const result = await extractHeadline("https://example.com/article");
+    expect(result).toBeNull();
+  });
+
+  test("returns null on network error", async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error("Network error"));
+
+    const result = await extractHeadline("https://example.com/article");
+    expect(result).toBeNull();
+  });
+});
+
+describe("checkService", () => {
+  test("returns true when headline words found in response", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: "<html><body>This is the Breaking News Article content with more text</body></html>",
+    });
+
+    const result = await checkService("https://archive.ph/newest/test", "Breaking News Article");
+    expect(result).toBe(true);
+  });
+
+  test("returns false when headline words not found in response", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: "<html><body>Completely unrelated content about cooking recipes</body></html>",
+    });
+
+    const result = await checkService("https://archive.ph/newest/test", "Breaking News Article");
+    expect(result).toBe(false);
+  });
+
+  test("returns true when no headline provided and HTTP succeeds", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: "<html><body>Some content</body></html>",
+    });
+
+    const result = await checkService("https://archive.ph/newest/test", null);
+    expect(result).toBe(true);
+  });
+
+  test("returns false on network error", async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error("timeout"));
+
+    const result = await checkService("https://archive.ph/newest/test", "Test Headline");
+    expect(result).toBe(false);
+  });
+});
+
+describe("getPaywallLinks", () => {
+  const assets = [
+    createPaywallAsset({name: "nytimes", domains: ["nytimes.com"], services: ["archive.today", "1ft.io"]}),
+    createPaywallAsset({name: "handelsblatt", domains: ["handelsblatt.com"], nofix: true}),
+    createPaywallAsset({name: "default", domains: ["*"], services: ["archive.today"]}),
+  ];
+
+  test("returns nofix result for nofix domain", async () => {
+    const result = await getPaywallLinks("https://www.handelsblatt.com/article", assets);
+    expect(result.nofix).toBe(true);
+    expect(result.services).toHaveLength(0);
+  });
+
+  test("returns nofix result for invalid URL", async () => {
+    const result = await getPaywallLinks("not-a-url", assets);
+    expect(result.nofix).toBe(true);
+  });
+
+  test("checks services for known domain", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: '<html><head><meta property="og:title" content="Big Story"></head><body>Big Story content here</body></html>',
+    });
+
+    const result = await getPaywallLinks("https://www.nytimes.com/article", assets);
+    expect(result.nofix).toBe(false);
+    expect(result.isDefault).toBe(false);
+    expect(result.services).toHaveLength(2);
+    const serviceNames = result.services.map(s => s.name).sort();
+    expect(serviceNames).toEqual(["1ft.io", "archive.today"]);
+    expect(result.services.every(s => s.available)).toBe(true);
+  });
+
+  test("marks isDefault for unknown domains", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: "<html><head><title>Some Article</title></head><body>Some Article text</body></html>",
+    });
+
+    const result = await getPaywallLinks("https://www.unknown-site.com/article", assets);
+    expect(result.nofix).toBe(false);
+    expect(result.isDefault).toBe(true);
+  });
+
+  test("deduplicates concurrent requests for the same URL", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: '<html><head><title>Dedup Test</title></head><body>Dedup Test content</body></html>',
+    });
+
+    const uniqueUrl = `https://www.nytimes.com/dedup-test-${Date.now()}`;
+    const [result1, result2] = await Promise.all([
+      getPaywallLinks(uniqueUrl, assets),
+      getPaywallLinks(uniqueUrl, assets),
+    ]);
+
+    expect(result1).toBe(result2);
+  });
+
+  test("ranks available services before unavailable ones", async () => {
+    let callCount = 0;
+    mockedAxios.get.mockImplementation(async (url: string) => {
+      callCount += 1;
+      if (1 === callCount) {
+        return {data: '<html><head><title>Rank Test</title></head><body>Rank Test article</body></html>'};
+      }
+
+      if (2 === callCount) {
+        throw new Error("service down");
+      }
+
+      return {data: '<html><body>Rank Test article text here</body></html>'};
+    });
+
+    const rankUrl = `https://www.nytimes.com/rank-test-${Date.now()}`;
+    const result = await getPaywallLinks(rankUrl, assets);
+    const availableServices = result.services.filter(s => s.available);
+    const unavailableServices = result.services.filter(s => !s.available);
+
+    if (availableServices.length > 0 && unavailableServices.length > 0) {
+      const lastAvailableIndex = result.services.findIndex(s => s === availableServices[availableServices.length - 1]);
+      const firstUnavailableIndex = result.services.findIndex(s => s === unavailableServices[0]);
+      expect(lastAvailableIndex).toBeLessThan(firstUnavailableIndex);
+    }
+  });
+});
+
+describe("getServiceSuccessRate", () => {
+  test("returns 0.5 for unknown service", () => {
+    expect(getServiceSuccessRate("never-seen-service")).toBe(0.5);
+  });
+});

--- a/modules/paywall.ts
+++ b/modules/paywall.ts
@@ -1,0 +1,269 @@
+import axios from "axios";
+import {PaywallAsset} from "./assets.js";
+import {getLogger} from "./logging.js";
+
+const logger = getLogger();
+
+const headlineTimeoutMs = 15_000;
+const serviceCheckTimeoutMs = 60_000;
+const inflightCacheTtlMs = 120_000;
+
+type ServiceRegistry = Record<string, (url: string) => string>;
+
+const inflightRequests = new Map<string, Promise<PaywallResult>>();
+const serviceStats = new Map<string, {successes: number; failures: number}>();
+
+export function getServiceSuccessRate(serviceName: string): number {
+  const stats = serviceStats.get(serviceName);
+  if (undefined === stats || 0 === stats.successes + stats.failures) {
+    return 0.5;
+  }
+
+  return stats.successes / (stats.successes + stats.failures);
+}
+
+function recordServiceResult(serviceName: string, available: boolean): void {
+  let stats = serviceStats.get(serviceName);
+  if (undefined === stats) {
+    stats = {successes: 0, failures: 0};
+    serviceStats.set(serviceName, stats);
+  }
+
+  if (true === available) {
+    stats.successes += 1;
+  } else {
+    stats.failures += 1;
+  }
+}
+
+function rankServices(services: PaywallServiceResult[]): PaywallServiceResult[] {
+  return [...services].sort((a, b) => {
+    if (a.available !== b.available) {
+      return a.available ? -1 : 1;
+    }
+
+    return getServiceSuccessRate(b.name) - getServiceSuccessRate(a.name);
+  });
+}
+
+export function getInflightCount(): number {
+  return inflightRequests.size;
+}
+
+const serviceRegistry: ServiceRegistry = {
+  "archive.today": (url: string) => `https://archive.ph/newest/${url}`,
+  "1ft.io": (url: string) => `https://1ft.io/${url}`,
+  "freedium": (url: string) => `https://freedium.cfd/${url}`,
+  "google-webcache": (url: string) => `https://webcache.googleusercontent.com/search?q=cache:${url}`,
+};
+
+export type PaywallServiceResult = {
+  name: string;
+  url: string;
+  available: boolean;
+};
+
+export type PaywallResult = {
+  originalUrl: string;
+  nofix: boolean;
+  isDefault: boolean;
+  headline: string | null;
+  services: PaywallServiceResult[];
+};
+
+export function extractHostname(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+export function matchPaywallAsset(url: string, paywallAssets: PaywallAsset[]): PaywallAsset | undefined {
+  const hostname = extractHostname(url);
+  if ("" === hostname) {
+    return undefined;
+  }
+
+  let defaultAsset: PaywallAsset | undefined;
+
+  for (const asset of paywallAssets) {
+    for (const domain of asset.domains ?? []) {
+      if ("*" === domain) {
+        defaultAsset = asset;
+        continue;
+      }
+
+      if (hostname === domain) {
+        return asset;
+      }
+
+      if (true === asset.subdomainWildcard && hostname.endsWith(`.${domain}`)) {
+        return asset;
+      }
+    }
+  }
+
+  return defaultAsset;
+}
+
+export function buildServiceUrl(serviceName: string, url: string): string | undefined {
+  const builder = serviceRegistry[serviceName];
+  if (undefined === builder) {
+    return undefined;
+  }
+
+  return builder(url);
+}
+
+export async function extractHeadline(url: string): Promise<string | null> {
+  try {
+    const response = await axios.get(url, {
+      timeout: headlineTimeoutMs,
+      maxRedirects: 5,
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; bot)",
+      },
+      responseType: "text",
+    });
+
+    const html = String(response.data);
+
+    const ogTitleMatch = html.match(/<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i)
+      ?? html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:title["']/i);
+    if (null !== ogTitleMatch) {
+      return ogTitleMatch[1].trim();
+    }
+
+    const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+    if (null !== titleMatch) {
+      return titleMatch[1].trim();
+    }
+
+    return null;
+  } catch (error: unknown) {
+    logger.log(
+      "debug",
+      `Failed to extract headline from ${url}: ${error}`,
+    );
+    return null;
+  }
+}
+
+export async function checkService(serviceUrl: string, headline: string | null): Promise<boolean> {
+  try {
+    const response = await axios.get(serviceUrl, {
+      timeout: serviceCheckTimeoutMs,
+      maxRedirects: 5,
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; bot)",
+      },
+      responseType: "text",
+      validateStatus: (status: number) => status < 400,
+    });
+
+    const body = String(response.data);
+
+    if (null !== headline && "" !== headline) {
+      const normalizedHeadline = headline.toLowerCase().replace(/\s+/g, " ").trim();
+      const words = normalizedHeadline.split(" ").filter(word => word.length > 3);
+      const significantWordCount = words.length;
+      if (0 === significantWordCount) {
+        return true;
+      }
+
+      const normalizedBody = body.toLowerCase();
+      let matchedWords = 0;
+      for (const word of words) {
+        if (normalizedBody.includes(word)) {
+          matchedWords += 1;
+        }
+      }
+
+      const matchRatio = matchedWords / significantWordCount;
+      return matchRatio >= 0.5;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function executePaywallLookup(url: string, paywallAssets: PaywallAsset[]): Promise<PaywallResult> {
+  const asset = matchPaywallAsset(url, paywallAssets);
+
+  if (undefined === asset) {
+    return {
+      originalUrl: url,
+      nofix: true,
+      isDefault: false,
+      headline: null,
+      services: [],
+    };
+  }
+
+  if (true === asset.nofix) {
+    return {
+      originalUrl: url,
+      nofix: true,
+      isDefault: false,
+      headline: null,
+      services: [],
+    };
+  }
+
+  const isDefault = "default" === asset.name;
+  const headline = await extractHeadline(url);
+
+  const serviceChecks = (asset.services ?? []).map(async (serviceName: string) => {
+    const serviceUrl = buildServiceUrl(serviceName, url);
+    if (undefined === serviceUrl) {
+      return {
+        name: serviceName,
+        url: "",
+        available: false,
+      };
+    }
+
+    const available = await checkService(serviceUrl, headline);
+    recordServiceResult(serviceName, available);
+    return {
+      name: serviceName,
+      url: serviceUrl,
+      available,
+    };
+  });
+
+  const services = await Promise.all(serviceChecks);
+
+  return {
+    originalUrl: url,
+    nofix: false,
+    isDefault,
+    headline,
+    services: rankServices(services),
+  };
+}
+
+export async function getPaywallLinks(url: string, paywallAssets: PaywallAsset[]): Promise<PaywallResult> {
+  const existing = inflightRequests.get(url);
+  if (undefined !== existing) {
+    logger.log(
+      "info",
+      `Paywall lookup already in-flight for ${url}, returning existing promise.`,
+    );
+    return existing;
+  }
+
+  const promise = executePaywallLookup(url, paywallAssets).finally(() => {
+    const timer = setTimeout(() => {
+      inflightRequests.delete(url);
+    }, inflightCacheTtlMs);
+    timer.unref();
+  });
+
+  inflightRequests.set(url, promise);
+  return promise;
+}

--- a/modules/slash-commands.define.test.ts
+++ b/modules/slash-commands.define.test.ts
@@ -455,20 +455,21 @@ describe("defineSlashCommands", () => {
     const payload = buildSlashCommandPayload(assets, [], []);
 
     expect(payload.slashCommands).toHaveLength(100);
-    expect(payload.assetCommandsRegistered).toBe(90);
-    expect(payload.fixedCommandsRegistered).toBe(10);
-    expect(payload.skippedCommandLimit).toBe(5);
+    expect(payload.assetCommandsRegistered).toBe(89);
+    expect(payload.fixedCommandsRegistered).toBe(11);
+    expect(payload.skippedCommandLimit).toBe(6);
     expect(payload.expectedCommandNames).toContain("quote");
     expect(payload.expectedCommandNames).toContain("calendar");
-    expect(payload.expectedCommandNames).toContain("asset-90");
-    expect(payload.expectedCommandNames).not.toContain("asset-91");
+    expect(payload.expectedCommandNames).toContain("paywall");
+    expect(payload.expectedCommandNames).toContain("asset-89");
+    expect(payload.expectedCommandNames).not.toContain("asset-90");
     expect(loggerMock.log).toHaveBeenCalledWith(
       "warn",
       expect.objectContaining({
         source: "slash-registration",
         max_commands_per_scope: 100,
         total_commands_registered: 100,
-        skipped_command_limit: 5,
+        skipped_command_limit: 6,
         message: "Slash command payload built with skipped asset triggers.",
       }),
     );

--- a/modules/slash-commands.ts
+++ b/modules/slash-commands.ts
@@ -6,6 +6,7 @@ import {getAssetByName, ImageAsset, TextAsset} from "./assets.js";
 import {cryptodice} from "./crypto-dice.js";
 import {getDiscordRateLimitRetryAfterMs, toDiscordTimerMs} from "./discord-retry-after.js";
 import {google, lmgtfy} from "./lmgtfy.js";
+import {getPaywallLinks, PaywallResult} from "./paywall.js";
 import {getDiscordLogger, getLogger} from "./logging.js";
 import {getRandomAsset} from "./random-asset.js";
 import {getRandomQuote} from "./random-quote.js";
@@ -35,7 +36,7 @@ const islandboiUnmuteTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const slashCommandRestTimeoutMs = 120_000;
 const slashCommandNameLogLimit = 20;
 const maxSlashCommandsPerScope = 100;
-const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "google", "8ball", "whatis", "quote", "islandboi", "sara", "earnings", "calendar"];
+const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "google", "8ball", "whatis", "quote", "islandboi", "sara", "earnings", "calendar", "paywall"];
 
 class SlashRegistrationMismatchError extends Error {
   constructor(message: string) {
@@ -701,6 +702,15 @@ function createFixedSlashCommands(whatIsAssetsChoices, userAssetsChoices) {
         .setRequired(false));
   fixedSlashCommands.push(slashCommandCalendar.toJSON());
 
+  const slashCommandPaywall = new SlashCommandBuilder()
+    .setName("paywall")
+    .setDescription("Paywall bypass")
+    .addStringOption(option =>
+      option.setName("url")
+        .setDescription("Article URL")
+        .setRequired(true));
+  fixedSlashCommands.push(slashCommandPaywall.toJSON());
+
   return fixedSlashCommands;
 }
 
@@ -1097,7 +1107,7 @@ export async function defineSlashCommands(assets, whatIsAssets, userAssets) {
   }
 }
 
-export function interactSlashCommands(client, assets, assetCommands, whatIsAssets, tickers: Ticker[]) {
+export function interactSlashCommands(client, assets, assetCommands, whatIsAssets, tickers: Ticker[], paywallAssets?) {
   const guildId = readSecret("discord_guild_ID").trim();
   // Respond to slash-commands
   client.on("interactionCreate", async interaction => {
@@ -1206,6 +1216,105 @@ export function interactSlashCommands(client, assets, assetCommands, whatIsAsset
           `Error replying to google slashcommand: ${error}`,
         );
       });
+    }
+
+    if ("paywall" === commandName) {
+      const rawUrl = interaction.options.getString("url", true).trim();
+
+      if (false === validator.isURL(rawUrl)) {
+        await interaction.reply({
+          content: "Ungueltige URL. Bitte eine vollstaendige URL angeben (z.B. https://www.example.com/article).",
+          ephemeral: true,
+        }).catch(error => {
+          logger.log(
+            "error",
+            `Error replying to paywall slashcommand (invalid URL): ${error}`,
+          );
+        });
+        return;
+      }
+
+      const url = rawUrl.startsWith("http") ? rawUrl : `https://${rawUrl}`;
+
+      const deferred = await interaction.deferReply().then(() => true).catch(error => {
+        logger.log(
+          "error",
+          `Error deferring paywall slashcommand reply: ${error}`,
+        );
+        return false;
+      });
+      if (false === deferred) {
+        return;
+      }
+
+      await interaction.editReply({
+        content: `Suche nach Paywall-Bypass fuer <${url}>... Das kann bis zu 60 Sekunden dauern.`,
+      }).catch(error => {
+        logger.log(
+          "error",
+          `Error sending paywall working message: ${error}`,
+        );
+      });
+
+      try {
+        const result: PaywallResult = await getPaywallLinks(url, paywallAssets ?? []);
+        const embed = new EmbedBuilder();
+
+        if (true === result.nofix) {
+          embed.setTitle("Paywall Bypass");
+          embed.setDescription(
+            `Fuer diese Seite ist kein Paywall-Service bekannt.\n\nAlternativen:\n• Browser-Extension: Bypass Paywalls Clean\n  <https://github.com/AsenCME/bypass-paywalls>`,
+          );
+          embed.addFields({name: "URL", value: `<${url}>`});
+        } else {
+          const title = true === result.isDefault
+            ? "Paywall Bypass (unbekannte Seite)"
+            : "Paywall Bypass";
+          embed.setTitle(title);
+
+          if (true === result.isDefault) {
+            embed.setDescription("Unbekannte Seite — versuche allgemeine Services:");
+          }
+
+          const lines: string[] = [];
+          for (const service of result.services) {
+            if (true === service.available) {
+              lines.push(`✅ **${service.name}**: <${service.url}>`);
+            } else {
+              lines.push(`❌ **${service.name}**: Nicht gefunden`);
+            }
+          }
+
+          if (0 === lines.length) {
+            lines.push("Keine Services verfuegbar.");
+          }
+
+          embed.addFields(
+            {name: "Original", value: `<${url}>`},
+            {name: "Ergebnisse", value: lines.join("\n")},
+          );
+        }
+
+        await interaction.editReply({content: "", embeds: [embed]}).catch(error => {
+          logger.log(
+            "error",
+            `Error replying to paywall slashcommand: ${error}`,
+          );
+        });
+      } catch (error: unknown) {
+        logger.log(
+          "error",
+          `Error processing paywall slashcommand: ${error}`,
+        );
+        await interaction.editReply({
+          content: "Fehler beim Verarbeiten der Anfrage. Bitte spaeter erneut versuchen.",
+        }).catch(editError => {
+          logger.log(
+            "error",
+            `Error sending paywall error message: ${editError}`,
+          );
+        });
+      }
     }
 
     if ("whatis" === commandName) {

--- a/modules/startup-orchestrator.ts
+++ b/modules/startup-orchestrator.ts
@@ -64,6 +64,7 @@ type SharedStartupData = {
   roleAssets: any[];
   calendarReminderAssets: any[];
   earningsReminderAssets: any[];
+  paywallAssets: any[];
   tickers: Ticker[];
   assetCommands: string[];
   assetCommandsWithPrefix: string[];
@@ -642,6 +643,7 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     roleAssets: [],
     calendarReminderAssets: [],
     earningsReminderAssets: [],
+    paywallAssets: [],
     tickers: [],
     assetCommands: [],
     assetCommandsWithPrefix: [],
@@ -727,7 +729,7 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     dependencies.startMncTimers(client, channelMncId);
     dependencies.addInlineResponses(client, sharedData.assets, sharedData.assetCommands);
     dependencies.addTriggerResponses(client, sharedData.assets, sharedData.assetCommandsWithPrefix, sharedData.whatIsAssets);
-    dependencies.interactSlashCommands(client, sharedData.assets, sharedData.assetCommands, sharedData.whatIsAssets, sharedData.tickers);
+    dependencies.interactSlashCommands(client, sharedData.assets, sharedData.assetCommands, sharedData.whatIsAssets, sharedData.tickers, sharedData.paywallAssets);
     startupState.markHandlersAttached();
 
     logger.log(
@@ -1309,6 +1311,15 @@ async function warmRemoteData({
       logger.log(
         "info",
         `Loaded and cached ${sharedData.earningsReminderAssets.length} earnings reminder assets.`,
+      );
+    })());
+
+    warmupTasks.push((async () => {
+      const paywallAssets = await runWarmupTaskWithRetry("paywall-assets", async () => dependencies.getAssets("paywall"));
+      replaceArray(sharedData.paywallAssets, paywallAssets);
+      logger.log(
+        "info",
+        `Loaded and cached ${sharedData.paywallAssets.length} paywall assets.`,
       );
     })());
 


### PR DESCRIPTION
Introduces a new /paywall <url> command that looks up compatible bypass services from a YAML asset file, extracts the article headline, verifies each service has the actual content, and returns working links. Includes per-URL dedup to prevent DoS, dynamic re-ranking by success rate, and honest "no known service" responses for hard-paywalled sites.