### PR TITLE
[codex] Migrate TypeScript module resolution to NodeNext

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,9 +1,15 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'node',
   testEnvironmentOptions: {
     globalsCleanup: 'off',
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      diagnostics: {
+        ignoreCodes: [151002],
+      },
+    }],
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/modules/market-data.ts
+++ b/modules/market-data.ts
@@ -1,5 +1,5 @@
 import {Client} from "discord.js";
-import ReconnectingWebSocket from "reconnecting-websocket";
+import ReconnectingWebSocketModule from "reconnecting-websocket";
 import WS from "ws";
 import {getAssets} from "./assets.js";
 import {getMarketDataClientCacheFactory} from "./discord-client-options.js";
@@ -35,6 +35,21 @@ const pendingStatusFlushIntervalMs = 1000;
 const marketStatusCheckIntervalMs = 60_000;
 const streamWatchdogIntervalMs = 30_000;
 const streamStaleTimeoutMs = 300_000;
+
+type ReconnectingWebSocketInstance = {
+  OPEN: number;
+  addEventListener: (type: "open" | "close" | "error" | "message", listener: (event: any) => void) => void;
+  readyState: number;
+  reconnect: () => void;
+  send: (data: string) => void;
+  url: string;
+};
+type ReconnectingWebSocketConstructor = new (
+  urlProvider: string | (() => string),
+  protocols?: string | string[],
+  options?: Record<string, unknown>
+) => ReconnectingWebSocketInstance;
+const ReconnectingWebSocket = ReconnectingWebSocketModule as unknown as ReconnectingWebSocketConstructor;
 
 // Launching multiple bots and websocket stream to display price information.
 // Discord-facing updates stay throttled, but the latest parsed tick is retained and flushed when due.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "module": "es2020",
+    "module": "nodenext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "target": "es2020",
     "lib": [
       "ES2021.String",


### PR DESCRIPTION
## Summary
- switch TypeScript module and module resolution settings to NodeNext
- add a narrow reconnecting-websocket constructor shim for NodeNext type compatibility
- move ts-jest diagnostics config into the transformer and suppress the known hybrid-module warning

## Validation
- npm run typecheck
- npm test -- --runInBand