### PR TITLE
[codex] Harden digest-based redeploy validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,15 @@ jobs:
         run: |
           echo "${{ secrets.COSIGN_KEY }}" > /tmp/cosign.key
           image_ref="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}"
-          cosign sign --yes --tlog-upload=true --key /tmp/cosign.key "${image_ref}"
+          commit_sha="${{ github.sha }}"
+          repository="${{ github.repository }}"
+          cosign sign \
+            --yes \
+            --tlog-upload=true \
+            --key /tmp/cosign.key \
+            -a "git_sha=${commit_sha}" \
+            -a "repository=${repository}" \
+            "${image_ref}"
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
   
@@ -167,8 +175,12 @@ jobs:
           REDEPLOY_URL: ${{ secrets.REDEPLOY_URL }}
           REDEPLOY_AUTH: ${{ secrets.REDEPLOY_AUTH }}
         run: |
+          image_digest="${{ needs.build.outputs.digest }}"
+          commit_sha="${{ github.sha }}"
           curl -fsS -X POST \
             -H "X-Hblwrk-Auth: ${REDEPLOY_AUTH}" \
+            -H "Content-Type: application/json" \
+            --data "{\"digest\":\"${image_digest}\",\"commit_sha\":\"${commit_sha}\"}" \
             "${REDEPLOY_URL}"
 
       - name: Actions Status Discord

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Coding guidance for this repo. Extracts the rules a contributor (human or agent)
 ## CI/CD invariants
 
 - `main` is the released branch. All work goes via feature branches and PRs.
-- The CI pipeline runs: tests + typecheck → Dockerfile validator + Checkov + Sysdig CIS benchmark → image build/push to `ghcr.io` → Trivy scan (HIGH/CRITICAL, fixed only) → cosign sign → webhook redeploy. Staging must report `/api/v1/ready` before production rolls.
+- The CI pipeline runs: tests + typecheck → Dockerfile validator + Checkov + Sysdig CIS benchmark → image build/push to `ghcr.io` → Trivy scan (HIGH/CRITICAL, fixed only) → cosign sign → webhook redeploy by image digest. Staging must report `/api/v1/ready` before production rolls.
 - Separate workflows run CodeQL, njsscan, and Semgrep. Treat their findings as blocking.
 - Don't loosen any of: `coverageThreshold`, `npm audit --audit-level=high`, Trivy severity filters, Checkov framework scope, image signing, or the staging readiness gate. If one is genuinely the wrong fit, raise it explicitly rather than editing it through.
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ The bot is deployed at our server, running as a docker container in Docker Swarm
 * Security scanning in the main workflow is executed using Checkov.
 * Additional security scanning is handled by dedicated CodeQL, njsscan and Semgrep workflows.
 * The container image is built, pushed and signed with cosign.
-* The server gets notified via webhook to start deployment.
-* The server-side redeploy script verifies the image signature and only deploys production after staging reports `/api/v1/ready`.
+* The server gets notified via webhook with the image digest and commit SHA to deploy.
+* The server-side redeploy script verifies that exact image digest and commit binding, then only deploys production after staging reports `/api/v1/ready`.
 
 The webhook runs as a user-mode `systemd` service for user `mheiland`, all relevant configuration can be found at that user's home directory.
 
@@ -235,6 +235,7 @@ Real-time market-data is being pulled in through a Websocket connection and dist
 The bots lifecycle is managed using the `tools/docker-compose-production.yml` file provided at this repository. It contains useful security settings, resource limits and injects secrets. The service is then deployed using Docker Swarm.
 
 ```bash
+DISCORD_BOT_IMAGE="ghcr.io/hblwrk/discord-bot-ts@sha256:<digest>" \
 docker stack deploy --with-registry-auth --prune --compose-file tools/docker-compose-production.yml discord-bot-ts_production
 docker stack rm discord-bot-ts_production
 ```

--- a/tools/docker-compose-production.yml
+++ b/tools/docker-compose-production.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   bot:
-    image: ghcr.io/hblwrk/discord-bot-ts:main
+    image: ${DISCORD_BOT_IMAGE}
     deploy:
       resources:
         limits:

--- a/tools/hooks.json
+++ b/tools/hooks.json
@@ -1,21 +1,28 @@
-[  
+[
   {
-  "id": "redeploy-XXX",
-  "execute-command": "/home/user/webhook/redeploy.sh",
-  "command-working-directory": "/home/user/webhook",
-  "response-message": "Redeploying bot.",
-  "trigger-rule":
-  {
-    "match":
-    {
-      "type": "value",
-      "value": "XXX",
-      "parameter":
+    "id": "redeploy-XXX",
+    "execute-command": "/home/user/webhook/redeploy.sh",
+    "command-working-directory": "/home/user/webhook",
+    "response-message": "Redeploying bot.",
+    "pass-arguments-to-command": [
       {
-        "source": "header",
-        "name": "X-Hblwrk-Auth"
+        "source": "payload",
+        "name": "digest"
+      },
+      {
+        "source": "payload",
+        "name": "commit_sha"
+      }
+    ],
+    "trigger-rule": {
+      "match": {
+        "type": "value",
+        "value": "XXX",
+        "parameter": {
+          "source": "header",
+          "name": "X-Hblwrk-Auth"
+        }
       }
     }
   }
-}
 ]

--- a/tools/redeploy.sh
+++ b/tools/redeploy.sh
@@ -3,104 +3,265 @@ set -euo pipefail
 
 export DOCKER_CONTENT_TRUST=1
 
-image="ghcr.io/hblwrk/discord-bot-ts:main"
-staging_service_name="discord-bot-ts_staging_bot"
-verify_output_file="$(mktemp)"
-trap 'rm -f "${verify_output_file}"' EXIT
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 sha256:<digest> <commit-sha>"
+  exit 64
+fi
 
-is_staging_healthy() {
-  if ! docker service inspect "${staging_service_name}" >/dev/null 2>&1; then
+image_digest="$1"
+commit_sha="$2"
+digest_pattern='^sha256:[0-9a-f]{64}$'
+commit_pattern='^[0-9a-f]{40}$'
+if ! [[ "${image_digest}" =~ ${digest_pattern} ]]; then
+  echo "Invalid image digest: ${image_digest}"
+  exit 64
+fi
+if ! [[ "${commit_sha}" =~ ${commit_pattern} ]]; then
+  echo "Invalid commit SHA: ${commit_sha}"
+  exit 64
+fi
+
+image="ghcr.io/hblwrk/discord-bot-ts@${image_digest}"
+repository="hblwrk/discord-bot-ts"
+staging_service_name="discord-bot-ts_staging_bot"
+production_service_name="discord-bot-ts_production_bot"
+staging_compose_file="docker-compose-staging.yml"
+production_compose_file="docker-compose-production.yml"
+verify_output_file="$(mktemp)"
+rendered_staging_compose_file="$(mktemp)"
+rendered_production_compose_file="$(mktemp)"
+trap 'rm -f "${verify_output_file}" "${rendered_staging_compose_file}" "${rendered_production_compose_file}"' EXIT
+
+render_compose_file() {
+  local source_file="$1"
+  local target_file="$2"
+
+  if ! grep -q '^[[:space:]]*image:[[:space:]]*${DISCORD_BOT_IMAGE}[[:space:]]*$' "${source_file}" \
+    && ! grep -q '^[[:space:]]*image:[[:space:]]*ghcr.io/hblwrk/discord-bot-ts' "${source_file}"; then
+    echo "Compose file ${source_file} does not declare a discord-bot-ts image."
     return 1
   fi
 
+  sed \
+    -e "s|^\([[:space:]]*image:[[:space:]]*\)\${DISCORD_BOT_IMAGE}[[:space:]]*$|\1${image}|" \
+    -e "s|^\([[:space:]]*image:[[:space:]]*\)ghcr.io/hblwrk/discord-bot-ts[^[:space:]]*[[:space:]]*$|\1${image}|" \
+    "${source_file}" >"${target_file}"
+
+  validate_rendered_compose_file "${target_file}"
+}
+
+validate_rendered_compose_file() {
+  local compose_file="$1"
+  local image_line_count
+  local expected_image_line_count
+
+  image_line_count="$(
+    grep -c '^[[:space:]]*image:[[:space:]]*' "${compose_file}" || true
+  )"
+  expected_image_line_count="$(
+    grep -F -c "image: ${image}" "${compose_file}" || true
+  )"
+
+  if [ "${image_line_count}" -ne 1 ] || [ "${expected_image_line_count}" -ne 1 ]; then
+    echo "Rendered compose file ${compose_file} does not contain exactly one expected image reference."
+    return 1
+  fi
+
+  if grep -q '\${DISCORD_BOT_IMAGE}' "${compose_file}"; then
+    echo "Rendered compose file ${compose_file} still contains DISCORD_BOT_IMAGE."
+    return 1
+  fi
+
+  if grep -q 'ghcr.io/hblwrk/discord-bot-ts:main' "${compose_file}"; then
+    echo "Rendered compose file ${compose_file} still contains mutable :main image reference."
+    return 1
+  fi
+}
+
+is_service_healthy() {
+  local service_name="$1"
   local update_state
+  local service_image
+  local desired_replicas
+  local task_rows
+  local task_count
+  local task_image
+  local task_state
+  local task_error
+  local healthy_container_ids
+  local healthy_container_count
+  local container_id
+  local container_image
+
+  if ! docker service inspect "${service_name}" >/dev/null 2>&1; then
+    return 1
+  fi
+
+  service_image="$(
+    docker service inspect \
+      --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}' \
+      "${service_name}" \
+      2>/dev/null
+  )"
+  if [ "${service_image}" != "${image}" ]; then
+    echo "${service_name} is configured for ${service_image}, expected ${image}."
+    return 1
+  fi
+
   update_state="$(
     docker service inspect \
       --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' \
-      "${staging_service_name}" \
+      "${service_name}" \
       2>/dev/null
   )"
   if [ -n "${update_state}" ] && [ "completed" != "${update_state}" ]; then
     return 1
   fi
 
-  local replicas
-  replicas="$(
-    docker service ls \
-      --filter "name=${staging_service_name}" \
-      --format '{{.Replicas}}' \
-      | head -n 1
+  desired_replicas="$(
+    docker service inspect \
+      --format '{{.Spec.Mode.Replicated.Replicas}}' \
+      "${service_name}" \
+      2>/dev/null
   )"
-  case "${replicas}" in
-    */*)
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-
-  local current_replicas
-  local desired_replicas
-  current_replicas="${replicas%%/*}"
-  desired_replicas="${replicas##*/}"
-  case "${current_replicas}" in
-    ""|*[!0-9]*)
-      return 1
-      ;;
-  esac
   case "${desired_replicas}" in
     ""|*[!0-9]*)
       return 1
       ;;
   esac
-  if [ "${desired_replicas}" -eq 0 ] || [ "${current_replicas}" -ne "${desired_replicas}" ]; then
+  if [ "${desired_replicas}" -eq 0 ]; then
     return 1
   fi
 
-  local healthy_container_count
-  healthy_container_count="$(
-    docker ps -q \
-      --filter "label=com.docker.swarm.service.name=${staging_service_name}" \
-      --filter "health=healthy" \
-      | wc -l | tr -d '[:space:]'
+  task_rows="$(
+    docker service ps \
+      --no-trunc \
+      --filter "desired-state=running" \
+      --format '{{.Image}}|{{.CurrentState}}|{{.Error}}' \
+      "${service_name}" \
+      2>/dev/null
   )"
+
+  task_count=0
+  while IFS='|' read -r task_image task_state task_error; do
+    if [ -z "${task_image}${task_state}${task_error}" ]; then
+      continue
+    fi
+
+    task_count=$((task_count + 1))
+
+    if [ "${task_image}" != "${image}" ]; then
+      echo "${service_name} task uses ${task_image}, expected ${image}."
+      return 1
+    fi
+
+    case "${task_state}" in
+      Running*)
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+
+    if [ -n "${task_error}" ]; then
+      echo "${service_name} task reports error: ${task_error}"
+      return 1
+    fi
+  done <<EOF
+${task_rows}
+EOF
+
+  if [ "${task_count}" -ne "${desired_replicas}" ]; then
+    return 1
+  fi
+
+  healthy_container_ids="$(
+    docker ps -q \
+      --filter "label=com.docker.swarm.service.name=${service_name}" \
+      --filter "health=healthy"
+  )"
+
+  healthy_container_count=0
+  for container_id in ${healthy_container_ids}; do
+    container_image="$(
+      docker inspect \
+        --format '{{.Config.Image}}' \
+        "${container_id}" \
+        2>/dev/null
+    )"
+    if [ "${container_image}" != "${image}" ]; then
+      echo "${service_name} container ${container_id} uses ${container_image}, expected ${image}."
+      return 1
+    fi
+
+    healthy_container_count=$((healthy_container_count + 1))
+  done
 
   [ "${healthy_container_count}" -eq "${desired_replicas}" ]
 }
 
-signature_valid=false
-if /usr/bin/cosign verify --key /home/user/cosign.pub "${image}" >"${verify_output_file}" 2>&1; then
-  signature_valid=true
-elif grep -q "signature not found in transparency log" "${verify_output_file}"; then
-  echo "Signature has no transparency-log entry. Retrying verification without tlog requirement."
-  if /usr/bin/cosign verify --insecure-ignore-tlog=true --key /home/user/cosign.pub "${image}" >"${verify_output_file}" 2>&1; then
-    signature_valid=true
-  fi
-fi
-
-if [ true = "${signature_valid}" ]; then
-  docker stack deploy --with-registry-auth --prune --compose-file docker-compose-staging.yml discord-bot-ts_staging
-
-  timeout_seconds=300
-  interval_seconds=10
-  elapsed_seconds=0
+wait_for_service_healthy() {
+  local service_name="$1"
+  local service_label="$2"
+  local timeout_seconds=300
+  local interval_seconds=10
+  local elapsed_seconds=0
 
   while [ "${elapsed_seconds}" -lt "${timeout_seconds}" ]; do
     sleep "${interval_seconds}"
     elapsed_seconds=$((elapsed_seconds + interval_seconds))
 
-    if is_staging_healthy; then
-      docker stack deploy --with-registry-auth --prune --compose-file docker-compose-production.yml discord-bot-ts_production
-      docker stack rm discord-bot-ts_staging
-      docker system prune -f
-      exit 0
+    if is_service_healthy "${service_name}"; then
+      return 0
     fi
 
-    echo "Staging service not healthy yet. Retry in ${interval_seconds} seconds."
+    echo "${service_label} service not healthy yet. Retry in ${interval_seconds} seconds."
   done
 
-  echo "Staging service did not become healthy after ${timeout_seconds} seconds, not deploying."
-  exit 23
+  echo "${service_label} service did not become healthy after ${timeout_seconds} seconds."
+  return 1
+}
+
+signature_valid=false
+if /usr/bin/cosign verify \
+  --key /home/user/cosign.pub \
+  -a "git_sha=${commit_sha}" \
+  -a "repository=${repository}" \
+  "${image}" >"${verify_output_file}" 2>&1; then
+  signature_valid=true
+elif grep -q "signature not found in transparency log" "${verify_output_file}"; then
+  echo "Signature has no transparency-log entry. Retrying verification without tlog requirement."
+  if /usr/bin/cosign verify \
+    --insecure-ignore-tlog=true \
+    --key /home/user/cosign.pub \
+    -a "git_sha=${commit_sha}" \
+    -a "repository=${repository}" \
+    "${image}" >"${verify_output_file}" 2>&1; then
+    signature_valid=true
+  fi
+fi
+
+if [ true = "${signature_valid}" ]; then
+  render_compose_file "${staging_compose_file}" "${rendered_staging_compose_file}"
+  render_compose_file "${production_compose_file}" "${rendered_production_compose_file}"
+
+  docker stack deploy --with-registry-auth --prune --compose-file "${rendered_staging_compose_file}" discord-bot-ts_staging
+
+  if ! wait_for_service_healthy "${staging_service_name}" "Staging"; then
+    echo "Staging did not validate, not deploying production."
+    exit 23
+  fi
+
+  docker stack deploy --with-registry-auth --prune --compose-file "${rendered_production_compose_file}" discord-bot-ts_production
+
+  if ! wait_for_service_healthy "${production_service_name}" "Production"; then
+    echo "Production did not validate, leaving staging deployed."
+    exit 24
+  fi
+
+  docker stack rm discord-bot-ts_staging
+  docker system prune -f
+  exit 0
 fi
 
 cat "${verify_output_file}"


### PR DESCRIPTION
## What changed

- Pass the CI build digest and commit SHA through the redeploy webhook.
- Sign container images with repository and commit annotations, then require those annotations during server-side cosign verification.
- Render staging and production compose files with the exact digest image reference.
- Validate rendered compose output, staging service state, running task images, healthy container images, and production rollout before removing staging.

## Why

Deployment previously scanned and signed a digest in CI but rolled out the mutable :main tag on the server. This keeps the deployed image tied to the digest and commit that CI produced and signed.

## Validation

- bash -n tools/redeploy.sh
- jq . tools/hooks.json
- git diff --check
- invalid digest and invalid commit smoke tests

Docker Swarm checks were not run locally because docker is not installed in this workspace.