### PR TITLE
[codex] add tastytrade crypto quote streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ SEC: 8-K Item 2.02, 9.01 https://www.sec.gov/Archives/edgar/data/320193/00003201
 
 ## Market data
 
-Real-time market-data is being pulled in through a Websocket connection and distributed via Discord bot nickname and presence information. Those bots can be joined to the server separately and their runtime information is managed as an asset. They require no oAuth2 scopes other than "bot".
+Real-time market-data is pulled in through websocket connections and distributed via Discord bot nickname and presence information. Those bots can be joined to the server separately and their runtime information is managed as an asset. They require no oAuth2 scopes other than "bot". Crypto market-data assets with a `tastytradeStreamerSymbol` use tastytrade quote streaming first and fall back to the existing Investing.com stream with capped exponential retry backoff; crypto assets without that field use Investing.com only.
 
 The `/delta` command uses tastytrade OAuth read access for option chains and live quote-streamer snapshots. It selects the first expiration on or after the requested DTE and returns the current underlying quote plus the call and put strikes around the requested absolute delta, including bid, mid, ask, size and IV. Option command headers mark the underlying quote as `market closed` outside US cash-market hours. Broker-backed option-data lookups are serialized, spaced by 10 seconds, and protected by a bounded queue.
 

--- a/assets/marketdata.yaml
+++ b/assets/marketdata.yaml
@@ -80,6 +80,7 @@
   suffix: "$"
   unit: "PCT"
   marketHours: "crypto"
+  tastytradeStreamerSymbol: "BTC/USD:CXTALP"
   decimals: 2
   lastUpdate: 0
   order: 0
@@ -94,6 +95,7 @@
   suffix: "$"
   unit: "PCT"
   marketHours: "crypto"
+  tastytradeStreamerSymbol: "ETH/USD:CXTALP"
   decimals: 2
   lastUpdate: 0
   order: 1
@@ -108,6 +110,7 @@
   suffix: "$"
   unit: "PCT"
   marketHours: "crypto"
+  tastytradeStreamerSymbol: "SOL/USD:CXTALP"
   decimals: 2
   lastUpdate: 0
   order: 2

--- a/modules/assets.test.ts
+++ b/modules/assets.test.ts
@@ -152,7 +152,8 @@ describe("getAssets", () => {
         id: 1175151,
         suffix: "$",
         unit: "PCT",
-        marketHours: "us_cash",
+        marketHours: "crypto",
+        tastytradeStreamerSymbol: "BTC/USD:CXTALP",
         decimals: 2,
         order: 1,
       }],
@@ -201,7 +202,8 @@ describe("getAssets", () => {
 
     expect(marketAsset?.botToken).toBe("market-token");
     expect(marketAsset?.botClientId).toBe("market-client-id");
-    expect(marketAsset?.marketHours).toBe("us_cash");
+    expect(marketAsset?.marketHours).toBe("crypto");
+    expect(marketAsset?.tastytradeStreamerSymbol).toBe("BTC/USD:CXTALP");
     expect(roleAsset?.trigger).toEqual(["role-message-id"]);
     expect(roleAsset?.id).toBe("role-id");
     expect(paywallAsset?.name).toBe("default");

--- a/modules/assets.ts
+++ b/modules/assets.ts
@@ -3,11 +3,35 @@ import yaml from "js-yaml";
 import fs from "node:fs";
 import {getFromDracoon} from "./dracoon-downloader.ts";
 import {getLogger} from "./logging.ts";
+import {type MarketHoursProfile} from "./market-data-types.ts";
 import {readSecret} from "./secrets.ts";
 
 const directory = "./assets";
 const fileExtension = ".yaml";
 const logger = getLogger();
+const supportedMarketHoursProfiles = new Set<string>([
+  "crypto",
+  "eu_cash",
+  "forex",
+  "us_cash",
+  "us_futures",
+]);
+
+function normalizeMarketHoursProfile(marketHours: string): MarketHoursProfile | undefined {
+  const normalizedMarketHours = marketHours.trim();
+  if (true === supportedMarketHoursProfiles.has(normalizedMarketHours)) {
+    return normalizedMarketHours as MarketHoursProfile;
+  }
+
+  if ("" !== normalizedMarketHours) {
+    logger.log(
+      "warn",
+      `Ignoring unsupported market data hours profile: ${normalizedMarketHours}`,
+    );
+  }
+
+  return undefined;
+}
 
 class BaseAsset {
   private _downloadFailed = false;
@@ -62,7 +86,8 @@ export class MarketDataAsset extends BaseAsset {
   private _id = 0;
   private _suffix = "";
   private _unit = "";
-  private _marketHours = "";
+  private _marketHours: MarketHoursProfile | undefined;
+  private _tastytradeStreamerSymbol = "";
   private _decimals = 0;
   private _lastUpdate = 0;
   private _order = 0;
@@ -131,12 +156,20 @@ export class MarketDataAsset extends BaseAsset {
     this._unit = unit;
   }
 
-  public get marketHours() {
+  public get marketHours(): MarketHoursProfile | undefined {
     return this._marketHours;
   }
 
-  public set marketHours(marketHours: string) {
-    this._marketHours = marketHours;
+  public set marketHours(marketHours: string | undefined) {
+    this._marketHours = normalizeMarketHoursProfile(marketHours ?? "");
+  }
+
+  public get tastytradeStreamerSymbol() {
+    return this._tastytradeStreamerSymbol;
+  }
+
+  public set tastytradeStreamerSymbol(tastytradeStreamerSymbol: string) {
+    this._tastytradeStreamerSymbol = tastytradeStreamerSymbol.trim();
   }
 
   public get decimals() {

--- a/modules/market-data-tastytrade.test.ts
+++ b/modules/market-data-tastytrade.test.ts
@@ -1,0 +1,278 @@
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {MarketDataSubscriptionType} from "@tastytrade/api";
+import {
+  startTastytradeCryptoStream,
+  type TastytradeCryptoStreamOptions,
+} from "./market-data-tastytrade.ts";
+import {type MarketDataAsset} from "./market-data-types.ts";
+
+type StreamerListener = (events: Record<string, unknown>[]) => void;
+
+function createCryptoAsset(overrides: Partial<MarketDataAsset> = {}): MarketDataAsset {
+  return {
+    botToken: "token",
+    botClientId: "btc-client",
+    botName: "Bitcoin/USD",
+    id: 1057391,
+    suffix: "$",
+    unit: "PCT",
+    marketHours: "crypto",
+    tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+    decimals: 2,
+    lastUpdate: 0,
+    order: 0,
+    ...overrides,
+  };
+}
+
+function createStreamer() {
+  let listener: StreamerListener | undefined;
+  return {
+    streamer: {
+      addEventListener: vi.fn((newListener: StreamerListener) => {
+        listener = newListener;
+        return vi.fn(() => {
+          listener = undefined;
+        });
+      }),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      subscribe: vi.fn(),
+    },
+    emit: (events: Record<string, unknown>[]) => {
+      listener?.(events);
+    },
+  };
+}
+
+function createOptions(overrides: Partial<TastytradeCryptoStreamOptions> = {}): TastytradeCryptoStreamOptions {
+  const stream = createStreamer();
+  return {
+    assets: [createCryptoAsset()],
+    clientFactory: vi.fn(() => ({
+      quoteStreamer: stream.streamer,
+    })),
+    logger: {
+      log: vi.fn(),
+    },
+    onFallback: vi.fn(),
+    onMarketData: vi.fn(),
+    onRecovered: vi.fn(),
+    random: () => 0.5,
+    readSecretFn: vi.fn(secretName => {
+      if ("tastytrade_client_secret" === secretName) {
+        return "client-secret";
+      }
+
+      if ("tastytrade_refresh_token" === secretName) {
+        return "refresh-token";
+      }
+
+      return "";
+    }),
+    ...overrides,
+  };
+}
+
+async function flushAsyncWork() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("tastytrade crypto market data stream", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-02T12:00:00.000Z"));
+    vi.clearAllMocks();
+  });
+
+  test("subscribes crypto streamer symbols and emits trade prices", async () => {
+    const stream = createStreamer();
+    const options = createOptions({
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    expect(stream.streamer.connect).toHaveBeenCalledTimes(1);
+    expect(stream.streamer.subscribe).toHaveBeenCalledWith(
+      ["BTC/USD:CXTALP"],
+      [
+        MarketDataSubscriptionType.Trade,
+        MarketDataSubscriptionType.Quote,
+        MarketDataSubscriptionType.Summary,
+      ],
+    );
+
+    stream.emit([{
+      eventSymbol: "BTC/USD:CXTALP",
+      eventType: "Trade",
+      price: 100,
+      priceChange: 1.5,
+      percentageChange: 1.52,
+    }]);
+
+    expect(options.onRecovered).toHaveBeenCalledTimes(1);
+    expect(options.onMarketData).toHaveBeenCalledWith(
+      expect.objectContaining({botClientId: "btc-client"}),
+      100,
+      1.5,
+      1.52,
+    );
+  });
+
+  test("uses quote mid price when bid and ask are available", async () => {
+    const stream = createStreamer();
+    const options = createOptions({
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    stream.emit([{
+      "event-symbol": "BTC/USD:CXTALP",
+      "event-type": "Quote",
+      "bid-price": 99,
+      "ask-price": 101,
+    }]);
+
+    expect(options.onMarketData).toHaveBeenCalledWith(
+      expect.objectContaining({botClientId: "btc-client"}),
+      100,
+      0,
+      0,
+    );
+  });
+
+  test("falls back and retries with capped exponential backoff when connect fails", async () => {
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("down"))
+      .mockRejectedValueOnce(new Error("still down"));
+    const stream = createStreamer();
+    stream.streamer.connect = connect;
+    const options = createOptions({
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    expect(options.onFallback).toHaveBeenCalledWith("Error: down");
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await flushAsyncWork();
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(options.onFallback).toHaveBeenLastCalledWith("Error: still down");
+
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(connect).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushAsyncWork();
+    expect(connect).toHaveBeenCalledTimes(3);
+  });
+
+  test("falls back when a connected stream stays stale and recovers on the next valid event", async () => {
+    const stream = createStreamer();
+    const options = createOptions({
+      assets: [createCryptoAsset({botClientId: "stale-btc-client"})],
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    await flushAsyncWork();
+
+    expect(options.onFallback).toHaveBeenCalledWith("no valid crypto quote for 300s");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flushAsyncWork();
+    stream.emit([{
+      eventSymbol: "BTC/USD:CXTALP",
+      eventType: "Trade",
+      price: 101,
+    }]);
+
+    expect(options.onRecovered).toHaveBeenCalledTimes(1);
+    expect(options.onMarketData).toHaveBeenCalledWith(
+      expect.objectContaining({botClientId: "stale-btc-client"}),
+      101,
+      0,
+      0,
+    );
+  });
+
+  test("falls back only the stale crypto symbol while other tastytrade symbols remain live", async () => {
+    const stream = createStreamer();
+    const btcAsset = createCryptoAsset({
+      botClientId: "btc-client",
+      tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+    });
+    const ethAsset = createCryptoAsset({
+      botClientId: "eth-client",
+      tastytradeStreamerSymbol: "ETH/USD:CXTALP",
+    });
+    const options = createOptions({
+      assets: [btcAsset, ethAsset],
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    stream.emit([{
+      eventSymbol: "BTC/USD:CXTALP",
+      eventType: "Trade",
+      price: 100,
+    }]);
+    await vi.advanceTimersByTimeAsync(299_999);
+    stream.emit([{
+      eventSymbol: "BTC/USD:CXTALP",
+      eventType: "Trade",
+      price: 101,
+    }]);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushAsyncWork();
+
+    expect(options.onFallback).toHaveBeenCalledWith(
+      "no valid ETH/USD:CXTALP crypto quote for 300s",
+      ethAsset,
+    );
+    expect(options.onFallback).not.toHaveBeenCalledWith(
+      expect.stringContaining("BTC/USD:CXTALP"),
+      btcAsset,
+    );
+  });
+
+  test("missing credentials fall back without overlapping retry attempts", async () => {
+    const options = createOptions({
+      readSecretFn: vi.fn(() => ""),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flushAsyncWork();
+
+    expect(options.clientFactory).not.toHaveBeenCalled();
+    expect(options.onFallback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/modules/market-data-tastytrade.ts
+++ b/modules/market-data-tastytrade.ts
@@ -1,0 +1,416 @@
+import TastytradeClient, {MarketDataSubscriptionType} from "@tastytrade/api";
+import WS from "ws";
+import {type MarketDataAsset} from "./market-data-types.ts";
+import {readSecret} from "./secrets.ts";
+
+type Logger = {
+  log: (level: string, message: unknown) => void;
+};
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+type TastytradeEvent = Record<string, unknown>;
+type TastytradeEventListener = (events: TastytradeEvent[]) => void;
+type TastytradeQuoteStreamer = {
+  addEventListener: (listener: TastytradeEventListener) => () => void;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  subscribe: (streamerSymbols: string[], types?: MarketDataSubscriptionType[] | null) => void;
+};
+type TastytradeMarketDataClient = {
+  quoteStreamer: TastytradeQuoteStreamer;
+};
+type TastytradeMarketDataClientFactory = (credentials: {
+  clientSecret: string;
+  refreshToken: string;
+}) => TastytradeMarketDataClient;
+
+type CryptoStreamAsset = {
+  asset: MarketDataAsset;
+  streamerSymbol: string;
+};
+
+export type TastytradeCryptoStreamOptions = {
+  assets: MarketDataAsset[];
+  clearTimeoutFn?: typeof clearTimeout;
+  clientFactory?: TastytradeMarketDataClientFactory;
+  logger: Logger;
+  now?: () => number;
+  onFallback: (reason: string, asset?: MarketDataAsset) => void;
+  onMarketData: (asset: MarketDataAsset, lastNumeric: number, priceChange: number, percentageChange: number) => void;
+  onRecovered: () => void;
+  random?: () => number;
+  readSecretFn?: typeof readSecret;
+  setTimeoutFn?: typeof setTimeout;
+};
+
+export type TastytradeCryptoStreamHandle = {
+  stop: () => void;
+};
+
+const retryBaseDelayMs = 30_000;
+const retryMaxDelayMs = 30 * 60_000;
+const retryJitterRatio = 0.2;
+const staleTimeoutMs = 300_000;
+const staleCheckIntervalMs = 30_000;
+const quoteSubscriptionTypes = [
+  MarketDataSubscriptionType.Trade,
+  MarketDataSubscriptionType.Quote,
+  MarketDataSubscriptionType.Summary,
+];
+
+const webSocketGlobal = globalThis as typeof globalThis & {
+  WebSocket?: unknown;
+};
+
+export function startTastytradeCryptoStream({
+  assets,
+  clearTimeoutFn = clearTimeout,
+  clientFactory = createTastytradeMarketDataClient,
+  logger,
+  now = () => Date.now(),
+  onFallback,
+  onMarketData,
+  onRecovered,
+  random = Math.random,
+  readSecretFn = readSecret,
+  setTimeoutFn = setTimeout,
+}: TastytradeCryptoStreamOptions): TastytradeCryptoStreamHandle {
+  const streamAssets = getCryptoStreamAssets(assets);
+  if (0 === streamAssets.length) {
+    return {
+      stop: () => {},
+    };
+  }
+
+  const assetByStreamerSymbol = new Map<string, MarketDataAsset>();
+  for (const streamAsset of streamAssets) {
+    assetByStreamerSymbol.set(streamAsset.streamerSymbol, streamAsset.asset);
+  }
+
+  let client: TastytradeMarketDataClient | undefined;
+  let connectedAtMs = 0;
+  let lastValidEventAtMs = 0;
+  const lastValidEventAtBySymbol = new Map<string, number>();
+  const fallbackSymbols = new Set<string>();
+  let live = false;
+  let reconnecting = false;
+  let retryDelayMs = retryBaseDelayMs;
+  let retryTimer: TimerHandle | undefined;
+  let staleTimer: TimerHandle | undefined;
+  let removeListener: (() => void) | undefined;
+  let stopped = false;
+  const previousPrices = new Map<string, number>();
+
+  const disconnect = () => {
+    if (undefined !== removeListener) {
+      removeListener();
+      removeListener = undefined;
+    }
+
+    if (undefined !== client) {
+      client.quoteStreamer.disconnect();
+      client = undefined;
+    }
+
+    connectedAtMs = 0;
+    live = false;
+  };
+
+  const clearTimer = (timer: TimerHandle | undefined) => {
+    if (undefined !== timer) {
+      clearTimeoutFn(timer);
+    }
+  };
+
+  const scheduleRetry = (reason: string) => {
+    clearTimer(retryTimer);
+    if (true === stopped) {
+      return;
+    }
+
+    const jitterMultiplier = 1 - retryJitterRatio + (random() * retryJitterRatio * 2);
+    const retryInMs = Math.round(retryDelayMs * jitterMultiplier);
+    logger.log(
+      "warn",
+      `Tastytrade crypto stream unavailable: ${reason}. Retrying in ${Math.round(retryInMs / 1000)}s.`,
+    );
+    retryTimer = setTimeoutFn(() => {
+      void connect();
+    }, retryInMs);
+    retryTimer.unref();
+    retryDelayMs = Math.min(retryDelayMs * 2, retryMaxDelayMs);
+  };
+
+  const fail = (reason: string) => {
+    clearTimer(staleTimer);
+    disconnect();
+    onFallback(reason);
+    scheduleRetry(reason);
+  };
+
+  const handleEvents: TastytradeEventListener = events => {
+    for (const event of events) {
+      const streamEvent = parseTastytradeCryptoEvent(event, assetByStreamerSymbol);
+      if (null === streamEvent) {
+        continue;
+      }
+
+      const previousPrice = previousPrices.get(getAssetKey(streamEvent.asset)) ?? null;
+      const priceChange = streamEvent.priceChange ?? (
+        null === previousPrice ? 0 : streamEvent.lastNumeric - previousPrice
+      );
+      const percentageChange = streamEvent.percentageChange ?? (
+        null === previousPrice || 0 === previousPrice
+          ? 0
+          : ((streamEvent.lastNumeric - previousPrice) / previousPrice) * 100
+      );
+
+      previousPrices.set(getAssetKey(streamEvent.asset), streamEvent.lastNumeric);
+      const eventTimeMs = now();
+      lastValidEventAtMs = eventTimeMs;
+      lastValidEventAtBySymbol.set(streamEvent.streamerSymbol, eventTimeMs);
+      fallbackSymbols.delete(streamEvent.streamerSymbol);
+      if (false === live) {
+        live = true;
+        retryDelayMs = retryBaseDelayMs;
+        onRecovered();
+      }
+
+      onMarketData(streamEvent.asset, streamEvent.lastNumeric, priceChange, percentageChange);
+    }
+  };
+
+  const scheduleStaleCheck = () => {
+    clearTimer(staleTimer);
+    if (true === stopped) {
+      return;
+    }
+
+    staleTimer = setTimeoutFn(() => {
+      const currentTimeMs = now();
+      const streamReferenceTimeMs = lastValidEventAtMs || connectedAtMs;
+      if (0 !== streamReferenceTimeMs && currentTimeMs - streamReferenceTimeMs >= staleTimeoutMs) {
+        fail(`no valid crypto quote for ${Math.floor((currentTimeMs - streamReferenceTimeMs) / 1000)}s`);
+        return;
+      }
+
+      for (const streamAsset of streamAssets) {
+        const symbolReferenceTimeMs = lastValidEventAtBySymbol.get(streamAsset.streamerSymbol) ?? connectedAtMs;
+        if (0 === symbolReferenceTimeMs ||
+            currentTimeMs - symbolReferenceTimeMs < staleTimeoutMs ||
+            true === fallbackSymbols.has(streamAsset.streamerSymbol)) {
+          continue;
+        }
+
+        fallbackSymbols.add(streamAsset.streamerSymbol);
+        onFallback(
+          `no valid ${streamAsset.streamerSymbol} crypto quote for ${Math.floor((currentTimeMs - symbolReferenceTimeMs) / 1000)}s`,
+          streamAsset.asset,
+        );
+      }
+
+      scheduleStaleCheck();
+    }, staleCheckIntervalMs);
+    staleTimer.unref();
+  };
+
+  const connect = async () => {
+    if (true === stopped || true === reconnecting) {
+      return;
+    }
+
+    reconnecting = true;
+    clearTimer(retryTimer);
+
+    try {
+      ensureWebSocketGlobal();
+      const clientSecret = readSecretFn("tastytrade_client_secret").trim();
+      const refreshToken = readSecretFn("tastytrade_refresh_token").trim();
+      if ("" === clientSecret || "" === refreshToken) {
+        throw new Error("tastytrade credentials are missing");
+      }
+
+      disconnect();
+      client = clientFactory({clientSecret, refreshToken});
+      removeListener = client.quoteStreamer.addEventListener(handleEvents);
+      await client.quoteStreamer.connect();
+      connectedAtMs = now();
+      lastValidEventAtMs = 0;
+      lastValidEventAtBySymbol.clear();
+      fallbackSymbols.clear();
+      client.quoteStreamer.subscribe(
+        streamAssets.map(streamAsset => streamAsset.streamerSymbol),
+        quoteSubscriptionTypes,
+      );
+      logger.log(
+        "info",
+        `Tastytrade crypto stream subscribed to ${streamAssets.length} symbols.`,
+      );
+      scheduleStaleCheck();
+    } catch (error) {
+      fail(String(error));
+    } finally {
+      reconnecting = false;
+    }
+  };
+
+  void connect();
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearTimer(retryTimer);
+      clearTimer(staleTimer);
+      disconnect();
+    },
+  };
+}
+
+function createTastytradeMarketDataClient(credentials: {
+  clientSecret: string;
+  refreshToken: string;
+}): TastytradeMarketDataClient {
+  return new TastytradeClient({
+    baseUrl: "https://api.tastyworks.com",
+    accountStreamerUrl: "wss://streamer.tastyworks.com",
+    clientSecret: credentials.clientSecret,
+    refreshToken: credentials.refreshToken,
+    oauthScopes: ["read"],
+  });
+}
+
+function ensureWebSocketGlobal() {
+  if (undefined === webSocketGlobal.WebSocket) {
+    webSocketGlobal.WebSocket = WS as unknown as typeof webSocketGlobal.WebSocket;
+  }
+}
+
+function getCryptoStreamAssets(assets: MarketDataAsset[]): CryptoStreamAsset[] {
+  return assets.flatMap(asset => {
+    if ("crypto" !== asset.marketHours) {
+      return [];
+    }
+
+    const streamerSymbol = asset.tastytradeStreamerSymbol?.trim();
+    if (!streamerSymbol) {
+      return [];
+    }
+
+    return [{
+      asset,
+      streamerSymbol,
+    }];
+  });
+}
+
+function getAssetKey(asset: MarketDataAsset): string {
+  return asset.botClientId || asset.name || String(asset.id);
+}
+
+function parseTastytradeCryptoEvent(
+  event: TastytradeEvent,
+  assetByStreamerSymbol: Map<string, MarketDataAsset>,
+): {
+  asset: MarketDataAsset;
+  lastNumeric: number;
+  percentageChange: number | null;
+  priceChange: number | null;
+  streamerSymbol: string;
+} | null {
+  const eventSymbol = getStringField(event, ["eventSymbol", "event-symbol", "symbol"]);
+  if (null === eventSymbol) {
+    return null;
+  }
+
+  const asset = assetByStreamerSymbol.get(eventSymbol);
+  if (!asset) {
+    return null;
+  }
+
+  const eventType = getStringField(event, ["eventType", "event-type", "type"]);
+  if (null !== eventType && false === quoteSubscriptionTypes.includes(eventType as MarketDataSubscriptionType)) {
+    return null;
+  }
+
+  const lastNumeric = getEventPrice(event);
+  if (null === lastNumeric) {
+    return null;
+  }
+
+  return {
+    asset,
+    lastNumeric,
+    percentageChange: getNumericField(event, [
+      "percentageChange",
+      "percentage-change",
+      "percentChange",
+      "percent-change",
+      "changePercent",
+      "change-percent",
+    ]),
+    priceChange: getNumericField(event, [
+      "priceChange",
+      "price-change",
+      "netChange",
+      "net-change",
+      "dayChange",
+      "day-change",
+      "change",
+    ]),
+    streamerSymbol: eventSymbol,
+  };
+}
+
+function getEventPrice(event: TastytradeEvent): number | null {
+  const bidPrice = getNumericField(event, ["bidPrice", "bid-price"]);
+  const askPrice = getNumericField(event, ["askPrice", "ask-price"]);
+  if (null !== bidPrice && null !== askPrice) {
+    return (bidPrice + askPrice) / 2;
+  }
+
+  return getNumericField(event, [
+    "price",
+    "lastPrice",
+    "last-price",
+    "last",
+    "dayClosePrice",
+    "day-close-price",
+  ]);
+}
+
+function getStringField(event: TastytradeEvent, fieldNames: string[]): string | null {
+  for (const fieldName of fieldNames) {
+    const value = event[fieldName];
+    if ("string" === typeof value && "" !== value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+function getNumericField(event: TastytradeEvent, fieldNames: string[]): number | null {
+  for (const fieldName of fieldNames) {
+    const parsedValue = parseNumericValue(event[fieldName]);
+    if (null !== parsedValue) {
+      return parsedValue;
+    }
+  }
+
+  return null;
+}
+
+function parseNumericValue(value: unknown): number | null {
+  if ("number" === typeof value && Number.isFinite(value)) {
+    return value;
+  }
+
+  if ("string" === typeof value) {
+    const parsedValue = Number(value.replaceAll(",", "").replace("%", "").trim());
+    if (Number.isFinite(parsedValue)) {
+      return parsedValue;
+    }
+  }
+
+  return null;
+}

--- a/modules/market-data-types.ts
+++ b/modules/market-data-types.ts
@@ -1,4 +1,5 @@
 export type MarketHoursProfile = "crypto" | "eu_cash" | "forex" | "us_cash" | "us_futures";
+export type MarketDataSource = "investing" | "tastytrade";
 export type DiscordPresenceStatus = "dnd" | "idle" | "invisible" | "online";
 
 export type MarketDataAsset = {
@@ -10,6 +11,7 @@ export type MarketDataAsset = {
   suffix: string;
   unit: string;
   marketHours?: MarketHoursProfile;
+  tastytradeStreamerSymbol?: string;
   decimals: number;
   lastUpdate: number;
   order: number;
@@ -30,6 +32,7 @@ export type ClientStatusState = {
 
 export type PendingClientStatusUpdate = {
   marketDataAsset: MarketDataAsset;
+  marketDataSource: MarketDataSource;
   nickname: string;
   openPresence: string;
   lastNumeric: number;
@@ -46,6 +49,7 @@ export type MarketPresenceData = {
 
 export type AppliedMarketDataUpdateLog = {
   source: "market-close-reconciler" | "stream-flush";
+  marketDataSource?: MarketDataSource;
   marketDataAsset: MarketDataAsset;
   nickname?: string | null;
   presence: string;
@@ -56,6 +60,7 @@ export type AppliedMarketDataUpdateLog = {
 };
 
 export type IncomingMarketDataUpdateLog = {
+  source: MarketDataSource;
   marketDataAsset: MarketDataAsset;
   botReady: boolean;
   nickname: string;

--- a/modules/market-data.test.ts
+++ b/modules/market-data.test.ts
@@ -11,6 +11,7 @@ import {
   mockGetAssets,
   mockLogger,
   mockReadSecret,
+  mockStartTastytradeCryptoStream,
   mockWebSocketConstructor,
   queuedClientIds,
   updateMarketData,
@@ -757,6 +758,140 @@ describe("updateMarketData", () => {
     expect(clientInstances[0]!.setNickname).toHaveBeenLastCalledWith("1⬛ 101.50$");
     expect(clientInstances[0]!.client.user.setPresence).toHaveBeenLastCalledWith(
       buildPresencePayload("Market closed.", "idle"),
+    );
+  });
+
+  test("uses tastytrade crypto updates and ignores Investing.com while tastytrade is active", async () => {
+    queuedClientIds.push("client-1");
+    const cryptoAsset = {
+      botToken: "token-1",
+      botName: "Bitcoin/USD",
+      botClientId: "client-1",
+      id: 1057391,
+      decimals: 2,
+      order: 0,
+      suffix: "$",
+      unit: "PCT",
+      marketHours: "crypto",
+      tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+      lastUpdate: 0,
+    };
+    mockGetAssets.mockResolvedValue([cryptoAsset]);
+
+    await updateMarketData();
+    clientInstances[0]!.handlers.get("clientReady")();
+
+    const tastytradeOptions = mockStartTastytradeCryptoStream.mock.calls[0]![0] as unknown as {
+      onMarketData: (asset: typeof cryptoAsset, lastNumeric: number, priceChange: number, percentageChange: number) => void;
+    };
+    tastytradeOptions.onMarketData(cryptoAsset, 100.5, 1.2, 1.23);
+    await flushAsyncWork();
+
+    expect(clientInstances[0]!.setNickname).toHaveBeenCalledWith("0🟩 100.50$");
+    expect(clientInstances[0]!.client.user.setPresence).toHaveBeenLastCalledWith(
+      buildPresencePayload("+1.20 (1.23%)", "online"),
+    );
+
+    await advanceFakeTime(16_000);
+    websocketInstances[0]!.handlers.get("message")({
+      data: buildSocketIoMarketMessage({
+        pid: 1057391,
+        last_numeric: 90,
+        pc: -10,
+        pcp: -10,
+      }),
+    });
+    await flushAsyncWork();
+
+    expect(clientInstances[0]!.setNickname).toHaveBeenCalledTimes(1);
+    expect(clientInstances[0]!.setNickname).toHaveBeenLastCalledWith("0🟩 100.50$");
+  });
+
+  test("uses Investing.com fallback for crypto after tastytrade fallback", async () => {
+    queuedClientIds.push("client-1");
+    const cryptoAsset = {
+      botToken: "token-1",
+      botName: "Bitcoin/USD",
+      botClientId: "client-1",
+      id: 1057391,
+      decimals: 2,
+      order: 0,
+      suffix: "$",
+      unit: "PCT",
+      marketHours: "crypto",
+      tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+      lastUpdate: 0,
+    };
+    mockGetAssets.mockResolvedValue([cryptoAsset]);
+
+    await updateMarketData();
+    clientInstances[0]!.handlers.get("clientReady")();
+
+    const tastytradeOptions = mockStartTastytradeCryptoStream.mock.calls[0]![0] as unknown as {
+      onFallback: (reason: string) => void;
+      onMarketData: (asset: typeof cryptoAsset, lastNumeric: number, priceChange: number, percentageChange: number) => void;
+    };
+    tastytradeOptions.onMarketData(cryptoAsset, 100.5, 1.2, 1.23);
+    await flushAsyncWork();
+
+    tastytradeOptions.onFallback("stream stale");
+    await advanceFakeTime(16_000);
+    websocketInstances[0]!.handlers.get("message")({
+      data: buildSocketIoMarketMessage({
+        pid: 1057391,
+        last_numeric: 90,
+        pc: -10,
+        pcp: -10,
+      }),
+    });
+    await flushAsyncWork();
+
+    expect(clientInstances[0]!.setNickname).toHaveBeenLastCalledWith("0🟥 90.00$");
+    expect(clientInstances[0]!.client.user.setPresence).toHaveBeenLastCalledWith(
+      buildPresencePayload("-10.00 (-10.00%)", "dnd"),
+    );
+  });
+
+  test("does not mark crypto market-data bots closed during the market reconciler", async () => {
+    queuedClientIds.push("client-1");
+    mockGetAssets.mockResolvedValue([
+      {
+        botToken: "token-1",
+        botName: "Bitcoin/USD",
+        botClientId: "client-1",
+        id: 1057391,
+        decimals: 2,
+        order: 0,
+        suffix: "$",
+        unit: "PCT",
+        marketHours: "crypto",
+        lastUpdate: 0,
+      },
+    ]);
+
+    await updateMarketData();
+    clientInstances[0]!.handlers.get("clientReady")();
+    expect(clientInstances[0]!.client.user.setPresence).toHaveBeenLastCalledWith(
+      buildPresencePayload("Market open.", "idle"),
+    );
+
+    websocketInstances[0]!.handlers.get("message")({
+      data: buildSocketIoMarketMessage({
+        pid: 1057391,
+        last_numeric: 100.5,
+        pc: 1.2,
+        pcp: 1.23,
+      }),
+    });
+    await flushAsyncWork();
+
+    vi.setSystemTime(new Date("2026-05-02T12:00:00.000Z"));
+    await advanceFakeTime(60_000);
+    await flushAsyncWork();
+
+    expect(clientInstances[0]!.setNickname).toHaveBeenLastCalledWith("0🟩 100.50$");
+    expect(clientInstances[0]!.client.user.setPresence).toHaveBeenLastCalledWith(
+      buildPresencePayload("+1.20 (1.23%)", "online"),
     );
   });
 });

--- a/modules/market-data.ts
+++ b/modules/market-data.ts
@@ -22,9 +22,11 @@ import {
   type ClientStatusState,
   type DiscordPresenceStatus,
   type IncomingMarketDataUpdateLog,
+  type MarketDataSource,
   type MarketDataAsset,
   type PendingClientStatusUpdate,
 } from "./market-data-types.ts";
+import {startTastytradeCryptoStream} from "./market-data-tastytrade.ts";
 
 const logger = getLogger();
 const websocketSubscribeDomain = "cmt-1-5-945629:%%domain-1:}";
@@ -34,6 +36,7 @@ const pendingStatusFlushIntervalMs = 1000;
 const marketStatusCheckIntervalMs = 60_000;
 const streamWatchdogIntervalMs = 30_000;
 const streamStaleTimeoutMs = 300_000;
+const marketOpenPresence = "Market open.";
 
 type ReconnectingWebSocketInstance = {
   OPEN: number;
@@ -97,7 +100,7 @@ export async function updateMarketData() {
       // Stay idle until a live tick arrives; the status reconciler flips closed sessions back later.
       const readyClient = client as Client<true>;
       readyClient.user.setPresence({
-        activities: [{name: marketClosedPresence}],
+        activities: [{name: getInitialMarketDataPresence(marketDataAsset)}],
         status: "idle",
       });
       clientsById.set(marketDataAsset.botClientId, readyClient);
@@ -151,8 +154,21 @@ function initInvestingCom(clientsById: Map<string, Client<true>>, marketDataAsse
   const memberByClientId = new Map<string, Promise<GuildMember>>();
   const statusByClientId = new Map<string, ClientStatusState>();
   const pendingStatusByClientId = new Map<string, PendingClientStatusUpdate>();
+  const activeSourceByAssetKey = new Map<string, MarketDataSource>();
+  const tastytradeCryptoAssetKeys = new Set(
+    marketDataAssets
+      .filter(isTastytradeCryptoAsset)
+      .map(getMarketDataAssetKey),
+  );
   let lastMessageAt = Date.now();
   let streamLive = false;
+
+  for (const cryptoAssetWithoutStreamerSymbol of marketDataAssets.filter(isCryptoAssetWithoutTastytradeStreamerSymbol)) {
+    logger.log(
+      "warn",
+      `Crypto market data asset ${cryptoAssetWithoutStreamerSymbol.name ?? cryptoAssetWithoutStreamerSymbol.botName} has no tastytrade streamer symbol; using Investing.com only.`,
+    );
+  }
 
   const pendingStatusFlushTimer = setInterval(() => {
     for (const clientId of pendingStatusByClientId.keys()) {
@@ -198,6 +214,123 @@ function initInvestingCom(clientsById: Map<string, Client<true>>, marketDataAsse
     }
   }, streamWatchdogIntervalMs);
   streamWatchdog.unref();
+
+  const handleMarketDataUpdate = (
+    marketDataAsset: MarketDataAsset,
+    lastNumeric: number,
+    priceChange: number,
+    percentageChange: number,
+    source: MarketDataSource,
+  ) => {
+    try {
+      const assetKey = getMarketDataAssetKey(marketDataAsset);
+      if ("tastytrade" === source) {
+        activeSourceByAssetKey.set(assetKey, "tastytrade");
+      } else if ("tastytrade" === activeSourceByAssetKey.get(assetKey)) {
+        return;
+      }
+
+      // Always show configured decimals
+      const lastPrice = lastNumeric.toFixed(marketDataAsset.decimals);
+      let lastPriceChange = priceChange.toFixed(marketDataAsset.decimals);
+      const lastPercentageChange = percentageChange.toFixed(2);
+
+      // Setting trend and presence information
+      let trend = "🟩";
+      if (lastPriceChange.startsWith("-")) {
+        trend = "🟥";
+      } else {
+        lastPriceChange = `+${lastPriceChange}`;
+      }
+
+      let presence = `${lastPriceChange} (${lastPercentageChange}%)`;
+
+      // Add ticker sorting
+      const name = `${marketDataAsset.order}${trend} ${lastPrice}${marketDataAsset.suffix}`;
+
+      // Wisdom by yolohama:
+      // % chg suggeriert dass die veränderung von 10 auf 15 (50%+) das selbe sind wie die veränderung von 100 auf 150. das ergibt aber nur bei einer stationären zeitreihe sinn. der vix ist nicht stationär. also quotiert man veränderungen in vol punkten
+      if ("PTS" === marketDataAsset.unit) {
+        presence = `${lastPriceChange}`;
+      }
+
+      const client = clientsById.get(marketDataAsset.botClientId);
+      logIncomingMarketDataUpdate({
+        source,
+        marketDataAsset,
+        botReady: "undefined" !== typeof client,
+        nickname: name,
+        presence,
+        lastNumeric,
+        priceChange,
+        percentageChange,
+      });
+
+      if ("undefined" === typeof client) {
+        logger.log(
+          "warn",
+          `Market data update skipped because bot client ${marketDataAsset.botClientId} is not ready.`,
+        );
+
+        return;
+      }
+
+      queuePendingClientStatusUpdate(
+        client,
+        clientsById,
+        marketDataAsset,
+        name,
+        presence,
+        lastNumeric,
+        priceChange,
+        percentageChange,
+        guildId,
+        memberByClientId,
+        statusByClientId,
+        pendingStatusByClientId,
+        source,
+      );
+      streamLive = true;
+    } catch (error) {
+      logger.log(
+        "error",
+        `Error updating market data bot status: ${error}`,
+      );
+    }
+  };
+
+  startTastytradeCryptoStream({
+    assets: marketDataAssets,
+    logger,
+    onFallback: (reason, marketDataAsset) => {
+      if (undefined !== marketDataAsset) {
+        activeSourceByAssetKey.set(getMarketDataAssetKey(marketDataAsset), "investing");
+      } else {
+        for (const assetKey of tastytradeCryptoAssetKeys) {
+          activeSourceByAssetKey.set(assetKey, "investing");
+        }
+      }
+      logger.log(
+        "warn",
+        `Using Investing.com fallback for crypto market data: ${reason}`,
+      );
+    },
+    onMarketData: (marketDataAsset, lastNumeric, priceChange, percentageChange) => {
+      handleMarketDataUpdate(
+        marketDataAsset,
+        lastNumeric,
+        priceChange,
+        percentageChange,
+        "tastytrade",
+      );
+    },
+    onRecovered: () => {
+      logger.log(
+        "info",
+        "Tastytrade crypto stream recovered.",
+      );
+    },
+  });
 
   // Respond to "connection open" event by sending subscription message
   wsClient.addEventListener("open", () => {
@@ -264,65 +397,13 @@ function initInvestingCom(clientsById: Map<string, Client<true>>, marketDataAsse
         return;
       }
 
-      // Always show configured decimals
-      const lastPrice = streamEvent.lastNumeric.toFixed(marketDataAsset.decimals);
-      let lastPriceChange = streamEvent.priceChange.toFixed(marketDataAsset.decimals);
-      const lastPercentageChange = streamEvent.percentageChange.toFixed(2);
-
-      // Setting trend and presence information
-      let trend = "🟩";
-      if (lastPriceChange.startsWith("-")) {
-        trend = "🟥";
-      } else {
-        lastPriceChange = `+${lastPriceChange}`;
-      }
-
-      let presence = `${lastPriceChange} (${lastPercentageChange}%)`;
-
-      // Add ticker sorting
-      const name = `${marketDataAsset.order}${trend} ${lastPrice}${marketDataAsset.suffix}`;
-
-      // Wisdom by yolohama:
-      // % chg suggeriert dass die veränderung von 10 auf 15 (50%+) das selbe sind wie die veränderung von 100 auf 150. das ergibt aber nur bei einer stationären zeitreihe sinn. der vix ist nicht stationär. also quotiert man veränderungen in vol punkten
-      if ("PTS" === marketDataAsset.unit) {
-        presence = `${lastPriceChange}`;
-      }
-
-      const client = clientsById.get(marketDataAsset.botClientId);
-      logIncomingMarketDataUpdate({
+      handleMarketDataUpdate(
         marketDataAsset,
-        botReady: "undefined" !== typeof client,
-        nickname: name,
-        presence,
-        lastNumeric: streamEvent.lastNumeric,
-        priceChange: streamEvent.priceChange,
-        percentageChange: streamEvent.percentageChange,
-      });
-
-      if ("undefined" === typeof client) {
-        logger.log(
-          "warn",
-          `Market data update skipped because bot client ${marketDataAsset.botClientId} is not ready.`,
-        );
-
-        return;
-      }
-
-      queuePendingClientStatusUpdate(
-        client,
-        clientsById,
-        marketDataAsset,
-        name,
-        presence,
         streamEvent.lastNumeric,
         streamEvent.priceChange,
         streamEvent.percentageChange,
-        guildId,
-        memberByClientId,
-        statusByClientId,
-        pendingStatusByClientId,
+        "investing",
       );
-      streamLive = true;
     } catch (error) {
       logger.log(
         "error",
@@ -417,12 +498,14 @@ function queuePendingClientStatusUpdate(
   memberByClientId: Map<string, Promise<GuildMember>>,
   statusByClientId: Map<string, ClientStatusState>,
   pendingStatusByClientId: Map<string, PendingClientStatusUpdate>,
+  source: MarketDataSource,
 ) {
   const pendingStatusUpdate = pendingStatusByClientId.get(client.user.id);
 
   if ("undefined" === typeof pendingStatusUpdate) {
     pendingStatusByClientId.set(client.user.id, {
       marketDataAsset,
+      marketDataSource: source,
       nickname,
       openPresence,
       lastNumeric,
@@ -432,6 +515,7 @@ function queuePendingClientStatusUpdate(
     });
   } else {
     pendingStatusUpdate.marketDataAsset = marketDataAsset;
+    pendingStatusUpdate.marketDataSource = source;
     pendingStatusUpdate.nickname = nickname;
     pendingStatusUpdate.openPresence = openPresence;
     pendingStatusUpdate.lastNumeric = lastNumeric;
@@ -502,6 +586,7 @@ async function flushPendingClientStatusUpdate(
     if (true === didUpdate) {
       logAppliedMarketDataUpdate({
         source: "stream-flush",
+        marketDataSource: pendingStatusUpdate.marketDataSource,
         marketDataAsset: pendingStatusUpdate.marketDataAsset,
         nickname: marketPresenceData.nickname,
         presence: marketPresenceData.presence,
@@ -634,6 +719,26 @@ function applyClientPresenceUpdate(
   return false;
 }
 
+function getMarketDataAssetKey(marketDataAsset: MarketDataAsset): string {
+  return marketDataAsset.botClientId || marketDataAsset.name || String(marketDataAsset.id);
+}
+
+function isTastytradeCryptoAsset(marketDataAsset: MarketDataAsset): boolean {
+  return "crypto" === marketDataAsset.marketHours &&
+    "string" === typeof marketDataAsset.tastytradeStreamerSymbol &&
+    "" !== marketDataAsset.tastytradeStreamerSymbol.trim();
+}
+
+function isCryptoAssetWithoutTastytradeStreamerSymbol(marketDataAsset: MarketDataAsset): boolean {
+  return "crypto" === marketDataAsset.marketHours && false === isTastytradeCryptoAsset(marketDataAsset);
+}
+
+function getInitialMarketDataPresence(marketDataAsset: MarketDataAsset): string {
+  return "crypto" === marketDataAsset.marketHours
+    ? marketOpenPresence
+    : marketClosedPresence;
+}
+
 function logAppliedMarketDataUpdate(logData: AppliedMarketDataUpdateLog) {
   logger.log("debug", {
     message: "market-data:update-applied",
@@ -642,6 +747,7 @@ function logAppliedMarketDataUpdate(logData: AppliedMarketDataUpdateLog) {
     bot_name: logData.marketDataAsset.botName,
     bot_client_id: logData.marketDataAsset.botClientId,
     market_data_pid: logData.marketDataAsset.id,
+    market_data_source: logData.marketDataSource,
     market_hours: logData.marketDataAsset.marketHours ?? "us_futures",
     nickname: logData.nickname,
     presence: logData.presence,
@@ -661,6 +767,7 @@ function logIncomingMarketDataUpdate(logData: IncomingMarketDataUpdateLog) {
     bot_name: logData.marketDataAsset.botName,
     bot_client_id: logData.marketDataAsset.botClientId,
     market_data_pid: logData.marketDataAsset.id,
+    market_data_source: logData.source,
     market_hours: logData.marketDataAsset.marketHours ?? "us_futures",
     bot_ready: logData.botReady,
     nickname: logData.nickname,

--- a/modules/test-utils/market-data.ts
+++ b/modules/test-utils/market-data.ts
@@ -46,6 +46,9 @@ type MockMarketClientInstance = {
 
 const mockGetAssets = vi.fn();
 const mockReadSecret = vi.fn();
+const mockStartTastytradeCryptoStream = vi.fn((_options: unknown) => ({
+  stop: vi.fn(),
+}));
 const websocketInstances: MockWebSocketClient[] = [];
 
 function createHandlerRegistry(): HandlerRegistry {
@@ -152,6 +155,10 @@ vi.mock("../secrets.ts", () => ({
   readSecret: (...args: unknown[]) => mockReadSecret(...args),
 }));
 
+vi.mock("../market-data-tastytrade.ts", () => ({
+  startTastytradeCryptoStream: (options: unknown) => mockStartTastytradeCryptoStream(options),
+}));
+
 const {updateMarketData} = await import("../market-data.ts");
 
 const marketOpenReferenceTime = new Date("2026-03-12T15:00:00.000Z");
@@ -192,6 +199,7 @@ export {
   mockGetAssets,
   mockLogger,
   mockReadSecret,
+  mockStartTastytradeCryptoStream,
   mockWebSocketConstructor,
   queuedClientIds,
   updateMarketData,


### PR DESCRIPTION
## Summary

Adds tastytrade/DxLink quote streaming as the preferred source for configured crypto market-data sub-bots, while keeping the existing Investing.com websocket as fallback.

## Details

- Adds explicit `tastytradeStreamerSymbol` support for market-data assets.
- Configures BTC/USD, ETH/USD, and SOL/USD for tastytrade crypto streaming.
- Leaves Monero on Investing.com because no tastytrade symbol is available.
- Reuses the existing Discord nickname/presence transport and throttling.
- Falls back per crypto asset when tastytrade fails or a symbol goes stale.
- Retries tastytrade with capped exponential backoff and jitter to avoid hammering the API.
- Shows crypto bots as `Market open.` instead of `Market closed.` before the first tick.

## Validation

- `npm test -- modules/market-data.test.ts modules/market-data-tastytrade.test.ts modules/market-data-hours.test.ts modules/assets.test.ts`
- `npm run typecheck`
- `npm test`
