### PR TITLE
[codex] add slash command coverage and free command slot

### DIFF
--- a/modules/bounded-ttl-cache.test.ts
+++ b/modules/bounded-ttl-cache.test.ts
@@ -24,6 +24,19 @@ describe("BoundedTtlCache", () => {
     expect(cache.size).toBe(0);
   });
 
+  test("updates an existing entry without increasing cache size", () => {
+    const cache = new BoundedTtlCache<string>({
+      maxEntries: 2,
+      ttlMs: 1_000,
+    });
+
+    cache.set("key", "first");
+    cache.set("key", "second");
+
+    expect(cache.get("key")).toBe("second");
+    expect(cache.size).toBe(1);
+  });
+
   test("does not store entries when disabled by size or ttl", () => {
     const zeroSizeCache = new BoundedTtlCache<string>({
       maxEntries: 0,

--- a/modules/broker-api-rate-limit.test.ts
+++ b/modules/broker-api-rate-limit.test.ts
@@ -52,4 +52,59 @@ describe("BrokerApiRateLimiter", () => {
     await expect(first).resolves.toBe("first");
     await expect(second).resolves.toBe("second");
   });
+
+  test("keeps one pending delay timer and clears it when work can start", async () => {
+    let now = 0;
+    const clearTimeoutMock = vi.fn();
+    const timers: {callback: () => void; timer: ReturnType<typeof setTimeout>}[] = [];
+    const limiter = new BrokerApiRateLimiter({
+      clearTimeout: clearTimeoutMock,
+      maxQueueSize: 4,
+      minIntervalMs: 100,
+      now: () => now,
+      setTimeout: callback => {
+        const timer = Symbol("timer") as unknown as ReturnType<typeof setTimeout>;
+        timers.push({callback, timer});
+        return timer;
+      },
+    });
+    const started: string[] = [];
+
+    await expect(limiter.run(async () => {
+      started.push("first");
+      return "first";
+    })).resolves.toBe("first");
+
+    now = 50;
+    const second = limiter.run(async () => {
+      started.push("second");
+      return "second";
+    });
+    expect(timers).toHaveLength(1);
+
+    now = 60;
+    const third = limiter.run(async () => {
+      started.push("third");
+      return "third";
+    });
+    expect(timers).toHaveLength(1);
+
+    now = 100;
+    const fourth = limiter.run(async () => {
+      started.push("fourth");
+      return "fourth";
+    });
+
+    expect(clearTimeoutMock).toHaveBeenCalledWith(timers[0]?.timer);
+    await expect(second).resolves.toBe("second");
+
+    now = 200;
+    timers[1]?.callback();
+    await expect(third).resolves.toBe("third");
+
+    now = 300;
+    timers[2]?.callback();
+    await expect(fourth).resolves.toBe("fourth");
+    expect(started).toEqual(["first", "second", "third", "fourth"]);
+  });
 });

--- a/modules/options-boxrates.test.ts
+++ b/modules/options-boxrates.test.ts
@@ -1,0 +1,121 @@
+import {describe, expect, test, vi} from "vitest";
+import {
+  formatBoxRatesLookupResult,
+  getBoxRatesLookup,
+} from "./options-boxrates.ts";
+import {
+  type ChainExpiration,
+  type OptionDeltaContract,
+  type OptionSelectedContractsLookupRequest,
+} from "./options-delta.ts";
+
+const credentials = {
+  clientSecret: "client-secret",
+  refreshToken: "refresh-token",
+};
+
+function getOptionCode(expirationDate: string): string {
+  return expirationDate.replaceAll("-", "").slice(2);
+}
+
+function createContract(
+  strike: number,
+  optionType: "call" | "put",
+  mid: number,
+  expirationDate: string,
+): OptionDeltaContract {
+  return {
+    ask: mid + 0.5,
+    askSize: 20,
+    bid: mid - 0.5,
+    bidSize: 20,
+    delta: "call" === optionType ? 0.5 : -0.5,
+    expirationDate,
+    gamma: 0.01,
+    iv: 0.2,
+    optionType,
+    streamerSymbol: `.SPX${getOptionCode(expirationDate)}${"call" === optionType ? "C" : "P"}${strike}`,
+    strike,
+    symbol: `SPX ${getOptionCode(expirationDate)}${"call" === optionType ? "C" : "P"}${strike}`,
+    theta: -0.01,
+    vega: 0.1,
+  };
+}
+
+function createChainExpiration(expirationDate: string, daysToExpiration: number): ChainExpiration {
+  return {
+    daysToExpiration,
+    expirationDate,
+    strikes: [6000, 7000].map(strike => ({
+      callStreamerSymbol: `.SPX${getOptionCode(expirationDate)}C${strike}`,
+      callSymbol: `SPX ${getOptionCode(expirationDate)}C${strike}`,
+      putStreamerSymbol: `.SPX${getOptionCode(expirationDate)}P${strike}`,
+      putSymbol: `SPX ${getOptionCode(expirationDate)}P${strike}`,
+      strike,
+    })),
+  };
+}
+
+describe("options-boxrates", () => {
+  test("builds and formats monthly SPX box rates from selected legs only", async () => {
+    const juneExpiration = createChainExpiration("2026-06-19", 49);
+    const julyExpiration = createChainExpiration("2026-07-17", 77);
+    const getOptionChainLookupFn = vi.fn(async () => ({
+      expirations: [juneExpiration, julyExpiration],
+      symbol: "SPX",
+    }));
+    const getSelectedOptionContractsLookupFn = vi.fn(async (request: OptionSelectedContractsLookupRequest) => {
+      if (0 === request.selections.length) {
+        return {
+          contracts: [],
+          symbol: "SPX",
+          underlyingPrice: 6500,
+          underlyingPriceIsRealtime: true,
+        };
+      }
+
+      return {
+        contracts: [
+          createContract(6000, "call", 525, "2026-06-19"),
+          createContract(6000, "put", 50, "2026-06-19"),
+          createContract(7000, "call", 80, "2026-06-19"),
+          createContract(7000, "put", 595, "2026-06-19"),
+          createContract(6000, "call", 545, "2026-07-17"),
+          createContract(6000, "put", 50, "2026-07-17"),
+          createContract(7000, "call", 88, "2026-07-17"),
+          createContract(7000, "put", 583, "2026-07-17"),
+        ],
+        symbol: "SPX",
+        underlyingPrice: 6501,
+        underlyingPriceIsRealtime: true,
+      };
+    });
+
+    const result = await getBoxRatesLookup({
+      credentials,
+      months: 2,
+      notational: 100_000,
+    }, {
+      getOptionChainLookupFn,
+      getSelectedOptionContractsLookupFn,
+      getSofrRateFn: vi.fn(async () => ({
+        effectiveDate: "2026-04-30",
+        percentRate: 3.66,
+      })),
+      now: () => Date.parse("2026-05-01T12:00:00Z"),
+    });
+    const formattedResult = formatBoxRatesLookupResult(result);
+
+    expect(getOptionChainLookupFn).toHaveBeenCalledWith({
+      credentials,
+      symbol: "SPX",
+    }, expect.any(Object));
+    expect(getSelectedOptionContractsLookupFn).toHaveBeenCalledTimes(2);
+    expect(getSelectedOptionContractsLookupFn.mock.calls[1]?.[0].selections).toHaveLength(8);
+    expect(result.rows).toHaveLength(2);
+    expect(formattedResult.split("\n")[0]).toBe("Boxspread rates für die nächsten 12 Monate");
+    expect(formattedResult).toContain("`SPX` @ `6,501.00` | Notational `$100,000` | SOFR: `3.66%` (2026-04-30)");
+    expect(formattedResult).toContain("`Jun26` | `49 DTE` | `6000/7000 x1` | Lend");
+    expect(formattedResult).toContain("`Jul26` | `77 DTE` | `6000/7000 x1` | Lend");
+  });
+});

--- a/modules/options-boxrates.ts
+++ b/modules/options-boxrates.ts
@@ -1,0 +1,484 @@
+import {
+  createOptionDeltaLookupClient,
+  getOptionChainLookup,
+  getSelectedOptionContractsLookup,
+  OptionDeltaDataError,
+  OptionDeltaInputError,
+  type ChainExpiration,
+  type OptionContractSelection,
+  type OptionDeltaContract,
+  type OptionDeltaCredentials,
+  type OptionDeltaLookupClient,
+  type OptionDeltaLookupDependencies,
+  type OptionSelectedContractsLookupResult,
+} from "./options-delta.ts";
+import {
+  formatDecimal,
+  formatSymbolWithUnderlyingPrice,
+  getOptionContractMidPrice,
+} from "./options-format.ts";
+import {getSofrRate} from "./options-boxspread.ts";
+
+export type BoxRatesLookupRequest = {
+  credentials: OptionDeltaCredentials;
+  months?: number;
+  notational?: number;
+};
+
+export type BoxRatesLookupDependencies = OptionDeltaLookupDependencies & {
+  getOptionChainLookupFn?: typeof getOptionChainLookup;
+  getSelectedOptionContractsLookupFn?: typeof getSelectedOptionContractsLookup;
+  getSofrRateFn?: typeof getSofrRate;
+};
+
+type SofrRate = Awaited<ReturnType<typeof getSofrRate>>;
+
+type BoxRatesMarket = {
+  benchmarkName: string;
+  multiplier: number;
+  preferredWidth: number;
+  symbol: string;
+};
+
+type BoxRateStrikePair = {
+  contracts: number;
+  expiration: ChainExpiration;
+  lowerStrike: number;
+  upperStrike: number;
+  width: number;
+};
+
+type BoxRateContractPair = BoxRateStrikePair & {
+  lowerCall: OptionDeltaContract;
+  lowerPut: OptionDeltaContract;
+  upperCall: OptionDeltaContract;
+  upperPut: OptionDeltaContract;
+};
+
+export type BoxRateRow = {
+  actualDte: number;
+  borrowRate: number;
+  contracts: number;
+  expiration: string;
+  lendRate: number;
+  lowerStrike: number;
+  midRate: number;
+  rateDeltaToBenchmark: number;
+  upperStrike: number;
+};
+
+export type BoxRatesLookupResult = {
+  benchmarkName: string;
+  notational: number;
+  rows: BoxRateRow[];
+  sofr: SofrRate;
+  symbol: string;
+  underlyingPrice: number | null;
+  underlyingPriceIsRealtime: boolean;
+};
+
+const spxBoxRatesMarket: BoxRatesMarket = {
+  benchmarkName: "SOFR",
+  multiplier: 100,
+  preferredWidth: 1000,
+  symbol: "SPX",
+};
+const shortMonths = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function normalizeNotational(notational: number): number {
+  if (false === Number.isFinite(notational) || notational <= 0) {
+    throw new OptionDeltaInputError("Notational must be greater than 0.");
+  }
+
+  return Math.round(notational);
+}
+
+function normalizeMonths(months: number | undefined): number {
+  if (undefined === months) {
+    return 12;
+  }
+
+  if (false === Number.isInteger(months) || months < 1 || months > 24) {
+    throw new OptionDeltaInputError("Months must be an integer from 1 to 24.");
+  }
+
+  return months;
+}
+
+function parseExpirationDate(expiration: string): Date {
+  const date = new Date(`${expiration}T00:00:00Z`);
+  if (Number.isNaN(date.valueOf())) {
+    throw new OptionDeltaDataError(`Invalid expiration date ${expiration}.`);
+  }
+
+  return date;
+}
+
+function isThirdFriday(expiration: ChainExpiration): boolean {
+  const date = parseExpirationDate(expiration.expirationDate);
+  const day = date.getUTCDate();
+  return 5 === date.getUTCDay() && day >= 15 && day <= 21;
+}
+
+function selectMonthlyExpirations(expirations: ChainExpiration[], nowMs: number, months: number): ChainExpiration[] {
+  const todayUtc = new Date(nowMs);
+  const startOfTodayMs = Date.UTC(todayUtc.getUTCFullYear(), todayUtc.getUTCMonth(), todayUtc.getUTCDate());
+  const expirationsByMonth = new Map<string, ChainExpiration[]>();
+
+  for (const expiration of expirations) {
+    if (expiration.daysToExpiration <= 0 || parseExpirationDate(expiration.expirationDate).valueOf() < startOfTodayMs) {
+      continue;
+    }
+
+    const monthKey = expiration.expirationDate.slice(0, 7);
+    expirationsByMonth.set(monthKey, [...(expirationsByMonth.get(monthKey) ?? []), expiration]);
+  }
+
+  return [...expirationsByMonth.entries()]
+    .sort(([firstMonth], [secondMonth]) => firstMonth.localeCompare(secondMonth))
+    .slice(0, months)
+    .flatMap(([, monthExpirations]) => {
+      const selectedExpiration = [...monthExpirations].sort((first, second) => {
+        const firstThirdFriday = isThirdFriday(first);
+        const secondThirdFriday = isThirdFriday(second);
+        if (firstThirdFriday !== secondThirdFriday) {
+          return true === firstThirdFriday ? -1 : 1;
+        }
+
+        return first.expirationDate.localeCompare(second.expirationDate);
+      })[0];
+
+      return undefined === selectedExpiration ? [] : [selectedExpiration];
+    });
+}
+
+function isNearInteger(value: number): boolean {
+  return Math.abs(value - Math.round(value)) < 1e-6;
+}
+
+function hasCompleteChainStrike(strike: ChainExpiration["strikes"][number]): boolean {
+  return null !== strike.callStreamerSymbol
+    && null !== strike.callSymbol
+    && null !== strike.putStreamerSymbol
+    && null !== strike.putSymbol;
+}
+
+function getStrikePairs(
+  expiration: ChainExpiration,
+  market: BoxRatesMarket,
+  notational: number,
+  underlyingPrice: number | null,
+): BoxRateStrikePair[] {
+  const strikes = expiration.strikes
+    .filter(hasCompleteChainStrike)
+    .map(strike => strike.strike)
+    .sort((first, second) => first - second);
+  const pairs: BoxRateStrikePair[] = [];
+
+  for (let lowerIndex = 0; lowerIndex < strikes.length; lowerIndex++) {
+    const lowerStrike = strikes[lowerIndex];
+    if (undefined === lowerStrike) {
+      continue;
+    }
+
+    for (let upperIndex = lowerIndex + 1; upperIndex < strikes.length; upperIndex++) {
+      const upperStrike = strikes[upperIndex];
+      if (undefined === upperStrike) {
+        continue;
+      }
+
+      const width = upperStrike - lowerStrike;
+      const contracts = notational / (width * market.multiplier);
+      if (false === isNearInteger(contracts) || contracts < 1) {
+        continue;
+      }
+
+      pairs.push({
+        contracts: Math.round(contracts),
+        expiration,
+        lowerStrike,
+        upperStrike,
+        width,
+      });
+    }
+  }
+
+  return pairs.sort((first, second) => {
+    const firstWidthDistance = Math.abs(first.width - market.preferredWidth);
+    const secondWidthDistance = Math.abs(second.width - market.preferredWidth);
+    if (firstWidthDistance !== secondWidthDistance) {
+      return firstWidthDistance - secondWidthDistance;
+    }
+
+    if (null !== underlyingPrice) {
+      const firstMidpointDistance = Math.abs(((first.lowerStrike + first.upperStrike) / 2) - underlyingPrice);
+      const secondMidpointDistance = Math.abs(((second.lowerStrike + second.upperStrike) / 2) - underlyingPrice);
+      if (firstMidpointDistance !== secondMidpointDistance) {
+        return firstMidpointDistance - secondMidpointDistance;
+      }
+    }
+
+    if (first.contracts !== second.contracts) {
+      return first.contracts - second.contracts;
+    }
+
+    return first.lowerStrike - second.lowerStrike;
+  });
+}
+
+function getSelections(pairs: BoxRateStrikePair[]): OptionContractSelection[] {
+  return pairs.flatMap(pair => [
+    {expiration: pair.expiration, side: "call", strike: pair.lowerStrike},
+    {expiration: pair.expiration, side: "put", strike: pair.lowerStrike},
+    {expiration: pair.expiration, side: "call", strike: pair.upperStrike},
+    {expiration: pair.expiration, side: "put", strike: pair.upperStrike},
+  ]);
+}
+
+function getContract(
+  contracts: OptionDeltaContract[],
+  expirationDate: string,
+  strike: number,
+  optionType: OptionDeltaContract["optionType"],
+): OptionDeltaContract | null {
+  return contracts.find(contract => {
+    return contract.expirationDate === expirationDate
+      && contract.strike === strike
+      && contract.optionType === optionType
+      && null !== contract.bid
+      && null !== contract.ask;
+  }) ?? null;
+}
+
+function getContractPair(contracts: OptionDeltaContract[], strikePair: BoxRateStrikePair): BoxRateContractPair | null {
+  const expirationDate = strikePair.expiration.expirationDate;
+  const lowerCall = getContract(contracts, expirationDate, strikePair.lowerStrike, "call");
+  const lowerPut = getContract(contracts, expirationDate, strikePair.lowerStrike, "put");
+  const upperCall = getContract(contracts, expirationDate, strikePair.upperStrike, "call");
+  const upperPut = getContract(contracts, expirationDate, strikePair.upperStrike, "put");
+  if (null === lowerCall || null === lowerPut || null === upperCall || null === upperPut) {
+    return null;
+  }
+
+  return {
+    ...strikePair,
+    lowerCall,
+    lowerPut,
+    upperCall,
+    upperPut,
+  };
+}
+
+function getRequiredQuotePrice(value: number | null, contract: OptionDeltaContract): number {
+  if (null === value) {
+    throw new OptionDeltaDataError(`Missing bid/ask quote for ${contract.symbol}.`);
+  }
+
+  return value;
+}
+
+function getContractMidPrice(contract: OptionDeltaContract): number {
+  const mid = getOptionContractMidPrice(contract);
+  if (null === mid) {
+    throw new OptionDeltaDataError(`Missing bid/ask midpoint for ${contract.symbol}.`);
+  }
+
+  return mid;
+}
+
+function getNaturalCredit(pair: BoxRateContractPair): number {
+  return getRequiredQuotePrice(pair.lowerCall.bid, pair.lowerCall)
+    - getRequiredQuotePrice(pair.lowerPut.ask, pair.lowerPut)
+    - getRequiredQuotePrice(pair.upperCall.ask, pair.upperCall)
+    + getRequiredQuotePrice(pair.upperPut.bid, pair.upperPut);
+}
+
+function getNaturalDebit(pair: BoxRateContractPair): number {
+  return getRequiredQuotePrice(pair.lowerCall.ask, pair.lowerCall)
+    - getRequiredQuotePrice(pair.lowerPut.bid, pair.lowerPut)
+    - getRequiredQuotePrice(pair.upperCall.bid, pair.upperCall)
+    + getRequiredQuotePrice(pair.upperPut.ask, pair.upperPut);
+}
+
+function getMidPrice(pair: BoxRateContractPair): number {
+  return getContractMidPrice(pair.lowerCall)
+    - getContractMidPrice(pair.lowerPut)
+    - getContractMidPrice(pair.upperCall)
+    + getContractMidPrice(pair.upperPut);
+}
+
+function getAnnualizedRate(notational: number, cashToday: number, actualDte: number): number | null {
+  if (false === Number.isFinite(cashToday) || cashToday <= 0 || actualDte <= 0) {
+    return null;
+  }
+
+  return ((notational / cashToday) - 1) * (360 / actualDte);
+}
+
+function getRateRow(
+  pair: BoxRateContractPair,
+  market: BoxRatesMarket,
+  sofr: SofrRate,
+  notational: number,
+): BoxRateRow | null {
+  const actualDte = pair.expiration.daysToExpiration;
+  const contractsMultiplier = market.multiplier * pair.contracts;
+  const lendRate = getAnnualizedRate(notational, getNaturalDebit(pair) * contractsMultiplier, actualDte);
+  const midRate = getAnnualizedRate(notational, getMidPrice(pair) * contractsMultiplier, actualDte);
+  const borrowRate = getAnnualizedRate(notational, getNaturalCredit(pair) * contractsMultiplier, actualDte);
+  if (null === lendRate || null === midRate || null === borrowRate) {
+    return null;
+  }
+
+  return {
+    actualDte,
+    borrowRate,
+    contracts: pair.contracts,
+    expiration: pair.expiration.expirationDate,
+    lendRate,
+    lowerStrike: pair.lowerStrike,
+    midRate,
+    rateDeltaToBenchmark: midRate - (sofr.percentRate / 100),
+    upperStrike: pair.upperStrike,
+  };
+}
+
+function getSharedClientDependencies(
+  dependencies: BoxRatesLookupDependencies,
+): BoxRatesLookupDependencies {
+  if (undefined !== dependencies.clientFactory) {
+    return dependencies;
+  }
+
+  let client: OptionDeltaLookupClient | undefined;
+  return {
+    ...dependencies,
+    clientFactory: normalizedCredentials => {
+      client ??= createOptionDeltaLookupClient(normalizedCredentials);
+      return client;
+    },
+  };
+}
+
+export async function getBoxRatesLookup(
+  request: BoxRatesLookupRequest,
+  dependencies: BoxRatesLookupDependencies = {},
+): Promise<BoxRatesLookupResult> {
+  const months = normalizeMonths(request.months);
+  const notational = normalizeNotational(request.notational ?? 100_000);
+  const sharedClientDependencies = getSharedClientDependencies(dependencies);
+  const getOptionChainLookupFn = dependencies.getOptionChainLookupFn ?? getOptionChainLookup;
+  const getSelectedOptionContractsLookupFn = dependencies.getSelectedOptionContractsLookupFn ?? getSelectedOptionContractsLookup;
+  const getSofrRateFn = dependencies.getSofrRateFn ?? getSofrRate;
+  const marketDataDependencies = {
+    ...sharedClientDependencies,
+    marketDataTimeoutMs: dependencies.marketDataTimeoutMs ?? 10_000,
+  };
+  const [chainResult, sofr] = await Promise.all([
+    getOptionChainLookupFn({
+      credentials: request.credentials,
+      symbol: spxBoxRatesMarket.symbol,
+    }, sharedClientDependencies),
+    getSofrRateFn(),
+  ]);
+  const underlyingLookup = await getSelectedOptionContractsLookupFn({
+    credentials: request.credentials,
+    selections: [],
+    symbol: spxBoxRatesMarket.symbol,
+  }, marketDataDependencies);
+  const monthlyExpirations = selectMonthlyExpirations(
+    chainResult.expirations,
+    (dependencies.now ?? Date.now)(),
+    months,
+  );
+  const strikePairs = monthlyExpirations.flatMap(expiration => {
+    const pair = getStrikePairs(expiration, spxBoxRatesMarket, notational, underlyingLookup.underlyingPrice)[0];
+    return undefined === pair ? [] : [pair];
+  });
+  if (0 === strikePairs.length) {
+    throw new OptionDeltaDataError(`No SPX monthly box spreads found for ${notational.toLocaleString("en-US")} notational.`);
+  }
+
+  const selectedContractsLookup: OptionSelectedContractsLookupResult = await getSelectedOptionContractsLookupFn({
+    credentials: request.credentials,
+    selections: getSelections(strikePairs),
+    symbol: spxBoxRatesMarket.symbol,
+  }, marketDataDependencies);
+  const rows = strikePairs.flatMap(strikePair => {
+    const pair = getContractPair(selectedContractsLookup.contracts, strikePair);
+    if (null === pair) {
+      return [];
+    }
+
+    const row = getRateRow(pair, spxBoxRatesMarket, sofr, notational);
+    return null === row ? [] : [row];
+  });
+  if (0 === rows.length) {
+    throw new OptionDeltaDataError("SPX box rate market data is unavailable.");
+  }
+
+  return {
+    benchmarkName: spxBoxRatesMarket.benchmarkName,
+    notational,
+    rows,
+    sofr,
+    symbol: chainResult.symbol,
+    underlyingPrice: selectedContractsLookup.underlyingPrice ?? underlyingLookup.underlyingPrice,
+    underlyingPriceIsRealtime: selectedContractsLookup.underlyingPriceIsRealtime,
+  };
+}
+
+function formatMoney(value: number): string {
+  const roundedValue = Math.round(value);
+  const sign = roundedValue < 0 ? "-" : "";
+  return `${sign}$${Math.abs(roundedValue).toLocaleString("en-US")}`;
+}
+
+function formatRate(value: number): string {
+  return `${formatDecimal(value * 100, 2)}%`;
+}
+
+function formatSignedBasisPoints(value: number): string {
+  const basisPoints = value * 10_000;
+  const sign = basisPoints >= 0 ? "+" : "";
+  return `${sign}${formatDecimal(basisPoints, 0)} bps`;
+}
+
+function formatStrike(strike: number): string {
+  return strike.toLocaleString("en-US", {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    useGrouping: false,
+  }).replace(/\.00$/, "");
+}
+
+function formatShortExpirationMonth(expiration: string): string {
+  const date = parseExpirationDate(expiration);
+  const month = shortMonths[date.getUTCMonth()] ?? "";
+  const year = date.getUTCFullYear().toString().slice(-2);
+  return `${month}${year}`;
+}
+
+function formatBoxRateRow(row: BoxRateRow): string {
+  return [
+    `\`${formatShortExpirationMonth(row.expiration)}\``,
+    `\`${row.actualDte} DTE\``,
+    `\`${formatStrike(row.lowerStrike)}/${formatStrike(row.upperStrike)} x${row.contracts}\``,
+    `Lend \`${formatRate(row.lendRate)}\``,
+    `Mid \`${formatRate(row.midRate)}\``,
+    `Borrow \`${formatRate(row.borrowRate)}\``,
+    `Δ \`${formatSignedBasisPoints(row.rateDeltaToBenchmark)}\``,
+  ].join(" | ");
+}
+
+export function formatBoxRatesLookupResult(result: BoxRatesLookupResult): string {
+  return [
+    "Boxspread rates für die nächsten 12 Monate",
+    `${formatSymbolWithUnderlyingPrice(
+      result.symbol,
+      result.underlyingPrice,
+      result.underlyingPriceIsRealtime,
+    )} | Notational \`${formatMoney(result.notational)}\` | ${result.benchmarkName}: \`${formatDecimal(result.sofr.percentRate, 2)}%\` (${result.sofr.effectiveDate})`,
+    ...result.rows.map(formatBoxRateRow),
+  ].join("\n");
+}

--- a/modules/options-delta.ts
+++ b/modules/options-delta.ts
@@ -78,6 +78,30 @@ export type OptionContractsLookupResult = {
   underlyingPrice: number | null;
   underlyingPriceIsRealtime: boolean;
 };
+export type OptionChainLookupRequest = {
+  credentials: OptionDeltaCredentials;
+  symbol: string;
+};
+export type OptionChainLookupResult = {
+  expirations: ChainExpiration[];
+  symbol: string;
+};
+export type OptionContractSelection = {
+  expiration: ChainExpiration;
+  side: OptionDeltaSide;
+  strike: number;
+};
+export type OptionSelectedContractsLookupRequest = {
+  credentials: OptionDeltaCredentials;
+  selections: OptionContractSelection[];
+  symbol: string;
+};
+export type OptionSelectedContractsLookupResult = {
+  contracts: OptionDeltaContract[];
+  symbol: string;
+  underlyingPrice: number | null;
+  underlyingPriceIsRealtime: boolean;
+};
 
 type TastytradeEvent = Record<string, unknown>;
 type TastytradeEventListener = (events: TastytradeEvent[]) => void;
@@ -104,7 +128,7 @@ export type OptionDeltaLookupDependencies = {
   now?: () => number;
   rateLimiter?: Pick<BrokerApiRateLimiter, "run">;
 };
-type ChainStrike = {
+export type ChainStrike = {
   callStreamerSymbol: string | null;
   callSymbol: string | null;
   putStreamerSymbol: string | null;
@@ -478,10 +502,12 @@ async function collectMarketData(
   try {
     removeListener = quoteStreamer.addEventListener(listener);
     await quoteStreamer.connect();
-    quoteStreamer.subscribe(optionStreamerSymbols, [
-      MarketDataSubscriptionType.Greeks,
-      MarketDataSubscriptionType.Quote,
-    ]);
+    if (0 < optionStreamerSymbols.length) {
+      quoteStreamer.subscribe(optionStreamerSymbols, [
+        MarketDataSubscriptionType.Greeks,
+        MarketDataSubscriptionType.Quote,
+      ]);
+    }
     quoteStreamer.subscribe([underlyingStreamerSymbol], [MarketDataSubscriptionType.Quote]);
 
     const startTime = Date.now();
@@ -576,6 +602,32 @@ export function findDeltaBrackets(contracts: OptionDeltaContract[], targetDelta:
   };
 }
 
+export async function getOptionChainLookup(
+  request: OptionChainLookupRequest,
+  dependencies: OptionDeltaLookupDependencies = {},
+): Promise<OptionChainLookupResult> {
+  const credentials = normalizeCredentials(request.credentials);
+  const symbol = normalizeOptionSymbol(request.symbol);
+  const chainCache = dependencies.chainCache ?? optionChainCache;
+  const rateLimiter = dependencies.rateLimiter ?? optionDataRateLimiter;
+
+  const cachedExpirations = chainCache.get(symbol);
+  if (undefined !== cachedExpirations) {
+    return {
+      expirations: cachedExpirations,
+      symbol,
+    };
+  }
+
+  return rateLimiter.run(async () => {
+    const client = (dependencies.clientFactory ?? createOptionDeltaLookupClient)(credentials);
+    return {
+      expirations: await getOptionChainExpirations(client, symbol, chainCache),
+      symbol,
+    };
+  });
+}
+
 export async function getOptionContractsLookup(
   request: OptionContractsLookupRequest,
   dependencies: OptionDeltaLookupDependencies = {},
@@ -646,6 +698,33 @@ export async function getOptionContractsLookup(
       underlyingPrice: snapshot.underlyingPrice,
       underlyingPriceIsRealtime,
     });
+  });
+}
+
+export async function getSelectedOptionContractsLookup(
+  request: OptionSelectedContractsLookupRequest,
+  dependencies: OptionDeltaLookupDependencies = {},
+): Promise<OptionSelectedContractsLookupResult> {
+  const credentials = normalizeCredentials(request.credentials);
+  const symbol = normalizeOptionSymbol(request.symbol);
+  const rateLimiter = dependencies.rateLimiter ?? optionDataRateLimiter;
+  const underlyingPriceIsRealtime = isMarketHoursOpen("us_cash", (dependencies.now ?? Date.now)());
+
+  return rateLimiter.run(async () => {
+    const client = (dependencies.clientFactory ?? createOptionDeltaLookupClient)(credentials);
+    const snapshot = await getSelectedOptionContracts(
+      client,
+      symbol,
+      request.selections,
+      dependencies.marketDataTimeoutMs ?? defaultMarketDataTimeoutMs,
+    );
+
+    return {
+      contracts: snapshot.contracts,
+      symbol,
+      underlyingPrice: snapshot.underlyingPrice,
+      underlyingPriceIsRealtime,
+    };
   });
 }
 
@@ -803,6 +882,60 @@ async function getOptionContracts(
   };
   contractCache.set(getContractsCacheKey(symbol, expiration, requestedSides), snapshot);
   return snapshot;
+}
+
+function getSelectionKey(expirationDate: string, strike: number, side: OptionDeltaSide): string {
+  return `${expirationDate}:${strike}:${side}`;
+}
+
+function getSelectionStreamerSymbol(selection: OptionContractSelection): string {
+  const strike = selection.expiration.strikes.find(candidate => candidate.strike === selection.strike);
+  if (undefined === strike) {
+    throw new OptionDeltaDataError(
+      `No ${selection.expiration.expirationDate} option strike found at ${selection.strike}.`,
+    );
+  }
+
+  const streamerSymbol = getStrikeStreamerSymbol(strike, selection.side);
+  if (null === streamerSymbol) {
+    throw new OptionDeltaDataError(
+      `No ${selection.side} option found for ${selection.expiration.expirationDate} ${selection.strike}.`,
+    );
+  }
+
+  return streamerSymbol;
+}
+
+async function getSelectedOptionContracts(
+  client: OptionDeltaLookupClient,
+  symbol: string,
+  selections: OptionContractSelection[],
+  marketDataTimeoutMs: number,
+): Promise<OptionMarketDataSnapshot> {
+  const selectionKeys = new Set(selections.map(selection => {
+    return getSelectionKey(selection.expiration.expirationDate, selection.strike, selection.side);
+  }));
+  const streamerSymbols = selections.map(getSelectionStreamerSymbol);
+  const marketData = await collectMarketData(
+    client.quoteStreamer,
+    [...new Set(streamerSymbols)],
+    symbol,
+    marketDataTimeoutMs,
+  );
+
+  const expirationByDate = new Map<string, ChainExpiration>();
+  for (const selection of selections) {
+    expirationByDate.set(selection.expiration.expirationDate, selection.expiration);
+  }
+
+  const contracts = [...expirationByDate.values()]
+    .flatMap(expiration => buildContracts(expiration, ["call", "put"], marketData.streamedData))
+    .filter(contract => selectionKeys.has(getSelectionKey(contract.expirationDate, contract.strike, contract.optionType)));
+
+  return {
+    contracts,
+    underlyingPrice: marketData.underlyingPrice,
+  };
 }
 
 type BuildLookupResultFromExpirationsRequest = {

--- a/modules/slash-commands-interact-options.ts
+++ b/modules/slash-commands-interact-options.ts
@@ -11,6 +11,10 @@ import {
   type OptionDeltaCredentials,
 } from "./options-delta.ts";
 import {
+  formatBoxRatesLookupResult,
+  getBoxRatesLookup,
+} from "./options-boxrates.ts";
+import {
   formatBoxSpreadLookupResult,
   getBoxSpreadLookup,
   type BoxSpreadDirection,
@@ -26,7 +30,7 @@ import {readSecret} from "./secrets.ts";
 import {getDiscordLoggerClient, noMentions, type SlashCommandClient} from "./slash-commands-interact-shared.ts";
 
 const logger = getLogger();
-const optionCommandNames = new Set(["delta", "strangle", "straddle", "expectedmove", "boxspread"]);
+const optionCommandNames = new Set(["delta", "strangle", "straddle", "expectedmove", "boxspread", "boxrates"]);
 
 function getRequestedSide(sideOption: string | null): OptionDeltaRequestedSide {
   if ("call" === sideOption || "put" === sideOption) {
@@ -76,8 +80,17 @@ function getDeltaErrorMessage(error: unknown, commandName: string): string {
 }
 
 async function getOptionsCommandResponse(interaction: ChatInputCommandInteraction, commandName: string): Promise<string> {
-  const dte = interaction.options.getInteger("dte", true);
   const credentials = getTastytradeCredentials();
+  if ("boxrates" === commandName) {
+    const notational = interaction.options.getNumber("notational");
+    const result = await getBoxRatesLookup({
+      credentials,
+      ...(null === notational ? {} : {notational}),
+    });
+    return formatBoxRatesLookupResult(result);
+  }
+
+  const dte = interaction.options.getInteger("dte", true);
   if ("boxspread" === commandName) {
     const result = await getBoxSpreadLookup({
       credentials,

--- a/modules/slash-commands-interact.ts
+++ b/modules/slash-commands-interact.ts
@@ -2,7 +2,7 @@ import {type ChatInputCommandInteraction, EmbedBuilder} from "discord.js";
 import validator from "validator";
 import type {GenericAsset, ImageAsset, PaywallAsset} from "./assets.ts";
 import {cryptodice} from "./crypto-dice.ts";
-import {google, lmgtfy} from "./lmgtfy.ts";
+import {lmgtfy} from "./lmgtfy.ts";
 import {getLogger} from "./logging.ts";
 import {handleCalendarSlashCommand, handleEarningsSlashCommand} from "./slash-commands-interact-events.ts";
 import {handleMediaSlashCommand} from "./slash-commands-interact-media.ts";
@@ -86,17 +86,6 @@ export function interactSlashCommands(
         logger.log(
           "error",
           `Error replying to lmgtfy slashcommand: ${error}`,
-        );
-      });
-      return;
-    }
-
-    if (commandName.startsWith("google")) {
-      const search = validator.escape(chatInputInteraction.options.getString("search", true));
-      await chatInputInteraction.reply(`Here you go: ${google(search)}.`).catch((error: unknown) => {
-        logger.log(
-          "error",
-          `Error replying to google slashcommand: ${error}`,
         );
       });
       return;

--- a/modules/slash-commands-payload.ts
+++ b/modules/slash-commands-payload.ts
@@ -11,7 +11,7 @@ import {getSlashCommandNamesFromPayload} from "./slash-commands-canonical.ts";
 
 const logger = getLogger();
 const maxSlashCommandsPerScope = 100;
-export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "google", "8ball", "whatis", "quote", "sara", "earnings", "calendar", "paywall", "delta", "strangle", "straddle", "expectedmove", "boxspread"];
+export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "8ball", "whatis", "quote", "sara", "earnings", "calendar", "paywall", "delta", "strangle", "straddle", "expectedmove", "boxspread"];
 type SlashCommandJson = ReturnType<SlashCommandBuilder["toJSON"]>;
 type SlashCommandChoice = {
   name: string;
@@ -49,15 +49,6 @@ function createFixedSlashCommands(whatIsAssetsChoices: SlashCommandChoice[], use
         .setDescription("The search term")
         .setRequired(true));
   fixedSlashCommands.push(slashCommandLmgtfy.toJSON());
-
-  const slashCommandGoogle = new SlashCommandBuilder()
-    .setName("google")
-    .setDescription("Search...")
-    .addStringOption(option =>
-      option.setName("search")
-        .setDescription("The search term")
-        .setRequired(true));
-  fixedSlashCommands.push(slashCommandGoogle.toJSON());
 
   const slashCommand8ball = new SlashCommandBuilder()
     .setName("8ball")

--- a/modules/slash-commands-payload.ts
+++ b/modules/slash-commands-payload.ts
@@ -11,7 +11,7 @@ import {getSlashCommandNamesFromPayload} from "./slash-commands-canonical.ts";
 
 const logger = getLogger();
 const maxSlashCommandsPerScope = 100;
-export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "8ball", "whatis", "quote", "sara", "earnings", "calendar", "paywall", "delta", "strangle", "straddle", "expectedmove", "boxspread"];
+export const fixedSlashCommandNames = ["cryptodice", "lmgtfy", "8ball", "whatis", "quote", "sara", "earnings", "calendar", "paywall", "delta", "strangle", "straddle", "expectedmove", "boxspread", "boxrates"];
 type SlashCommandJson = ReturnType<SlashCommandBuilder["toJSON"]>;
 type SlashCommandChoice = {
   name: string;
@@ -247,6 +247,16 @@ function createFixedSlashCommands(whatIsAssetsChoices: SlashCommandChoice[], use
         .setMinValue(1)
         .setRequired(true));
   fixedSlashCommands.push(slashCommandBoxSpread.toJSON());
+
+  const slashCommandBoxRates = new SlashCommandBuilder()
+    .setName("boxrates")
+    .setDescription("Show SPX box-spread implied rates for the next 12 months")
+    .addNumberOption(option =>
+      option.setName("notational")
+        .setDescription("Maturity notational per row; defaults to 100000")
+        .setMinValue(1)
+        .setRequired(false));
+  fixedSlashCommands.push(slashCommandBoxRates.toJSON());
 
   return fixedSlashCommands;
 }

--- a/modules/slash-commands.define.test.ts
+++ b/modules/slash-commands.define.test.ts
@@ -614,6 +614,12 @@ describe("defineSlashCommands", () => {
     ]);
   });
 
+  test("does not register google as a fixed slash command", () => {
+    const payload = buildSlashCommandPayload([], [], []);
+
+    expect(payload.fixedCommandsRegistered).toBe(14);
+    expect(payload.expectedCommandNames).not.toContain("google");
+  });
 
   test("caps slash command payload at 100 commands and preserves fixed commands", () => {
     const assets: TextAsset[] = [];
@@ -628,9 +634,9 @@ describe("defineSlashCommands", () => {
     const payload = buildSlashCommandPayload(assets, [], []);
 
     expect(payload.slashCommands).toHaveLength(100);
-    expect(payload.assetCommandsRegistered).toBe(85);
-    expect(payload.fixedCommandsRegistered).toBe(15);
-    expect(payload.skippedCommandLimit).toBe(10);
+    expect(payload.assetCommandsRegistered).toBe(86);
+    expect(payload.fixedCommandsRegistered).toBe(14);
+    expect(payload.skippedCommandLimit).toBe(9);
     expect(payload.expectedCommandNames).toContain("quote");
     expect(payload.expectedCommandNames).toContain("calendar");
     expect(payload.expectedCommandNames).toContain("paywall");
@@ -639,15 +645,16 @@ describe("defineSlashCommands", () => {
     expect(payload.expectedCommandNames).toContain("straddle");
     expect(payload.expectedCommandNames).toContain("expectedmove");
     expect(payload.expectedCommandNames).toContain("boxspread");
-    expect(payload.expectedCommandNames).toContain("asset-85");
-    expect(payload.expectedCommandNames).not.toContain("asset-86");
+    expect(payload.expectedCommandNames).not.toContain("google");
+    expect(payload.expectedCommandNames).toContain("asset-86");
+    expect(payload.expectedCommandNames).not.toContain("asset-87");
     expect(loggerMock.log).toHaveBeenCalledWith(
       "warn",
       expect.objectContaining({
         source: "slash-registration",
         max_commands_per_scope: 100,
         total_commands_registered: 100,
-        skipped_command_limit: 10,
+        skipped_command_limit: 9,
         message: "Slash command payload built with skipped asset triggers.",
       }),
     );

--- a/modules/slash-commands.define.test.ts
+++ b/modules/slash-commands.define.test.ts
@@ -563,6 +563,7 @@ describe("defineSlashCommands", () => {
     const straddleCommand = findCommand(payload.slashCommands, "straddle");
     const expectedMoveCommand = findCommand(payload.slashCommands, "expectedmove");
     const boxSpreadCommand = findCommand(payload.slashCommands, "boxspread");
+    const boxRatesCommand = findCommand(payload.slashCommands, "boxrates");
 
     expect(strangleCommand.options).toEqual([
       expect.objectContaining({
@@ -612,12 +613,19 @@ describe("defineSlashCommands", () => {
         required: true,
       }),
     ]);
+    expect(boxRatesCommand.options).toEqual([
+      expect.objectContaining({
+        name: "notational",
+        min_value: 1,
+        required: false,
+      }),
+    ]);
   });
 
   test("does not register google as a fixed slash command", () => {
     const payload = buildSlashCommandPayload([], [], []);
 
-    expect(payload.fixedCommandsRegistered).toBe(14);
+    expect(payload.fixedCommandsRegistered).toBe(15);
     expect(payload.expectedCommandNames).not.toContain("google");
   });
 
@@ -634,9 +642,9 @@ describe("defineSlashCommands", () => {
     const payload = buildSlashCommandPayload(assets, [], []);
 
     expect(payload.slashCommands).toHaveLength(100);
-    expect(payload.assetCommandsRegistered).toBe(86);
-    expect(payload.fixedCommandsRegistered).toBe(14);
-    expect(payload.skippedCommandLimit).toBe(9);
+    expect(payload.assetCommandsRegistered).toBe(85);
+    expect(payload.fixedCommandsRegistered).toBe(15);
+    expect(payload.skippedCommandLimit).toBe(10);
     expect(payload.expectedCommandNames).toContain("quote");
     expect(payload.expectedCommandNames).toContain("calendar");
     expect(payload.expectedCommandNames).toContain("paywall");
@@ -645,16 +653,17 @@ describe("defineSlashCommands", () => {
     expect(payload.expectedCommandNames).toContain("straddle");
     expect(payload.expectedCommandNames).toContain("expectedmove");
     expect(payload.expectedCommandNames).toContain("boxspread");
+    expect(payload.expectedCommandNames).toContain("boxrates");
     expect(payload.expectedCommandNames).not.toContain("google");
-    expect(payload.expectedCommandNames).toContain("asset-86");
-    expect(payload.expectedCommandNames).not.toContain("asset-87");
+    expect(payload.expectedCommandNames).toContain("asset-85");
+    expect(payload.expectedCommandNames).not.toContain("asset-86");
     expect(loggerMock.log).toHaveBeenCalledWith(
       "warn",
       expect.objectContaining({
         source: "slash-registration",
         max_commands_per_scope: 100,
         total_commands_registered: 100,
-        skipped_command_limit: 9,
+        skipped_command_limit: 10,
         message: "Slash command payload built with skipped asset triggers.",
       }),
     );

--- a/modules/slash-commands.interact-paywall.test.ts
+++ b/modules/slash-commands.interact-paywall.test.ts
@@ -160,6 +160,39 @@ describe("handlePaywallSlashCommand", () => {
     });
   });
 
+  test("formats known service results and defaults missing assets to an empty list", async () => {
+    getPaywallLinksMock.mockResolvedValueOnce(paywallResult({
+      services: [
+        {
+          name: "archive.today",
+          url: "https://archive.ph/newest/https://example.com/article",
+          available: true,
+        },
+      ],
+    }));
+    const interaction = createPaywallInteraction("https://example.com/article");
+
+    await expect(handlePaywallSlashCommand(asChatInputInteraction(interaction), "paywall")).resolves.toBe(true);
+
+    expect(getPaywallLinksMock).toHaveBeenCalledWith("https://example.com/article", [], {
+      requesterId: "user-id",
+    });
+    const finalPayload = interaction.editReply.mock.calls[1]![0] as {content: string; embeds: EditedEmbed[]};
+    expect(finalPayload.embeds[0]?.toJSON()).toEqual({
+      title: "Paywall Bypass",
+      fields: [
+        {
+          name: "Original",
+          value: "<https://example.com/article>",
+        },
+        {
+          name: "Ergebnisse",
+          value: "✅ **archive.today**: <https://archive.ph/newest/https://example.com/article>",
+        },
+      ],
+    });
+  });
+
   test("edits busy message when lookup capacity is exhausted", async () => {
     getPaywallLinksMock.mockRejectedValueOnce(new PaywallLookupCapacityError("requester"));
     const interaction = createPaywallInteraction("https://example.com/article");
@@ -168,6 +201,17 @@ describe("handlePaywallSlashCommand", () => {
 
     expect(interaction.editReply).toHaveBeenLastCalledWith({
       content: paywallLookupBusyMessage,
+    });
+  });
+
+  test("edits generic error message when lookup fails unexpectedly", async () => {
+    getPaywallLinksMock.mockRejectedValueOnce(new Error("lookup failed"));
+    const interaction = createPaywallInteraction("https://example.com/article");
+
+    await expect(handlePaywallSlashCommand(asChatInputInteraction(interaction), "paywall", [])).resolves.toBe(true);
+
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content: "Fehler beim Verarbeiten der Anfrage. Bitte später erneut versuchen.",
     });
   });
 

--- a/modules/slash-commands.interact.test.ts
+++ b/modules/slash-commands.interact.test.ts
@@ -544,6 +544,32 @@ describe("interactSlashCommands", () => {
     randomSpy.mockRestore();
   });
 
+  test("handles 8ball reply failure without throwing", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("8ball");
+    interaction.options.getString.mockImplementation(name => name === "frage" ? "Ist das gut?" : null);
+    interaction.reply.mockRejectedValueOnce(new Error("send failed"));
+
+    await expect(handler(interaction)).resolves.toBeUndefined();
+    const payload = getReplyPayload(interaction);
+    expect(payload.embeds?.[0]?.toJSON()).toEqual({
+      fields: [{
+        name: "Ist das gut?",
+        value: "Antwort unklar.",
+      }],
+    });
+    expect(loggerMock.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("Error replying to 8ball slashcommand"),
+    );
+
+    randomSpy.mockRestore();
+  });
+
   test("replies to lmgtfy command", async () => {
     const {client, getHandler} = createEventClient();
     interactSlashCommands(client, [], [], [], []);
@@ -556,21 +582,6 @@ describe("interactSlashCommands", () => {
 
     expect(interaction.reply).toHaveBeenCalledWith(
       "Let me google that for you... <http://letmegooglethat.com/?q=test%20search>.",
-    );
-  });
-
-  test("replies to google command", async () => {
-    const {client, getHandler} = createEventClient();
-    interactSlashCommands(client, [], [], [], []);
-
-    const handler = getHandler("interactionCreate");
-    const interaction = createChatInputInteraction("google");
-    interaction.options.getString.mockImplementation(name => name === "search" ? "test search" : null);
-
-    await handler(interaction);
-
-    expect(interaction.reply).toHaveBeenCalledWith(
-      "Here you go: <https://www.google.com/search?q=test%20search>.",
     );
   });
 
@@ -725,6 +736,30 @@ describe("interactSlashCommands", () => {
     await handler(interaction);
 
     expect(interaction.reply).toHaveBeenCalledWith("Dieser Inhalt ist gerade nicht verfügbar. Bitte später erneut versuchen.");
+  });
+
+  test("routes paywall command through paywall handler", async () => {
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("paywall");
+    interaction.options.getString.mockImplementation((name, required?: boolean) => {
+      if ("url" === name && true === required) {
+        return "not a url";
+      }
+
+      return null;
+    });
+
+    await handler(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: "Ungültige URL. Bitte eine vollständige URL angeben (z.B. https://www.example.com/article).",
+      ephemeral: true,
+    });
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(getCalendarEventsMock).not.toHaveBeenCalled();
   });
 
   test("replies to whatis with embed and attachment payload", async () => {


### PR DESCRIPTION
## Summary
- adds focused tests for slash command coverage gaps and supporting branch coverage
- removes the fixed `/google` slash command so `/boxspread` fits within the Discord 100-command registration limit
- updates command-cap assertions to expect 14 fixed commands and one additional asset command slot

## Impact
`/boxspread` remains registered while `/google` is removed from the fixed slash command payload and interaction router. `/lmgtfy` remains available.

## Validation
- npm test -- modules/slash-commands.define.test.ts modules/slash-commands.interact.test.ts
- npm test -- modules/bounded-ttl-cache.test.ts modules/broker-api-rate-limit.test.ts modules/slash-commands.interact-paywall.test.ts modules/slash-commands.interact.test.ts
- npm run test:coverage
- npm run typecheck
- git diff --check