### PR TITLE
Fix tastytrade crypto streamer symbols

### DIFF
--- a/assets/marketdata.yaml
+++ b/assets/marketdata.yaml
@@ -80,7 +80,7 @@
   suffix: "$"
   unit: "PCT"
   marketHours: "crypto"
-  tastytradeStreamerSymbol: "BTC/USD:CXTALP"
+  tastytradeStreamerSymbol: "BTC/USD"
   decimals: 2
   lastUpdate: 0
   order: 0
@@ -95,7 +95,7 @@
   suffix: "$"
   unit: "PCT"
   marketHours: "crypto"
-  tastytradeStreamerSymbol: "ETH/USD:CXTALP"
+  tastytradeStreamerSymbol: "ETH/USD"
   decimals: 2
   lastUpdate: 0
   order: 1
@@ -110,7 +110,7 @@
   suffix: "$"
   unit: "PCT"
   marketHours: "crypto"
-  tastytradeStreamerSymbol: "SOL/USD:CXTALP"
+  tastytradeStreamerSymbol: "SOL/USD"
   decimals: 2
   lastUpdate: 0
   order: 2

--- a/modules/assets.test.ts
+++ b/modules/assets.test.ts
@@ -153,7 +153,7 @@ describe("getAssets", () => {
         suffix: "$",
         unit: "PCT",
         marketHours: "crypto",
-        tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+        tastytradeStreamerSymbol: "BTC/USD",
         decimals: 2,
         order: 1,
       }],
@@ -203,7 +203,7 @@ describe("getAssets", () => {
     expect(marketAsset?.botToken).toBe("market-token");
     expect(marketAsset?.botClientId).toBe("market-client-id");
     expect(marketAsset?.marketHours).toBe("crypto");
-    expect(marketAsset?.tastytradeStreamerSymbol).toBe("BTC/USD:CXTALP");
+    expect(marketAsset?.tastytradeStreamerSymbol).toBe("BTC/USD");
     expect(roleAsset?.trigger).toEqual(["role-message-id"]);
     expect(roleAsset?.id).toBe("role-id");
     expect(paywallAsset?.name).toBe("default");
@@ -243,10 +243,10 @@ describe("getAssets", () => {
     const marketDataAsset = new MarketDataAsset();
 
     marketDataAsset.marketHours = "crypto";
-    marketDataAsset.tastytradeStreamerSymbol = " BTC/USD:CXTALP ";
+    marketDataAsset.tastytradeStreamerSymbol = " BTC/USD ";
 
     expect(marketDataAsset.marketHours).toBe("crypto");
-    expect(marketDataAsset.tastytradeStreamerSymbol).toBe("BTC/USD:CXTALP");
+    expect(marketDataAsset.tastytradeStreamerSymbol).toBe("BTC/USD");
 
     marketDataAsset.marketHours = "unsupported";
 

--- a/modules/market-data-tastytrade.test.ts
+++ b/modules/market-data-tastytrade.test.ts
@@ -17,7 +17,7 @@ function createCryptoAsset(overrides: Partial<MarketDataAsset> = {}): MarketData
     suffix: "$",
     unit: "PCT",
     marketHours: "crypto",
-    tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+    tastytradeStreamerSymbol: "BTC/USD",
     decimals: 2,
     lastUpdate: 0,
     order: 0,
@@ -99,7 +99,7 @@ describe("tastytrade crypto market data stream", () => {
 
     expect(stream.streamer.connect).toHaveBeenCalledTimes(1);
     expect(stream.streamer.subscribe).toHaveBeenCalledWith(
-      ["BTC/USD:CXTALP"],
+      ["BTC/USD"],
       [
         MarketDataSubscriptionType.Trade,
         MarketDataSubscriptionType.Quote,
@@ -108,7 +108,7 @@ describe("tastytrade crypto market data stream", () => {
     );
 
     stream.emit([{
-      eventSymbol: "BTC/USD:CXTALP",
+      eventSymbol: "BTC/USD",
       eventType: "Trade",
       price: 100,
       priceChange: 1.5,
@@ -136,7 +136,7 @@ describe("tastytrade crypto market data stream", () => {
     await flushAsyncWork();
 
     stream.emit([{
-      "event-symbol": "BTC/USD:CXTALP",
+      "event-symbol": "BTC/USD",
       "event-type": "Quote",
       "bid-price": 99,
       "ask-price": 101,
@@ -204,7 +204,7 @@ describe("tastytrade crypto market data stream", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     await flushAsyncWork();
     stream.emit([{
-      eventSymbol: "BTC/USD:CXTALP",
+      eventSymbol: "BTC/USD",
       eventType: "Trade",
       price: 101,
     }]);
@@ -222,11 +222,11 @@ describe("tastytrade crypto market data stream", () => {
     const stream = createStreamer();
     const btcAsset = createCryptoAsset({
       botClientId: "btc-client",
-      tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+      tastytradeStreamerSymbol: "BTC/USD",
     });
     const ethAsset = createCryptoAsset({
       botClientId: "eth-client",
-      tastytradeStreamerSymbol: "ETH/USD:CXTALP",
+      tastytradeStreamerSymbol: "ETH/USD",
     });
     const options = createOptions({
       assets: [btcAsset, ethAsset],
@@ -239,13 +239,13 @@ describe("tastytrade crypto market data stream", () => {
     await flushAsyncWork();
 
     stream.emit([{
-      eventSymbol: "BTC/USD:CXTALP",
+      eventSymbol: "BTC/USD",
       eventType: "Trade",
       price: 100,
     }]);
     await vi.advanceTimersByTimeAsync(299_999);
     stream.emit([{
-      eventSymbol: "BTC/USD:CXTALP",
+      eventSymbol: "BTC/USD",
       eventType: "Trade",
       price: 101,
     }]);
@@ -253,11 +253,11 @@ describe("tastytrade crypto market data stream", () => {
     await flushAsyncWork();
 
     expect(options.onFallback).toHaveBeenCalledWith(
-      "no valid ETH/USD:CXTALP crypto quote for 300s",
+      "no valid ETH/USD crypto quote for 300s",
       ethAsset,
     );
     expect(options.onFallback).not.toHaveBeenCalledWith(
-      expect.stringContaining("BTC/USD:CXTALP"),
+      expect.stringContaining("BTC/USD"),
       btcAsset,
     );
   });

--- a/modules/market-data.test.ts
+++ b/modules/market-data.test.ts
@@ -773,7 +773,7 @@ describe("updateMarketData", () => {
       suffix: "$",
       unit: "PCT",
       marketHours: "crypto",
-      tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+      tastytradeStreamerSymbol: "BTC/USD",
       lastUpdate: 0,
     };
     mockGetAssets.mockResolvedValue([cryptoAsset]);
@@ -819,7 +819,7 @@ describe("updateMarketData", () => {
       suffix: "$",
       unit: "PCT",
       marketHours: "crypto",
-      tastytradeStreamerSymbol: "BTC/USD:CXTALP",
+      tastytradeStreamerSymbol: "BTC/USD",
       lastUpdate: 0,
     };
     mockGetAssets.mockResolvedValue([cryptoAsset]);


### PR DESCRIPTION
Switch crypto tastytrade streamer symbols from the stale CXTALP-suffixed values to the plain UI/API symbols. The old BTC/USD:CXTALP subscription produced no valid BTC quote and forced the Investing.com fallback after the stale timeout.\n\nValidation:\n- npm run test:coverage\n- npm run lint\n- npm run typecheck