### PR TITLE
[codex] Add option delta command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ echo -n "hunter10" | docker secret create production_discord_btcusd_client_ID -
 
 Check the `config.json` example below for a reference set of configuration parameters. Keep it in sync with key references in `assets/*.yaml` and secrets in `tools/docker-compose-production.yml`.
 
+The `/delta` command reads `tastytrade_client_secret` and `tastytrade_refresh_token` only when the command is used. Deployments without these secrets start normally and return a not-configured response for `/delta`.
+
 By defining a set of secrets per developer, multiple bots can be run at the same time based off different code streams. When running outside of Docker, the code looks for `config.json` and expects the following syntax. Mind that all values which are not set in this example require some sort of password or Discord bot- or server-specific ID.
 
 `loglevel` is optional and defaults to `info`. Supported values are `error`, `warn`, `info`, `http`, `verbose`, `debug` and `silly`.  
@@ -145,6 +147,8 @@ The health-check server port can be overridden via the `HEALTHCHECK_PORT` enviro
   "discord_10y_client_ID": "",
   "discord_30y_token": "",
   "discord_30y_client_ID": "",
+  "tastytrade_client_secret": "",
+  "tastytrade_refresh_token": "",
   "dracoon_password": "",
   "hblwrk_channel_NYSEAnnouncement_ID": "",
   "hblwrk_gainslosses_thread_ID": "",
@@ -236,6 +240,8 @@ SEC: 8-K Item 2.02, 9.01 https://www.sec.gov/Archives/edgar/data/320193/00003201
 ## Market data
 
 Real-time market-data is being pulled in through a Websocket connection and distributed via Discord bot nickname and presence information. Those bots can be joined to the server separately and their runtime information is managed as an asset. They require no oAuth2 scopes other than "bot".
+
+The `/delta` command uses tastytrade OAuth read access for option chains and live quote-streamer snapshots. It selects the first expiration on or after the requested DTE and returns the call and put strikes around the requested absolute delta, including bid, mid, ask, size and IV.
 
 ## Service lifecycle
 

--- a/modules/options-delta.test.ts
+++ b/modules/options-delta.test.ts
@@ -1,0 +1,386 @@
+import {MarketDataSubscriptionType} from "@tastytrade/api";
+import {describe, expect, test, vi} from "vitest";
+import {
+  findDeltaBrackets,
+  formatOptionDeltaLookupResult,
+  getOptionDeltaLookup,
+  normalizeOptionSymbol,
+  normalizeTargetDelta,
+  OptionDeltaConfigurationError,
+  OptionDeltaDataError,
+  OptionDeltaInputError,
+  parseTastytradeNestedOptionChain,
+  selectExpirationForDte,
+  type OptionDeltaContract,
+} from "./options-delta.ts";
+
+function createNestedOptionChainItems() {
+  return [{
+    expirations: [
+      {
+        "expiration-date": "2026-06-12",
+        "days-to-expiration": 42,
+        strikes: [],
+      },
+      {
+        "expiration-date": "2026-06-19",
+        "days-to-expiration": 49,
+        strikes: [
+          {
+            "strike-price": "440",
+            call: "AAPL 260619C00440000",
+            "call-streamer-symbol": ".AAPL260619C440",
+            put: "AAPL 260619P00440000",
+            "put-streamer-symbol": ".AAPL260619P440",
+          },
+          {
+            "strike-price": "445",
+            call: "AAPL 260619C00445000",
+            "call-streamer-symbol": ".AAPL260619C445",
+            put: "AAPL 260619P00445000",
+            "put-streamer-symbol": ".AAPL260619P445",
+          },
+          {
+            "strike-price": "450",
+            call: "AAPL 260619C00450000",
+            "call-streamer-symbol": ".AAPL260619C450",
+            put: "AAPL 260619P00450000",
+            "put-streamer-symbol": ".AAPL260619P450",
+          },
+        ],
+      },
+    ],
+  }];
+}
+
+function createOptionContract(strike: number, delta: number, optionType: "call" | "put"): OptionDeltaContract {
+  return {
+    ask: 1.4,
+    askSize: 20,
+    bid: 1.2,
+    bidSize: 10,
+    delta,
+    expirationDate: "2026-06-19",
+    gamma: 0.02,
+    iv: 0.555,
+    optionType,
+    streamerSymbol: `.AAPL260619${"call" === optionType ? "C" : "P"}${strike}`,
+    strike,
+    symbol: `AAPL 260619${"call" === optionType ? "C" : "P"}${strike}`,
+    theta: -0.04,
+    vega: 0.08,
+  };
+}
+
+describe("options-delta", () => {
+  test("normalizes symbols and rejects unsupported input", () => {
+    expect(normalizeOptionSymbol("brk.b")).toBe("BRK/B");
+    expect(() => normalizeOptionSymbol("AAPL$")).toThrow(OptionDeltaInputError);
+    expect(normalizeTargetDelta(0.4)).toBe(0.4);
+    expect(() => normalizeTargetDelta(1)).toThrow(OptionDeltaInputError);
+  });
+
+  test("parses sdk and raw option-chain shapes and rolls to the next expiration", () => {
+    const sdkExpirations = parseTastytradeNestedOptionChain(createNestedOptionChainItems());
+    const rawExpirations = parseTastytradeNestedOptionChain({
+      data: {
+        items: createNestedOptionChainItems(),
+      },
+    });
+
+    expect(sdkExpirations).toHaveLength(2);
+    expect(rawExpirations).toHaveLength(2);
+    expect(selectExpirationForDte(sdkExpirations, 42)).toMatchObject({
+      expiration: {
+        expirationDate: "2026-06-12",
+        daysToExpiration: 42,
+      },
+      rolled: false,
+    });
+    expect(selectExpirationForDte(sdkExpirations, 45)).toMatchObject({
+      expiration: {
+        expirationDate: "2026-06-19",
+        daysToExpiration: 49,
+      },
+      rolled: true,
+    });
+  });
+
+  test("finds contracts below and above an absolute target delta", () => {
+    const brackets = findDeltaBrackets([
+      createOptionContract(440, 0.38, "call"),
+      createOptionContract(445, 0.32, "call"),
+      createOptionContract(450, 0.25, "call"),
+    ], 0.3);
+
+    expect(brackets.below?.strike).toBe(450);
+    expect(brackets.above?.strike).toBe(445);
+  });
+
+  test("fetches the selected expiration and brackets calls and puts from streamed greeks", async () => {
+    let listener: ((events: Record<string, unknown>[]) => void) | undefined;
+    const marketDataBySymbol = new Map<string, {
+      ask: number;
+      askSize: number;
+      bid: number;
+      bidSize: number;
+      delta: number;
+      volatility: number;
+    }>([
+      [".AAPL260619C440", {ask: 3.2, askSize: 12, bid: 3.0, bidSize: 8, delta: 0.38, volatility: 0.51}],
+      [".AAPL260619C445", {ask: 2.3, askSize: 10, bid: 2.1, bidSize: 7, delta: 0.32, volatility: 0.53}],
+      [".AAPL260619C450", {ask: 1.4, askSize: 20, bid: 1.2, bidSize: 10, delta: 0.25, volatility: 0.555}],
+      [".AAPL260619P440", {ask: 1.1, askSize: 9, bid: 0.9, bidSize: 6, delta: -0.24, volatility: 0.54}],
+      [".AAPL260619P445", {ask: 1.7, askSize: 11, bid: 1.5, bidSize: 7, delta: -0.27, volatility: 0.56}],
+      [".AAPL260619P450", {ask: 2.6, askSize: 14, bid: 2.4, bidSize: 8, delta: -0.34, volatility: 0.58}],
+    ]);
+    const quoteStreamer = {
+      addEventListener: vi.fn((nextListener: (events: Record<string, unknown>[]) => void) => {
+        listener = nextListener;
+        return vi.fn();
+      }),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(),
+      subscribe: vi.fn((streamerSymbols: string[]) => {
+        const events: Record<string, unknown>[] = [];
+        for (const streamerSymbol of streamerSymbols) {
+          const marketData = marketDataBySymbol.get(streamerSymbol);
+          if (undefined === marketData) {
+            continue;
+          }
+
+          events.push({
+            eventSymbol: streamerSymbol,
+            eventType: "Quote",
+            askPrice: marketData.ask,
+            askSize: marketData.askSize,
+            bidPrice: marketData.bid,
+            bidSize: marketData.bidSize,
+          });
+          events.push({
+            eventSymbol: streamerSymbol,
+            eventType: "Greeks",
+            delta: marketData.delta,
+            gamma: 0.02,
+            theta: -0.04,
+            vega: 0.08,
+            volatility: marketData.volatility,
+          });
+        }
+
+        listener?.(events);
+      }),
+    };
+    const fakeClient = {
+      instrumentsService: {
+        getNestedOptionChain: vi.fn(async () => createNestedOptionChainItems()),
+      },
+      quoteStreamer,
+    };
+
+    const result = await getOptionDeltaLookup({
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      delta: 0.3,
+      dte: 45,
+      side: "both",
+      symbol: "aapl",
+    }, {
+      clientFactory: () => fakeClient,
+      marketDataTimeoutMs: 20,
+    });
+
+    const callResult = result.sideResults.find(sideResult => "call" === sideResult.side);
+    const putResult = result.sideResults.find(sideResult => "put" === sideResult.side);
+    expect(fakeClient.instrumentsService.getNestedOptionChain).toHaveBeenCalledWith("AAPL");
+    expect(quoteStreamer.subscribe).toHaveBeenCalledWith(expect.arrayContaining([
+      ".AAPL260619C440",
+      ".AAPL260619C445",
+      ".AAPL260619C450",
+      ".AAPL260619P440",
+      ".AAPL260619P445",
+      ".AAPL260619P450",
+    ]), [
+      MarketDataSubscriptionType.Greeks,
+      MarketDataSubscriptionType.Quote,
+    ]);
+    expect(quoteStreamer.disconnect).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      actualDte: 49,
+      expiration: "2026-06-19",
+      requestedDte: 45,
+      requestedSide: "both",
+      rolled: true,
+      symbol: "AAPL",
+      targetDelta: 0.3,
+    });
+    expect(callResult?.contractsConsidered).toBe(3);
+    expect(callResult?.brackets.below?.strike).toBe(450);
+    expect(callResult?.brackets.above?.strike).toBe(445);
+    expect(putResult?.contractsConsidered).toBe(3);
+    expect(putResult?.brackets.below?.strike).toBe(445);
+    expect(putResult?.brackets.above?.strike).toBe(450);
+
+    const formattedResult = formatOptionDeltaLookupResult(result);
+    expect(formattedResult).toContain("Expiry `2026-06-19` (49 DTE, requested 45)");
+    expect(formattedResult).toContain("`450C` | strike `450` | delta `0.250`");
+    expect(formattedResult).toContain("bid/mid/ask `1.20 / 1.30 / 1.40`");
+    expect(formattedResult).toContain("IV `55.5%`");
+    expect(formattedResult).toContain("`450P` | strike `450` | delta `0.340`");
+  });
+
+  test("supports single-side lookups and hyphenated dxlink event fields", async () => {
+    let listener: ((events: Record<string, unknown>[]) => void) | undefined;
+    const quoteStreamer = {
+      addEventListener: vi.fn((nextListener: (events: Record<string, unknown>[]) => void) => {
+        listener = nextListener;
+        return vi.fn();
+      }),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(),
+      subscribe: vi.fn((streamerSymbols: string[]) => {
+        listener?.(streamerSymbols.flatMap(streamerSymbol => [
+          {
+            "event-symbol": streamerSymbol,
+            "event-type": "Quote",
+            "ask-price": 2.2,
+            "ask-size": 12,
+            "bid-price": 2.0,
+            "bid-size": 8,
+          },
+          {
+            "event-symbol": streamerSymbol,
+            "event-type": "Greeks",
+            delta: -0.31,
+            volatility: 0.45,
+          },
+        ]));
+      }),
+    };
+
+    const result = await getOptionDeltaLookup({
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      delta: 0.3,
+      dte: 49,
+      side: "put",
+      symbol: "aapl",
+    }, {
+      clientFactory: () => ({
+        instrumentsService: {
+          getNestedOptionChain: vi.fn(async () => createNestedOptionChainItems()),
+        },
+        quoteStreamer,
+      }),
+      marketDataTimeoutMs: 20,
+    });
+
+    expect(result.requestedSide).toBe("put");
+    expect(result.sideResults).toHaveLength(1);
+    expect(result.sideResults[0]).toMatchObject({
+      side: "put",
+      contractsConsidered: 3,
+    });
+    expect(quoteStreamer.subscribe).toHaveBeenCalledWith(expect.arrayContaining([
+      ".AAPL260619P440",
+      ".AAPL260619P445",
+      ".AAPL260619P450",
+    ]), [
+      MarketDataSubscriptionType.Greeks,
+      MarketDataSubscriptionType.Quote,
+    ]);
+    expect(quoteStreamer.subscribe.mock.calls[0]![0]).not.toContain(".AAPL260619C440");
+  });
+
+  test("reports missing credentials, expirations and streamer symbols as lookup errors", async () => {
+    const emptyQuoteStreamer = {
+      addEventListener: vi.fn(() => vi.fn()),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(),
+      subscribe: vi.fn(),
+    };
+    const baseRequest = {
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      delta: 0.3,
+      dte: 45,
+      side: "call" as const,
+      symbol: "AAPL",
+    };
+
+    await expect(getOptionDeltaLookup({
+      ...baseRequest,
+      credentials: {
+        clientSecret: " ",
+        refreshToken: "refresh-token",
+      },
+    })).rejects.toThrow(OptionDeltaConfigurationError);
+    await expect(getOptionDeltaLookup({
+      ...baseRequest,
+      dte: 45.5,
+    })).rejects.toThrow(OptionDeltaInputError);
+    await expect(getOptionDeltaLookup(baseRequest, {
+      clientFactory: () => ({
+        instrumentsService: {
+          getNestedOptionChain: vi.fn(async () => []),
+        },
+        quoteStreamer: emptyQuoteStreamer,
+      }),
+    })).rejects.toThrow(OptionDeltaDataError);
+    await expect(getOptionDeltaLookup(baseRequest, {
+      clientFactory: () => ({
+        instrumentsService: {
+          getNestedOptionChain: vi.fn(async () => [{
+            expirations: [{
+              "expiration-date": "2026-06-19",
+              "days-to-expiration": 49,
+              strikes: [{
+                "strike-price": "450",
+              }],
+            }],
+          }]),
+        },
+        quoteStreamer: emptyQuoteStreamer,
+      }),
+    })).rejects.toThrow(OptionDeltaDataError);
+  });
+
+  test("formats unavailable quotes and missing brackets", () => {
+    const formattedResult = formatOptionDeltaLookupResult({
+      actualDte: 49,
+      expiration: "2026-06-19",
+      requestedDte: 49,
+      requestedSide: "put",
+      rolled: false,
+      sideResults: [{
+        brackets: {
+          above: {
+            ...createOptionContract(450, -0.34, "put"),
+            ask: null,
+            askSize: null,
+            bid: null,
+            bidSize: null,
+            iv: null,
+          },
+          below: null,
+        },
+        contractsConsidered: 1,
+        side: "put",
+      }],
+      symbol: "AAPL",
+      targetDelta: 0.3,
+    });
+
+    expect(formattedResult).toContain("Expiry `2026-06-19` (49 DTE)");
+    expect(formattedResult).toContain("Below target: Keine passende Option gefunden.");
+    expect(formattedResult).toContain("bid/mid/ask `n/a / n/a / n/a`");
+    expect(formattedResult).toContain("size `n/a x n/a`");
+    expect(formattedResult).toContain("IV `n/a`");
+  });
+});

--- a/modules/options-delta.ts
+++ b/modules/options-delta.ts
@@ -1,0 +1,654 @@
+import TastytradeClient, {MarketDataSubscriptionType} from "@tastytrade/api";
+import WS from "ws";
+
+export type OptionDeltaSide = "call" | "put";
+export type OptionDeltaRequestedSide = OptionDeltaSide | "both";
+
+export type OptionDeltaCredentials = {
+  clientSecret: string;
+  refreshToken: string;
+};
+
+export type OptionDeltaLookupRequest = {
+  credentials: OptionDeltaCredentials;
+  delta: number;
+  dte: number;
+  side: OptionDeltaRequestedSide;
+  symbol: string;
+};
+
+export type OptionDeltaContract = {
+  ask: number | null;
+  askSize: number | null;
+  bid: number | null;
+  bidSize: number | null;
+  delta: number;
+  expirationDate: string;
+  gamma: number | null;
+  iv: number | null;
+  optionType: OptionDeltaSide;
+  streamerSymbol: string;
+  strike: number;
+  symbol: string;
+  theta: number | null;
+  vega: number | null;
+};
+
+export type OptionDeltaBracket = {
+  above: OptionDeltaContract | null;
+  below: OptionDeltaContract | null;
+};
+
+export type OptionDeltaSideResult = {
+  brackets: OptionDeltaBracket;
+  contractsConsidered: number;
+  side: OptionDeltaSide;
+};
+
+export type OptionDeltaLookupResult = {
+  actualDte: number;
+  expiration: string;
+  requestedDte: number;
+  requestedSide: OptionDeltaRequestedSide;
+  rolled: boolean;
+  sideResults: OptionDeltaSideResult[];
+  symbol: string;
+  targetDelta: number;
+};
+
+type TastytradeEvent = Record<string, unknown>;
+type TastytradeEventListener = (events: TastytradeEvent[]) => void;
+type TastytradeQuoteStreamer = {
+  addEventListener: (listener: TastytradeEventListener) => () => void;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  subscribe: (streamerSymbols: string[], types?: MarketDataSubscriptionType[] | null) => void;
+};
+type TastytradeClientLike = {
+  instrumentsService: {
+    getNestedOptionChain: (symbol: string) => Promise<unknown>;
+  };
+  quoteStreamer: TastytradeQuoteStreamer;
+};
+type TastytradeClientFactory = (credentials: OptionDeltaCredentials) => TastytradeClientLike;
+type OptionDeltaLookupDependencies = {
+  clientFactory?: TastytradeClientFactory;
+  marketDataTimeoutMs?: number;
+};
+type ChainStrike = {
+  callStreamerSymbol: string | null;
+  callSymbol: string | null;
+  putStreamerSymbol: string | null;
+  putSymbol: string | null;
+  strike: number;
+};
+type ChainExpiration = {
+  daysToExpiration: number;
+  expirationDate: string;
+  strikes: ChainStrike[];
+};
+type SelectedExpiration = {
+  expiration: ChainExpiration;
+  rolled: boolean;
+};
+type StreamedMarketData = {
+  ask: number | null;
+  askSize: number | null;
+  bid: number | null;
+  bidSize: number | null;
+  delta: number | null;
+  gamma: number | null;
+  iv: number | null;
+  theta: number | null;
+  vega: number | null;
+};
+
+const defaultMarketDataTimeoutMs = 5500;
+const webSocketGlobal = globalThis as {
+  WebSocket?: unknown;
+};
+
+export class OptionDeltaInputError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "OptionDeltaInputError";
+  }
+}
+
+export class OptionDeltaConfigurationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "OptionDeltaConfigurationError";
+  }
+}
+
+export class OptionDeltaDataError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "OptionDeltaDataError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
+}
+
+function toArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (null === value || undefined === value) {
+    return [];
+  }
+
+  return [value];
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if ("number" === typeof value && Number.isFinite(value)) {
+    return value;
+  }
+
+  if ("string" === typeof value && "" !== value.trim()) {
+    const parsedValue = Number(value);
+    if (Number.isFinite(parsedValue)) {
+      return parsedValue;
+    }
+  }
+
+  return null;
+}
+
+function getNumber(record: Record<string, unknown>, key: string): number | null {
+  return toFiniteNumber(record[key]);
+}
+
+function getString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return "string" === typeof value && "" !== value.trim() ? value : null;
+}
+
+function getEventSymbol(event: TastytradeEvent): string | null {
+  return getString(event, "eventSymbol") ?? getString(event, "event-symbol");
+}
+
+function getEventType(event: TastytradeEvent): string | null {
+  return getString(event, "eventType") ?? getString(event, "event-type");
+}
+
+function normalizeCredentials(credentials: OptionDeltaCredentials): OptionDeltaCredentials {
+  const clientSecret = credentials.clientSecret.trim();
+  const refreshToken = credentials.refreshToken.trim();
+  if ("" === clientSecret || "" === refreshToken) {
+    throw new OptionDeltaConfigurationError("Option data credentials are missing.");
+  }
+
+  return {
+    clientSecret,
+    refreshToken,
+  };
+}
+
+export function normalizeOptionSymbol(symbol: string): string {
+  const normalizedSymbol = symbol.trim().toUpperCase().replaceAll(".", "/");
+  if (false === /^[A-Z0-9/]{1,16}$/.test(normalizedSymbol)) {
+    throw new OptionDeltaInputError("Symbol must use letters, numbers, slash, or dot notation.");
+  }
+
+  return normalizedSymbol;
+}
+
+export function normalizeTargetDelta(delta: number): number {
+  if (false === Number.isFinite(delta) || delta <= 0 || delta >= 1) {
+    throw new OptionDeltaInputError("Delta must be greater than 0 and lower than 1.");
+  }
+
+  return delta;
+}
+
+function normalizeDte(dte: number): number {
+  if (false === Number.isInteger(dte) || dte < 0 || dte > 3650) {
+    throw new OptionDeltaInputError("DTE must be an integer from 0 to 3650.");
+  }
+
+  return dte;
+}
+
+function ensureWebSocketGlobal() {
+  if (undefined === webSocketGlobal.WebSocket) {
+    webSocketGlobal.WebSocket = WS;
+  }
+}
+
+function createTastytradeClient(credentials: OptionDeltaCredentials): TastytradeClientLike {
+  ensureWebSocketGlobal();
+  return new TastytradeClient({
+    baseUrl: "https://api.tastyworks.com",
+    accountStreamerUrl: "wss://streamer.tastyworks.com",
+    clientSecret: credentials.clientSecret,
+    refreshToken: credentials.refreshToken,
+    oauthScopes: ["read"],
+  });
+}
+
+function parseChainStrike(strikeData: unknown): ChainStrike | null {
+  if (false === isRecord(strikeData)) {
+    return null;
+  }
+
+  const strike = getNumber(strikeData, "strike-price");
+  if (null === strike) {
+    return null;
+  }
+
+  return {
+    callStreamerSymbol: getString(strikeData, "call-streamer-symbol"),
+    callSymbol: getString(strikeData, "call"),
+    putStreamerSymbol: getString(strikeData, "put-streamer-symbol"),
+    putSymbol: getString(strikeData, "put"),
+    strike,
+  };
+}
+
+function parseChainExpiration(expirationData: unknown): ChainExpiration | null {
+  if (false === isRecord(expirationData)) {
+    return null;
+  }
+
+  const expirationDate = getString(expirationData, "expiration-date");
+  const daysToExpiration = getNumber(expirationData, "days-to-expiration");
+  if (null === expirationDate || null === daysToExpiration) {
+    return null;
+  }
+
+  const strikes: ChainStrike[] = [];
+  for (const strikeData of toArray(expirationData["strikes"])) {
+    const strike = parseChainStrike(strikeData);
+    if (null !== strike) {
+      strikes.push(strike);
+    }
+  }
+
+  return {
+    daysToExpiration,
+    expirationDate,
+    strikes,
+  };
+}
+
+export function parseTastytradeNestedOptionChain(chainData: unknown): ChainExpiration[] {
+  let chainItems: unknown[] = [];
+  if (Array.isArray(chainData)) {
+    chainItems = chainData;
+  } else if (isRecord(chainData) && isRecord(chainData["data"])) {
+    chainItems = toArray(chainData["data"]["items"]);
+  } else if (isRecord(chainData)) {
+    chainItems = toArray(chainData["items"]);
+  }
+
+  const expirations: ChainExpiration[] = [];
+  for (const itemData of chainItems) {
+    if (false === isRecord(itemData)) {
+      continue;
+    }
+
+    for (const expirationData of toArray(itemData["expirations"])) {
+      const expiration = parseChainExpiration(expirationData);
+      if (null !== expiration) {
+        expirations.push(expiration);
+      }
+    }
+  }
+
+  return expirations.sort((first, second) => first.daysToExpiration - second.daysToExpiration);
+}
+
+export function selectExpirationForDte(expirations: ChainExpiration[], dte: number): SelectedExpiration | null {
+  const normalizedDte = normalizeDte(dte);
+  for (const expiration of [...expirations].sort((first, second) => first.daysToExpiration - second.daysToExpiration)) {
+    if (expiration.daysToExpiration >= normalizedDte) {
+      return {
+        expiration,
+        rolled: expiration.daysToExpiration !== normalizedDte,
+      };
+    }
+  }
+
+  return null;
+}
+
+function getRequestedSides(side: OptionDeltaRequestedSide): OptionDeltaSide[] {
+  if ("both" === side) {
+    return ["call", "put"];
+  }
+
+  return [side];
+}
+
+function getStrikeStreamerSymbol(strike: ChainStrike, side: OptionDeltaSide): string | null {
+  return "call" === side ? strike.callStreamerSymbol : strike.putStreamerSymbol;
+}
+
+function getStrikeOptionSymbol(strike: ChainStrike, side: OptionDeltaSide): string | null {
+  return "call" === side ? strike.callSymbol : strike.putSymbol;
+}
+
+function initializeStreamedMarketData(): StreamedMarketData {
+  return {
+    ask: null,
+    askSize: null,
+    bid: null,
+    bidSize: null,
+    delta: null,
+    gamma: null,
+    iv: null,
+    theta: null,
+    vega: null,
+  };
+}
+
+function mergeQuoteEvent(marketData: StreamedMarketData, event: TastytradeEvent): StreamedMarketData {
+  return {
+    ...marketData,
+    ask: getNumber(event, "askPrice") ?? getNumber(event, "ask-price") ?? marketData.ask,
+    askSize: getNumber(event, "askSize") ?? getNumber(event, "ask-size") ?? marketData.askSize,
+    bid: getNumber(event, "bidPrice") ?? getNumber(event, "bid-price") ?? marketData.bid,
+    bidSize: getNumber(event, "bidSize") ?? getNumber(event, "bid-size") ?? marketData.bidSize,
+  };
+}
+
+function mergeGreeksEvent(marketData: StreamedMarketData, event: TastytradeEvent): StreamedMarketData {
+  return {
+    ...marketData,
+    delta: getNumber(event, "delta") ?? marketData.delta,
+    gamma: getNumber(event, "gamma") ?? marketData.gamma,
+    iv: getNumber(event, "volatility") ?? marketData.iv,
+    theta: getNumber(event, "theta") ?? marketData.theta,
+    vega: getNumber(event, "vega") ?? marketData.vega,
+  };
+}
+
+function hasGreeks(marketData: StreamedMarketData | undefined): boolean {
+  return undefined !== marketData && null !== marketData.delta;
+}
+
+function hasQuote(marketData: StreamedMarketData | undefined): boolean {
+  return undefined !== marketData && (null !== marketData.bid || null !== marketData.ask);
+}
+
+function hasRequiredMarketData(
+  streamedData: Map<string, StreamedMarketData>,
+  greeksSymbols: string[],
+  quoteSymbols: string[],
+): boolean {
+  return greeksSymbols.every(symbol => hasGreeks(streamedData.get(symbol)))
+    && quoteSymbols.every(symbol => hasQuote(streamedData.get(symbol)));
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+async function collectMarketData(
+  quoteStreamer: TastytradeQuoteStreamer,
+  streamerSymbols: string[],
+  timeoutMs: number,
+): Promise<Map<string, StreamedMarketData>> {
+  const streamedData = new Map<string, StreamedMarketData>();
+  const symbolSet = new Set(streamerSymbols);
+  const quoteSymbols: string[] = [];
+  const greeksSymbols: string[] = [];
+  let removeListener: (() => void) | undefined;
+
+  const listener: TastytradeEventListener = events => {
+    for (const event of events) {
+      const eventSymbol = getEventSymbol(event);
+      if (null === eventSymbol || false === symbolSet.has(eventSymbol)) {
+        continue;
+      }
+
+      const eventType = getEventType(event);
+      const existingMarketData = streamedData.get(eventSymbol) ?? initializeStreamedMarketData();
+      if ("Quote" === eventType) {
+        streamedData.set(eventSymbol, mergeQuoteEvent(existingMarketData, event));
+      } else if ("Greeks" === eventType) {
+        streamedData.set(eventSymbol, mergeGreeksEvent(existingMarketData, event));
+      }
+    }
+  };
+
+  try {
+    removeListener = quoteStreamer.addEventListener(listener);
+    await quoteStreamer.connect();
+    quoteStreamer.subscribe(streamerSymbols, [
+      MarketDataSubscriptionType.Greeks,
+      MarketDataSubscriptionType.Quote,
+    ]);
+
+    quoteSymbols.push(...streamerSymbols);
+    greeksSymbols.push(...streamerSymbols);
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeoutMs) {
+      if (true === hasRequiredMarketData(streamedData, greeksSymbols, quoteSymbols)) {
+        break;
+      }
+
+      await wait(100);
+    }
+
+    return streamedData;
+  } finally {
+    if (undefined !== removeListener) {
+      removeListener();
+    }
+
+    quoteStreamer.disconnect();
+  }
+}
+
+function buildContracts(
+  expiration: ChainExpiration,
+  requestedSides: OptionDeltaSide[],
+  streamedData: Map<string, StreamedMarketData>,
+): OptionDeltaContract[] {
+  const contracts: OptionDeltaContract[] = [];
+
+  for (const strike of expiration.strikes) {
+    for (const side of requestedSides) {
+      const streamerSymbol = getStrikeStreamerSymbol(strike, side);
+      const optionSymbol = getStrikeOptionSymbol(strike, side);
+      if (null === streamerSymbol || null === optionSymbol) {
+        continue;
+      }
+
+      const marketData = streamedData.get(streamerSymbol);
+      if (undefined === marketData || null === marketData.delta) {
+        continue;
+      }
+
+      contracts.push({
+        ask: marketData.ask,
+        askSize: marketData.askSize,
+        bid: marketData.bid,
+        bidSize: marketData.bidSize,
+        delta: marketData.delta,
+        expirationDate: expiration.expirationDate,
+        gamma: marketData.gamma,
+        iv: marketData.iv,
+        optionType: side,
+        streamerSymbol,
+        strike: strike.strike,
+        symbol: optionSymbol,
+        theta: marketData.theta,
+        vega: marketData.vega,
+      });
+    }
+  }
+
+  return contracts;
+}
+
+export function findDeltaBrackets(contracts: OptionDeltaContract[], targetDelta: number): OptionDeltaBracket {
+  const eligibleContracts = contracts
+    .filter(contract => {
+      const absoluteDelta = Math.abs(contract.delta);
+      return Number.isFinite(absoluteDelta) && absoluteDelta > 0 && absoluteDelta < 1;
+    })
+    .sort((first, second) => Math.abs(first.delta) - Math.abs(second.delta));
+
+  let below: OptionDeltaContract | null = null;
+  let above: OptionDeltaContract | null = null;
+
+  for (const contract of eligibleContracts) {
+    const absoluteDelta = Math.abs(contract.delta);
+    if (absoluteDelta <= targetDelta) {
+      below = contract;
+      continue;
+    }
+
+    above = contract;
+    break;
+  }
+
+  return {
+    above,
+    below,
+  };
+}
+
+export async function getOptionDeltaLookup(
+  request: OptionDeltaLookupRequest,
+  dependencies: OptionDeltaLookupDependencies = {},
+): Promise<OptionDeltaLookupResult> {
+  const credentials = normalizeCredentials(request.credentials);
+  const symbol = normalizeOptionSymbol(request.symbol);
+  const dte = normalizeDte(request.dte);
+  const targetDelta = normalizeTargetDelta(request.delta);
+  const requestedSides = getRequestedSides(request.side);
+  const client = (dependencies.clientFactory ?? createTastytradeClient)(credentials);
+  const chainData = await client.instrumentsService.getNestedOptionChain(symbol);
+  const expirations = parseTastytradeNestedOptionChain(chainData);
+  const selectedExpiration = selectExpirationForDte(expirations, dte);
+  if (null === selectedExpiration) {
+    throw new OptionDeltaDataError(`No option expiration found on or after ${dte} DTE for ${symbol}.`);
+  }
+
+  const streamerSymbols = selectedExpiration.expiration.strikes.flatMap(strike => {
+    return requestedSides.flatMap(side => getStrikeStreamerSymbol(strike, side) ?? []);
+  });
+  if (0 === streamerSymbols.length) {
+    throw new OptionDeltaDataError(`No option contracts found for ${symbol} ${selectedExpiration.expiration.expirationDate}.`);
+  }
+
+  const streamedData = await collectMarketData(
+    client.quoteStreamer,
+    [...new Set(streamerSymbols)],
+    dependencies.marketDataTimeoutMs ?? defaultMarketDataTimeoutMs,
+  );
+  const contracts = buildContracts(selectedExpiration.expiration, requestedSides, streamedData);
+  const sideResults = requestedSides.map(side => {
+    const sideContracts = contracts.filter(contract => contract.optionType === side);
+    return {
+      brackets: findDeltaBrackets(sideContracts, targetDelta),
+      contractsConsidered: sideContracts.length,
+      side,
+    };
+  });
+
+  return {
+    actualDte: selectedExpiration.expiration.daysToExpiration,
+    expiration: selectedExpiration.expiration.expirationDate,
+    requestedDte: dte,
+    requestedSide: request.side,
+    rolled: selectedExpiration.rolled,
+    sideResults,
+    symbol,
+    targetDelta,
+  };
+}
+
+function formatDecimal(value: number, digits = 2): string {
+  return value.toLocaleString("en-US", {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+}
+
+function formatOptionalPrice(value: number | null): string {
+  if (null === value) {
+    return "n/a";
+  }
+
+  return formatDecimal(value);
+}
+
+function formatOptionalSize(value: number | null): string {
+  if (null === value) {
+    return "n/a";
+  }
+
+  return Math.round(value).toLocaleString("en-US", {
+    maximumFractionDigits: 0,
+  });
+}
+
+function formatOptionalPercent(value: number | null): string {
+  if (null === value) {
+    return "n/a";
+  }
+
+  return `${formatDecimal(value * 100, 1)}%`;
+}
+
+function getMidPrice(contract: OptionDeltaContract): number | null {
+  if (null !== contract.bid && null !== contract.ask) {
+    return (contract.bid + contract.ask) / 2;
+  }
+
+  return null;
+}
+
+function getContractName(contract: OptionDeltaContract): string {
+  const suffix = "call" === contract.optionType ? "C" : "P";
+  return `${formatDecimal(contract.strike).replace(/\.00$/, "")}${suffix}`;
+}
+
+function formatContractLine(label: string, contract: OptionDeltaContract | null): string {
+  if (null === contract) {
+    return `${label}: Keine passende Option gefunden.`;
+  }
+
+  const mid = getMidPrice(contract);
+  return [
+    `${label}: \`${getContractName(contract)}\``,
+    `strike \`${formatDecimal(contract.strike).replace(/\.00$/, "")}\``,
+    `delta \`${formatDecimal(Math.abs(contract.delta), 3)}\``,
+    `bid/mid/ask \`${formatOptionalPrice(contract.bid)} / ${formatOptionalPrice(mid)} / ${formatOptionalPrice(contract.ask)}\``,
+    `size \`${formatOptionalSize(contract.bidSize)} x ${formatOptionalSize(contract.askSize)}\``,
+    `IV \`${formatOptionalPercent(contract.iv)}\``,
+  ].join(" | ");
+}
+
+function formatSideTitle(side: OptionDeltaSide): string {
+  return "call" === side ? "Calls" : "Puts";
+}
+
+export function formatOptionDeltaLookupResult(result: OptionDeltaLookupResult): string {
+  const expirationText = true === result.rolled
+    ? `Expiry \`${result.expiration}\` (${result.actualDte} DTE, requested ${result.requestedDte})`
+    : `Expiry \`${result.expiration}\` (${result.actualDte} DTE)`;
+  const lines = [
+    `**${result.symbol} target delta ${formatDecimal(result.targetDelta, 2)} | ${expirationText}**`,
+  ];
+
+  for (const sideResult of result.sideResults) {
+    lines.push(`**${formatSideTitle(sideResult.side)}**`);
+    lines.push(formatContractLine("Below target", sideResult.brackets.below));
+    lines.push(formatContractLine("Above target", sideResult.brackets.above));
+  }
+
+  return lines.join("\n");
+}

--- a/modules/slash-commands-interact-options.ts
+++ b/modules/slash-commands-interact-options.ts
@@ -1,0 +1,121 @@
+import {type ChatInputCommandInteraction} from "discord.js";
+import {getDiscordLogger, getLogger} from "./logging.ts";
+import {
+  formatOptionDeltaLookupResult,
+  getOptionDeltaLookup,
+  OptionDeltaConfigurationError,
+  OptionDeltaDataError,
+  OptionDeltaInputError,
+  type OptionDeltaRequestedSide,
+  type OptionDeltaCredentials,
+} from "./options-delta.ts";
+import {readSecret} from "./secrets.ts";
+import {getDiscordLoggerClient, noMentions, type SlashCommandClient} from "./slash-commands-interact-shared.ts";
+
+const logger = getLogger();
+
+function getRequestedSide(sideOption: string | null): OptionDeltaRequestedSide {
+  if ("call" === sideOption || "put" === sideOption) {
+    return sideOption;
+  }
+
+  return "both";
+}
+
+function getTastytradeCredentials(): OptionDeltaCredentials {
+  try {
+    return {
+      clientSecret: readSecret("tastytrade_client_secret"),
+      refreshToken: readSecret("tastytrade_refresh_token"),
+    };
+  } catch (_error: unknown) {
+    throw new OptionDeltaConfigurationError("Option data credentials are missing.");
+  }
+}
+
+function getDeltaErrorMessage(error: unknown): string {
+  if (error instanceof OptionDeltaConfigurationError) {
+    return "Optionsdaten sind fuer /delta noch nicht konfiguriert.";
+  }
+
+  if (error instanceof OptionDeltaInputError) {
+    return `Ungueltige Eingabe: ${error.message}`;
+  }
+
+  if (error instanceof OptionDeltaDataError) {
+    return error.message;
+  }
+
+  return "Optionsdaten konnten gerade nicht geladen werden. Bitte spaeter erneut versuchen.";
+}
+
+export async function handleDeltaSlashCommand(
+  client: SlashCommandClient,
+  interaction: ChatInputCommandInteraction,
+  commandName: string,
+): Promise<boolean> {
+  if ("delta" !== commandName) {
+    return false;
+  }
+
+  const discordLogger = getDiscordLogger(getDiscordLoggerClient(client));
+  discordLogger.log(
+    "info",
+    {
+      username: `${interaction.user.username}`,
+      message: "Using delta slashcommand",
+      channel: `${interaction.channel}`,
+    },
+  );
+
+  const deferred = await interaction.deferReply().then(() => true).catch((error: unknown) => {
+    logger.log(
+      "error",
+      `Error deferring delta slashcommand: ${error}`,
+    );
+    return false;
+  });
+  if (false === deferred) {
+    return true;
+  }
+
+  try {
+    const symbol = interaction.options.getString("symbol", true);
+    const dte = interaction.options.getInteger("dte", true);
+    const delta = interaction.options.getNumber("delta", true);
+    const side = getRequestedSide(interaction.options.getString("side"));
+    const result = await getOptionDeltaLookup({
+      credentials: getTastytradeCredentials(),
+      delta,
+      dte,
+      side,
+      symbol,
+    });
+
+    await interaction.editReply({
+      content: formatOptionDeltaLookupResult(result),
+      allowedMentions: noMentions,
+    }).catch((error: unknown) => {
+      logger.log(
+        "error",
+        `Error replying to delta slashcommand: ${error}`,
+      );
+    });
+  } catch (error: unknown) {
+    logger.log(
+      "warn",
+      `Error loading delta slashcommand: ${error}`,
+    );
+    await interaction.editReply({
+      content: getDeltaErrorMessage(error),
+      allowedMentions: noMentions,
+    }).catch((replyError: unknown) => {
+      logger.log(
+        "error",
+        `Error replying to delta slashcommand failure: ${replyError}`,
+      );
+    });
+  }
+
+  return true;
+}

--- a/modules/slash-commands-interact.ts
+++ b/modules/slash-commands-interact.ts
@@ -8,6 +8,7 @@ import {readSecret} from "./secrets.ts";
 import {handleCalendarSlashCommand, handleEarningsSlashCommand} from "./slash-commands-interact-events.ts";
 import {handleIslandboiSlashCommand} from "./slash-commands-interact-islandboi.ts";
 import {handleMediaSlashCommand} from "./slash-commands-interact-media.ts";
+import {handleDeltaSlashCommand} from "./slash-commands-interact-options.ts";
 import {handlePaywallSlashCommand} from "./slash-commands-interact-paywall.ts";
 import {type SlashCommandClient} from "./slash-commands-interact-shared.ts";
 import {type Ticker} from "./tickers.ts";
@@ -110,6 +111,10 @@ export function interactSlashCommands(
     }
 
     if (true === await handleIslandboiSlashCommand(client, chatInputInteraction, commandName, guildId)) {
+      return;
+    }
+
+    if (true === await handleDeltaSlashCommand(client, chatInputInteraction, commandName)) {
       return;
     }
 

--- a/modules/slash-commands-payload.ts
+++ b/modules/slash-commands-payload.ts
@@ -11,7 +11,7 @@ import {getSlashCommandNamesFromPayload} from "./slash-commands-canonical.ts";
 
 const logger = getLogger();
 const maxSlashCommandsPerScope = 100;
-export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "google", "8ball", "whatis", "quote", "islandboi", "sara", "earnings", "calendar", "paywall"];
+export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "google", "8ball", "whatis", "quote", "islandboi", "sara", "earnings", "calendar", "paywall", "delta"];
 type SlashCommandJson = ReturnType<SlashCommandBuilder["toJSON"]>;
 type SlashCommandChoice = {
   name: string;
@@ -153,6 +153,35 @@ function createFixedSlashCommands(whatIsAssetsChoices: SlashCommandChoice[], use
         .setDescription("Article URL")
         .setRequired(true));
   fixedSlashCommands.push(slashCommandPaywall.toJSON());
+
+  const slashCommandDelta = new SlashCommandBuilder()
+    .setName("delta")
+    .setDescription("Find option strikes around a target delta")
+    .addStringOption(option =>
+      option.setName("symbol")
+        .setDescription("Underlying symbol")
+        .setRequired(true))
+    .addIntegerOption(option =>
+      option.setName("dte")
+        .setDescription("Target days to expiration")
+        .setMinValue(0)
+        .setMaxValue(3650)
+        .setRequired(true))
+    .addNumberOption(option =>
+      option.setName("delta")
+        .setDescription("Absolute target delta, for example 0.30")
+        .setMinValue(0.01)
+        .setMaxValue(0.99)
+        .setRequired(true))
+    .addStringOption(option =>
+      option.setName("side")
+        .setDescription("Calls, puts, or both when omitted")
+        .setRequired(false)
+        .addChoices(
+          {name: "Calls", value: "call"},
+          {name: "Puts", value: "put"},
+        ));
+  fixedSlashCommands.push(slashCommandDelta.toJSON());
 
   return fixedSlashCommands;
 }

--- a/modules/slash-commands.define.test.ts
+++ b/modules/slash-commands.define.test.ts
@@ -524,6 +524,39 @@ describe("defineSlashCommands", () => {
     }));
   });
 
+  test("registers delta command with optional side selector", () => {
+    const payload = buildSlashCommandPayload([], [], []);
+    const deltaCommand = findCommand(payload.slashCommands, "delta");
+
+    expect(deltaCommand.description).toBe("Find option strikes around a target delta");
+    expect(deltaCommand.options).toEqual([
+      expect.objectContaining({
+        name: "symbol",
+        required: true,
+      }),
+      expect.objectContaining({
+        name: "dte",
+        min_value: 0,
+        max_value: 3650,
+        required: true,
+      }),
+      expect.objectContaining({
+        name: "delta",
+        min_value: 0.01,
+        max_value: 0.99,
+        required: true,
+      }),
+      expect.objectContaining({
+        name: "side",
+        required: false,
+        choices: [
+          {name: "Calls", value: "call"},
+          {name: "Puts", value: "put"},
+        ],
+      }),
+    ]);
+  });
+
   test("caps slash command payload at 100 commands and preserves fixed commands", () => {
     const assets: TextAsset[] = [];
     for (let index = 1; index <= 95; index++) {
@@ -537,21 +570,22 @@ describe("defineSlashCommands", () => {
     const payload = buildSlashCommandPayload(assets, [], []);
 
     expect(payload.slashCommands).toHaveLength(100);
-    expect(payload.assetCommandsRegistered).toBe(89);
-    expect(payload.fixedCommandsRegistered).toBe(11);
-    expect(payload.skippedCommandLimit).toBe(6);
+    expect(payload.assetCommandsRegistered).toBe(88);
+    expect(payload.fixedCommandsRegistered).toBe(12);
+    expect(payload.skippedCommandLimit).toBe(7);
     expect(payload.expectedCommandNames).toContain("quote");
     expect(payload.expectedCommandNames).toContain("calendar");
     expect(payload.expectedCommandNames).toContain("paywall");
-    expect(payload.expectedCommandNames).toContain("asset-89");
-    expect(payload.expectedCommandNames).not.toContain("asset-90");
+    expect(payload.expectedCommandNames).toContain("delta");
+    expect(payload.expectedCommandNames).toContain("asset-88");
+    expect(payload.expectedCommandNames).not.toContain("asset-89");
     expect(loggerMock.log).toHaveBeenCalledWith(
       "warn",
       expect.objectContaining({
         source: "slash-registration",
         max_commands_per_scope: 100,
         total_commands_registered: 100,
-        skipped_command_limit: 6,
+        skipped_command_limit: 7,
         message: "Slash command payload built with skipped asset triggers.",
       }),
     );

--- a/modules/slash-commands.interact.test.ts
+++ b/modules/slash-commands.interact.test.ts
@@ -3,11 +3,38 @@ import {ImageAsset, TextAsset, UserQuoteAsset} from "./assets.ts";
 import {interactSlashCommands} from "./slash-commands.ts";
 import {getCalendarEvents, getCalendarMessages} from "./calendar.ts";
 import {getEarningsMessages, getEarningsResult} from "./earnings.ts";
+import {
+  formatOptionDeltaLookupResult,
+  getOptionDeltaLookup,
+  OptionDeltaDataError,
+  OptionDeltaInputError,
+  type OptionDeltaLookupResult,
+} from "./options-delta.ts";
 import {createChatInputInteraction, createEventClient} from "./test-utils/discord-mocks.ts";
 import {beforeEach, describe, expect, test, vi} from "vitest";
 
+const readSecretMock = vi.hoisted(() => vi.fn((secretName: string) => {
+  void secretName;
+  return "";
+}));
+const {
+  formatOptionDeltaLookupResultMock,
+  getOptionDeltaLookupMock,
+} = vi.hoisted(() => ({
+  formatOptionDeltaLookupResultMock: vi.fn(),
+  getOptionDeltaLookupMock: vi.fn(),
+}));
+
 vi.mock("./secrets.ts", () => ({
-  readSecret: vi.fn(() => ""),
+  readSecret: readSecretMock,
+}));
+
+vi.mock("./options-delta.ts", () => ({
+  formatOptionDeltaLookupResult: formatOptionDeltaLookupResultMock,
+  getOptionDeltaLookup: getOptionDeltaLookupMock,
+  OptionDeltaConfigurationError: class OptionDeltaConfigurationError extends Error {},
+  OptionDeltaDataError: class OptionDeltaDataError extends Error {},
+  OptionDeltaInputError: class OptionDeltaInputError extends Error {},
 }));
 
 const loggerMock = vi.hoisted(() => ({
@@ -40,6 +67,8 @@ const getCalendarEventsMock = getCalendarEvents as MockedFunction<typeof getCale
 const getCalendarMessagesMock = getCalendarMessages as MockedFunction<typeof getCalendarMessages>;
 const getEarningsResultMock = getEarningsResult as MockedFunction<typeof getEarningsResult>;
 const getEarningsMessagesMock = getEarningsMessages as MockedFunction<typeof getEarningsMessages>;
+const getOptionDeltaLookupMockTyped = getOptionDeltaLookup as MockedFunction<typeof getOptionDeltaLookup>;
+const formatOptionDeltaLookupResultMockTyped = formatOptionDeltaLookupResult as MockedFunction<typeof formatOptionDeltaLookupResult>;
 
 function createImageAsset({
   fileContent,
@@ -87,6 +116,9 @@ function getReplyPayload(interaction: ReturnType<typeof createChatInputInteracti
 describe("interactSlashCommands", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    readSecretMock.mockImplementation(secretName => "discord_guild_ID" === secretName ? "guild-id" : "");
+    getOptionDeltaLookupMockTyped.mockReset();
+    formatOptionDeltaLookupResultMockTyped.mockReset();
     getCalendarEventsMock.mockResolvedValue([]);
     getCalendarMessagesMock.mockReturnValue({
       messages: [],
@@ -105,6 +137,279 @@ describe("interactSlashCommands", () => {
       truncated: false,
       totalEvents: 0,
       includedEvents: 0,
+    });
+  });
+
+  test("delta defaults to both sides and replies with formatted lookup", async () => {
+    const lookupResult: OptionDeltaLookupResult = {
+      actualDte: 49,
+      expiration: "2026-06-19",
+      requestedDte: 45,
+      requestedSide: "both",
+      rolled: true,
+      sideResults: [],
+      symbol: "AAPL",
+      targetDelta: 0.3,
+    };
+    readSecretMock.mockImplementation(secretName => {
+      if ("discord_guild_ID" === secretName) {
+        return "guild-id";
+      }
+
+      if ("tastytrade_client_secret" === secretName) {
+        return "client-secret";
+      }
+
+      if ("tastytrade_refresh_token" === secretName) {
+        return "refresh-token";
+      }
+
+      return "";
+    });
+    getOptionDeltaLookupMockTyped.mockResolvedValue(lookupResult);
+    formatOptionDeltaLookupResultMockTyped.mockReturnValue("delta-response");
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("delta");
+    interaction.options.getString.mockImplementation(name => {
+      if ("symbol" === name) {
+        return "AAPL";
+      }
+
+      return null;
+    });
+    interaction.options.getInteger.mockImplementation(name => "dte" === name ? 45 : null);
+    interaction.options.getNumber.mockImplementation(name => "delta" === name ? 0.3 : null);
+
+    await handler(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
+    expect(getOptionDeltaLookupMockTyped).toHaveBeenCalledWith({
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      delta: 0.3,
+      dte: 45,
+      side: "both",
+      symbol: "AAPL",
+    });
+    expect(formatOptionDeltaLookupResultMockTyped).toHaveBeenCalledWith(lookupResult);
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: "delta-response",
+      allowedMentions: {
+        parse: [],
+      },
+    });
+  });
+
+  test("delta forwards an explicit put side option", async () => {
+    const lookupResult: OptionDeltaLookupResult = {
+      actualDte: 49,
+      expiration: "2026-06-19",
+      requestedDte: 45,
+      requestedSide: "put",
+      rolled: true,
+      sideResults: [],
+      symbol: "AAPL",
+      targetDelta: 0.3,
+    };
+    readSecretMock.mockImplementation(secretName => {
+      if ("discord_guild_ID" === secretName) {
+        return "guild-id";
+      }
+
+      if ("tastytrade_client_secret" === secretName) {
+        return "client-secret";
+      }
+
+      if ("tastytrade_refresh_token" === secretName) {
+        return "refresh-token";
+      }
+
+      return "";
+    });
+    getOptionDeltaLookupMockTyped.mockResolvedValue(lookupResult);
+    formatOptionDeltaLookupResultMockTyped.mockReturnValue("delta-response");
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("delta");
+    interaction.options.getString.mockImplementation(name => {
+      if ("symbol" === name) {
+        return "AAPL";
+      }
+
+      if ("side" === name) {
+        return "put";
+      }
+
+      return null;
+    });
+    interaction.options.getInteger.mockImplementation(name => "dte" === name ? 45 : null);
+    interaction.options.getNumber.mockImplementation(name => "delta" === name ? 0.3 : null);
+
+    await handler(interaction);
+
+    expect(getOptionDeltaLookupMockTyped).toHaveBeenCalledWith(expect.objectContaining({
+      side: "put",
+    }));
+  });
+
+  test("delta replies with configuration fallback when tastytrade secrets are missing", async () => {
+    readSecretMock.mockImplementation(secretName => {
+      if ("discord_guild_ID" === secretName) {
+        return "guild-id";
+      }
+
+      throw new Error(`missing ${secretName}`);
+    });
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("delta");
+    interaction.options.getString.mockImplementation(name => "symbol" === name ? "AAPL" : null);
+    interaction.options.getInteger.mockImplementation(name => "dte" === name ? 45 : null);
+    interaction.options.getNumber.mockImplementation(name => "delta" === name ? 0.3 : null);
+
+    await handler(interaction);
+
+    expect(getOptionDeltaLookupMockTyped).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: "Optionsdaten sind fuer /delta noch nicht konfiguriert.",
+      allowedMentions: {
+        parse: [],
+      },
+    });
+  });
+
+  test("delta logs and stops when deferReply fails", async () => {
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("delta");
+    interaction.deferReply.mockRejectedValueOnce(new Error("defer failed"));
+
+    await handler(interaction);
+
+    expect(getOptionDeltaLookupMockTyped).not.toHaveBeenCalled();
+    expect(interaction.editReply).not.toHaveBeenCalled();
+    expect(loggerMock.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("Error deferring delta slashcommand"),
+    );
+  });
+
+  test("delta replies with input error fallback", async () => {
+    readSecretMock.mockImplementation(secretName => {
+      if ("discord_guild_ID" === secretName) {
+        return "guild-id";
+      }
+
+      if ("tastytrade_client_secret" === secretName) {
+        return "client-secret";
+      }
+
+      if ("tastytrade_refresh_token" === secretName) {
+        return "refresh-token";
+      }
+
+      return "";
+    });
+    getOptionDeltaLookupMockTyped.mockRejectedValue(new OptionDeltaInputError("bad delta"));
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("delta");
+    interaction.options.getString.mockImplementation(name => "symbol" === name ? "AAPL" : null);
+    interaction.options.getInteger.mockImplementation(name => "dte" === name ? 45 : null);
+    interaction.options.getNumber.mockImplementation(name => "delta" === name ? 0.3 : null);
+
+    await handler(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: "Ungueltige Eingabe: bad delta",
+      allowedMentions: {
+        parse: [],
+      },
+    });
+  });
+
+  test("delta replies with data error fallback", async () => {
+    readSecretMock.mockImplementation(secretName => {
+      if ("discord_guild_ID" === secretName) {
+        return "guild-id";
+      }
+
+      if ("tastytrade_client_secret" === secretName) {
+        return "client-secret";
+      }
+
+      if ("tastytrade_refresh_token" === secretName) {
+        return "refresh-token";
+      }
+
+      return "";
+    });
+    getOptionDeltaLookupMockTyped.mockRejectedValue(new OptionDeltaDataError("No option expiration found."));
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("delta");
+    interaction.options.getString.mockImplementation(name => "symbol" === name ? "AAPL" : null);
+    interaction.options.getInteger.mockImplementation(name => "dte" === name ? 45 : null);
+    interaction.options.getNumber.mockImplementation(name => "delta" === name ? 0.3 : null);
+
+    await handler(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: "No option expiration found.",
+      allowedMentions: {
+        parse: [],
+      },
+    });
+  });
+
+  test("delta replies with generic fallback for unexpected errors", async () => {
+    readSecretMock.mockImplementation(secretName => {
+      if ("discord_guild_ID" === secretName) {
+        return "guild-id";
+      }
+
+      if ("tastytrade_client_secret" === secretName) {
+        return "client-secret";
+      }
+
+      if ("tastytrade_refresh_token" === secretName) {
+        return "refresh-token";
+      }
+
+      return "";
+    });
+    getOptionDeltaLookupMockTyped.mockRejectedValue(new Error("upstream failed"));
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("delta");
+    interaction.options.getString.mockImplementation(name => "symbol" === name ? "AAPL" : null);
+    interaction.options.getInteger.mockImplementation(name => "dte" === name ? 45 : null);
+    interaction.options.getNumber.mockImplementation(name => "delta" === name ? 0.3 : null);
+
+    await handler(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: "Optionsdaten konnten gerade nicht geladen werden. Bitte spaeter erneut versuchen.",
+      allowedMentions: {
+        parse: [],
+      },
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@tastytrade/api": "^7.0.1",
         "axios": "^1.15.2",
         "class-transformer": "^0.5.1",
         "discord.js": "^14.26.3",
@@ -247,6 +248,51 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@dxfeed/dxlink-api": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dxfeed/dxlink-api/-/dxlink-api-0.3.0.tgz",
+      "integrity": "sha512-0XTR6M3kDMnhiOoR/UfCw1iUHLUY4If4u1XHG/p18P2bmUOrmGOJQQQt+2crtoHzcDnhs2tSc4ecefdsNxnTeg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@dxfeed/dxlink-core": "0.3.0",
+        "@dxfeed/dxlink-dom": "0.3.0",
+        "@dxfeed/dxlink-feed": "0.3.0",
+        "@dxfeed/dxlink-websocket-client": "0.3.0"
+      }
+    },
+    "node_modules/@dxfeed/dxlink-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dxfeed/dxlink-core/-/dxlink-core-0.3.0.tgz",
+      "integrity": "sha512-Yvz9ZtNa0MonNTyaZUbOWj+5Geb6TYMJScot6NfvIKzuSktk2STTMHdmQj7wM1AyCeSwhK26jFuVbdOwABKpbw==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@dxfeed/dxlink-dom": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dxfeed/dxlink-dom/-/dxlink-dom-0.3.0.tgz",
+      "integrity": "sha512-JUVOlz72M5LCmTwdg4bCtz15RPWDgl7Eek6FG/vzHpfIb9oNNTuxJYKU0rh44N+IRja0wfIra7ObpB0dWQuu7A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@dxfeed/dxlink-core": "0.3.0"
+      }
+    },
+    "node_modules/@dxfeed/dxlink-feed": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dxfeed/dxlink-feed/-/dxlink-feed-0.3.0.tgz",
+      "integrity": "sha512-aay3XHNEiN9RnfKYd+xvtL2hKHB2UP4OI2T/ed/7CEgrwMXOvps9yD02vPg+A2+JQusIyqG+F9OEDn1S432HNA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@dxfeed/dxlink-core": "0.3.0"
+      }
+    },
+    "node_modules/@dxfeed/dxlink-websocket-client": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dxfeed/dxlink-websocket-client/-/dxlink-websocket-client-0.3.0.tgz",
+      "integrity": "sha512-nhFKN/q1WuOmGVswVhfmI+lwPy7w9Ys5SocWn6MmCUyHkz6+tTityLIBg72yjF+rW4DZXFVmH15AgtG4f0sfVQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@dxfeed/dxlink-core": "0.3.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -942,6 +988,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tastytrade/api": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@tastytrade/api/-/api-7.0.1.tgz",
+      "integrity": "sha512-6SkEPomiMWP4I8dv5ZHDAnRsbKu8tD8gjaARBa747GWnuy4i5PbzdEyPCnzA9RzcFcS8i6wILXeKU8FbEV12Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dxfeed/dxlink-api": "^0.3.0",
+        "@types/lodash": "^4.17.16",
+        "@types/qs": "^6.9.18",
+        "axios": "^1.9.0",
+        "isomorphic-ws": "^5.0.0",
+        "lodash": "^4.17.21",
+        "qs": "^6.14.0",
+        "uuid": "^11.1.0",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1039,6 +1106,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
@@ -1061,8 +1134,7 @@
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -3021,6 +3093,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -4566,6 +4647,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/validator": {
       "version": "13.15.35",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "@tastytrade/api": "^7.0.1",
     "axios": "^1.15.2",
     "class-transformer": "^0.5.1",
     "discord.js": "^14.26.3",

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,1 @@
 # Todo
-
-## Features
-
-* "prune" inactive members after 12 months, timer, <https://discord.js.org/#/docs/main/stable/typedef/GuildPruneMembersOptions>
-* /delta <symbol> <dte> befehl einbauen, der einem dann sagt, welche zwei prices über/unter dem delta liegen


### PR DESCRIPTION
## Summary
- Add the /delta slash command for option strikes around an absolute target delta.
- Roll requested DTE to the next available expiration and return calls, puts, or both.
- Keep provider and account details out of Discord-visible responses.
- Remove open feature entries from todo.md.

## Validation
- npm run typecheck
- npm run test:coverage
- npm audit --audit-level=high

## Notes
- Production can start without the option-data secrets mounted; /delta returns a generic not-configured response until credentials are available.