### PR TITLE
[codex] raise test coverage to 80 percent

### DIFF
--- a/modules/calendar.test.ts
+++ b/modules/calendar.test.ts
@@ -1,10 +1,32 @@
-import {describe, expect, test} from "vitest";
+import {beforeEach, describe, expect, test, vi} from "vitest";
+
+const {
+  mockLogger,
+  mockPostWithRetry,
+} = vi.hoisted(() => ({
+  mockLogger: {
+    log: vi.fn(),
+  },
+  mockPostWithRetry: vi.fn(),
+}));
+
+vi.mock("./http-retry.ts", () => ({
+  postWithRetry: mockPostWithRetry,
+}));
+
+vi.mock("./logging.ts", () => ({
+  getLogger: () => mockLogger,
+}));
+
 import {
   CALENDAR_CONTINUATION_LABEL,
   CALENDAR_MAX_MESSAGE_LENGTH,
   CalendarEvent,
+  getCalendarEvents,
+  getCalendarEventsResult,
   getCalendarEventDateTime,
   getCalendarMessages,
+  getCalendarText,
 } from "./calendar.ts";
 
 function createCalendarEvent(date: string, time: string, name: string, country = "🇺🇸"): CalendarEvent {
@@ -17,6 +39,15 @@ function createCalendarEvent(date: string, time: string, name: string, country =
 }
 
 describe("getCalendarMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00+02:00"));
+    mockPostWithRetry.mockResolvedValue({
+      data: [],
+    });
+  });
+
   test("converts calendar event date and time into a Berlin timestamp", () => {
     const calendarEvent = createCalendarEvent("2025-03-03", "14:30", "CPI");
 
@@ -46,6 +77,70 @@ describe("getCalendarMessages", () => {
     expect(batch.messages[0]!).toContain("Wichtige Termine:\n\n**Montag, 3. März 2025**");
     expect(batch.messages[0]!).toContain("Event A");
     expect(batch.messages[0]!).toContain("Event B");
+  });
+
+  test("loads calendar events, rolls weekend starts, filters range, and maps country flags", async () => {
+    mockPostWithRetry.mockResolvedValueOnce({
+      data: [
+        {
+          Country: 840,
+          EventName: "US Payrolls",
+          FullDate: "2026-05-04T12:30:00Z",
+        },
+        {
+          Country: 999,
+          EventName: "Eurozone CPI",
+          FullDate: "2026-05-05T08:00:00Z",
+        },
+        {
+          Country: 123,
+          EventName: "Out of range",
+          FullDate: "2026-05-07T08:00:00Z",
+        },
+      ],
+    });
+
+    const result = await getCalendarEventsResult("2026-05-02", 1);
+
+    expect(mockPostWithRetry).toHaveBeenCalledWith(
+      "https://www.mql5.com/en/economic-calendar/content",
+      expect.stringContaining("from=2026-05-04T00%3A00%3A00&to=2026-05-05T23%3A59%3A59"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-Requested-With": "XMLHttpRequest",
+        }),
+      }),
+    );
+    expect(result.status).toBe("ok");
+    expect(result.events.map(event => `${event.time} ${event.country} ${event.name}`)).toEqual([
+      "14:30 🇺🇸 US Payrolls",
+      "10:00 🇪🇺 Eurozone CPI",
+    ]);
+  });
+
+  test("handles empty, short and failed calendar loader responses", async () => {
+    mockPostWithRetry.mockResolvedValueOnce({
+      data: [{
+        Country: 840,
+        EventName: "Ignored singleton",
+        FullDate: "2026-05-01T12:30:00Z",
+      }],
+    });
+    await expect(getCalendarEvents("", 0)).resolves.toEqual([]);
+
+    mockPostWithRetry.mockRejectedValueOnce(new Error("network"));
+    await expect(getCalendarEventsResult("2026-05-03", 0)).resolves.toEqual({
+      events: [],
+      status: "error",
+    });
+    expect(mockLogger.log).toHaveBeenCalledWith("error", expect.stringContaining("Loading calendar failed"));
+  });
+
+  test("formats calendar text wrapper for empty and non-empty event lists", () => {
+    expect(getCalendarText([])).toBe("none");
+    expect(getCalendarText([
+      createCalendarEvent("2025-03-03", "10:00", "Event A"),
+    ])).toContain("Event A");
   });
 
   test("uses a custom title when provided", () => {
@@ -156,6 +251,28 @@ describe("getCalendarMessages", () => {
     expect(batch.messages).toHaveLength(3);
     expect(batch.includedEvents).toBeLessThan(batch.totalEvents);
     expect(batch.messages[2]!).toContain("... weitere Termine konnten wegen Discord-Limits nicht angezeigt werden.");
+  });
+
+  test("supports keepDayTogether false and truncation note fit/fallback paths", () => {
+    const calendarEvents = [
+      createCalendarEvent("2025-03-03", "09:00", `Event A ${"X".repeat(120)}`),
+      createCalendarEvent("2025-03-04", "09:00", `Event B ${"Y".repeat(120)}`),
+    ];
+
+    const roomy = getCalendarMessages(calendarEvents, {
+      maxMessageLength: 220,
+      maxMessages: 1,
+      keepDayTogether: false,
+    });
+    expect(roomy.truncated).toBe(true);
+    expect(roomy.messages[0]).toContain("... weitere Termine konnten wegen Discord-Limits nicht angezeigt werden.");
+
+    const tiny = getCalendarMessages(calendarEvents, {
+      maxMessageLength: 10,
+      maxMessages: 1,
+      keepDayTogether: false,
+    });
+    expect(tiny.messages[0]).toBe("... weiter");
   });
 
   test("keeps each chunk at or below the default Discord-safe message length", () => {

--- a/modules/discord-retry-after.test.ts
+++ b/modules/discord-retry-after.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, test} from "vitest";
+import {
+  getDiscordRateLimitRetryAfterMs,
+  getDiscordRetryAfterHeaderMs,
+  toDiscordRetryAfterFieldMs,
+  toDiscordRetryAfterHeaderMs,
+  toDiscordTimerMs,
+} from "./discord-retry-after.ts";
+
+describe("discord-retry-after", () => {
+  test("normalizes millisecond and retry-after-second fields", () => {
+    expect(toDiscordTimerMs(12.1)).toBe(13);
+    expect(toDiscordTimerMs(" 12.1 ")).toBe(13);
+    expect(toDiscordTimerMs(0)).toBeUndefined();
+    expect(toDiscordTimerMs("")).toBeUndefined();
+    expect(toDiscordTimerMs("nope")).toBeUndefined();
+
+    expect(toDiscordRetryAfterFieldMs(1.2)).toBe(1200);
+    expect(toDiscordRetryAfterFieldMs("1.2")).toBe(1200);
+    expect(toDiscordRetryAfterFieldMs(-1)).toBeUndefined();
+  });
+
+  test("normalizes retry-after headers from seconds and dates", () => {
+    const now = Date.parse("2026-05-01T12:00:00.000Z");
+
+    expect(toDiscordRetryAfterHeaderMs(["2.4"], now)).toBe(2400);
+    expect(toDiscordRetryAfterHeaderMs(3, now)).toBe(3000);
+    expect(toDiscordRetryAfterHeaderMs("Fri, 01 May 2026 12:00:05 GMT", now)).toBe(5000);
+    expect(toDiscordRetryAfterHeaderMs("Fri, 01 May 2026 11:59:59 GMT", now)).toBeUndefined();
+    expect(toDiscordRetryAfterHeaderMs("not a date", now)).toBeUndefined();
+    expect(toDiscordRetryAfterHeaderMs([], now)).toBeUndefined();
+  });
+
+  test("reads retry-after headers from fetch-like and plain header bags", () => {
+    const now = Date.parse("2026-05-01T12:00:00.000Z");
+    const fetchHeaders = {
+      get: (headerName: string) => "retry-after" === headerName ? "1.5" : undefined,
+    };
+
+    expect(getDiscordRetryAfterHeaderMs(fetchHeaders, now)).toBe(1500);
+    expect(getDiscordRetryAfterHeaderMs({"Retry-After": "2"}, now)).toBe(2000);
+    expect(getDiscordRetryAfterHeaderMs({"retry-after": 3}, now)).toBe(3000);
+    expect(getDiscordRetryAfterHeaderMs(null, now)).toBeUndefined();
+    expect(getDiscordRetryAfterHeaderMs({"retry-after": ""}, now)).toBeUndefined();
+  });
+
+  test("uses the largest retry value from known Discord error shapes", () => {
+    const now = Date.parse("2026-05-01T12:00:00.000Z");
+    const error = Object.assign(new Error("limited"), {
+      retryAfterMs: 100,
+      retryAfter: 200,
+      sublimitTimeout: 300,
+      timeToReset: 400,
+      retry_after: 0.5,
+      rawError: {
+        retryAfter: 600,
+        retry_after: 0.7,
+      },
+      headers: {
+        "retry-after": "0.8",
+      },
+      response: {
+        headers: {
+          "retry-after": "0.9",
+        },
+      },
+    });
+
+    expect(getDiscordRateLimitRetryAfterMs(error, now)).toBe(900);
+    expect(getDiscordRateLimitRetryAfterMs("not-error", now)).toBeUndefined();
+    expect(getDiscordRateLimitRetryAfterMs(new Error("plain"), now)).toBeUndefined();
+  });
+});

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -1,10 +1,15 @@
 import {describe, expect, test} from "vitest";
 import {
   decodeHtmlEntities,
+  formatEps,
+  formatUsdCompact,
   getEarningsResultMessage,
   getMessageMetrics,
   htmlToText,
+  normalizeCik,
+  normalizeTickerSymbol,
   parseEarningsDocument,
+  parseNumber,
 } from "./earnings-results-format.ts";
 import {type EarningsEvent} from "./earnings.ts";
 
@@ -202,5 +207,125 @@ describe("earnings result formatting", () => {
     expect(decodeHtmlEntities("A&amp;B &lt;tag&gt; &amp;lt;safe&amp;gt; &#36;1")).toBe(
       "A&B <tag> &lt;safe&gt; $1",
     );
+  });
+
+  test("uses Nasdaq actual EPS when SEC metrics do not contain EPS", () => {
+    const event: EarningsEvent = {
+      ticker: "ABC",
+      when: "after_close",
+      date: "2026-05-01",
+      importance: 1,
+      epsConsensus: "$1.00",
+    };
+
+    const metrics = getMessageMetrics([
+      {
+        key: "revenue",
+        label: "Revenue",
+        numericValue: 99_500_000_000,
+        value: "$99.5B",
+      },
+    ], {
+      actualEps: 1,
+      consensusEps: 1,
+      consensusRevenue: 100_000_000_000,
+    }, event);
+
+    expect(metrics[0]).toMatchObject({
+      key: "nasdaq_eps",
+      estimate: "$1",
+      outcome: "inline",
+      value: "$1",
+    });
+    expect(metrics.find(metric => "revenue" === metric.key)).toMatchObject({
+      estimate: "$100B",
+      outcome: "miss",
+    });
+  });
+
+  test("formats message without quarter, filing items, estimate or outlook", () => {
+    const message = getEarningsResultMessage({
+      companyName: "Example",
+      filing: {
+        form: "10-Q",
+        items: [],
+      },
+      filingUrl: "https://www.sec.gov/example",
+      metrics: [{
+        key: "production",
+        label: "Production",
+        value: "1,200 boepd",
+      }],
+      parsedDocument: {
+        metrics: [],
+        outlook: [],
+      },
+      ticker: " ex ",
+    });
+
+    expect(message).toBe([
+      "💰 **Earnings: Example (`EX`)**",
+      "Production: `1,200 boepd`",
+      "SEC: 10-Q https://www.sec.gov/example",
+    ].join("\n"));
+  });
+
+  test("parses alternate metric shapes and numeric edge cases", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Example reports Q3 2026 results</h1>
+          <p>$ in billions</p>
+          <p>Guidance EPS $9.99</p>
+          <p>GAAP diluted EPS $0.24</p>
+          <p>Net sales were $2.5 billion, up from 2025.</p>
+          <p>Net income was $300 million.</p>
+          <p>Production was 1,234 boepd.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q3 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "gaap_eps",
+        value: "$0.24",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 2_500_000_000,
+        value: "$2.5B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 300_000_000,
+        value: "$300M",
+      }),
+      expect.objectContaining({
+        key: "production",
+        value: "1,234 boepd",
+      }),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$9.99");
+  });
+
+  test("formats and normalizes exported result helpers", () => {
+    expect(parseNumber(1.5)).toBe(1.5);
+    expect(parseNumber(Number.NaN)).toBeNull();
+    expect(parseNumber("(1,234.5)")).toBe(-1234.5);
+    expect(parseNumber("24c")).toBe(0.24);
+    expect(parseNumber("--")).toBeNull();
+    expect(parseNumber({})).toBeNull();
+
+    expect(formatEps(-1.2)).toBe("-$1.2");
+    expect(formatUsdCompact(-1_250_000_000_000)).toBe("-$1.25T");
+    expect(formatUsdCompact(12_300_000)).toBe("$12.3M");
+    expect(formatUsdCompact(123)).toBe("$123");
+
+    expect(normalizeTickerSymbol(" brk-b ")).toBe("BRK.B");
+    expect(normalizeCik(123.9)).toBe("0000000123");
+    expect(normalizeCik("0000012345")).toBe("0000012345");
+    expect(normalizeCik("abc")).toBeNull();
+    expect(normalizeCik(null)).toBeNull();
   });
 });

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -99,4 +99,64 @@ describe("extractOutlookMetrics", () => {
       "EPS $1.20.",
     ])).toEqual([]);
   });
+
+  test("extracts single-value outlook metrics across supported value types", () => {
+    const metrics = extractOutlookMetrics([
+      "Guidance",
+      "Revenue should show double-digit growth.",
+      "Earnings per share expected to be ($0.25).",
+      "Gross margin approximately 44.5%.",
+      "Operating income about $1.2 trillion.",
+      "Opex of $2.4bn.",
+      "Capital expenditures roughly $12m.",
+      "Tax rate not available.",
+    ]);
+
+    expect(metrics).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        value: "double-digit growth",
+      },
+      {
+        key: "eps",
+        label: "EPS",
+        value: "-$0.25",
+      },
+      {
+        key: "gross_margin",
+        label: "Gross margin",
+        value: "44.5%",
+      },
+      {
+        key: "operating_income",
+        label: "Operating income",
+        value: "$1.2T",
+      },
+      {
+        key: "operating_expenses",
+        label: "Operating expenses",
+        value: "$2.4B",
+      },
+      {
+        key: "tax_rate",
+        label: "Tax rate",
+        value: "not available",
+      },
+    ]);
+  });
+
+  test("limits outlook scanning and ignores unusable fallback values", () => {
+    const lines = [
+      "Business Outlook",
+      "Revenue:",
+      `Free cash flow ${"x".repeat(90)}.`,
+    ];
+    for (let index = 0; index < 35; index++) {
+      lines.push(`Filler ${index}`);
+    }
+    lines.push("Revenue $99B");
+
+    expect(extractOutlookMetrics(lines)).toEqual([]);
+  });
 });

--- a/modules/earnings-utils.test.ts
+++ b/modules/earnings-utils.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, test} from "vitest";
+import {
+  formatMarketCapUsdShort,
+  getKnownValueOrFallback,
+  getNormalizedString,
+  getNumericValueFromNasdaqCapString,
+} from "./earnings-utils.ts";
+
+describe("earnings-utils", () => {
+  test("normalizes known string values", () => {
+    expect(getNormalizedString(" value ")).toBe("value");
+    expect(getNormalizedString(" ")).toBeNull();
+    expect(getNormalizedString(123)).toBeNull();
+    expect(getKnownValueOrFallback("  known  ")).toBe("known");
+    expect(getKnownValueOrFallback(" ")).toBe("n/a");
+  });
+
+  test("parses Nasdaq market cap strings", () => {
+    expect(getNumericValueFromNasdaqCapString("$1.2T")).toBe(1_200_000_000_000);
+    expect(getNumericValueFromNasdaqCapString("3.4B")).toBe(3_400_000_000);
+    expect(getNumericValueFromNasdaqCapString("5.6M")).toBe(5_600_000);
+    expect(getNumericValueFromNasdaqCapString("7.8K")).toBe(7_800);
+    expect(getNumericValueFromNasdaqCapString("12,345")).toBe(12345);
+    expect(getNumericValueFromNasdaqCapString("n/a")).toBeNull();
+  });
+
+  test("formats short market caps", () => {
+    expect(formatMarketCapUsdShort(1_200_000_000)).toBe("$1.2B");
+  });
+});

--- a/modules/health-check.test.ts
+++ b/modules/health-check.test.ts
@@ -245,4 +245,30 @@ describe("runHealthCheck", () => {
       }),
     );
   });
+
+  test("normalizes non-Error listener failures", () => {
+    runHealthCheck(() => createState(), mockLogger);
+
+    const errorHandler = mockOn.mock.calls.find(call => "error" === call[0])?.[1] as ((error: unknown) => void) | undefined;
+    errorHandler?.("plain failure");
+
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({
+        error_code: "UNKNOWN",
+        error_message: "plain failure",
+      }),
+    );
+
+    const codedError = Object.assign(new Error("numeric code"), {code: 123});
+    errorHandler?.(codedError);
+
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({
+        error_code: "UNKNOWN",
+        error_message: "numeric code",
+      }),
+    );
+  });
 });

--- a/modules/inline-response.test.ts
+++ b/modules/inline-response.test.ts
@@ -1,4 +1,4 @@
-import {EmojiAsset} from "./assets.ts";
+import {EmojiAsset, TextAsset} from "./assets.ts";
 import {addInlineResponses} from "./inline-response.ts";
 import {createEventClient, createMessage} from "./test-utils/discord-mocks.ts";
 import {beforeEach, describe, expect, test, vi} from "vitest";
@@ -114,6 +114,61 @@ describe("addInlineResponses", () => {
     await handler(message);
 
     expect(message.react).toHaveBeenCalledWith("\ud83d\ude4c");
+  });
+
+  test("uses first array triggerRegex for wo trigger special case", async () => {
+    const {client, getHandler} = createEventClient();
+    const asset = createEmojiAsset("wo", ["\ud83d\ude4c"], ["\\bwo\\b!"] as unknown as string);
+
+    addInlineResponses(client, [asset], ["wo"]);
+
+    const handler = getHandler("messageCreate");
+    const message = createMessage("wo!");
+
+    await handler(message);
+
+    expect(message.react).toHaveBeenCalledWith("\ud83d\ude4c");
+  });
+
+  test("falls back to normal wo trigger matching when special regex is empty", async () => {
+    const {client, getHandler} = createEventClient();
+    const asset = createEmojiAsset("wo", ["\ud83d\ude4c"], [] as unknown as string);
+
+    addInlineResponses(client, [asset], ["wo"]);
+
+    const handler = getHandler("messageCreate");
+    const message = createMessage("wo now");
+
+    await handler(message);
+
+    expect(message.react).toHaveBeenCalledWith("\ud83d\ude4c");
+  });
+
+
+  test("does not react when command token, asset type, response, or trigger boundary do not match", async () => {
+    const {client, getHandler} = createEventClient();
+    const emojiAsset = createEmojiAsset("party", [123]);
+    const textAsset = new TextAsset();
+    textAsset.trigger = ["party"];
+
+    addInlineResponses(client, [
+      emojiAsset,
+      textAsset,
+      createEmojiAsset("cash", ["💵"]),
+    ], ["party", "cash"]);
+
+    const handler = getHandler("messageCreate");
+    const noCommandMessage = createMessage("nothing here");
+    await handler(noCommandMessage);
+    expect(noCommandMessage.react).not.toHaveBeenCalled();
+
+    const invalidResponseMessage = createMessage("party now");
+    await handler(invalidResponseMessage);
+    expect(invalidResponseMessage.react).not.toHaveBeenCalled();
+
+    const boundaryMessage = createMessage("cashflow");
+    await handler(boundaryMessage);
+    expect(boundaryMessage.react).not.toHaveBeenCalled();
   });
 
   test("handles reaction failures without crashing", async () => {

--- a/modules/market-data-stream.test.ts
+++ b/modules/market-data-stream.test.ts
@@ -1,0 +1,84 @@
+import {describe, expect, test} from "vitest";
+import {
+  getPayloadLogPreview,
+  isPotentialMarketDataPayload,
+  normalizeEventData,
+  parseStreamEvent,
+} from "./market-data-stream.ts";
+
+describe("market-data-stream", () => {
+  test("normalizes websocket message data shapes", () => {
+    expect(normalizeEventData("payload")).toBe("payload");
+    expect(normalizeEventData(Buffer.from("buffered"))).toBe("buffered");
+    expect(normalizeEventData(new TextEncoder().encode("array-buffer").buffer)).toBe("array-buffer");
+    expect(normalizeEventData({data: "nope"})).toBeNull();
+  });
+
+  test("parses direct, framed, nested and delimited market stream payloads", () => {
+    expect(parseStreamEvent(JSON.stringify({
+      pid: "123",
+      last_numeric: "1,234.50",
+      pc: "+5.5",
+      pcp: "1.25%",
+    }))).toEqual({
+      pid: 123,
+      lastNumeric: 1234.5,
+      priceChange: 5.5,
+      percentageChange: 1.25,
+    });
+
+    const framed = `a[${JSON.stringify(JSON.stringify({
+      message: JSON.stringify({
+        pid: 456,
+        last_numeric: 99.5,
+        pc: -1.2,
+        pcp: -0.5,
+      }),
+    }))}]`;
+    expect(parseStreamEvent(framed)).toEqual({
+      pid: 456,
+      lastNumeric: 99.5,
+      priceChange: -1.2,
+      percentageChange: -0.5,
+    });
+
+    expect(parseStreamEvent(`prefix::${JSON.stringify({
+      pid: 789,
+      last_numeric: 10,
+      pc: 0.1,
+      pcp: 0.2,
+    })}`)?.pid).toBe(789);
+    expect(parseStreamEvent(`noise ${JSON.stringify({
+      pid: 321,
+      last_numeric: 10,
+      pc: 0,
+      pcp: 0,
+    })} tail`)?.pid).toBe(321);
+  });
+
+  test("rejects malformed or incomplete market stream payloads", () => {
+    expect(parseStreamEvent("")).toBeNull();
+    expect(parseStreamEvent("a[not-json")).toBeNull();
+    expect(parseStreamEvent(JSON.stringify({
+      pid: 123,
+      last_numeric: "missing other fields",
+    }))).toBeNull();
+    expect(parseStreamEvent(JSON.stringify({
+      pid: Number.POSITIVE_INFINITY,
+      last_numeric: 1,
+      pc: 1,
+      pcp: 1,
+    }))).toBeNull();
+  });
+
+  test("detects likely payloads and truncates log previews", () => {
+    expect(isPotentialMarketDataPayload("pid-123::payload")).toBe(true);
+    expect(isPotentialMarketDataPayload("last_numeric")).toBe(true);
+    expect(isPotentialMarketDataPayload("{\"pid\":123}")).toBe(true);
+    expect(isPotentialMarketDataPayload("{\\\"pid\\\":123}")).toBe(true);
+    expect(isPotentialMarketDataPayload("heartbeat")).toBe(false);
+
+    expect(getPayloadLogPreview("  one\n two\tthree  ")).toBe("one two three");
+    expect(getPayloadLogPreview("x".repeat(501))).toBe(`${"x".repeat(500)}...`);
+  });
+});

--- a/modules/options-boxrates.test.ts
+++ b/modules/options-boxrates.test.ts
@@ -137,6 +137,10 @@ describe("options-boxrates", () => {
     })).rejects.toThrow(OptionDeltaInputError);
     await expect(getBoxRatesLookup({
       credentials,
+      months: 25,
+    })).rejects.toThrow(OptionDeltaInputError);
+    await expect(getBoxRatesLookup({
+      credentials,
       notational: 0,
     })).rejects.toThrow(OptionDeltaInputError);
   });
@@ -303,6 +307,54 @@ describe("options-boxrates", () => {
     expect(result.rows[0]?.expiration).toBe("2026-06-19");
   });
 
+  test("filters expired and incomplete chain strikes and falls back to underlying probe price", async () => {
+    const expiredExpiration = createChainExpiration("2026-04-17", 0);
+    const incompleteExpiration = createChainExpiration("2026-05-15", 14);
+    incompleteExpiration.strikes[0]!.callSymbol = null;
+    const validExpiration = createChainExpiration("2026-06-19", 49, [6000, 6500, 7000]);
+    const getSelectedOptionContractsLookupFn = vi.fn(async (request: OptionSelectedContractsLookupRequest) => {
+      if (0 === request.selections.length) {
+        return {
+          contracts: [],
+          symbol: "SPX",
+          underlyingPrice: 6500,
+          underlyingPriceIsRealtime: false,
+        };
+      }
+
+      return {
+        contracts: [
+          createContract(6000, "call", 525, "2026-06-19"),
+          createContract(6000, "put", 50, "2026-06-19"),
+          createContract(7000, "call", 80, "2026-06-19"),
+          createContract(7000, "put", 595, "2026-06-19"),
+        ],
+        symbol: "SPX",
+        underlyingPrice: null,
+        underlyingPriceIsRealtime: false,
+      };
+    });
+
+    const result = await getBoxRatesLookup({
+      credentials,
+      months: 3,
+      notational: 100_000,
+    }, {
+      getOptionChainLookupFn: vi.fn(async () => ({
+        expirations: [expiredExpiration, incompleteExpiration, validExpiration],
+        symbol: "SPX",
+      })),
+      getSelectedOptionContractsLookupFn,
+      getSofrRateFn: createSofrRateLookup(),
+      now: () => Date.parse("2026-05-01T12:00:00Z"),
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.expiration).toBe("2026-06-19");
+    expect(result.underlyingPrice).toBe(6500);
+    expect(formatBoxRatesLookupResult(result)).toContain("`SPX` @ `6,500.00` (market closed)");
+  });
+
   test("formats signed money and basis points", () => {
     const formattedResult = formatBoxRatesLookupResult({
       benchmarkName: "SOFR",
@@ -341,5 +393,27 @@ describe("options-boxrates", () => {
     expect(formattedResult).toContain("Mkt `1.00%-2.00%`");
     expect(formattedResult).toContain("Mkt `wide`");
     expect(formattedResult).toContain("Δ `-100 bps`");
+    expect(() => formatBoxRatesLookupResult({
+      benchmarkName: "SOFR",
+      notational: 100_000,
+      rows: [{
+        actualDte: 1,
+        borrowRate: 0.02,
+        contracts: 1,
+        expiration: "not-a-date",
+        lendRate: 0.01,
+        lowerStrike: 6000,
+        midRate: 0.015,
+        rateDeltaToBenchmark: 0,
+        upperStrike: 7000,
+      }],
+      sofr: {
+        effectiveDate: "2026-04-30",
+        percentRate: 2.5,
+      },
+      symbol: "SPX",
+      underlyingPrice: 6500,
+      underlyingPriceIsRealtime: true,
+    })).toThrow(OptionDeltaDataError);
   });
 });

--- a/modules/options-boxspread.test.ts
+++ b/modules/options-boxspread.test.ts
@@ -1,10 +1,27 @@
 import {describe, expect, test, vi} from "vitest";
+
+const {
+  mockGetWithRetry,
+} = vi.hoisted(() => ({
+  mockGetWithRetry: vi.fn(),
+}));
+
+vi.mock("./http-retry.ts", () => ({
+  getWithRetry: mockGetWithRetry,
+}));
+
 import {
   formatBoxSpreadLookupResult,
   getBoxSpreadLookup,
+  getSofrRate,
   type BoxSpreadDirection,
 } from "./options-boxspread.ts";
-import {type OptionContractsLookupResult, type OptionDeltaContract} from "./options-delta.ts";
+import {
+  type OptionContractsLookupResult,
+  type OptionDeltaContract,
+  OptionDeltaDataError,
+  OptionDeltaInputError,
+} from "./options-delta.ts";
 
 const credentials = {
   clientSecret: "client-secret",
@@ -75,6 +92,46 @@ async function getFormattedBoxSpread(direction: BoxSpreadDirection) {
 }
 
 describe("options-boxspread", () => {
+  test("loads, validates and caches SOFR from the New York Fed response", async () => {
+    mockGetWithRetry
+      .mockResolvedValueOnce({
+        data: {
+          refRates: [],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          refRates: [{
+            effectiveDate: "2026-04-30",
+            percentRate: "3.66",
+            type: "SOFR",
+          }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          refRates: [{
+            effectiveDate: "2026-04-30",
+            percentRate: 3.66,
+            type: "SOFR",
+          }],
+        },
+      });
+
+    await expect(getSofrRate()).rejects.toThrow(OptionDeltaDataError);
+    await expect(getSofrRate()).rejects.toThrow(OptionDeltaDataError);
+
+    await expect(getSofrRate()).resolves.toEqual({
+      effectiveDate: "2026-04-30",
+      percentRate: 3.66,
+    });
+    await expect(getSofrRate()).resolves.toEqual({
+      effectiveDate: "2026-04-30",
+      percentRate: 3.66,
+    });
+    expect(mockGetWithRetry).toHaveBeenCalledTimes(3);
+  });
+
   test("builds and formats an SPX borrow box from the four-leg mid", async () => {
     const {
       formattedResult,
@@ -142,5 +199,118 @@ describe("options-boxspread", () => {
     expect(result.width).toBe(1000);
     expect(result.contracts).toBe(10);
     expect(formatBoxSpreadLookupResult(result)).toContain("Sell 10 Aug21'26 6000 Call");
+  });
+
+  test("rejects invalid direction and notational before market data is used", async () => {
+    const getOptionContractsLookupFn = vi.fn(async () => createContractsLookupResult());
+    const getSofrRateFn = vi.fn(async () => ({
+      effectiveDate: "2026-04-30",
+      percentRate: 3.66,
+    }));
+
+    await expect(getBoxSpreadLookup({
+      credentials,
+      direction: "hold" as BoxSpreadDirection,
+      dte: 112,
+      notational: 100_000,
+    }, {
+      getOptionContractsLookupFn,
+      getSofrRateFn,
+    })).rejects.toThrow(OptionDeltaInputError);
+    await expect(getBoxSpreadLookup({
+      credentials,
+      direction: "borrow",
+      dte: 112,
+      notational: 0,
+    }, {
+      getOptionContractsLookupFn,
+      getSofrRateFn,
+    })).rejects.toThrow(OptionDeltaInputError);
+    expect(getOptionContractsLookupFn).not.toHaveBeenCalled();
+  });
+
+  test("reports unavailable box pairs and non-finite market prices", async () => {
+    await expect(getBoxSpreadLookup({
+      credentials,
+      direction: "borrow",
+      dte: 112,
+      notational: 100_000,
+    }, {
+      getOptionContractsLookupFn: vi.fn(async () => createContractsLookupResult({
+        contracts: [
+          createContract(6000, "call", 560),
+          createContract(6501, "put", 567),
+        ],
+      })),
+      getSofrRateFn: vi.fn(async () => ({
+        effectiveDate: "2026-04-30",
+        percentRate: 3.66,
+      })),
+    })).rejects.toThrow(OptionDeltaDataError);
+
+    await expect(getBoxSpreadLookup({
+      credentials,
+      direction: "borrow",
+      dte: 112,
+      notational: 100_000,
+    }, {
+      getOptionContractsLookupFn: vi.fn(async () => createContractsLookupResult({
+        contracts: [
+          {...createContract(6000, "call", 560), bid: Number.NaN},
+          createContract(6000, "put", 50),
+          createContract(7000, "call", 90),
+          createContract(7000, "put", 567.9),
+        ],
+      })),
+      getSofrRateFn: vi.fn(async () => ({
+        effectiveDate: "2026-04-30",
+        percentRate: 3.66,
+      })),
+    })).rejects.toThrow("Box spread limit price is unavailable.");
+  });
+
+  test("formats rolled expirations, closed markets, ordinal suffixes and negative rate delta", () => {
+    const baseResult = {
+      actualDte: 113,
+      benchmarkName: "SOFR",
+      cashToday: 98_790,
+      contracts: 1,
+      currency: "USD",
+      direction: "borrow" as const,
+      expiration: "2026-08-01",
+      financingAmount: 1_210,
+      impliedRate: 0.03,
+      legs: [
+        {action: "Sell" as const, contract: createContract(6000.5, "call", 560), quantity: 1},
+        {action: "Buy" as const, contract: createContract(6000.5, "put", 50), quantity: 1},
+      ],
+      limitPrice: 987.9,
+      naturalCredit: 985.9,
+      naturalDebit: 989.9,
+      notational: 100_000,
+      rateDeltaToBenchmark: -0.0066,
+      requestedDte: 112,
+      rolled: true,
+      sofr: {
+        effectiveDate: "2026-04-30",
+        percentRate: 3.66,
+      },
+      symbol: "SPX",
+      underlyingPrice: null,
+      underlyingPriceIsRealtime: false,
+      width: 1000.5,
+    };
+
+    const first = formatBoxSpreadLookupResult(baseResult);
+    expect(first).toContain("`SPX` @ `n/a` (market closed)");
+    expect(first).toContain("Expiry `2026-08-01` (`113` DTE, requested `112`)");
+    expect(first).toContain("August 1st, 2026");
+    expect(first).toContain("Δ: `-66 bps`");
+    expect(first).toContain("Sell 1 Aug21'26 6000.50 Call");
+
+    expect(formatBoxSpreadLookupResult({...baseResult, expiration: "2026-08-02"})).toContain("August 2nd, 2026");
+    expect(formatBoxSpreadLookupResult({...baseResult, expiration: "2026-08-03"})).toContain("August 3rd, 2026");
+    expect(formatBoxSpreadLookupResult({...baseResult, expiration: "2026-08-11"})).toContain("August 11th, 2026");
+    expect(() => formatBoxSpreadLookupResult({...baseResult, expiration: "not-a-date"})).toThrow(OptionDeltaDataError);
   });
 });

--- a/modules/options-delta.test.ts
+++ b/modules/options-delta.test.ts
@@ -8,7 +8,9 @@ import {
   formatOptionDeltaLookupResult,
   getOptionDeltaLookup,
   getSelectedOptionContractsLookup,
+  getOptionContractsLookup,
   normalizeOptionSymbol,
+  normalizeDte,
   normalizeTargetDelta,
   OptionDeltaConfigurationError,
   OptionDeltaDataError,
@@ -102,6 +104,9 @@ describe("options-delta", () => {
     expect(() => normalizeOptionSymbol("AAPL$")).toThrow(OptionDeltaInputError);
     expect(normalizeTargetDelta(0.4)).toBe(0.4);
     expect(() => normalizeTargetDelta(1)).toThrow(OptionDeltaInputError);
+    expect(normalizeDte(0)).toBe(0);
+    expect(() => normalizeDte(-1)).toThrow(OptionDeltaInputError);
+    expect(() => normalizeDte(3651)).toThrow(OptionDeltaInputError);
   });
 
   test("parses sdk and raw option-chain shapes and rolls to the next expiration", () => {
@@ -128,6 +133,50 @@ describe("options-delta", () => {
       },
       rolled: true,
     });
+    expect(selectExpirationForDte(sdkExpirations, 3650)).toBeNull();
+  });
+
+  test("ignores malformed option-chain items while preserving valid strikes", () => {
+    expect(parseTastytradeNestedOptionChain(null)).toEqual([]);
+    expect(parseTastytradeNestedOptionChain({
+      items: [
+        null,
+        {
+          expirations: [
+            null,
+            {
+              "expiration-date": "2026-06-19",
+              "days-to-expiration": "49",
+              strikes: [
+                null,
+                {"strike-price": "bad"},
+                {
+                  "strike-price": "450",
+                  call: "AAPL 260619C00450000",
+                  "call-streamer-symbol": ".AAPL260619C450",
+                  put: " ",
+                },
+              ],
+            },
+            {
+              "expiration-date": " ",
+              "days-to-expiration": 56,
+              strikes: [],
+            },
+          ],
+        },
+      ],
+    })).toEqual([{
+      daysToExpiration: 49,
+      expirationDate: "2026-06-19",
+      strikes: [{
+        callStreamerSymbol: ".AAPL260619C450",
+        callSymbol: "AAPL 260619C00450000",
+        putStreamerSymbol: null,
+        putSymbol: null,
+        strike: 450,
+      }],
+    }]);
   });
 
   test("finds contracts below and above an absolute target delta", () => {
@@ -139,6 +188,15 @@ describe("options-delta", () => {
 
     expect(brackets.below?.strike).toBe(450);
     expect(brackets.above?.strike).toBe(445);
+
+    expect(findDeltaBrackets([
+      createOptionContract(430, 0, "call"),
+      createOptionContract(435, Number.NaN, "call"),
+      createOptionContract(440, 1.2, "call"),
+    ], 0.3)).toEqual({
+      above: null,
+      below: null,
+    });
   });
 
   test("fetches the selected expiration and brackets calls and puts from streamed greeks", async () => {
@@ -598,6 +656,115 @@ describe("options-delta", () => {
     expect(rateLimiter.run).not.toHaveBeenCalled();
   });
 
+  test("returns cached contract lookup snapshots and filters one side from both-side cache", async () => {
+    const selectedExpiration = parseTastytradeNestedOptionChain(createNestedOptionChainItems())[1]!;
+    const chainCache = new BoundedTtlCache<ChainExpiration[]>({
+      maxEntries: 10,
+      ttlMs: 60_000,
+    });
+    const contractCache = new BoundedTtlCache<OptionMarketDataSnapshot>({
+      maxEntries: 10,
+      ttlMs: 60_000,
+    });
+    chainCache.set("AAPL", [selectedExpiration]);
+    contractCache.set("AAPL:2026-06-19:call+put", {
+      contracts: [
+        createOptionContract(440, 0.31, "call"),
+        createOptionContract(440, -0.31, "put"),
+      ],
+      underlyingPrice: 190.1,
+    });
+    const rateLimiter = {
+      run: vi.fn(),
+    };
+
+    const result = await getOptionContractsLookup({
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      dte: 49,
+      side: "put",
+      symbol: "aapl",
+    }, {
+      chainCache,
+      clientFactory: vi.fn(),
+      contractCache,
+      now: () => new Date("2026-05-01T20:00:00-04:00").valueOf(),
+      rateLimiter,
+    });
+
+    expect(result.contracts).toHaveLength(1);
+    expect(result.contracts[0]?.optionType).toBe("put");
+    expect(result.underlyingPrice).toBe(190.1);
+    expect(result.underlyingPriceIsRealtime).toBe(false);
+    expect(rateLimiter.run).not.toHaveBeenCalled();
+  });
+
+  test("fetches option contracts with default both side and quote-only underlying price", async () => {
+    let listener: ((events: Record<string, unknown>[]) => void) | undefined;
+    const quoteStreamer = {
+      addEventListener: vi.fn((nextListener: (events: Record<string, unknown>[]) => void) => {
+        listener = nextListener;
+        return undefined as unknown as () => void;
+      }),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(),
+      subscribe: vi.fn((streamerSymbols: string[]) => {
+        listener?.([
+          {eventType: "Quote"},
+          {eventSymbol: "IGNORED", eventType: "Quote", askPrice: 1},
+          {eventSymbol: ".AAPL260619C440", eventType: "Trade", askPrice: 9},
+          ...streamerSymbols.flatMap(streamerSymbol => {
+            if ("AAPL" === streamerSymbol) {
+              return [{
+                eventSymbol: streamerSymbol,
+                eventType: "Quote",
+                askPrice: 190.5,
+              }];
+            }
+
+            return [
+              {
+                eventSymbol: streamerSymbol,
+                eventType: "Quote",
+                askPrice: 2.2,
+              },
+              {
+                eventSymbol: streamerSymbol,
+                eventType: "Greeks",
+                delta: streamerSymbol.includes("P") ? -0.31 : 0.31,
+              },
+            ];
+          }),
+        ]);
+      }),
+    };
+
+    const result = await getOptionContractsLookup({
+      credentials: {
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      dte: 49,
+      symbol: "aapl",
+    }, {
+      ...createLookupDependencies(),
+      clientFactory: () => ({
+        instrumentsService: {
+          getNestedOptionChain: vi.fn(async () => createNestedOptionChainItems()),
+        },
+        quoteStreamer,
+      }),
+      marketDataTimeoutMs: 20,
+    });
+
+    expect(result.requestedSide).toBe("both");
+    expect(result.contracts).toHaveLength(6);
+    expect(result.underlyingPrice).toBe(190.5);
+    expect(quoteStreamer.disconnect).toHaveBeenCalledTimes(1);
+  });
+
   test("reports missing credentials, expirations and streamer symbols as lookup errors", async () => {
     const emptyQuoteStreamer = {
       addEventListener: vi.fn(() => vi.fn()),
@@ -652,6 +819,24 @@ describe("options-delta", () => {
         },
         quoteStreamer: emptyQuoteStreamer,
       }),
+    })).rejects.toThrow(OptionDeltaDataError);
+    const selectedExpiration = parseTastytradeNestedOptionChain(createNestedOptionChainItems())[0]!;
+    const chainCache = new BoundedTtlCache<ChainExpiration[]>({
+      maxEntries: 10,
+      ttlMs: 60_000,
+    });
+    chainCache.set("AAPL", [selectedExpiration]);
+    await expect(getOptionContractsLookup({
+      credentials: baseRequest.credentials,
+      dte: 500,
+      symbol: "AAPL",
+    }, {
+      chainCache,
+      contractCache: new BoundedTtlCache<OptionMarketDataSnapshot>({
+        maxEntries: 10,
+        ttlMs: 60_000,
+      }),
+      rateLimiter: immediateRateLimiter,
     })).rejects.toThrow(OptionDeltaDataError);
   });
 

--- a/modules/options-format.test.ts
+++ b/modules/options-format.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, test} from "vitest";
+import type {OptionDeltaContract} from "./options-delta.ts";
+import {
+  formatOptionDeltaLookupResult,
+  getClosestDeltaContract,
+  getOptionContractSpreadPercent,
+} from "./options-format.ts";
+
+function createContract(strike: number, delta: number, optionType: "call" | "put", bid = 1, ask = 1.2): OptionDeltaContract {
+  return {
+    ask,
+    askSize: 10,
+    bid,
+    bidSize: 10,
+    delta,
+    expirationDate: "2026-06-19",
+    gamma: null,
+    iv: null,
+    optionType,
+    streamerSymbol: `.SPX260619${"call" === optionType ? "C" : "P"}${strike}`,
+    strike,
+    symbol: `SPX 260619${"call" === optionType ? "C" : "P"}${strike}`,
+    theta: null,
+    vega: null,
+  };
+}
+
+describe("options-format", () => {
+  test("selects closest delta contracts and marks wide spreads", () => {
+    const below = createContract(6000, 0.25, "call");
+    const above = createContract(6100, 0.35, "call", 1, 2);
+
+    expect(getClosestDeltaContract({below, above: null}, 0.3)).toBe(below);
+    expect(getClosestDeltaContract({below, above}, 0.34)).toBe(above);
+    expect(getOptionContractSpreadPercent({...above, bid: 0, ask: 0})).toBeNull();
+
+    const formatted = formatOptionDeltaLookupResult({
+      actualDte: 49,
+      expiration: "2026-06-19",
+      requestedDte: 49,
+      requestedSide: "call",
+      rolled: false,
+      sideResults: [{
+        brackets: {
+          above,
+          below,
+        },
+        contractsConsidered: 2,
+        side: "call",
+      }],
+      symbol: "SPX",
+      targetDelta: 0.3,
+      underlyingPrice: 6500,
+      underlyingPriceIsRealtime: true,
+    });
+
+    expect(formatted).toContain("`wide spread`");
+  });
+});

--- a/modules/slash-commands-canonical.test.ts
+++ b/modules/slash-commands-canonical.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, test} from "vitest";
+import {
+  computeSlashRegistrationDiff,
+  getSlashCommandNamesFromPayload,
+  getSlashCommandPayloadHash,
+  hasSlashRegistrationMismatch,
+} from "./slash-commands-canonical.ts";
+
+describe("slash-commands-canonical", () => {
+  test("normalizes command names, options, choices and unsupported payload shapes", () => {
+    const payload = [
+      {
+        name: "beta",
+        description: "Beta",
+        options: [{
+          type: "3",
+          name: "symbol",
+          description: "Symbol",
+          required: true,
+          autocomplete: true,
+          min_value: 1,
+          max_value: 10,
+          min_length: 2,
+          max_length: 5,
+          channel_types: ["0", 11],
+          choices: [
+            {name: "A", value: "a"},
+            "bad-choice",
+          ],
+          options: [
+            {type: 4, name: "nested", description: "Nested"},
+            "bad-option",
+          ],
+        }],
+      },
+      {
+        name: "alpha",
+        description: "Alpha",
+      },
+      "bad-command",
+    ];
+
+    expect(getSlashCommandNamesFromPayload(payload)).toEqual(["alpha", "beta"]);
+    expect(getSlashCommandNamesFromPayload("not-array")).toEqual([]);
+    expect(getSlashCommandPayloadHash(payload)).toContain("\"min_value\":1");
+    expect(getSlashCommandPayloadHash(payload)).toContain("\"channel_types\":[0,11]");
+    expect(getSlashCommandPayloadHash(payload)).toContain("\"name\":\"\"");
+  });
+
+  test("computes missing, unexpected, changed and truncated registration diff", () => {
+    const expected = [
+      {name: "alpha", description: "Alpha"},
+      {name: "beta", description: "Beta"},
+    ];
+    const returned = [
+      {name: "beta", description: "Changed"},
+      {name: "gamma", description: "Gamma"},
+    ];
+
+    const diff = computeSlashRegistrationDiff(expected, returned);
+
+    expect(diff).toEqual({
+      expectedCommandNames: ["alpha", "beta"],
+      returnedCommandNames: ["beta", "gamma"],
+      missingCommandNames: ["alpha"],
+      unexpectedCommandNames: ["gamma"],
+      changedCommandNames: ["beta"],
+      truncated: false,
+    });
+    expect(hasSlashRegistrationMismatch(diff)).toBe(true);
+
+    expect(computeSlashRegistrationDiff(expected, [])).toMatchObject({
+      missingCommandNames: ["alpha", "beta"],
+      truncated: true,
+    });
+    expect(hasSlashRegistrationMismatch(computeSlashRegistrationDiff(expected, expected))).toBe(false);
+  });
+});

--- a/modules/timer-reminders.test.ts
+++ b/modules/timer-reminders.test.ts
@@ -1,0 +1,112 @@
+import {describe, expect, test} from "vitest";
+import {CalendarReminderAsset, EarningsReminderAsset} from "./assets.ts";
+import {CalendarEvent} from "./calendar.ts";
+import type {EarningsEvent} from "./earnings-types.ts";
+import {
+  getAllowedRoleMentions,
+  getCalendarReminderMessage,
+  getEarningsReminderMessage,
+  getMatchedCalendarReminderEventGroups,
+  getMatchedEarningsReminderEvents,
+  getNormalizedRoleId,
+} from "./timer-reminders.ts";
+
+function createCalendarEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  const event = new CalendarEvent();
+  event.date = "2026-05-04";
+  event.time = "14:30";
+  event.country = "🇺🇸";
+  event.name = "ISM Manufacturing PMI";
+  Object.assign(event, overrides);
+  return event;
+}
+
+function createCalendarReminderAsset(overrides: Partial<CalendarReminderAsset> = {}): CalendarReminderAsset {
+  const asset = new CalendarReminderAsset();
+  asset.name = "macro";
+  asset.roleId = "role-1";
+  asset.eventNameSubstrings = [" PMI ", "", "ignored"];
+  asset.countryFlags = ["🇺🇸", ""];
+  Object.assign(asset, overrides);
+  return asset;
+}
+
+function createEarningsReminderAsset(overrides: Partial<EarningsReminderAsset> = {}): EarningsReminderAsset {
+  const asset = new EarningsReminderAsset();
+  asset.roleId = "role-earnings";
+  asset.tickerSymbols = ["BRK/B", "AAPL", "", "msft"];
+  Object.assign(asset, overrides);
+  return asset;
+}
+
+function createEarningsEvent(overrides: Partial<EarningsEvent> = {}): EarningsEvent {
+  return {
+    date: "2026-05-04",
+    importance: 1,
+    ticker: "AAPL",
+    when: "before_open",
+    ...overrides,
+  };
+}
+
+describe("timer-reminders", () => {
+  test("formats role mentions and normalizes role ids", () => {
+    expect(getAllowedRoleMentions("role-1")).toEqual({
+      parse: [],
+      roles: ["role-1"],
+    });
+    expect(getNormalizedRoleId(" role-1 ")).toBe("role-1");
+    expect(getNormalizedRoleId(" ")).toBeUndefined();
+    expect(getNormalizedRoleId(undefined)).toBeUndefined();
+  });
+
+  test("groups matching calendar reminder events and skips invalid assets", () => {
+    const matchingEvent = createCalendarEvent();
+    const duplicateKeyEvent = createCalendarEvent({
+      name: "ISM Manufacturing PMI Final",
+    });
+    const wrongCountryEvent = createCalendarEvent({
+      country: "🇪🇺",
+      name: "Eurozone PMI",
+    });
+    const groups = getMatchedCalendarReminderEventGroups([
+      createCalendarReminderAsset(),
+      createCalendarReminderAsset({roleId: " "}),
+      createCalendarReminderAsset({eventNameSubstrings: []}),
+      createCalendarReminderAsset({countryFlags: ["🇪🇺"]}),
+    ], [
+      matchingEvent,
+      duplicateKeyEvent,
+      wrongCountryEvent,
+    ]);
+
+    expect(groups).toHaveLength(2);
+    const usGroup = groups.find(group => "🇺🇸" === group.events[0]?.country);
+    expect(usGroup?.events).toHaveLength(2);
+    expect(getCalendarReminderMessage("role-1", usGroup?.events ?? [])).toBe(
+      "<@&role-1> Heute wichtig: `14:30` 🇺🇸 ISM Manufacturing PMI, ISM Manufacturing PMI Final",
+    );
+    expect(getCalendarReminderMessage("role-1", [])).toBe("<@&role-1> Heute wichtig:");
+  });
+
+  test("matches earnings reminder tickers, removes duplicates and formats by time bucket", () => {
+    const asset = createEarningsReminderAsset();
+    const matchedEvents = getMatchedEarningsReminderEvents(asset, [
+      createEarningsEvent({ticker: "MSFT", when: "after_close"}),
+      createEarningsEvent({ticker: "BRK-B", when: "during_session"}),
+      createEarningsEvent({ticker: "AAPL", when: "before_open"}),
+      createEarningsEvent({ticker: "AAPL", when: "before_open", importance: 2}),
+      createEarningsEvent({ticker: "TSLA", when: "after_close"}),
+    ]);
+
+    expect(matchedEvents.map(event => `${event.ticker}:${event.when}`)).toEqual([
+      "AAPL:before_open",
+      "BRK-B:during_session",
+      "MSFT:after_close",
+    ]);
+    expect(getEarningsReminderMessage("role-earnings", matchedEvents)).toBe(
+      "<@&role-earnings> Heute Earnings: `AAPL` (vor Handelsbeginn); `BRK.B` (während der Handelszeiten); `MSFT` (nach Handelsschluss)",
+    );
+    expect(getMatchedEarningsReminderEvents(createEarningsReminderAsset({tickerSymbols: []}), matchedEvents)).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         statements: 85,
         lines: 85,
         functions: 84,
-        branches: 74,
+        branches: 80,
         "modules/assets.ts": {
           statements: 94,
           lines: 94,


### PR DESCRIPTION
## Summary
- Add focused tests across calendar, earnings, options, inline response, health check, stream, slash command, reminder, formatting, and retry helpers.
- Raise the global Vitest branch coverage threshold to 80% while keeping the stricter statement, line, and function thresholds.

## Validation
- npm run test:coverage
- npm run typecheck
- git diff --check