### PR TITLE
[codex] Protect option data lookups and add strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ SEC: 8-K Item 2.02, 9.01 https://www.sec.gov/Archives/edgar/data/320193/00003201
 
 Real-time market-data is being pulled in through a Websocket connection and distributed via Discord bot nickname and presence information. Those bots can be joined to the server separately and their runtime information is managed as an asset. They require no oAuth2 scopes other than "bot".
 
-The `/delta` command uses tastytrade OAuth read access for option chains and live quote-streamer snapshots. It selects the first expiration on or after the requested DTE and returns the call and put strikes around the requested absolute delta, including bid, mid, ask, size and IV.
+The `/delta` command uses tastytrade OAuth read access for option chains and live quote-streamer snapshots. It selects the first expiration on or after the requested DTE and returns the call and put strikes around the requested absolute delta, including bid, mid, ask, size and IV. Broker-backed option-data lookups are serialized, spaced by 10 seconds, and protected by a bounded queue.
 
 ## Service lifecycle
 

--- a/modules/bounded-ttl-cache.test.ts
+++ b/modules/bounded-ttl-cache.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, test} from "vitest";
+import {BoundedTtlCache} from "./bounded-ttl-cache.ts";
+
+describe("BoundedTtlCache", () => {
+  test("expires entries and evicts the least recently used entry", () => {
+    let now = 1_000;
+    const cache = new BoundedTtlCache<string>({
+      maxEntries: 2,
+      now: () => now,
+      ttlMs: 500,
+    });
+
+    cache.set("first", "one");
+    cache.set("second", "two");
+    expect(cache.get("first")).toBe("one");
+
+    cache.set("third", "three");
+    expect(cache.get("second")).toBeUndefined();
+    expect(cache.get("first")).toBe("one");
+    expect(cache.get("third")).toBe("three");
+
+    now = 1_501;
+    expect(cache.get("first")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  test("does not store entries when disabled by size or ttl", () => {
+    const zeroSizeCache = new BoundedTtlCache<string>({
+      maxEntries: 0,
+      ttlMs: 1_000,
+    });
+    const zeroTtlCache = new BoundedTtlCache<string>({
+      maxEntries: 1,
+      ttlMs: 0,
+    });
+
+    zeroSizeCache.set("key", "value");
+    zeroTtlCache.set("key", "value");
+
+    expect(zeroSizeCache.get("key")).toBeUndefined();
+    expect(zeroTtlCache.get("key")).toBeUndefined();
+  });
+});

--- a/modules/bounded-ttl-cache.ts
+++ b/modules/bounded-ttl-cache.ts
@@ -1,0 +1,77 @@
+type BoundedTtlCacheDependencies = {
+  maxEntries: number;
+  now?: () => number;
+  ttlMs: number;
+};
+type BoundedTtlCacheEntry<Value> = {
+  expiresAt: number;
+  value: Value;
+};
+
+export class BoundedTtlCache<Value> {
+  private readonly entries = new Map<string, BoundedTtlCacheEntry<Value>>();
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+  private readonly ttlMs: number;
+
+  public constructor(dependencies: BoundedTtlCacheDependencies) {
+    this.maxEntries = Math.max(0, dependencies.maxEntries);
+    this.now = dependencies.now ?? Date.now;
+    this.ttlMs = Math.max(0, dependencies.ttlMs);
+  }
+
+  public get(key: string): Value | undefined {
+    const entry = this.entries.get(key);
+    if (undefined === entry) {
+      return undefined;
+    }
+
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      return undefined;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.value;
+  }
+
+  public set(key: string, value: Value) {
+    if (0 === this.maxEntries || 0 === this.ttlMs) {
+      return;
+    }
+
+    this.deleteExpiredEntries();
+    if (true === this.entries.has(key)) {
+      this.entries.delete(key);
+    }
+
+    while (this.entries.size >= this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (undefined === oldestKey) {
+        break;
+      }
+
+      this.entries.delete(oldestKey);
+    }
+
+    this.entries.set(key, {
+      expiresAt: this.now() + this.ttlMs,
+      value,
+    });
+  }
+
+  public get size(): number {
+    this.deleteExpiredEntries();
+    return this.entries.size;
+  }
+
+  private deleteExpiredEntries() {
+    const now = this.now();
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}

--- a/modules/broker-api-rate-limit.test.ts
+++ b/modules/broker-api-rate-limit.test.ts
@@ -1,0 +1,55 @@
+import {afterEach, describe, expect, test, vi} from "vitest";
+import {BrokerApiRateLimitError, BrokerApiRateLimiter} from "./broker-api-rate-limit.ts";
+
+describe("BrokerApiRateLimiter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("runs one operation at a time and spaces operation starts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+    const limiter = new BrokerApiRateLimiter({
+      maxQueueSize: 2,
+      minIntervalMs: 1_000,
+    });
+    const startedAt: number[] = [];
+
+    const first = limiter.run(async () => {
+      startedAt.push(Date.now());
+      return "first";
+    });
+    const second = limiter.run(async () => {
+      startedAt.push(Date.now());
+      return "second";
+    });
+
+    await expect(first).resolves.toBe("first");
+    expect(startedAt).toEqual([0]);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(startedAt).toEqual([0]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(second).resolves.toBe("second");
+    expect(startedAt).toEqual([0, 1_000]);
+  });
+
+  test("rejects when the bounded queue is full", async () => {
+    let releaseFirst: (value: string) => void = () => {};
+    const limiter = new BrokerApiRateLimiter({
+      maxQueueSize: 1,
+      minIntervalMs: 1_000,
+    });
+    const first = limiter.run(() => new Promise<string>(resolve => {
+      releaseFirst = resolve;
+    }));
+
+    const second = limiter.run(async () => "second");
+    await expect(limiter.run(async () => "third")).rejects.toThrow(BrokerApiRateLimitError);
+
+    releaseFirst("first");
+    await expect(first).resolves.toBe("first");
+    await expect(second).resolves.toBe("second");
+  });
+});

--- a/modules/broker-api-rate-limit.ts
+++ b/modules/broker-api-rate-limit.ts
@@ -1,0 +1,104 @@
+type BrokerApiOperation<T> = () => Promise<T>;
+type BrokerApiRateLimiterTimer = ReturnType<typeof setTimeout>;
+type BrokerApiRateLimiterDependencies = {
+  clearTimeout?: (timer: BrokerApiRateLimiterTimer) => void;
+  maxQueueSize?: number;
+  minIntervalMs?: number;
+  now?: () => number;
+  setTimeout?: (callback: () => void, delayMs: number) => BrokerApiRateLimiterTimer;
+};
+type BrokerApiQueueItem<T> = {
+  operation: BrokerApiOperation<T>;
+  reject: (error: unknown) => void;
+  resolve: (value: T) => void;
+};
+
+const defaultMinIntervalMs = 10_000;
+const defaultMaxQueueSize = 4;
+
+export class BrokerApiRateLimitError extends Error {
+  public constructor(message = "Option data requests are busy. Please retry shortly.") {
+    super(message);
+    this.name = "BrokerApiRateLimitError";
+  }
+}
+
+export class BrokerApiRateLimiter {
+  private active = false;
+  private readonly clearTimeoutCallback: (timer: BrokerApiRateLimiterTimer) => void;
+  private nextStartAt = 0;
+  private readonly maxQueueSize: number;
+  private readonly minIntervalMs: number;
+  private readonly now: () => number;
+  private readonly queue: BrokerApiQueueItem<unknown>[] = [];
+  private readonly setTimeoutCallback: (callback: () => void, delayMs: number) => BrokerApiRateLimiterTimer;
+  private timer: BrokerApiRateLimiterTimer | undefined;
+
+  public constructor(dependencies: BrokerApiRateLimiterDependencies = {}) {
+    this.clearTimeoutCallback = dependencies.clearTimeout ?? clearTimeout;
+    this.maxQueueSize = dependencies.maxQueueSize ?? defaultMaxQueueSize;
+    this.minIntervalMs = dependencies.minIntervalMs ?? defaultMinIntervalMs;
+    this.now = dependencies.now ?? Date.now;
+    this.setTimeoutCallback = dependencies.setTimeout ?? setTimeout;
+  }
+
+  public run<T>(operation: BrokerApiOperation<T>): Promise<T> {
+    if (this.queue.length >= this.maxQueueSize) {
+      return Promise.reject(new BrokerApiRateLimitError());
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        operation,
+        reject,
+        resolve,
+      } as BrokerApiQueueItem<unknown>);
+      this.schedule();
+    });
+  }
+
+  private schedule() {
+    if (true === this.active || 0 === this.queue.length) {
+      return;
+    }
+
+    const delayMs = Math.max(0, this.nextStartAt - this.now());
+    if (0 < delayMs) {
+      if (undefined === this.timer) {
+        this.timer = this.setTimeoutCallback(() => {
+          this.timer = undefined;
+          this.schedule();
+        }, delayMs);
+      }
+
+      return;
+    }
+
+    if (undefined !== this.timer) {
+      this.clearTimeoutCallback(this.timer);
+      this.timer = undefined;
+    }
+
+    this.startNext();
+  }
+
+  private startNext() {
+    const queueItem = this.queue.shift();
+    if (undefined === queueItem) {
+      return;
+    }
+
+    this.active = true;
+    this.nextStartAt = this.now() + this.minIntervalMs;
+
+    Promise.resolve()
+      .then(() => queueItem.operation())
+      .then(queueItem.resolve, queueItem.reject)
+      .finally(() => {
+        this.active = false;
+        this.schedule();
+      });
+  }
+}
+
+export const optionDataRateLimiter = new BrokerApiRateLimiter();

--- a/modules/options-delta.test.ts
+++ b/modules/options-delta.test.ts
@@ -1,6 +1,8 @@
 import {MarketDataSubscriptionType} from "@tastytrade/api";
 import {describe, expect, test, vi} from "vitest";
+import {BoundedTtlCache} from "./bounded-ttl-cache.ts";
 import {
+  type ChainExpiration,
   findDeltaBrackets,
   formatOptionDeltaLookupResult,
   getOptionDeltaLookup,
@@ -12,7 +14,26 @@ import {
   parseTastytradeNestedOptionChain,
   selectExpirationForDte,
   type OptionDeltaContract,
+  type OptionDeltaLookupDependencies,
 } from "./options-delta.ts";
+
+const immediateRateLimiter = {
+  run: <T>(operation: () => Promise<T>) => operation(),
+};
+
+function createLookupDependencies(): Pick<OptionDeltaLookupDependencies, "chainCache" | "contractCache" | "rateLimiter"> {
+  return {
+    chainCache: new BoundedTtlCache<ChainExpiration[]>({
+      maxEntries: 10,
+      ttlMs: 60_000,
+    }),
+    contractCache: new BoundedTtlCache<OptionDeltaContract[]>({
+      maxEntries: 10,
+      ttlMs: 60_000,
+    }),
+    rateLimiter: immediateRateLimiter,
+  };
+}
 
 function createNestedOptionChainItems() {
   return [{
@@ -188,6 +209,7 @@ describe("options-delta", () => {
       side: "both",
       symbol: "aapl",
     }, {
+      ...createLookupDependencies(),
       clientFactory: () => fakeClient,
       marketDataTimeoutMs: 20,
     });
@@ -224,9 +246,10 @@ describe("options-delta", () => {
     expect(putResult?.brackets.above?.strike).toBe(450);
 
     const formattedResult = formatOptionDeltaLookupResult(result);
-    expect(formattedResult).toContain("Expiry `2026-06-19` (49 DTE, requested 45)");
+    expect(formattedResult).toContain("Expiry `2026-06-19` (`49` DTE, requested `45`)");
     expect(formattedResult).toContain("`450C` | strike `450` | delta `0.250`");
     expect(formattedResult).toContain("bid/mid/ask `1.20 / 1.30 / 1.40`");
+    expect(formattedResult).toContain("spread `15.4%`");
     expect(formattedResult).toContain("IV `55.5%`");
     expect(formattedResult).toContain("`450P` | strike `450` | delta `0.340`");
   });
@@ -270,6 +293,7 @@ describe("options-delta", () => {
       side: "put",
       symbol: "aapl",
     }, {
+      ...createLookupDependencies(),
       clientFactory: () => ({
         instrumentsService: {
           getNestedOptionChain: vi.fn(async () => createNestedOptionChainItems()),
@@ -296,6 +320,71 @@ describe("options-delta", () => {
     expect(quoteStreamer.subscribe.mock.calls[0]![0]).not.toContain(".AAPL260619C440");
   });
 
+  test("reuses cached chain and contract snapshots without another broker call", async () => {
+    let listener: ((events: Record<string, unknown>[]) => void) | undefined;
+    const lookupDependencies = createLookupDependencies();
+    const quoteStreamer = {
+      addEventListener: vi.fn((nextListener: (events: Record<string, unknown>[]) => void) => {
+        listener = nextListener;
+        return vi.fn();
+      }),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(),
+      subscribe: vi.fn((streamerSymbols: string[]) => {
+        listener?.(streamerSymbols.flatMap(streamerSymbol => [
+          {
+            eventSymbol: streamerSymbol,
+            eventType: "Quote",
+            askPrice: 1.2,
+            bidPrice: 1.0,
+          },
+          {
+            eventSymbol: streamerSymbol,
+            eventType: "Greeks",
+            delta: streamerSymbol.includes("P") ? -0.31 : 0.31,
+            volatility: 0.45,
+          },
+        ]));
+      }),
+    };
+    const fakeClient = {
+      instrumentsService: {
+        getNestedOptionChain: vi.fn(async () => createNestedOptionChainItems()),
+      },
+      quoteStreamer,
+    };
+    const request = {
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      delta: 0.3,
+      dte: 49,
+      side: "both" as const,
+      symbol: "AAPL",
+    };
+
+    await getOptionDeltaLookup(request, {
+      ...lookupDependencies,
+      clientFactory: () => fakeClient,
+      marketDataTimeoutMs: 20,
+    });
+    const cachedResult = await getOptionDeltaLookup({
+      ...request,
+      delta: 0.2,
+      side: "call",
+    }, {
+      ...lookupDependencies,
+      clientFactory: () => fakeClient,
+      marketDataTimeoutMs: 20,
+    });
+
+    expect(fakeClient.instrumentsService.getNestedOptionChain).toHaveBeenCalledTimes(1);
+    expect(quoteStreamer.subscribe).toHaveBeenCalledTimes(1);
+    expect(cachedResult.sideResults).toHaveLength(1);
+    expect(cachedResult.sideResults[0]?.side).toBe("call");
+  });
+
   test("reports missing credentials, expirations and streamer symbols as lookup errors", async () => {
     const emptyQuoteStreamer = {
       addEventListener: vi.fn(() => vi.fn()),
@@ -320,12 +409,13 @@ describe("options-delta", () => {
         clientSecret: " ",
         refreshToken: "refresh-token",
       },
-    })).rejects.toThrow(OptionDeltaConfigurationError);
+    }, createLookupDependencies())).rejects.toThrow(OptionDeltaConfigurationError);
     await expect(getOptionDeltaLookup({
       ...baseRequest,
       dte: 45.5,
-    })).rejects.toThrow(OptionDeltaInputError);
+    }, createLookupDependencies())).rejects.toThrow(OptionDeltaInputError);
     await expect(getOptionDeltaLookup(baseRequest, {
+      ...createLookupDependencies(),
       clientFactory: () => ({
         instrumentsService: {
           getNestedOptionChain: vi.fn(async () => []),
@@ -334,6 +424,7 @@ describe("options-delta", () => {
       }),
     })).rejects.toThrow(OptionDeltaDataError);
     await expect(getOptionDeltaLookup(baseRequest, {
+      ...createLookupDependencies(),
       clientFactory: () => ({
         instrumentsService: {
           getNestedOptionChain: vi.fn(async () => [{
@@ -377,7 +468,7 @@ describe("options-delta", () => {
       targetDelta: 0.3,
     });
 
-    expect(formattedResult).toContain("Expiry `2026-06-19` (49 DTE)");
+    expect(formattedResult).toContain("Expiry `2026-06-19` (`49` DTE)");
     expect(formattedResult).toContain("Below target: Keine passende Option gefunden.");
     expect(formattedResult).toContain("bid/mid/ask `n/a / n/a / n/a`");
     expect(formattedResult).toContain("size `n/a x n/a`");

--- a/modules/options-delta.ts
+++ b/modules/options-delta.ts
@@ -1,5 +1,8 @@
 import TastytradeClient, {MarketDataSubscriptionType} from "@tastytrade/api";
 import WS from "ws";
+import {BoundedTtlCache} from "./bounded-ttl-cache.ts";
+import {optionDataRateLimiter, type BrokerApiRateLimiter} from "./broker-api-rate-limit.ts";
+export {formatOptionDeltaLookupResult, getClosestDeltaContract, getOptionContractMidPrice} from "./options-format.ts";
 
 export type OptionDeltaSide = "call" | "put";
 export type OptionDeltaRequestedSide = OptionDeltaSide | "both";
@@ -71,9 +74,13 @@ type TastytradeClientLike = {
   quoteStreamer: TastytradeQuoteStreamer;
 };
 type TastytradeClientFactory = (credentials: OptionDeltaCredentials) => TastytradeClientLike;
-type OptionDeltaLookupDependencies = {
+type OptionDeltaCache<Value> = Pick<BoundedTtlCache<Value>, "get" | "set">;
+export type OptionDeltaLookupDependencies = {
+  chainCache?: OptionDeltaCache<ChainExpiration[]>;
   clientFactory?: TastytradeClientFactory;
+  contractCache?: OptionDeltaCache<OptionDeltaContract[]>;
   marketDataTimeoutMs?: number;
+  rateLimiter?: Pick<BrokerApiRateLimiter, "run">;
 };
 type ChainStrike = {
   callStreamerSymbol: string | null;
@@ -82,7 +89,7 @@ type ChainStrike = {
   putSymbol: string | null;
   strike: number;
 };
-type ChainExpiration = {
+export type ChainExpiration = {
   daysToExpiration: number;
   expirationDate: string;
   strikes: ChainStrike[];
@@ -104,6 +111,16 @@ type StreamedMarketData = {
 };
 
 const defaultMarketDataTimeoutMs = 5500;
+const optionChainCacheTtlMs = 5 * 60 * 1000;
+const optionContractCacheTtlMs = 20 * 1000;
+const optionChainCache = new BoundedTtlCache<ChainExpiration[]>({
+  maxEntries: 32,
+  ttlMs: optionChainCacheTtlMs,
+});
+const optionContractCache = new BoundedTtlCache<OptionDeltaContract[]>({
+  maxEntries: 24,
+  ttlMs: optionContractCacheTtlMs,
+});
 const webSocketGlobal = globalThis as {
   WebSocket?: unknown;
 };
@@ -528,127 +545,208 @@ export async function getOptionDeltaLookup(
   const dte = normalizeDte(request.dte);
   const targetDelta = normalizeTargetDelta(request.delta);
   const requestedSides = getRequestedSides(request.side);
-  const client = (dependencies.clientFactory ?? createTastytradeClient)(credentials);
-  const chainData = await client.instrumentsService.getNestedOptionChain(symbol);
-  const expirations = parseTastytradeNestedOptionChain(chainData);
-  const selectedExpiration = selectExpirationForDte(expirations, dte);
+  const chainCache = dependencies.chainCache ?? optionChainCache;
+  const contractCache = dependencies.contractCache ?? optionContractCache;
+  const rateLimiter = dependencies.rateLimiter ?? optionDataRateLimiter;
+
+  const cachedExpirations = chainCache.get(symbol);
+  if (undefined === cachedExpirations) {
+    return rateLimiter.run(async () => {
+      const client = (dependencies.clientFactory ?? createTastytradeClient)(credentials);
+      const expirations = await getOptionChainExpirations(client, symbol, chainCache);
+      return buildLookupResultFromExpirations({
+        client,
+        contractCache,
+        dte,
+        marketDataTimeoutMs: dependencies.marketDataTimeoutMs ?? defaultMarketDataTimeoutMs,
+        requestedSide: request.side,
+        requestedSides,
+        symbol,
+        targetDelta,
+      }, expirations);
+    });
+  }
+
+  const selectedExpiration = selectExpirationForDte(cachedExpirations, dte);
   if (null === selectedExpiration) {
     throw new OptionDeltaDataError(`No option expiration found on or after ${dte} DTE for ${symbol}.`);
   }
 
-  const streamerSymbols = selectedExpiration.expiration.strikes.flatMap(strike => {
+  const cachedContracts = getCachedContracts(contractCache, symbol, selectedExpiration.expiration, requestedSides);
+  if (undefined !== cachedContracts) {
+    return buildLookupResult({
+      contracts: cachedContracts,
+      requestedDte: dte,
+      requestedSide: request.side,
+      requestedSides,
+      selectedExpiration,
+      symbol,
+      targetDelta,
+    });
+  }
+
+  return rateLimiter.run(async () => {
+    const client = (dependencies.clientFactory ?? createTastytradeClient)(credentials);
+    const contracts = await getOptionContracts(
+      client,
+      symbol,
+      selectedExpiration.expiration,
+      requestedSides,
+      dependencies.marketDataTimeoutMs ?? defaultMarketDataTimeoutMs,
+      contractCache,
+    );
+
+    return buildLookupResult({
+      contracts,
+      requestedDte: dte,
+      requestedSide: request.side,
+      requestedSides,
+      selectedExpiration,
+      symbol,
+      targetDelta,
+    });
+  });
+}
+
+async function getOptionChainExpirations(
+  client: TastytradeClientLike,
+  symbol: string,
+  chainCache: OptionDeltaCache<ChainExpiration[]>,
+): Promise<ChainExpiration[]> {
+  const cachedExpirations = chainCache.get(symbol);
+  if (undefined !== cachedExpirations) {
+    return cachedExpirations;
+  }
+
+  const chainData = await client.instrumentsService.getNestedOptionChain(symbol);
+  const expirations = parseTastytradeNestedOptionChain(chainData);
+  chainCache.set(symbol, expirations);
+  return expirations;
+}
+
+function getContractsCacheKey(symbol: string, expiration: ChainExpiration, requestedSides: OptionDeltaSide[]): string {
+  return `${symbol}:${expiration.expirationDate}:${requestedSides.join("+")}`;
+}
+
+function getCachedContracts(
+  contractCache: OptionDeltaCache<OptionDeltaContract[]>,
+  symbol: string,
+  expiration: ChainExpiration,
+  requestedSides: OptionDeltaSide[],
+): OptionDeltaContract[] | undefined {
+  const cachedContracts = contractCache.get(getContractsCacheKey(symbol, expiration, requestedSides));
+  if (undefined !== cachedContracts) {
+    return cachedContracts;
+  }
+
+  if (1 === requestedSides.length) {
+    const cachedBothSidesContracts = contractCache.get(getContractsCacheKey(symbol, expiration, ["call", "put"]));
+    if (undefined !== cachedBothSidesContracts) {
+      return cachedBothSidesContracts.filter(contract => contract.optionType === requestedSides[0]);
+    }
+  }
+
+  return undefined;
+}
+
+async function getOptionContracts(
+  client: TastytradeClientLike,
+  symbol: string,
+  expiration: ChainExpiration,
+  requestedSides: OptionDeltaSide[],
+  marketDataTimeoutMs: number,
+  contractCache: OptionDeltaCache<OptionDeltaContract[]>,
+): Promise<OptionDeltaContract[]> {
+  const cachedContracts = getCachedContracts(contractCache, symbol, expiration, requestedSides);
+  if (undefined !== cachedContracts) {
+    return cachedContracts;
+  }
+
+  const streamerSymbols = expiration.strikes.flatMap(strike => {
     return requestedSides.flatMap(side => getStrikeStreamerSymbol(strike, side) ?? []);
   });
   if (0 === streamerSymbols.length) {
-    throw new OptionDeltaDataError(`No option contracts found for ${symbol} ${selectedExpiration.expiration.expirationDate}.`);
+    throw new OptionDeltaDataError(`No option contracts found for ${symbol} ${expiration.expirationDate}.`);
   }
 
   const streamedData = await collectMarketData(
     client.quoteStreamer,
     [...new Set(streamerSymbols)],
-    dependencies.marketDataTimeoutMs ?? defaultMarketDataTimeoutMs,
+    marketDataTimeoutMs,
   );
-  const contracts = buildContracts(selectedExpiration.expiration, requestedSides, streamedData);
-  const sideResults = requestedSides.map(side => {
-    const sideContracts = contracts.filter(contract => contract.optionType === side);
+  const contracts = buildContracts(expiration, requestedSides, streamedData);
+  contractCache.set(getContractsCacheKey(symbol, expiration, requestedSides), contracts);
+  return contracts;
+}
+
+type BuildLookupResultFromExpirationsRequest = {
+  client: TastytradeClientLike;
+  contractCache: OptionDeltaCache<OptionDeltaContract[]>;
+  dte: number;
+  marketDataTimeoutMs: number;
+  requestedSide: OptionDeltaRequestedSide;
+  requestedSides: OptionDeltaSide[];
+  symbol: string;
+  targetDelta: number;
+};
+
+async function buildLookupResultFromExpirations(
+  request: BuildLookupResultFromExpirationsRequest,
+  expirations: ChainExpiration[],
+): Promise<OptionDeltaLookupResult> {
+  const selectedExpiration = selectExpirationForDte(expirations, request.dte);
+  if (null === selectedExpiration) {
+    throw new OptionDeltaDataError(`No option expiration found on or after ${request.dte} DTE for ${request.symbol}.`);
+  }
+
+  const contracts = await getOptionContracts(
+    request.client,
+    request.symbol,
+    selectedExpiration.expiration,
+    request.requestedSides,
+    request.marketDataTimeoutMs,
+    request.contractCache,
+  );
+
+  return buildLookupResult({
+    contracts,
+    requestedDte: request.dte,
+    requestedSide: request.requestedSide,
+    requestedSides: request.requestedSides,
+    selectedExpiration,
+    symbol: request.symbol,
+    targetDelta: request.targetDelta,
+  });
+}
+
+type BuildLookupResultRequest = {
+  contracts: OptionDeltaContract[];
+  requestedDte: number;
+  requestedSide: OptionDeltaRequestedSide;
+  requestedSides: OptionDeltaSide[];
+  selectedExpiration: SelectedExpiration;
+  symbol: string;
+  targetDelta: number;
+};
+
+function buildLookupResult(request: BuildLookupResultRequest): OptionDeltaLookupResult {
+  const sideResults = request.requestedSides.map(side => {
+    const sideContracts = request.contracts.filter(contract => contract.optionType === side);
     return {
-      brackets: findDeltaBrackets(sideContracts, targetDelta),
+      brackets: findDeltaBrackets(sideContracts, request.targetDelta),
       contractsConsidered: sideContracts.length,
       side,
     };
   });
 
   return {
-    actualDte: selectedExpiration.expiration.daysToExpiration,
-    expiration: selectedExpiration.expiration.expirationDate,
-    requestedDte: dte,
-    requestedSide: request.side,
-    rolled: selectedExpiration.rolled,
+    actualDte: request.selectedExpiration.expiration.daysToExpiration,
+    expiration: request.selectedExpiration.expiration.expirationDate,
+    requestedDte: request.requestedDte,
+    requestedSide: request.requestedSide,
+    rolled: request.selectedExpiration.rolled,
     sideResults,
-    symbol,
-    targetDelta,
+    symbol: request.symbol,
+    targetDelta: request.targetDelta,
   };
-}
-
-function formatDecimal(value: number, digits = 2): string {
-  return value.toLocaleString("en-US", {
-    maximumFractionDigits: digits,
-    minimumFractionDigits: digits,
-  });
-}
-
-function formatOptionalPrice(value: number | null): string {
-  if (null === value) {
-    return "n/a";
-  }
-
-  return formatDecimal(value);
-}
-
-function formatOptionalSize(value: number | null): string {
-  if (null === value) {
-    return "n/a";
-  }
-
-  return Math.round(value).toLocaleString("en-US", {
-    maximumFractionDigits: 0,
-  });
-}
-
-function formatOptionalPercent(value: number | null): string {
-  if (null === value) {
-    return "n/a";
-  }
-
-  return `${formatDecimal(value * 100, 1)}%`;
-}
-
-function getMidPrice(contract: OptionDeltaContract): number | null {
-  if (null !== contract.bid && null !== contract.ask) {
-    return (contract.bid + contract.ask) / 2;
-  }
-
-  return null;
-}
-
-function getContractName(contract: OptionDeltaContract): string {
-  const suffix = "call" === contract.optionType ? "C" : "P";
-  return `${formatDecimal(contract.strike).replace(/\.00$/, "")}${suffix}`;
-}
-
-function formatContractLine(label: string, contract: OptionDeltaContract | null): string {
-  if (null === contract) {
-    return `${label}: Keine passende Option gefunden.`;
-  }
-
-  const mid = getMidPrice(contract);
-  return [
-    `${label}: \`${getContractName(contract)}\``,
-    `strike \`${formatDecimal(contract.strike).replace(/\.00$/, "")}\``,
-    `delta \`${formatDecimal(Math.abs(contract.delta), 3)}\``,
-    `bid/mid/ask \`${formatOptionalPrice(contract.bid)} / ${formatOptionalPrice(mid)} / ${formatOptionalPrice(contract.ask)}\``,
-    `size \`${formatOptionalSize(contract.bidSize)} x ${formatOptionalSize(contract.askSize)}\``,
-    `IV \`${formatOptionalPercent(contract.iv)}\``,
-  ].join(" | ");
-}
-
-function formatSideTitle(side: OptionDeltaSide): string {
-  return "call" === side ? "Calls" : "Puts";
-}
-
-export function formatOptionDeltaLookupResult(result: OptionDeltaLookupResult): string {
-  const expirationText = true === result.rolled
-    ? `Expiry \`${result.expiration}\` (${result.actualDte} DTE, requested ${result.requestedDte})`
-    : `Expiry \`${result.expiration}\` (${result.actualDte} DTE)`;
-  const lines = [
-    `**${result.symbol} target delta ${formatDecimal(result.targetDelta, 2)} | ${expirationText}**`,
-  ];
-
-  for (const sideResult of result.sideResults) {
-    lines.push(`**${formatSideTitle(sideResult.side)}**`);
-    lines.push(formatContractLine("Below target", sideResult.brackets.below));
-    lines.push(formatContractLine("Above target", sideResult.brackets.above));
-  }
-
-  return lines.join("\n");
 }

--- a/modules/options-format.ts
+++ b/modules/options-format.ts
@@ -1,0 +1,115 @@
+import {
+  type OptionDeltaBracket,
+  type OptionDeltaContract,
+  type OptionDeltaLookupResult,
+  type OptionDeltaSide,
+} from "./options-delta.ts";
+
+export function formatDecimal(value: number, digits = 2): string {
+  return value.toLocaleString("en-US", {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+}
+
+export function formatOptionalPrice(value: number | null): string {
+  if (null === value) {
+    return "n/a";
+  }
+
+  return formatDecimal(value);
+}
+
+export function formatOptionalSize(value: number | null): string {
+  if (null === value) {
+    return "n/a";
+  }
+
+  return Math.round(value).toLocaleString("en-US", {
+    maximumFractionDigits: 0,
+  });
+}
+
+export function formatOptionalPercent(value: number | null): string {
+  if (null === value) {
+    return "n/a";
+  }
+
+  return `${formatDecimal(value * 100, 1)}%`;
+}
+
+export function getOptionContractMidPrice(contract: OptionDeltaContract): number | null {
+  if (null !== contract.bid && null !== contract.ask) {
+    return (contract.bid + contract.ask) / 2;
+  }
+
+  return null;
+}
+
+export function getOptionContractSpreadPercent(contract: OptionDeltaContract): number | null {
+  const mid = getOptionContractMidPrice(contract);
+  if (null === mid || 0 >= mid || null === contract.bid || null === contract.ask) {
+    return null;
+  }
+
+  return (contract.ask - contract.bid) / mid;
+}
+
+export function getClosestDeltaContract(bracket: OptionDeltaBracket, targetDelta: number): OptionDeltaContract | null {
+  if (null === bracket.below) {
+    return bracket.above;
+  }
+
+  if (null === bracket.above) {
+    return bracket.below;
+  }
+
+  const belowDistance = Math.abs(Math.abs(bracket.below.delta) - targetDelta);
+  const aboveDistance = Math.abs(Math.abs(bracket.above.delta) - targetDelta);
+  return belowDistance <= aboveDistance ? bracket.below : bracket.above;
+}
+
+export function getContractName(contract: OptionDeltaContract): string {
+  const suffix = "call" === contract.optionType ? "C" : "P";
+  return `${formatDecimal(contract.strike).replace(/\.00$/, "")}${suffix}`;
+}
+
+function formatContractLine(label: string, contract: OptionDeltaContract | null): string {
+  if (null === contract) {
+    return `${label}: Keine passende Option gefunden.`;
+  }
+
+  const mid = getOptionContractMidPrice(contract);
+  const spreadPercent = getOptionContractSpreadPercent(contract);
+  const liquidityNote = null !== spreadPercent && 0.2 < spreadPercent ? " | `wide spread`" : "";
+  return [
+    `${label}: \`${getContractName(contract)}\``,
+    `strike \`${formatDecimal(contract.strike).replace(/\.00$/, "")}\``,
+    `delta \`${formatDecimal(Math.abs(contract.delta), 3)}\``,
+    `bid/mid/ask \`${formatOptionalPrice(contract.bid)} / ${formatOptionalPrice(mid)} / ${formatOptionalPrice(contract.ask)}\``,
+    `spread \`${formatOptionalPercent(spreadPercent)}\`${liquidityNote}`,
+    `size \`${formatOptionalSize(contract.bidSize)} x ${formatOptionalSize(contract.askSize)}\``,
+    `IV \`${formatOptionalPercent(contract.iv)}\``,
+  ].join(" | ");
+}
+
+function formatSideTitle(side: OptionDeltaSide): string {
+  return "call" === side ? "Calls" : "Puts";
+}
+
+export function formatOptionDeltaLookupResult(result: OptionDeltaLookupResult): string {
+  const expirationText = true === result.rolled
+    ? `Expiry \`${result.expiration}\` (\`${result.actualDte}\` DTE, requested \`${result.requestedDte}\`)`
+    : `Expiry \`${result.expiration}\` (\`${result.actualDte}\` DTE)`;
+  const lines = [
+    `**\`${result.symbol}\` target delta \`${formatDecimal(result.targetDelta, 2)}\` | ${expirationText}**`,
+  ];
+
+  for (const sideResult of result.sideResults) {
+    lines.push(`**${formatSideTitle(sideResult.side)}**`);
+    lines.push(formatContractLine("Below target", sideResult.brackets.below));
+    lines.push(formatContractLine("Above target", sideResult.brackets.above));
+  }
+
+  return lines.join("\n");
+}

--- a/modules/options-strategy.test.ts
+++ b/modules/options-strategy.test.ts
@@ -1,0 +1,157 @@
+import {describe, expect, test, vi} from "vitest";
+import {BoundedTtlCache} from "./bounded-ttl-cache.ts";
+import {
+  type ChainExpiration,
+  type OptionDeltaContract,
+  type OptionDeltaLookupDependencies,
+} from "./options-delta.ts";
+import {
+  formatExpectedMoveLookupResult,
+  formatOptionStrangleLookupResult,
+  getOptionStraddleLookup,
+  getOptionStrangleLookup,
+} from "./options-strategy.ts";
+
+const immediateRateLimiter = {
+  run: <T>(operation: () => Promise<T>) => operation(),
+};
+
+function createLookupDependencies(): Pick<OptionDeltaLookupDependencies, "chainCache" | "contractCache" | "rateLimiter"> {
+  return {
+    chainCache: new BoundedTtlCache<ChainExpiration[]>({
+      maxEntries: 10,
+      ttlMs: 60_000,
+    }),
+    contractCache: new BoundedTtlCache<OptionDeltaContract[]>({
+      maxEntries: 10,
+      ttlMs: 60_000,
+    }),
+    rateLimiter: immediateRateLimiter,
+  };
+}
+
+function createNestedOptionChainItems() {
+  return [{
+    expirations: [{
+      "expiration-date": "2026-06-19",
+      "days-to-expiration": 49,
+      strikes: [
+        {
+          "strike-price": "440",
+          call: "AAPL 260619C00440000",
+          "call-streamer-symbol": ".AAPL260619C440",
+          put: "AAPL 260619P00440000",
+          "put-streamer-symbol": ".AAPL260619P440",
+        },
+        {
+          "strike-price": "445",
+          call: "AAPL 260619C00445000",
+          "call-streamer-symbol": ".AAPL260619C445",
+          put: "AAPL 260619P00445000",
+          "put-streamer-symbol": ".AAPL260619P445",
+        },
+      ],
+    }],
+  }];
+}
+
+function createFakeClient() {
+  let listener: ((events: Record<string, unknown>[]) => void) | undefined;
+  const marketDataBySymbol = new Map<string, {
+    ask: number;
+    bid: number;
+    delta: number;
+  }>([
+    [".AAPL260619C440", {ask: 6.2, bid: 6.0, delta: 0.52}],
+    [".AAPL260619C445", {ask: 2.2, bid: 2.0, delta: 0.17}],
+    [".AAPL260619P440", {ask: 2.4, bid: 2.2, delta: -0.18}],
+    [".AAPL260619P445", {ask: 6.4, bid: 6.2, delta: -0.51}],
+  ]);
+
+  return {
+    instrumentsService: {
+      getNestedOptionChain: vi.fn(async () => createNestedOptionChainItems()),
+    },
+    quoteStreamer: {
+      addEventListener: vi.fn((nextListener: (events: Record<string, unknown>[]) => void) => {
+        listener = nextListener;
+        return vi.fn();
+      }),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(),
+      subscribe: vi.fn((streamerSymbols: string[]) => {
+        listener?.(streamerSymbols.flatMap(streamerSymbol => {
+          const marketData = marketDataBySymbol.get(streamerSymbol);
+          if (undefined === marketData) {
+            return [];
+          }
+
+          return [
+            {
+              eventSymbol: streamerSymbol,
+              eventType: "Quote",
+              askPrice: marketData.ask,
+              bidPrice: marketData.bid,
+            },
+            {
+              eventSymbol: streamerSymbol,
+              eventType: "Greeks",
+              delta: marketData.delta,
+              volatility: 0.45,
+            },
+          ];
+        }));
+      }),
+    },
+  };
+}
+
+describe("options-strategy", () => {
+  test("builds and formats a default-delta strangle", async () => {
+    const fakeClient = createFakeClient();
+    const result = await getOptionStrangleLookup({
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      dte: 49,
+      symbol: "AAPL",
+    }, {
+      ...createLookupDependencies(),
+      clientFactory: () => fakeClient,
+      marketDataTimeoutMs: 20,
+    });
+
+    expect(result.targetDelta).toBe(0.16);
+    expect(result.call?.strike).toBe(445);
+    expect(result.put?.strike).toBe(440);
+    expect(result.midTotal).toBe(4.4);
+    expect(formatOptionStrangleLookupResult(result)).toContain("**`AAPL` `0.16` delta strangle");
+    expect(formatOptionStrangleLookupResult(result)).toContain("Breakevens: `435.60 / 449.40`");
+  });
+
+  test("builds an ATM straddle and expected-move output with monospace market values", async () => {
+    const fakeClient = createFakeClient();
+    const result = await getOptionStraddleLookup({
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      dte: 49,
+      symbol: "AAPL",
+    }, {
+      ...createLookupDependencies(),
+      clientFactory: () => fakeClient,
+      marketDataTimeoutMs: 20,
+    });
+
+    const formattedResult = formatExpectedMoveLookupResult(result);
+    expect(result.targetDelta).toBe(0.5);
+    expect(result.call?.strike).toBe(440);
+    expect(result.put?.strike).toBe(445);
+    expect(result.midTotal).toBe(12.4);
+    expect(formattedResult).toContain("**`AAPL` expected move");
+    expect(formattedResult).toContain("ATM straddle mid: `12.40`");
+    expect(formattedResult).toContain("Move proxy: `+/- 12.40`");
+  });
+});

--- a/modules/options-strategy.ts
+++ b/modules/options-strategy.ts
@@ -1,0 +1,154 @@
+import {
+  getClosestDeltaContract,
+  getOptionContractMidPrice,
+  getOptionDeltaLookup,
+  type OptionDeltaContract,
+  type OptionDeltaCredentials,
+  type OptionDeltaLookupDependencies,
+  type OptionDeltaLookupResult,
+} from "./options-delta.ts";
+import {formatDecimal, formatOptionalPrice, getContractName} from "./options-format.ts";
+
+export type OptionStrategyLookupRequest = {
+  credentials: OptionDeltaCredentials;
+  delta?: number;
+  dte: number;
+  symbol: string;
+};
+
+export type OptionStrategyLookupResult = {
+  actualDte: number;
+  call: OptionDeltaContract | null;
+  expiration: string;
+  midTotal: number | null;
+  put: OptionDeltaContract | null;
+  requestedDte: number;
+  rolled: boolean;
+  symbol: string;
+  targetDelta: number;
+};
+
+const defaultStrangleDelta = 0.16;
+const straddleDelta = 0.5;
+
+function sumOptional(first: number | null, second: number | null): number | null {
+  if (null === first || null === second) {
+    return null;
+  }
+
+  return first + second;
+}
+
+function getSideContract(result: OptionDeltaLookupResult, side: "call" | "put"): OptionDeltaContract | null {
+  const sideResult = result.sideResults.find(candidate => candidate.side === side);
+  if (undefined === sideResult) {
+    return null;
+  }
+
+  return getClosestDeltaContract(sideResult.brackets, result.targetDelta);
+}
+
+function toStrategyResult(result: OptionDeltaLookupResult): OptionStrategyLookupResult {
+  const call = getSideContract(result, "call");
+  const put = getSideContract(result, "put");
+  return {
+    actualDte: result.actualDte,
+    call,
+    expiration: result.expiration,
+    midTotal: sumOptional(
+      null === call ? null : getOptionContractMidPrice(call),
+      null === put ? null : getOptionContractMidPrice(put),
+    ),
+    put,
+    requestedDte: result.requestedDte,
+    rolled: result.rolled,
+    symbol: result.symbol,
+    targetDelta: result.targetDelta,
+  };
+}
+
+export async function getOptionStrangleLookup(
+  request: OptionStrategyLookupRequest,
+  dependencies: OptionDeltaLookupDependencies = {},
+): Promise<OptionStrategyLookupResult> {
+  const result = await getOptionDeltaLookup({
+    credentials: request.credentials,
+    delta: request.delta ?? defaultStrangleDelta,
+    dte: request.dte,
+    side: "both",
+    symbol: request.symbol,
+  }, dependencies);
+
+  return toStrategyResult(result);
+}
+
+export async function getOptionStraddleLookup(
+  request: Omit<OptionStrategyLookupRequest, "delta">,
+  dependencies: OptionDeltaLookupDependencies = {},
+): Promise<OptionStrategyLookupResult> {
+  const result = await getOptionDeltaLookup({
+    credentials: request.credentials,
+    delta: straddleDelta,
+    dte: request.dte,
+    side: "both",
+    symbol: request.symbol,
+  }, dependencies);
+
+  return toStrategyResult(result);
+}
+
+function formatExpiration(result: OptionStrategyLookupResult): string {
+  return true === result.rolled
+    ? `Expiry \`${result.expiration}\` (\`${result.actualDte}\` DTE, requested \`${result.requestedDte}\`)`
+    : `Expiry \`${result.expiration}\` (\`${result.actualDte}\` DTE)`;
+}
+
+function formatLeg(label: string, contract: OptionDeltaContract | null): string {
+  if (null === contract) {
+    return `${label}: Keine passende Option gefunden.`;
+  }
+
+  return [
+    `${label}: \`${getContractName(contract)}\``,
+    `strike \`${formatDecimal(contract.strike).replace(/\.00$/, "")}\``,
+    `delta \`${formatDecimal(Math.abs(contract.delta), 3)}\``,
+    `mid \`${formatOptionalPrice(getOptionContractMidPrice(contract))}\``,
+  ].join(" | ");
+}
+
+function formatBreakevens(result: OptionStrategyLookupResult): string {
+  if (null === result.put || null === result.call || null === result.midTotal) {
+    return "Breakevens: `n/a`";
+  }
+
+  return `Breakevens: \`${formatDecimal(result.put.strike - result.midTotal)} / ${formatDecimal(result.call.strike + result.midTotal)}\``;
+}
+
+export function formatOptionStrangleLookupResult(result: OptionStrategyLookupResult): string {
+  return [
+    `**\`${result.symbol}\` \`${formatDecimal(result.targetDelta, 2)}\` delta strangle | ${formatExpiration(result)}**`,
+    formatLeg("Put", result.put),
+    formatLeg("Call", result.call),
+    `Credit mid: \`${formatOptionalPrice(result.midTotal)}\``,
+    formatBreakevens(result),
+  ].join("\n");
+}
+
+export function formatOptionStraddleLookupResult(result: OptionStrategyLookupResult): string {
+  return [
+    `**\`${result.symbol}\` ATM straddle | ${formatExpiration(result)}**`,
+    formatLeg("Put", result.put),
+    formatLeg("Call", result.call),
+    `Straddle mid: \`${formatOptionalPrice(result.midTotal)}\``,
+  ].join("\n");
+}
+
+export function formatExpectedMoveLookupResult(result: OptionStrategyLookupResult): string {
+  return [
+    `**\`${result.symbol}\` expected move | ${formatExpiration(result)}**`,
+    `ATM straddle mid: \`${formatOptionalPrice(result.midTotal)}\``,
+    `Move proxy: \`+/- ${formatOptionalPrice(result.midTotal)}\``,
+    formatLeg("Put", result.put),
+    formatLeg("Call", result.call),
+  ].join("\n");
+}

--- a/modules/slash-commands-interact-options.ts
+++ b/modules/slash-commands-interact-options.ts
@@ -1,4 +1,5 @@
 import {type ChatInputCommandInteraction} from "discord.js";
+import {BrokerApiRateLimitError} from "./broker-api-rate-limit.ts";
 import {getDiscordLogger, getLogger} from "./logging.ts";
 import {
   formatOptionDeltaLookupResult,
@@ -9,10 +10,18 @@ import {
   type OptionDeltaRequestedSide,
   type OptionDeltaCredentials,
 } from "./options-delta.ts";
+import {
+  formatExpectedMoveLookupResult,
+  formatOptionStraddleLookupResult,
+  formatOptionStrangleLookupResult,
+  getOptionStraddleLookup,
+  getOptionStrangleLookup,
+} from "./options-strategy.ts";
 import {readSecret} from "./secrets.ts";
 import {getDiscordLoggerClient, noMentions, type SlashCommandClient} from "./slash-commands-interact-shared.ts";
 
 const logger = getLogger();
+const optionCommandNames = new Set(["delta", "strangle", "straddle", "expectedmove"]);
 
 function getRequestedSide(sideOption: string | null): OptionDeltaRequestedSide {
   if ("call" === sideOption || "put" === sideOption) {
@@ -34,19 +43,68 @@ function getTastytradeCredentials(): OptionDeltaCredentials {
 }
 
 function getDeltaErrorMessage(error: unknown): string {
+  if (error instanceof BrokerApiRateLimitError) {
+    return "Optionsdaten sind gerade ausgelastet. Bitte gleich erneut versuchen.";
+  }
+
   if (error instanceof OptionDeltaConfigurationError) {
-    return "Optionsdaten sind fuer /delta noch nicht konfiguriert.";
+    return "Optionsdaten sind für /delta noch nicht konfiguriert.";
   }
 
   if (error instanceof OptionDeltaInputError) {
-    return `Ungueltige Eingabe: ${error.message}`;
+    return `Ungültige Eingabe: ${error.message}`;
   }
 
   if (error instanceof OptionDeltaDataError) {
     return error.message;
   }
 
-  return "Optionsdaten konnten gerade nicht geladen werden. Bitte spaeter erneut versuchen.";
+  return "Optionsdaten konnten gerade nicht geladen werden. Bitte später erneut versuchen.";
+}
+
+async function getOptionsCommandResponse(interaction: ChatInputCommandInteraction, commandName: string): Promise<string> {
+  const symbol = interaction.options.getString("symbol", true);
+  const dte = interaction.options.getInteger("dte", true);
+  const credentials = getTastytradeCredentials();
+  if ("strangle" === commandName) {
+    const delta = interaction.options.getNumber("delta");
+    const result = await getOptionStrangleLookup({
+      credentials,
+      dte,
+      symbol,
+      ...(null === delta ? {} : {delta}),
+    });
+    return formatOptionStrangleLookupResult(result);
+  }
+
+  if ("straddle" === commandName) {
+    const result = await getOptionStraddleLookup({
+      credentials,
+      dte,
+      symbol,
+    });
+    return formatOptionStraddleLookupResult(result);
+  }
+
+  if ("expectedmove" === commandName) {
+    const result = await getOptionStraddleLookup({
+      credentials,
+      dte,
+      symbol,
+    });
+    return formatExpectedMoveLookupResult(result);
+  }
+
+  const delta = interaction.options.getNumber("delta", true);
+  const side = getRequestedSide(interaction.options.getString("side"));
+  const result = await getOptionDeltaLookup({
+    credentials,
+    delta,
+    dte,
+    side,
+    symbol,
+  });
+  return formatOptionDeltaLookupResult(result);
 }
 
 export async function handleDeltaSlashCommand(
@@ -54,7 +112,7 @@ export async function handleDeltaSlashCommand(
   interaction: ChatInputCommandInteraction,
   commandName: string,
 ): Promise<boolean> {
-  if ("delta" !== commandName) {
+  if (false === optionCommandNames.has(commandName)) {
     return false;
   }
 
@@ -63,7 +121,7 @@ export async function handleDeltaSlashCommand(
     "info",
     {
       username: `${interaction.user.username}`,
-      message: "Using delta slashcommand",
+      message: `Using ${commandName} slashcommand`,
       channel: `${interaction.channel}`,
     },
   );
@@ -80,20 +138,8 @@ export async function handleDeltaSlashCommand(
   }
 
   try {
-    const symbol = interaction.options.getString("symbol", true);
-    const dte = interaction.options.getInteger("dte", true);
-    const delta = interaction.options.getNumber("delta", true);
-    const side = getRequestedSide(interaction.options.getString("side"));
-    const result = await getOptionDeltaLookup({
-      credentials: getTastytradeCredentials(),
-      delta,
-      dte,
-      side,
-      symbol,
-    });
-
     await interaction.editReply({
-      content: formatOptionDeltaLookupResult(result),
+      content: await getOptionsCommandResponse(interaction, commandName),
       allowedMentions: noMentions,
     }).catch((error: unknown) => {
       logger.log(

--- a/modules/slash-commands-payload.ts
+++ b/modules/slash-commands-payload.ts
@@ -11,7 +11,7 @@ import {getSlashCommandNamesFromPayload} from "./slash-commands-canonical.ts";
 
 const logger = getLogger();
 const maxSlashCommandsPerScope = 100;
-export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "google", "8ball", "whatis", "quote", "islandboi", "sara", "earnings", "calendar", "paywall", "delta"];
+export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "google", "8ball", "whatis", "quote", "islandboi", "sara", "earnings", "calendar", "paywall", "delta", "strangle", "straddle", "expectedmove"];
 type SlashCommandJson = ReturnType<SlashCommandBuilder["toJSON"]>;
 type SlashCommandChoice = {
   name: string;
@@ -182,6 +182,61 @@ function createFixedSlashCommands(whatIsAssetsChoices: SlashCommandChoice[], use
           {name: "Puts", value: "put"},
         ));
   fixedSlashCommands.push(slashCommandDelta.toJSON());
+
+  const slashCommandStrangle = new SlashCommandBuilder()
+    .setName("strangle")
+    .setDescription("Find option legs for a short strangle")
+    .addStringOption(option =>
+      option.setName("symbol")
+        .setDescription("Underlying symbol")
+        .setRequired(true))
+    .addIntegerOption(option =>
+      option.setName("dte")
+        .setDescription("Target days to expiration")
+        .setMinValue(0)
+        .setMaxValue(3650)
+        .setRequired(true))
+    .addNumberOption(option =>
+      option.setName("delta")
+        .setDescription("Absolute target delta")
+        .setMinValue(0.01)
+        .setMaxValue(0.99)
+        .setRequired(false)
+        .addChoices(
+          {name: "0.16 delta", value: 0.16},
+          {name: "0.30 delta", value: 0.3},
+        ));
+  fixedSlashCommands.push(slashCommandStrangle.toJSON());
+
+  const slashCommandStraddle = new SlashCommandBuilder()
+    .setName("straddle")
+    .setDescription("Find the ATM option straddle")
+    .addStringOption(option =>
+      option.setName("symbol")
+        .setDescription("Underlying symbol")
+        .setRequired(true))
+    .addIntegerOption(option =>
+      option.setName("dte")
+        .setDescription("Target days to expiration")
+        .setMinValue(0)
+        .setMaxValue(3650)
+        .setRequired(true));
+  fixedSlashCommands.push(slashCommandStraddle.toJSON());
+
+  const slashCommandExpectedMove = new SlashCommandBuilder()
+    .setName("expectedmove")
+    .setDescription("Estimate the option-implied move from the ATM straddle")
+    .addStringOption(option =>
+      option.setName("symbol")
+        .setDescription("Underlying symbol")
+        .setRequired(true))
+    .addIntegerOption(option =>
+      option.setName("dte")
+        .setDescription("Target days to expiration")
+        .setMinValue(0)
+        .setMaxValue(3650)
+        .setRequired(true));
+  fixedSlashCommands.push(slashCommandExpectedMove.toJSON());
 
   return fixedSlashCommands;
 }

--- a/modules/slash-commands.define.test.ts
+++ b/modules/slash-commands.define.test.ts
@@ -557,6 +557,44 @@ describe("defineSlashCommands", () => {
     ]);
   });
 
+  test("registers option strategy commands", () => {
+    const payload = buildSlashCommandPayload([], [], []);
+    const strangleCommand = findCommand(payload.slashCommands, "strangle");
+    const straddleCommand = findCommand(payload.slashCommands, "straddle");
+    const expectedMoveCommand = findCommand(payload.slashCommands, "expectedmove");
+
+    expect(strangleCommand.options).toEqual([
+      expect.objectContaining({
+        name: "symbol",
+        required: true,
+      }),
+      expect.objectContaining({
+        name: "dte",
+        required: true,
+      }),
+      expect.objectContaining({
+        name: "delta",
+        required: false,
+        choices: [
+          {name: "0.16 delta", value: 0.16},
+          {name: "0.30 delta", value: 0.3},
+        ],
+      }),
+    ]);
+    expect(straddleCommand.options).toEqual([
+      expect.objectContaining({
+        name: "symbol",
+        required: true,
+      }),
+      expect.objectContaining({
+        name: "dte",
+        required: true,
+      }),
+    ]);
+    expect(expectedMoveCommand.options).toEqual(straddleCommand.options);
+  });
+
+
   test("caps slash command payload at 100 commands and preserves fixed commands", () => {
     const assets: TextAsset[] = [];
     for (let index = 1; index <= 95; index++) {
@@ -570,22 +608,25 @@ describe("defineSlashCommands", () => {
     const payload = buildSlashCommandPayload(assets, [], []);
 
     expect(payload.slashCommands).toHaveLength(100);
-    expect(payload.assetCommandsRegistered).toBe(88);
-    expect(payload.fixedCommandsRegistered).toBe(12);
-    expect(payload.skippedCommandLimit).toBe(7);
+    expect(payload.assetCommandsRegistered).toBe(85);
+    expect(payload.fixedCommandsRegistered).toBe(15);
+    expect(payload.skippedCommandLimit).toBe(10);
     expect(payload.expectedCommandNames).toContain("quote");
     expect(payload.expectedCommandNames).toContain("calendar");
     expect(payload.expectedCommandNames).toContain("paywall");
     expect(payload.expectedCommandNames).toContain("delta");
-    expect(payload.expectedCommandNames).toContain("asset-88");
-    expect(payload.expectedCommandNames).not.toContain("asset-89");
+    expect(payload.expectedCommandNames).toContain("strangle");
+    expect(payload.expectedCommandNames).toContain("straddle");
+    expect(payload.expectedCommandNames).toContain("expectedmove");
+    expect(payload.expectedCommandNames).toContain("asset-85");
+    expect(payload.expectedCommandNames).not.toContain("asset-86");
     expect(loggerMock.log).toHaveBeenCalledWith(
       "warn",
       expect.objectContaining({
         source: "slash-registration",
         max_commands_per_scope: 100,
         total_commands_registered: 100,
-        skipped_command_limit: 7,
+        skipped_command_limit: 10,
         message: "Slash command payload built with skipped asset triggers.",
       }),
     );

--- a/modules/slash-commands.interact.test.ts
+++ b/modules/slash-commands.interact.test.ts
@@ -280,7 +280,7 @@ describe("interactSlashCommands", () => {
 
     expect(getOptionDeltaLookupMockTyped).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenCalledWith({
-      content: "Optionsdaten sind fuer /delta noch nicht konfiguriert.",
+      content: "Optionsdaten sind für /delta noch nicht konfiguriert.",
       allowedMentions: {
         parse: [],
       },
@@ -334,7 +334,7 @@ describe("interactSlashCommands", () => {
     await handler(interaction);
 
     expect(interaction.editReply).toHaveBeenCalledWith({
-      content: "Ungueltige Eingabe: bad delta",
+      content: "Ungültige Eingabe: bad delta",
       allowedMentions: {
         parse: [],
       },
@@ -406,7 +406,7 @@ describe("interactSlashCommands", () => {
     await handler(interaction);
 
     expect(interaction.editReply).toHaveBeenCalledWith({
-      content: "Optionsdaten konnten gerade nicht geladen werden. Bitte spaeter erneut versuchen.",
+      content: "Optionsdaten konnten gerade nicht geladen werden. Bitte später erneut versuchen.",
       allowedMentions: {
         parse: [],
       },


### PR DESCRIPTION
## Summary
- Add a process-local broker API limiter: one option-data lookup at a time, 10 seconds between starts, bounded queue.
- Add bounded TTL caches for option chains and short-lived quote/Greek snapshots to avoid repeated upstream calls.
- Enrich option output with spread percentage/liquidity notes and monospace market values.
- Add /strangle, /straddle, and /expectedmove commands on the same cached/rate-limited option-data path.
- Use proper German umlauts in Discord-facing option error text.

## Validation
- npm run typecheck
- npm run test:coverage
- npm audit --audit-level=high

## Notes
- npm audit reports only moderate uuid advisories through @tastytrade/api; the high-severity audit gate passes.
- Discord-visible option responses do not expose broker/provider/account/API details.