### PR TITLE
Fix tastytrade stream CI issues

### DIFF
--- a/modules/assets.test.ts
+++ b/modules/assets.test.ts
@@ -35,7 +35,7 @@ vi.mock("./logging.ts", () => ({
   }),
 }));
 
-import {EmojiAsset, getAssetByName, getAssets, getGenericAssets} from "./assets.ts";
+import {EmojiAsset, getAssetByName, getAssets, getGenericAssets, MarketDataAsset} from "./assets.ts";
 
 describe("getAssets", () => {
   beforeEach(() => {
@@ -210,6 +210,51 @@ describe("getAssets", () => {
     expect(paywallAsset?.domains).toEqual(["*"]);
     expect(paywallAsset?.services).toEqual(["archive.today"]);
     expect(paywallAsset?.subdomainWildcard).toBe(true);
+  });
+
+  test("loads whatis assets through the DRACOON image path", async () => {
+    yamlLoadMock.mockReturnValue([
+      {
+        fileName: "faq.png",
+        location: "dracoon",
+        locationId: "faq-id",
+        name: "whatis_faq",
+        title: "FAQ",
+        trigger: ["faq"],
+      },
+    ]);
+    getFromDracoonMock.mockResolvedValue(Buffer.from("faq-buffer"));
+
+    const assets = await getAssets("whatis");
+
+    expect(assets).toHaveLength(1);
+    expect(assets[0]?.name).toBe("whatis_faq");
+    expect(assets[0]?.fileContent).toEqual(Buffer.from("faq-buffer"));
+    expect(getFromDracoonMock).toHaveBeenCalledWith("dracoon-secret", "faq-id");
+  });
+
+  test("ignores unknown asset types", async () => {
+    yamlLoadMock.mockReturnValue([{name: "unknown"}]);
+
+    await expect(getAssets("unknown")).resolves.toEqual([]);
+  });
+
+  test("normalizes market data streaming config values", () => {
+    const marketDataAsset = new MarketDataAsset();
+
+    marketDataAsset.marketHours = "crypto";
+    marketDataAsset.tastytradeStreamerSymbol = " BTC/USD:CXTALP ";
+
+    expect(marketDataAsset.marketHours).toBe("crypto");
+    expect(marketDataAsset.tastytradeStreamerSymbol).toBe("BTC/USD:CXTALP");
+
+    marketDataAsset.marketHours = "unsupported";
+
+    expect(marketDataAsset.marketHours).toBeUndefined();
+    expect(loggerMock.log).toHaveBeenCalledWith(
+      "warn",
+      "Ignoring unsupported market data hours profile: unsupported",
+    );
   });
 
   test("loads generic assets across all generic asset files", async () => {

--- a/modules/market-data-tastytrade.ts
+++ b/modules/market-data-tastytrade.ts
@@ -406,7 +406,7 @@ function parseNumericValue(value: unknown): number | null {
   }
 
   if ("string" === typeof value) {
-    const parsedValue = Number(value.replaceAll(",", "").replace("%", "").trim());
+    const parsedValue = Number(value.replaceAll(",", "").replaceAll("%", "").trim());
     if (Number.isFinite(parsedValue)) {
       return parsedValue;
     }

--- a/modules/market-data.test.ts
+++ b/modules/market-data.test.ts
@@ -781,7 +781,7 @@ describe("updateMarketData", () => {
     await updateMarketData();
     clientInstances[0]!.handlers.get("clientReady")();
 
-    const tastytradeOptions = mockStartTastytradeCryptoStream.mock.calls[0]![0] as unknown as {
+    const tastytradeOptions = mockStartTastytradeCryptoStream.mock.calls[0]![0] as {
       onMarketData: (asset: typeof cryptoAsset, lastNumeric: number, priceChange: number, percentageChange: number) => void;
     };
     tastytradeOptions.onMarketData(cryptoAsset, 100.5, 1.2, 1.23);
@@ -827,7 +827,7 @@ describe("updateMarketData", () => {
     await updateMarketData();
     clientInstances[0]!.handlers.get("clientReady")();
 
-    const tastytradeOptions = mockStartTastytradeCryptoStream.mock.calls[0]![0] as unknown as {
+    const tastytradeOptions = mockStartTastytradeCryptoStream.mock.calls[0]![0] as {
       onFallback: (reason: string) => void;
       onMarketData: (asset: typeof cryptoAsset, lastNumeric: number, priceChange: number, percentageChange: number) => void;
     };


### PR DESCRIPTION
Fixes the two lint errors reported on PR #1664 and the CodeQL string-replacement alert in the tastytrade numeric parser.\n\nValidation:\n- npm run lint\n- npm test -- modules/market-data.test.ts modules/market-data-tastytrade.test.ts modules/market-data-hours.test.ts modules/assets.test.ts\n- npm run typecheck