### PR TITLE
[codex] adjust earnings post padding

### DIFF
--- a/modules/earnings-format-render.ts
+++ b/modules/earnings-format-render.ts
@@ -1,0 +1,325 @@
+import {
+  earningsWhenLabelByWhen,
+  type EarningsEvent,
+  type EarningsWhen,
+  unknownValueLabel,
+} from "./earnings-types.ts";
+import {
+  formatMarketCapUsdShort,
+  getNormalizedString,
+  getNumericValueFromNasdaqCapString,
+} from "./earnings-utils.ts";
+import {getFormattedExpectedMoveText, getFormattedExpectedMoveUnderlyingPriceText} from "./earnings-option-format.ts";
+
+export type EarningsSectionRow = {
+  event: EarningsEvent;
+  lineOverride?: string;
+  when: EarningsWhen;
+};
+
+type EarningsLineWidths = {
+  ticker: number;
+  marketCap: number;
+};
+
+export type EarningsMessageChunk = {
+  eventCount: number;
+  messageIndex: number;
+  sections: EarningsMessageChunkSection[];
+};
+
+export type EarningsMessageChunkSection = {
+  continuation: boolean;
+  label: string;
+  rows: EarningsSectionRow[];
+};
+
+function getEarningsLineWidths(rows: EarningsSectionRow[]): EarningsLineWidths {
+  let tickerWidth = 1;
+  let marketCapWidth = unknownValueLabel.length;
+
+  for (const row of rows) {
+    if (undefined !== row.lineOverride) {
+      continue;
+    }
+
+    const {event: earningsEvent} = row;
+    tickerWidth = Math.max(tickerWidth, earningsEvent.ticker.length);
+
+    const marketCapText = getFormattedMarketCapText(
+      earningsEvent.marketCap,
+      earningsEvent.marketCapText
+    );
+    marketCapWidth = Math.max(marketCapWidth, marketCapText.length);
+  }
+
+  return {
+    ticker: tickerWidth,
+    marketCap: marketCapWidth,
+  };
+}
+
+function getEarningsSectionHeading(
+  label: string,
+  continuation: boolean,
+  continuationLabel: string
+): string {
+  if (false === continuation) {
+    return `**${label}:**`;
+  }
+
+  return `**${label} ${continuationLabel}:**`;
+}
+
+function getEarningsSectionText(
+  label: string,
+  rows: EarningsSectionRow[],
+  continuation: boolean,
+  continuationLabel: string,
+  highlightedTickerSymbols: Set<string>,
+  lineWidths: EarningsLineWidths
+): string {
+  const heading = getEarningsSectionHeading(label, continuation, continuationLabel);
+  const sectionLines: string[] = [];
+  let previousWhen: EarningsWhen | null = null;
+
+  for (const row of rows) {
+    if (row.when !== previousWhen) {
+      sectionLines.push("");
+      sectionLines.push(getEarningsWhenSubheading(row.when));
+      previousWhen = row.when;
+    }
+
+    sectionLines.push(row.lineOverride ?? getEarningsEventLine(
+      row.event,
+      highlightedTickerSymbols,
+      lineWidths
+    ));
+  }
+
+  return `${heading}\n${sectionLines.join("\n")}\n\n`;
+}
+
+export function getEmptyEarningsMessageChunk(messageIndex: number): EarningsMessageChunk {
+  return {
+    eventCount: 0,
+    messageIndex,
+    sections: [],
+  };
+}
+
+export function getEarningsMessageChunkSection(
+  label: string,
+  rows: EarningsSectionRow[],
+  continuation: boolean
+): EarningsMessageChunkSection {
+  return {
+    continuation,
+    label,
+    rows: [...rows],
+  };
+}
+
+export function canAppendToEarningsChunk(
+  chunk: EarningsMessageChunk,
+  section: EarningsMessageChunkSection,
+  highlightedTickerSymbols: Set<string>,
+  maxMessageLength: number,
+  title: string,
+  continuationLabel: string
+): boolean {
+  const candidateChunk = cloneEarningsChunk(chunk);
+  appendToEarningsChunk(candidateChunk, section);
+  return getEarningsChunkText(
+    candidateChunk,
+    title,
+    highlightedTickerSymbols,
+    continuationLabel
+  ).length <= maxMessageLength;
+}
+
+export function appendToEarningsChunk(
+  chunk: EarningsMessageChunk,
+  section: EarningsMessageChunkSection
+) {
+  chunk.sections.push({
+    ...section,
+    rows: [...section.rows],
+  });
+  chunk.eventCount += section.rows.length;
+}
+
+export function cloneEarningsChunk(chunk: EarningsMessageChunk): EarningsMessageChunk {
+  return {
+    eventCount: chunk.eventCount,
+    messageIndex: chunk.messageIndex,
+    sections: chunk.sections.map(section => ({
+      ...section,
+      rows: [...section.rows],
+    })),
+  };
+}
+
+function getEarningsChunkRows(chunk: EarningsMessageChunk): EarningsSectionRow[] {
+  return chunk.sections.flatMap(section => section.rows);
+}
+
+export function getEarningsChunkText(
+  chunk: EarningsMessageChunk,
+  title: string,
+  highlightedTickerSymbols: Set<string>,
+  continuationLabel: string
+): string {
+  const prefix = (0 === chunk.messageIndex && 0 < title.length) ? `${title}\n` : "";
+  const lineWidths = getEarningsLineWidths(getEarningsChunkRows(chunk));
+  const sectionText = chunk.sections.map(section => getEarningsSectionText(
+    section.label,
+    section.rows,
+    section.continuation,
+    continuationLabel,
+    highlightedTickerSymbols,
+    lineWidths
+  )).join("");
+
+  return `${prefix}${sectionText}`;
+}
+
+export function getTruncatedEarningsSectionRow(
+  row: EarningsSectionRow,
+  label: string,
+  continuation: boolean,
+  chunk: EarningsMessageChunk,
+  highlightedTickerSymbols: Set<string>,
+  maxMessageLength: number,
+  title: string,
+  continuationLabel: string
+): EarningsSectionRow {
+  const fullLine = getEarningsEventLine(
+    row.event,
+    highlightedTickerSymbols,
+    getEarningsLineWidths([row])
+  );
+  let bestLine = "";
+  let low = 0;
+  let high = fullLine.length;
+
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidateLine = truncateEarningsLine(fullLine, midpoint);
+    const candidateRow = {
+      ...row,
+      lineOverride: candidateLine,
+    };
+    const candidateSection = getEarningsMessageChunkSection(
+      label,
+      [candidateRow],
+      continuation
+    );
+
+    if (true === canAppendToEarningsChunk(chunk, candidateSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+      bestLine = candidateLine;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+
+  return {
+    ...row,
+    lineOverride: bestLine,
+  };
+}
+
+function truncateEarningsLine(line: string, maxLength: number): string {
+  if (line.length <= maxLength) {
+    return line;
+  }
+
+  if (maxLength <= 3) {
+    return line.slice(0, maxLength);
+  }
+
+  return `${line.slice(0, maxLength - 3)}...`;
+}
+
+function getEarningsEventLine(
+  earningsEvent: EarningsEvent,
+  highlightedTickerSymbols: Set<string>,
+  lineWidths: EarningsLineWidths
+): string {
+  const ticker = getFormattedTicker(
+    earningsEvent.ticker,
+    highlightedTickerSymbols,
+    lineWidths.ticker
+  );
+  const marketCapText = getFormattedMarketCapText(earningsEvent.marketCap, earningsEvent.marketCapText);
+  const epsConsensus = getFormattedEpsConsensusText(earningsEvent.epsConsensus);
+  const paddedMarketCapText = getPaddedEarningsColumnText(
+    marketCapText,
+    lineWidths.marketCap
+  );
+  const expectedMoveText = getFormattedExpectedMoveText(earningsEvent);
+  const underlyingPriceText = getFormattedExpectedMoveUnderlyingPriceText(earningsEvent);
+
+  return `${ticker} 💰 MCap: \`${paddedMarketCapText}\`${underlyingPriceText} 🔮 EPS: \`${epsConsensus}\`${expectedMoveText}`;
+}
+
+function getFormattedMarketCapText(
+  marketCap: number | null | undefined,
+  marketCapText: string | undefined
+): string {
+  if ("number" === typeof marketCap && Number.isFinite(marketCap) && marketCap >= 0) {
+    return formatMarketCapUsdShort(marketCap);
+  }
+
+  const normalizedMarketCapText = getNormalizedString(marketCapText);
+  if (null === normalizedMarketCapText) {
+    return unknownValueLabel;
+  }
+
+  const parsedMarketCap = getNumericValueFromNasdaqCapString(normalizedMarketCapText);
+  if (null === parsedMarketCap) {
+    return unknownValueLabel;
+  }
+
+  return formatMarketCapUsdShort(parsedMarketCap);
+}
+
+function getFormattedEpsConsensusText(
+  epsConsensus: string | undefined
+): string {
+  return getNormalizedString(epsConsensus) ?? unknownValueLabel;
+}
+
+function getPaddedEarningsColumnText(
+  text: string,
+  width: number
+): string {
+  return text.padEnd(width, " ");
+}
+
+function getFormattedTicker(
+  ticker: string,
+  highlightedTickerSymbols: Set<string>,
+  width: number
+): string {
+  const tickerText = `\`${getPaddedEarningsColumnText(ticker, width)}\``;
+  if (true === highlightedTickerSymbols.has(ticker)) {
+    return `**${tickerText}**`;
+  }
+
+  return tickerText;
+}
+
+function getEarningsWhenLabel(earningsWhen: EarningsWhen): string {
+  const label = earningsWhenLabelByWhen.get(earningsWhen);
+  if (undefined !== label) {
+    return label;
+  }
+
+  return "Während der Handelszeiten oder unbekannter Zeitpunkt";
+}
+
+function getEarningsWhenSubheading(earningsWhen: EarningsWhen): string {
+  return `**${getEarningsWhenLabel(earningsWhen)}:**`;
+}

--- a/modules/earnings-format.ts
+++ b/modules/earnings-format.ts
@@ -5,40 +5,27 @@ import {
   EARNINGS_CONTINUATION_LABEL,
   EARNINGS_MAX_MESSAGE_LENGTH,
   earningsTruncationNote,
-  earningsWhenLabelByWhen,
   earningsWhenSortRankByWhen,
   type EarningsEvent,
   type EarningsMessageBatch,
   type EarningsMessageOptions,
   type EarningsWhen,
-  unknownValueLabel,
 } from "./earnings-types.ts";
 import {
-  formatMarketCapUsdShort,
-  getNormalizedString,
-  getNumericValueFromNasdaqCapString,
-} from "./earnings-utils.ts";
-import {getFormattedExpectedMoveText, getFormattedExpectedMoveUnderlyingPriceText} from "./earnings-option-format.ts";
-
-type EarningsSectionRow = {
-  when: EarningsWhen;
-  line: string;
-};
+  appendToEarningsChunk,
+  canAppendToEarningsChunk,
+  cloneEarningsChunk,
+  getEarningsChunkText,
+  getEarningsMessageChunkSection,
+  getEmptyEarningsMessageChunk,
+  getTruncatedEarningsSectionRow,
+  type EarningsMessageChunk,
+  type EarningsSectionRow,
+} from "./earnings-format-render.ts";
 
 type EarningsSection = {
   label: string;
   rows: EarningsSectionRow[];
-};
-
-type EarningsLineWidths = {
-  ticker: number;
-  marketCap: number;
-  eps: number;
-};
-
-type EarningsMessageChunk = {
-  content: string;
-  eventCount: number;
 };
 
 type EventsByDateBucket = {
@@ -144,8 +131,7 @@ function buildEarningsMessageBatch(
 ): EarningsMessageBatch {
   const {maxMessageLength, maxMessages, continuationLabel} = options;
   const sections = getEarningsSections(
-    filteredAndSortedEvents,
-    highlightedTickerSymbols
+    filteredAndSortedEvents
   );
   if (0 === sections.length) {
     return {
@@ -159,28 +145,27 @@ function buildEarningsMessageBatch(
   const title = getEarningsTitle(filteredAndSortedEvents);
 
   const chunks: EarningsMessageChunk[] = [];
-  let currentChunk = getEmptyEarningsMessageChunk(0, title);
+  let currentChunk = getEmptyEarningsMessageChunk(0);
   let contentTruncated = false;
 
   for (const section of sections) {
-    const fullSectionText = getEarningsSectionText(
+    const fullSection = getEarningsMessageChunkSection(
       section.label,
       section.rows,
-      false,
-      continuationLabel
+      false
     );
-    if (true === canAppendToEarningsChunk(currentChunk, fullSectionText, maxMessageLength)) {
-      appendToEarningsChunk(currentChunk, fullSectionText, section.rows.length);
+    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+      appendToEarningsChunk(currentChunk, fullSection);
       continue;
     }
 
     if (0 < currentChunk.eventCount) {
       chunks.push(cloneEarningsChunk(currentChunk));
-      currentChunk = getEmptyEarningsMessageChunk(chunks.length, title);
+      currentChunk = getEmptyEarningsMessageChunk(chunks.length);
     }
 
-    if (true === canAppendToEarningsChunk(currentChunk, fullSectionText, maxMessageLength)) {
-      appendToEarningsChunk(currentChunk, fullSectionText, section.rows.length);
+    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+      appendToEarningsChunk(currentChunk, fullSection);
       continue;
     }
 
@@ -195,14 +180,13 @@ function buildEarningsMessageBatch(
         }
 
         const candidateRows = [...sectionRows, nextRow];
-        const candidateSectionText = getEarningsSectionText(
+        const candidateSection = getEarningsMessageChunkSection(
           section.label,
           candidateRows,
-          continuation,
-          continuationLabel
+          continuation
         );
 
-        if (canAppendToEarningsChunk(currentChunk, candidateSectionText, maxMessageLength)) {
+        if (canAppendToEarningsChunk(currentChunk, candidateSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
           sectionRows.push(nextRow);
           rowIndex++;
         } else {
@@ -211,41 +195,44 @@ function buildEarningsMessageBatch(
       }
 
       if (0 === sectionRows.length) {
+        if (0 < currentChunk.eventCount) {
+          chunks.push(cloneEarningsChunk(currentChunk));
+          currentChunk = getEmptyEarningsMessageChunk(chunks.length);
+          continue;
+        }
+
         const rawRow = section.rows[rowIndex];
         if (undefined === rawRow) {
           break;
         }
 
-        const headingText = `${getEarningsSectionHeading(section.label, continuation, continuationLabel)}\n${getEarningsWhenSubheading(rawRow.when)}\n`;
-        const availableRowLength = maxMessageLength - getAppendedEarningsChunkText(currentChunk, headingText).length - 1;
-        if (availableRowLength <= 0 && 0 < currentChunk.eventCount) {
-          chunks.push(cloneEarningsChunk(currentChunk));
-          currentChunk = getEmptyEarningsMessageChunk(chunks.length, title);
-          continue;
-        }
-
-        const truncatedRow = {
-          ...rawRow,
-          line: truncateEarningsLine(rawRow.line, Math.max(availableRowLength, 1)),
-        };
+        const truncatedRow = getTruncatedEarningsSectionRow(
+          rawRow,
+          section.label,
+          continuation,
+          currentChunk,
+          highlightedTickerSymbols,
+          maxMessageLength,
+          title,
+          continuationLabel
+        );
         sectionRows.push(truncatedRow);
         rowIndex++;
-        if (rawRow.line !== truncatedRow.line) {
+        if (undefined !== truncatedRow.lineOverride) {
           contentTruncated = true;
         }
       }
 
-      const sectionText = getEarningsSectionText(
+      const sectionChunk = getEarningsMessageChunkSection(
         section.label,
         sectionRows,
-        continuation,
-        continuationLabel
+        continuation
       );
-      appendToEarningsChunk(currentChunk, sectionText, sectionRows.length);
+      appendToEarningsChunk(currentChunk, sectionChunk);
 
       if (rowIndex < section.rows.length) {
         chunks.push(cloneEarningsChunk(currentChunk));
-        currentChunk = getEmptyEarningsMessageChunk(chunks.length, title);
+        currentChunk = getEmptyEarningsMessageChunk(chunks.length);
         continuation = true;
       }
     }
@@ -262,7 +249,12 @@ function buildEarningsMessageBatch(
     visibleChunks = visibleChunks.slice(0, maxMessages);
   }
 
-  const messages = visibleChunks.map(chunk => chunk.content.trimEnd());
+  const messages = visibleChunks.map(chunk => getEarningsChunkText(
+    chunk,
+    title,
+    highlightedTickerSymbols,
+    continuationLabel
+  ).trimEnd());
   const includedEvents = visibleChunks.reduce(
     (sum, chunk) => sum + chunk.eventCount,
     0
@@ -483,12 +475,8 @@ function isBluechipMarketCap(marketCap: number | null | undefined): boolean {
   return marketCap >= bluechipMinMarketCap;
 }
 
-function getEarningsSections(
-  earningsEvents: EarningsEvent[],
-  highlightedTickerSymbols: Set<string>
-): EarningsSection[] {
+function getEarningsSections(earningsEvents: EarningsEvent[]): EarningsSection[] {
   const orderedSections: EarningsSection[] = [];
-  const lineWidths = getEarningsLineWidths(earningsEvents);
   let previousDateStamp = "";
 
   for (const earningsEvent of earningsEvents) {
@@ -506,144 +494,16 @@ function getEarningsSections(
     }
 
     currentSection.rows.push({
+      event: earningsEvent,
       when: earningsEvent.when,
-      line: getEarningsEventLine(
-        earningsEvent,
-        highlightedTickerSymbols,
-        lineWidths
-      ),
     });
   }
 
   return orderedSections;
 }
 
-function getEarningsLineWidths(
-  earningsEvents: EarningsEvent[]
-): EarningsLineWidths {
-  let tickerWidth = 1;
-  let marketCapWidth = unknownValueLabel.length;
-  let epsWidth = unknownValueLabel.length;
-
-  for (const earningsEvent of earningsEvents) {
-    tickerWidth = Math.max(tickerWidth, earningsEvent.ticker.length);
-
-    const marketCapText = getFormattedMarketCapText(
-      earningsEvent.marketCap,
-      earningsEvent.marketCapText
-    );
-    marketCapWidth = Math.max(marketCapWidth, marketCapText.length);
-
-    const epsConsensus = getFormattedEpsConsensusText(earningsEvent.epsConsensus);
-    epsWidth = Math.max(epsWidth, epsConsensus.length);
-  }
-
-  return {
-    ticker: tickerWidth,
-    marketCap: marketCapWidth,
-    eps: epsWidth,
-  };
-}
-
 function getFriendlyDate(dateStamp: string): string {
   return moment(dateStamp).locale("de").format("dddd, Do MMMM YYYY");
-}
-
-function getEarningsSectionHeading(
-  label: string,
-  continuation: boolean,
-  continuationLabel: string
-): string {
-  if (false === continuation) {
-    return `**${label}:**`;
-  }
-
-  return `**${label} ${continuationLabel}:**`;
-}
-
-function getEarningsSectionText(
-  label: string,
-  rows: EarningsSectionRow[],
-  continuation: boolean,
-  continuationLabel: string
-): string {
-  const heading = getEarningsSectionHeading(label, continuation, continuationLabel);
-  const sectionLines: string[] = [];
-  let previousWhen: EarningsWhen | null = null;
-
-  for (const row of rows) {
-    if (row.when !== previousWhen) {
-      sectionLines.push("");
-      sectionLines.push(getEarningsWhenSubheading(row.when));
-      previousWhen = row.when;
-    }
-
-    sectionLines.push(row.line);
-  }
-
-  return `${heading}\n${sectionLines.join("\n")}\n\n`;
-}
-
-function getEmptyEarningsMessageChunk(
-  messageIndex: number,
-  title: string
-): EarningsMessageChunk {
-  const prefix = (0 === messageIndex && 0 < title.length) ? `${title}\n` : "";
-  return {
-    content: prefix,
-    eventCount: 0,
-  };
-}
-
-function getAppendedEarningsChunkText(
-  chunk: EarningsMessageChunk,
-  text: string
-): string {
-  if ("" === chunk.content) {
-    return text;
-  }
-
-  if (chunk.content.endsWith("\n")) {
-    return `${chunk.content}${text}`;
-  }
-
-  return `${chunk.content}\n${text}`;
-}
-
-function canAppendToEarningsChunk(
-  chunk: EarningsMessageChunk,
-  text: string,
-  maxMessageLength: number
-): boolean {
-  return getAppendedEarningsChunkText(chunk, text).length <= maxMessageLength;
-}
-
-function appendToEarningsChunk(
-  chunk: EarningsMessageChunk,
-  text: string,
-  eventCount: number
-) {
-  chunk.content = getAppendedEarningsChunkText(chunk, text);
-  chunk.eventCount += eventCount;
-}
-
-function cloneEarningsChunk(chunk: EarningsMessageChunk): EarningsMessageChunk {
-  return {
-    content: chunk.content,
-    eventCount: chunk.eventCount,
-  };
-}
-
-function truncateEarningsLine(line: string, maxLength: number): string {
-  if (line.length <= maxLength) {
-    return line;
-  }
-
-  if (maxLength <= 3) {
-    return line.slice(0, maxLength);
-  }
-
-  return `${line.slice(0, maxLength - 3)}...`;
 }
 
 function appendEarningsTruncationNote(
@@ -698,90 +558,4 @@ function getSortableMarketCap(marketCap: number | null | undefined): number {
 
 function getEarningsWhenSortRank(earningsWhen: EarningsWhen): number {
   return earningsWhenSortRankByWhen.get(earningsWhen) ?? Number.MAX_SAFE_INTEGER;
-}
-
-function getEarningsEventLine(
-  earningsEvent: EarningsEvent,
-  highlightedTickerSymbols: Set<string>,
-  lineWidths: EarningsLineWidths
-): string {
-  const ticker = getFormattedTicker(
-    earningsEvent.ticker,
-    highlightedTickerSymbols,
-    lineWidths.ticker
-  );
-  const marketCapText = getFormattedMarketCapText(earningsEvent.marketCap, earningsEvent.marketCapText);
-  const epsConsensus = getFormattedEpsConsensusText(earningsEvent.epsConsensus);
-  const paddedMarketCapText = getPaddedEarningsColumnText(
-    marketCapText,
-    lineWidths.marketCap
-  );
-  const paddedEpsConsensus = getPaddedEarningsColumnText(
-    epsConsensus,
-    lineWidths.eps
-  );
-  const expectedMoveText = getFormattedExpectedMoveText(earningsEvent);
-  const underlyingPriceText = getFormattedExpectedMoveUnderlyingPriceText(earningsEvent);
-
-  return `${ticker} 💰 MCap: \`${paddedMarketCapText}\`${underlyingPriceText} 🔮 EPS: \`${paddedEpsConsensus}\`${expectedMoveText}`;
-}
-
-function getFormattedMarketCapText(
-  marketCap: number | null | undefined,
-  marketCapText: string | undefined
-): string {
-  if ("number" === typeof marketCap && Number.isFinite(marketCap) && marketCap >= 0) {
-    return formatMarketCapUsdShort(marketCap);
-  }
-
-  const normalizedMarketCapText = getNormalizedString(marketCapText);
-  if (null === normalizedMarketCapText) {
-    return unknownValueLabel;
-  }
-
-  const parsedMarketCap = getNumericValueFromNasdaqCapString(normalizedMarketCapText);
-  if (null === parsedMarketCap) {
-    return unknownValueLabel;
-  }
-
-  return formatMarketCapUsdShort(parsedMarketCap);
-}
-
-function getFormattedEpsConsensusText(
-  epsConsensus: string | undefined
-): string {
-  return getNormalizedString(epsConsensus) ?? unknownValueLabel;
-}
-
-function getPaddedEarningsColumnText(
-  text: string,
-  width: number
-): string {
-  return text.padEnd(width, " ");
-}
-
-function getFormattedTicker(
-  ticker: string,
-  highlightedTickerSymbols: Set<string>,
-  width: number
-): string {
-  const tickerText = `\`${getPaddedEarningsColumnText(ticker, width)}\``;
-  if (true === highlightedTickerSymbols.has(ticker)) {
-    return `**${tickerText}**`;
-  }
-
-  return tickerText;
-}
-
-function getEarningsWhenLabel(earningsWhen: EarningsWhen): string {
-  const label = earningsWhenLabelByWhen.get(earningsWhen);
-  if (undefined !== label) {
-    return label;
-  }
-
-  return "Während der Handelszeiten oder unbekannter Zeitpunkt";
-}
-
-function getEarningsWhenSubheading(earningsWhen: EarningsWhen): string {
-  return `**${getEarningsWhenLabel(earningsWhen)}:**`;
 }

--- a/modules/earnings-option-format.ts
+++ b/modules/earnings-option-format.ts
@@ -42,5 +42,5 @@ export function getFormattedExpectedMoveText(earningsEvent: EarningsEvent): stri
     return "";
   }
 
-  return ` 🎯 Move: \`+/- $${formatOptionalPrice(earningsEvent.expectedMove)}${getExpectedMoveDetailsText(earningsEvent)}\``;
+  return ` 🎯 Move: \`± $${formatOptionalPrice(earningsEvent.expectedMove)}${getExpectedMoveDetailsText(earningsEvent)}\``;
 }

--- a/modules/earnings.test.ts
+++ b/modules/earnings.test.ts
@@ -408,7 +408,7 @@ describe("getEarningsText", () => {
     expect(parsedLines[2]!.ticker.trim()).toBe("NEXT");
     expect(new Set(parsedLines.map(entry => entry.ticker.length)).size).toBe(1);
     expect(new Set(parsedLines.map(entry => entry.marketCap.length)).size).toBe(1);
-    expect(new Set(parsedLines.map(entry => entry.eps.length)).size).toBe(1);
+    expect(parsedLines.map(entry => entry.eps)).toEqual(["1.20", "0.50", "0.75"]);
     expect(lines[0]!).not.toContain("Während der Handelszeiten oder unbekannter Zeitpunkt");
   });
 });
@@ -465,7 +465,7 @@ describe("getEarningsMessages", () => {
     expect(parsedLines[0]!.eps.trim()).toBe("2.20");
     expect(new Set(parsedLines.map(entry => entry.ticker.length)).size).toBe(1);
     expect(new Set(parsedLines.map(entry => entry.marketCap.length)).size).toBe(1);
-    expect(new Set(parsedLines.map(entry => entry.eps.length)).size).toBe(1);
+    expect(parsedLines.map(entry => entry.eps)).toEqual(["2.20", "0.10", "0.80"]);
   });
 
   test("includes expected move details when earnings events are enriched", () => {
@@ -484,7 +484,40 @@ describe("getEarningsMessages", () => {
     });
 
     expect(batch.messages[0]!).toContain("💰 MCap: `$2.8T` 📈 Last: `$190.42` 🔮 EPS:");
-    expect(batch.messages[0]!).toContain("🎯 Move: `+/- $12.40 (6.5%, 3 DTE)`");
+    expect(batch.messages[0]!).toContain("🎯 Move: `± $12.40 (6.5%, 3 DTE)`");
+  });
+
+  test("scopes ticker and market cap padding to each message chunk", () => {
+    const batch = getEarningsMessages([
+      getEarningsEvent({
+        ticker: "VERYLONGTICKER",
+        when: "before_open",
+        companyName: "Very Long Co",
+        marketCap: 999_500_000_000,
+        marketCapText: "$999.5B",
+        epsConsensus: "10.00",
+      }),
+      getEarningsEvent({
+        ticker: "SM",
+        when: "before_open",
+        companyName: "Small Co",
+        marketCap: 1_000_000_000,
+        marketCapText: "$1B",
+        epsConsensus: "0.10",
+      }),
+    ], "all", [], {
+      maxMessageLength: 150,
+      maxMessages: 3,
+    });
+
+    expect(batch.messages).toHaveLength(2);
+    const secondMessageLine = batch.messages[1]!
+      .split("\n")
+      .find(line => line.includes(" MCap: "));
+    expect(secondMessageLine).toBeDefined();
+    const parsedLine = parseEarningsLine(secondMessageLine!);
+    expect(parsedLine.ticker).toBe("SM");
+    expect(parsedLine.marketCap).toBe("$1B");
   });
 
   test("sub-sorts a day by time bucket before market cap", () => {

--- a/modules/options-strategy.test.ts
+++ b/modules/options-strategy.test.ts
@@ -163,6 +163,6 @@ describe("options-strategy", () => {
     expect(formattedStraddleResult.split("\n")[0]).toBe("`AAPL` @ `442.00` | ATM Straddle | Expiry `2026-06-19` (`49` DTE)");
     expect(formattedResult.split("\n")[0]).toBe("`AAPL` @ `442.00` | Expected Move | Expiry `2026-06-19` (`49` DTE)");
     expect(formattedResult).toContain("ATM straddle mid `12.40`");
-    expect(formattedResult).toContain("Move proxy: `+/- 12.40`");
+    expect(formattedResult).toContain("Move proxy: `± 12.40`");
   });
 });

--- a/modules/options-strategy.ts
+++ b/modules/options-strategy.ts
@@ -162,7 +162,7 @@ export function formatExpectedMoveLookupResult(result: OptionStrategyLookupResul
       result.underlyingPrice,
       result.underlyingPriceIsRealtime,
     )} | Expected Move | ${formatExpiration(result)}`,
-    `Move proxy: \`+/- ${formatOptionalPrice(result.midTotal)}\` | ATM straddle mid \`${formatOptionalPrice(result.midTotal)}\``,
+    `Move proxy: \`± ${formatOptionalPrice(result.midTotal)}\` | ATM straddle mid \`${formatOptionalPrice(result.midTotal)}\``,
     formatLeg("Put", result.put),
     formatLeg("Call", result.call),
   ].join("\n");


### PR DESCRIPTION
## Summary
- scope earnings ticker and market cap padding to each rendered post
- remove EPS padding and render expected moves with ±
- keep options strategy move output consistent with ±

## Validation
- npm test -- modules/earnings.test.ts modules/options-strategy.test.ts
- npm run typecheck
- npm test
- npm run test:coverage
- npm run lint