### PR TITLE
[codex] Use other announcements for earnings results

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ echo -n "hunter5" | docker secret create production_hblwrk_channel_NYSEAnnouncem
 echo -n "hunter6" | docker secret create production_hblwrk_gainslosses_thread_ID -
 echo -n "hunter7" | docker secret create production_hblwrk_channel_MNCAnnouncement_ID -
 echo -n "hunter8" | docker secret create production_hblwrk_channel_OtherAnnouncement_ID -
-echo -n "hunter8b" | docker secret create production_hblwrk_channel_BreakingNews_ID -
 echo -n "hunter9" | docker secret create production_discord_btcusd_token -
 echo -n "hunter10" | docker secret create production_discord_btcusd_client_ID -
 ...
@@ -147,7 +146,6 @@ The health-check server port can be overridden via the `HEALTHCHECK_PORT` enviro
   "dracoon_password": "",
   "hblwrk_channel_NYSEAnnouncement_ID": "",
   "hblwrk_gainslosses_thread_ID": "",
-  "hblwrk_channel_BreakingNews_ID": "",
   "hblwrk_channel_MNCAnnouncement_ID": "",
   "hblwrk_channel_OtherAnnouncement_ID": "",
   "hblwrk_channel_logging_ID": "",
@@ -193,7 +191,7 @@ If DRACOON downloads fail during startup, the bot keeps those assets marked as t
 
 ### Reminder assets
 
-Calendar reminders and earnings reminders are configured as YAML assets and both post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements post into `hblwrk_channel_BreakingNews_ID` after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. They ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
+Calendar reminders, earnings reminders, and earnings result announcements post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements are sent after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. They ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
 
 Calendar reminder assets are matched against the current day and sent at `08:30 Europe/Berlin`, immediately after the general daily calendar post. If multiple matching calendar items share the same release minute, the bot bundles them into a single reminder ping:
 

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -118,7 +118,7 @@ describe("earnings result announcements", () => {
     });
   });
 
-  test("builds a breaking-news announcement from a watched SEC filing", async () => {
+  test("builds an earnings result announcement from a watched SEC filing", async () => {
     const result = await getEarningsResultAnnouncements({
       dependencies: {
         getEarningsResultFn,

--- a/modules/startup-orchestrator.test.ts
+++ b/modules/startup-orchestrator.test.ts
@@ -138,7 +138,7 @@ describe("startBot", () => {
     expect(mocks.startEarningsResultWatcher).toHaveBeenCalledTimes(1);
     expect(mocks.startEarningsResultWatcher).toHaveBeenCalledWith(
       expect.anything(),
-      "breaking-news",
+      "other",
     );
     expect(mocks.addInlineResponses).toHaveBeenCalledTimes(1);
     expect(mocks.addTriggerResponses).toHaveBeenCalledTimes(1);
@@ -648,7 +648,6 @@ describe("startBot", () => {
         discord_token: "token",
         hblwrk_channel_NYSEAnnouncement_ID: "nyse",
         hblwrk_gainslosses_thread_ID: "gains-losses-thread",
-        hblwrk_channel_BreakingNews_ID: "breaking-news",
         hblwrk_channel_MNCAnnouncement_ID: "mnc",
         hblwrk_channel_OtherAnnouncement_ID: "other",
         hblwrk_channel_clownboard_ID: "clownboard",

--- a/modules/startup-orchestrator.ts
+++ b/modules/startup-orchestrator.ts
@@ -148,7 +148,6 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
   const environment = dependencies.readSecret("environment").trim();
   const channelNyseId = dependencies.readSecret("hblwrk_channel_NYSEAnnouncement_ID").trim();
   const gainsLossesThreadId = dependencies.readSecret("hblwrk_gainslosses_thread_ID").trim();
-  const channelBreakingNewsId = dependencies.readSecret("hblwrk_channel_BreakingNews_ID").trim();
   const channelMncId = dependencies.readSecret("hblwrk_channel_MNCAnnouncement_ID").trim();
   const channelOtherId = dependencies.readSecret("hblwrk_channel_OtherAnnouncement_ID").trim();
   const channelClownboardId = dependencies.readSecret("hblwrk_channel_clownboard_ID").trim();
@@ -211,7 +210,6 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     startupState.markDiscordLoggedIn();
     await runStartupPreflight(client, logger, {
       brokerYesRoleId,
-      channelBreakingNewsId,
       channelClownboardId,
       channelMncId,
       channelNyseId,
@@ -226,7 +224,7 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     dependencies.clownboard(client, channelClownboardId);
     dependencies.startNyseTimers(client, channelNyseId, gainsLossesThreadId);
     dependencies.startMncTimers(client, channelMncId);
-    dependencies.startEarningsResultWatcher(client, channelBreakingNewsId);
+    dependencies.startEarningsResultWatcher(client, channelOtherId);
     dependencies.addInlineResponses(client, sharedData.assets, sharedData.assetCommands);
     dependencies.addTriggerResponses(client, sharedData.assets, sharedData.assetCommandsWithPrefix, sharedData.whatIsAssets, sharedData.paywallAssets);
     dependencies.interactSlashCommands(client, sharedData.assets, sharedData.assetCommands, sharedData.whatIsAssets, sharedData.tickers, sharedData.paywallAssets);

--- a/modules/startup-preflight.ts
+++ b/modules/startup-preflight.ts
@@ -20,7 +20,6 @@ type StartupPreflightFailure = {
 type StartupPreflightOptions = {
   brokerYesRoleId: string;
   channelClownboardId: string;
-  channelBreakingNewsId: string;
   channelMncId: string;
   channelNyseId: string;
   channelOtherId: string;
@@ -228,15 +227,6 @@ export async function runStartupPreflight(
   await checkChannel({
     channelId: options.channelNyseId,
     label: "NYSE announcements",
-    requireSendCapability: true,
-    requiredPermissions: [
-      PermissionFlagsBits.ViewChannel,
-      PermissionFlagsBits.SendMessages,
-    ],
-  });
-  await checkChannel({
-    channelId: options.channelBreakingNewsId,
-    label: "Breaking news",
     requireSendCapability: true,
     requiredPermissions: [
       PermissionFlagsBits.ViewChannel,

--- a/modules/test-utils/startup-orchestrator.ts
+++ b/modules/test-utils/startup-orchestrator.ts
@@ -70,7 +70,7 @@ export function createMockClient(options: {
     PermissionFlagsBits.AddReactions,
   ];
   const missingChannelIdSet = new Set(missingChannelIds);
-  const channelIds = ["nyse", "breaking-news", "mnc", "other", "clownboard", ...Object.keys(channelPermissionsById)];
+  const channelIds = ["nyse", "mnc", "other", "clownboard", ...Object.keys(channelPermissionsById)];
   const channelsById = new Map<string, any>();
   for (const channelId of channelIds) {
     if (true === missingChannelIdSet.has(channelId)) {
@@ -176,7 +176,6 @@ export function createDependencies(overrides = {}) {
       discord_token: "token",
       hblwrk_channel_NYSEAnnouncement_ID: "nyse",
       hblwrk_gainslosses_thread_ID: "gains-losses-thread",
-      hblwrk_channel_BreakingNews_ID: "breaking-news",
       hblwrk_channel_MNCAnnouncement_ID: "mnc",
       hblwrk_channel_OtherAnnouncement_ID: "other",
       hblwrk_channel_clownboard_ID: "clownboard",
@@ -295,4 +294,3 @@ export function createDependencies(overrides = {}) {
     },
   };
 }
-

--- a/tools/docker-compose-production.yml
+++ b/tools/docker-compose-production.yml
@@ -51,7 +51,6 @@ services:
       - production_discord_30y_client_ID
       - production_dracoon_password
       - production_hblwrk_channel_NYSEAnnouncement_ID
-      - production_hblwrk_channel_BreakingNews_ID
       - production_hblwrk_channel_MNCAnnouncement_ID
       - production_hblwrk_channel_OtherAnnouncement_ID
       - production_hblwrk_channel_logging_ID
@@ -151,8 +150,6 @@ secrets:
   production_dracoon_password:
     external: true
   production_hblwrk_channel_NYSEAnnouncement_ID:
-    external: true
-  production_hblwrk_channel_BreakingNews_ID:
     external: true
   production_hblwrk_channel_MNCAnnouncement_ID:
     external: true


### PR DESCRIPTION
## Summary
- route earnings result announcements to `hblwrk_channel_OtherAnnouncement_ID`
- remove the unused `hblwrk_channel_BreakingNews_ID` startup/preflight wiring
- drop the obsolete BreakingNews secret from README and production compose

## Root Cause
Earnings result announcements still used a separate BreakingNews channel setting, but that channel is not part of the active announcement setup.

## Impact
Earnings result announcements post to the same announcements channel used by regular earnings and market calendar posts. Deployments no longer need a BreakingNews channel secret.

## Validation
- `npx jest modules/startup-orchestrator.test.ts modules/earnings-results.test.ts --runInBand`
- `npm run typecheck`
- `npm run test:coverage`