### PR TITLE
[codex] fix sec request user agent

### DIFF
--- a/modules/earnings-results-sec.test.ts
+++ b/modules/earnings-results-sec.test.ts
@@ -140,6 +140,15 @@ describe("SEC earnings result source", () => {
     expect(firstMap.has("BAD")).toBe(false);
     expect(secondMap).toBe(firstMap);
     expect(getWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(getWithRetryFn).toHaveBeenCalledWith(
+      "https://www.sec.gov/files/company_tickers.json",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Accept-Encoding": "gzip, deflate",
+          "User-Agent": "hblwrk discord-bot-ts admin@hblwrk.de",
+        }),
+      }),
+    );
   });
 
   test("loads current 8-K and 6-K filings, logs failed feeds, and dedupes accessions", async () => {

--- a/modules/earnings-results-sec.ts
+++ b/modules/earnings-results-sec.ts
@@ -60,8 +60,9 @@ const secTickerMapTtlMs = 24 * 60 * 60_000;
 const secCompanyTickersEndpoint = "https://www.sec.gov/files/company_tickers.json";
 const secCurrentFilingsEndpoint = "https://www.sec.gov/cgi-bin/browse-edgar";
 const secRequestHeaders = {
-  "User-Agent": "hblwrk-discord-bot/1.0 github.com/hblwrk/discord-bot-ts",
+  "User-Agent": "hblwrk discord-bot-ts admin@hblwrk.de",
   "Accept": "application/json, text/plain, */*",
+  "Accept-Encoding": "gzip, deflate",
 };
 
 let secTickerMapCache: SecTickerMapCache | undefined;


### PR DESCRIPTION
## Summary

Updates SEC EDGAR requests to use a declared contact-style User-Agent that SEC accepts under its fair-access filtering.

## Root Cause

The previous SEC User-Agent identified only the project URL. SEC returned HTTP 403 for the ticker map request with that header, while a contact-style User-Agent for the same endpoint returned HTTP 200.

## Impact

Earnings result scans can load `company_tickers.json` again and avoid skipping scans because the SEC ticker map request is blocked.

## Validation

- `npm test -- modules/earnings-results-sec.test.ts modules/earnings-results.test.ts`
- `npm run typecheck`
