### PR TITLE
[codex] Tighten earnings result scope and parsing

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -187,6 +187,157 @@ describe("earnings result formatting", () => {
     expect(parsedDocument.outlook).toEqual([]);
   });
 
+  test("ignores release-title guidance and raw comparison rows in outlook output", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>L.B. Foster Company Announces Strong Sales Growth and Profitability Expansion in 2026 First Quarter; Reaffirms Full Year 2026 Financial Guidance</h1>
+          <p>First quarter net sales totaled $121.1 million, up 23.9% over last year.</p>
+          <p>First quarter net income of $1.5 million was up $3.6 million over last year.</p>
+          <table>
+            <tr><td>$ in thousands, unless otherwise noted:</td></tr>
+            <tr><td>Net sales</td><td>$</td><td>121,144</td><td>$</td><td>97,792</td><td>23.9%</td></tr>
+            <tr><td>Operating income (loss)</td><td>2,045</td><td>(1,923)</td><td>206.3%</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 121_100_000,
+        value: "$121.1M",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 1_500_000,
+        value: "$1.5M",
+      }),
+    ]));
+    expect(parsedDocument.outlook).toEqual([]);
+  });
+
+  test("applies local table money units for main metrics", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Example reports Q1 2026 results</h1>
+          <table>
+            <tr><td>$ in thousands, except per share amounts</td></tr>
+            <tr><td>Product revenue, net</td></tr>
+            <tr><td>$</td><td>116,357</td><td>$</td><td>88,158</td></tr>
+            <tr><td>Net income</td><td>$</td><td>55,932</td><td>$</td><td>35,733</td></tr>
+          </table>
+          <table>
+            <tr><td>(in millions, except per share data)</td></tr>
+            <tr><td>Sales</td><td>$</td><td>13,653</td><td>$</td><td>13,074</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 116_357_000,
+        value: "$116.36M",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 55_932_000,
+        value: "$55.93M",
+      }),
+    ]));
+
+    const salesOnlyDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>SalesCo reports Q2 2026 results</h1>
+          <table>
+            <tr><td>(in millions, except per share data)</td></tr>
+            <tr><td>Sales</td><td>$</td><td>13,653</td><td>$</td><td>13,074</td></tr>
+            <tr><td>Net Income Per Share</td><td>$</td><td>0.73</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(salesOnlyDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 13_653_000_000,
+        value: "$13.65B",
+      }),
+    ]));
+
+    const perShareDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>IncomeCo reports Q1 2026 results</h1>
+          <p>Net income for the three months ended March 31, 2026 was $55.9 million, or $1.91 per common share.</p>
+        </body>
+      </html>
+    `);
+
+    expect(perShareDocument.metrics).toEqual([
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 55_900_000,
+        value: "$55.9M",
+      }),
+    ]);
+  });
+
+  test("skips generic production mentions without operational units", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Example reports Q1 2026 results</h1>
+          <p>Company took delivery of a new venue featuring its latest in-house production on March 31, 2026.</p>
+          <p>Production was 1,234 boepd.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "production",
+        value: "1,234 boepd",
+      }),
+    ]));
+    expect(parsedDocument.metrics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "production",
+        value: "31",
+      }),
+    ]));
+  });
+
+  test("does not use per-share headline values as net income", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Example reports first quarter 2026 results</h1>
+          <p>NET INCOME OF $0.78 PER SHARE AND CORE INCOME OF $0.83 PER SHARE</p>
+          <p>Net income of $211 million versus $274 million in the prior year quarter.</p>
+          <table>
+            <tr><td>($ millions, except per share data)</td></tr>
+            <tr><td>Non-insurance warranty revenue (expense)</td><td>18</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual([
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 211_000_000,
+        value: "$211M",
+      }),
+    ]);
+  });
+
   test("removes script/style blocks with spaced closing tags", () => {
     const text = htmlToText(`
       <p>Revenue $10 billion</p>
@@ -320,6 +471,7 @@ describe("earnings result formatting", () => {
     expect(formatEps(-1.2)).toBe("-$1.2");
     expect(formatUsdCompact(-1_250_000_000_000)).toBe("-$1.25T");
     expect(formatUsdCompact(12_300_000)).toBe("$12.3M");
+    expect(formatUsdCompact(750_000)).toBe("$750K");
     expect(formatUsdCompact(123)).toBe("$123");
 
     expect(normalizeTickerSymbol(" brk-b ")).toBe("BRK.B");

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -75,18 +75,19 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\btotal\s+revenues?(?:\s+and\s+other\s+income)?\b/i,
       /\bnet\s+sales\b/i,
       /\brevenues?\b/i,
+      /\bsales\b/i,
     ],
-    skipPattern: /\bcost\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b/i,
+    skipPattern: /\bcost\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b/i,
     valueType: "money",
   },
   {
     key: "net_income",
     label: "Net income",
     patterns: [
-      /\bnet\s+income(?:\s+attributable[^|,]*)?\b/i,
-      /\bnet\s+earnings\b/i,
+      /\bnet\s+income(?!\s+per\s+(?:common\s+)?share)(?:\s+attributable[^|,]*)?\b/i,
+      /\bnet\s+earnings(?!\s+per\s+(?:common\s+)?share)\b/i,
     ],
-    skipPattern: /\bper\s+(?:common\s+)?share\b|\beps\b/i,
+    skipPattern: /\beps\b/i,
     valueType: "money",
   },
   {
@@ -111,7 +112,7 @@ export function parseEarningsDocument(html: string): ParsedEarningsDocument {
   const lines = getMeaningfulLines(text);
   return {
     headline: getDocumentHeadline(lines),
-    metrics: extractEarningsMetrics(lines, text),
+    metrics: extractEarningsMetrics(lines),
     outlook: extractOutlookMetrics(lines),
     quarterLabel: getQuarterLabel(text),
   };
@@ -284,17 +285,16 @@ function getQuarterLabel(text: string): string | undefined {
   return undefined;
 }
 
-function extractEarningsMetrics(lines: string[], text: string): EarningsResultMetric[] {
+function extractEarningsMetrics(lines: string[]): EarningsResultMetric[] {
   const metrics: EarningsResultMetric[] = [];
   const seenKeys = new Set<string>();
-  const moneyScale = getMoneyScale(text);
 
   for (const definition of earningsMetricDefinitions) {
     if (true === seenKeys.has(definition.key)) {
       continue;
     }
 
-    const metric = extractMetric(lines, definition, moneyScale);
+    const metric = extractMetric(lines, definition);
     if (null === metric) {
       continue;
     }
@@ -309,19 +309,28 @@ function extractEarningsMetrics(lines: string[], text: string): EarningsResultMe
 function extractMetric(
   lines: string[],
   definition: MetricDefinition,
-  moneyScale: number,
 ): EarningsResultMetric | null {
-  for (const line of lines) {
+  for (const [lineIndex, line] of lines.entries()) {
     if (definition.skipPattern?.test(line)) {
       continue;
     }
 
-    const pattern = definition.patterns.find(candidatePattern => candidatePattern.test(line));
+    if ("net_income" === definition.key && true === isPerShareOnlyNetIncomeLine(line)) {
+      continue;
+    }
+
+    const metricLine = getMetricLineWithContinuation(lines, lineIndex);
+    const pattern = definition.patterns.find(candidatePattern => candidatePattern.test(metricLine));
     if (!pattern) {
       continue;
     }
 
-    const metricValue = extractMetricValue(line, pattern, definition.valueType, moneyScale);
+    const metricValue = extractMetricValue(
+      metricLine,
+      pattern,
+      definition.valueType,
+      getContextMoneyScale(lines, lineIndex),
+    );
     if (null === metricValue) {
       continue;
     }
@@ -337,11 +346,30 @@ function extractMetric(
   return null;
 }
 
+function isPerShareOnlyNetIncomeLine(line: string): boolean {
+  return /\bper\s+(?:common\s+|diluted\s+)?share\b/i.test(line) &&
+    false === /\b(?:trillion|billion|million|thousand)s?\b/i.test(line);
+}
+
+function getMetricLineWithContinuation(lines: string[], lineIndex: number): string {
+  const line = lines[lineIndex] ?? "";
+  const nextLine = lines[lineIndex + 1];
+  if (undefined === nextLine || false === isValueOnlyLine(nextLine)) {
+    return line;
+  }
+
+  return `${line} ${nextLine}`;
+}
+
+function isValueOnlyLine(line: string): boolean {
+  return /^[\s|$€£¥(),.\-\d%—–]+$/.test(line);
+}
+
 function extractMetricValue(
   line: string,
   pattern: RegExp,
   valueType: MetricValueType,
-  moneyScale: number,
+  contextMoneyScale: number,
 ): {numericValue: number; value: string} | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
@@ -353,13 +381,16 @@ function extractMetricValue(
   }
 
   if ("money" === valueType) {
-    const parsedValue = findNumericValue(searchText, {skipPercentages: true});
+    const parsedValue = findNumericValue(searchText, {
+      requireMoneyCue: 1 === contextMoneyScale,
+      skipPercentages: true,
+    });
     if (null === parsedValue) {
       return null;
     }
 
     const explicitScale = getExplicitMoneyScale(searchText);
-    const amount = parsedValue * (explicitScale ?? moneyScale);
+    const amount = parsedValue * (explicitScale ?? contextMoneyScale);
     return {
       numericValue: amount,
       value: formatUsdCompact(amount),
@@ -371,35 +402,66 @@ function extractMetricValue(
     return null;
   }
 
+  const trailingUnit = getTrailingUnit(searchText);
+  if (null === trailingUnit) {
+    return null;
+  }
+
   return {
     numericValue: value,
-    value: formatPlainNumber(value, getTrailingUnit(searchText)),
+    value: formatPlainNumber(value, trailingUnit),
   };
 }
 
-function getMoneyScale(text: string): number {
-  if (/\b(?:in\s+)?(?:millions|million)\s+of\s+dollars\b/i.test(text) ||
-      /\$\s+in\s+millions\b/i.test(text)) {
-    return 1_000_000;
-  }
+function getContextMoneyScale(lines: string[], lineIndex: number): number {
+  for (let index = lineIndex; index >= 0 && index >= lineIndex - 30; index--) {
+    const line = lines[index];
+    if (undefined === line) {
+      continue;
+    }
 
-  if (/\b(?:in\s+)?(?:billions|billion)\s+of\s+dollars\b/i.test(text) ||
-      /\$\s+in\s+billions\b/i.test(text)) {
-    return 1_000_000_000;
+    const scale = getMoneyScaleFromContextText(line);
+    if (null !== scale) {
+      return scale;
+    }
   }
 
   return 1;
 }
 
+function getMoneyScaleFromContextText(text: string): number | null {
+  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?thousands(?:\s+of\s+dollars)?\b/i.test(text)) {
+    return 1_000;
+  }
+
+  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?millions(?:\s+of\s+dollars)?\b/i.test(text)) {
+    return 1_000_000;
+  }
+
+  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?billions(?:\s+of\s+dollars)?\b/i.test(text)) {
+    return 1_000_000_000;
+  }
+
+  return null;
+}
+
 function getExplicitMoneyScale(text: string): number | null {
-  const unitMatch = text.match(/\b(billion|billions|bn|million|millions|mm)\b/i);
+  const unitMatch = text.match(/\b(trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands)\b/i);
   const unit = unitMatch?.[1]?.toLowerCase();
   if (!unit) {
     return null;
   }
 
+  if ("trillion" === unit || "trillions" === unit || "tn" === unit) {
+    return 1_000_000_000_000;
+  }
+
   if ("billion" === unit || "billions" === unit || "bn" === unit) {
     return 1_000_000_000;
+  }
+
+  if ("thousand" === unit || "thousands" === unit) {
+    return 1_000;
   }
 
   return 1_000_000;
@@ -407,9 +469,9 @@ function getExplicitMoneyScale(text: string): number | null {
 
 function findNumericValue(
   text: string,
-  options: {maxAbsValue?: number; skipPercentages?: boolean;} = {},
+  options: {maxAbsValue?: number; requireMoneyCue?: boolean; skipPercentages?: boolean;} = {},
 ): number | null {
-  const numberMatches = text.matchAll(/\(?-?\$?\d{1,3}(?:,\d{3})*(?:\.\d+)?\)?|\(?-?\$?\d+(?:\.\d+)?\)?/g);
+  const numberMatches = text.matchAll(/\(?-?\$?\s*(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?/g);
   for (const numberMatch of numberMatches) {
     const token = numberMatch[0];
     const endIndex = numberMatch.index + token.length;
@@ -419,6 +481,11 @@ function findNumericValue(
 
     const value = parseNumber(token);
     if (null === value) {
+      continue;
+    }
+
+    if (true === options.requireMoneyCue &&
+        false === hasMoneyCue(text, numberMatch.index, endIndex, token)) {
       continue;
     }
 
@@ -436,6 +503,20 @@ function findNumericValue(
   return null;
 }
 
+function hasMoneyCue(text: string, startIndex: number, endIndex: number, token: string): boolean {
+  if (token.includes("$")) {
+    return true;
+  }
+
+  const beforeToken = text.slice(Math.max(0, startIndex - 8), startIndex);
+  if (/\$[\s|()–-]*$/.test(beforeToken)) {
+    return true;
+  }
+
+  const afterToken = text.slice(endIndex, endIndex + 18);
+  return /^\s*(?:trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands)\b/i.test(afterToken);
+}
+
 export function parseNumber(value: unknown): number | null {
   if ("number" === typeof value) {
     return Number.isFinite(value) ? value : null;
@@ -447,6 +528,7 @@ export function parseNumber(value: unknown): number | null {
 
   const normalizedValue = value
     .replace(/^\((.*)\)$/, "-$1")
+    .replace(/^\((.*)$/, "-$1")
     .replaceAll("$", "")
     .replaceAll(",", "")
     .replaceAll("%", "")
@@ -484,6 +566,10 @@ export function formatUsdCompact(value: number): string {
 
   if (absoluteValue >= 1_000_000) {
     return `${sign}$${formatDecimal(absoluteValue / 1_000_000)}M`;
+  }
+
+  if (absoluteValue >= 1_000) {
+    return `${sign}$${formatDecimal(absoluteValue / 1_000)}K`;
   }
 
   return `${sign}$${formatDecimal(absoluteValue)}`;

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -98,6 +98,42 @@ describe("extractOutlookMetrics", () => {
       "Appendix",
       "EPS $1.20.",
     ])).toEqual([]);
+
+    expect(extractOutlookMetrics([
+      "ExampleCo Announces First Quarter Results; Reaffirms Full Year Guidance",
+      "Revenue | $ | 121,144 | | | $ | 97,792 | | | | | 23.9",
+      "Operating income (loss) | | 2,045 | | | (1,923) | | | | | 206.3",
+    ])).toEqual([]);
+  });
+
+  test("ignores dense comparison-table rows inside outlook sections", () => {
+    expect(extractOutlookMetrics([
+      "Business Outlook",
+      "Revenue | $ | 121,144 | | | $ | 97,792 | | | | | 23.9",
+      "Operating income (loss) | | 2,045 | | | (1,923) | | | | | 206.3",
+    ])).toEqual([]);
+  });
+
+  test("ignores outlook mentions in summary bullets and extracts later guidance", () => {
+    expect(extractOutlookMetrics([
+      "Revenue guidance raised to $442-$447M; Reiterating Q4 FY26 Adj EBITDA breakeven",
+      "Revenue exceeded guidance, coming in at $110.7 million.",
+      "Fiscal 2026 Financial Guidance",
+      "The following statements are based on current expectations for fiscal 2026. The following statements are forward-looking, and actual results could differ materially depending on market conditions.",
+      "Total revenue in the range of $442 million to $447 million.",
+      "Gross margin to be above 52% for fiscal 2026.",
+    ])).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        value: "$442M to $447M",
+      },
+      {
+        key: "gross_margin",
+        label: "Gross margin",
+        value: "52%",
+      },
+    ]);
   });
 
   test("extracts single-value outlook metrics across supported value types", () => {

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -120,13 +120,28 @@ function getOutlookSectionLines(lines: string[]): string[] {
 }
 
 function isOutlookHeading(line: string): boolean {
-  return line.length <= 140 &&
-    /\b(?:outlook|guidance|business\s+outlook|financial\s+outlook|fiscal\s+\d{4}\s+outlook|quarter\s+outlook)\b/i.test(line) &&
-    false === /\bforward-looking\s+statements?\b/i.test(line);
+  if (line.length > 140 ||
+      /\b(?:announces?|reports?|reported|results?)\b/i.test(line) ||
+      /\bforward-looking\s+statements?\b/i.test(line)) {
+    return false;
+  }
+
+  const normalizedLine = line
+    .replace(/^[\s•–—-]+/, "")
+    .replace(/[\s|–—-]+$/, "")
+    .trim();
+
+  return /^(?:business\s+|financial\s+)?(?:outlook|guidance)\b/i.test(normalizedLine) ||
+    /^(?:fiscal\s+)?(?:20\d{2}|fy\s?\d{2}|q[1-4]\s+20\d{2}|quarter)\b.*\b(?:outlook|guidance)\b/i.test(normalizedLine);
 }
 
 function isOutlookSectionEnd(line: string): boolean {
-  if (/\b(?:forward-looking\s+statements?|safe\s+harbor|conference\s+call|about\s+|press\s+contact|investor\s+relations|condensed\s+consolidated|financial\s+statements?|non-gaap|reconciliation)\b/i.test(line)) {
+  if (line.length <= 140 &&
+      /\b(?:forward-looking\s+statements?|safe\s+harbor|legal\s+notice\s+regarding\s+forward-looking)\b/i.test(line)) {
+    return true;
+  }
+
+  if (/\b(?:conference\s+call|about\s+|press\s+contact|investor\s+relations|condensed\s+consolidated|financial\s+statements?|non-gaap|reconciliation)\b/i.test(line)) {
     return true;
   }
 
@@ -139,6 +154,10 @@ function extractOutlookMetric(
   definition: OutlookMetricDefinition,
 ): EarningsOutlookMetric | null {
   for (const line of lines) {
+    if (true === isNoisyOutlookLine(line)) {
+      continue;
+    }
+
     const pattern = definition.patterns.find(candidatePattern => candidatePattern.test(line));
     if (!pattern) {
       continue;
@@ -159,6 +178,11 @@ function extractOutlookMetric(
   return null;
 }
 
+function isNoisyOutlookLine(line: string): boolean {
+  const pipeCount = line.match(/\|/g)?.length ?? 0;
+  return pipeCount >= 4;
+}
+
 function extractOutlookValue(
   line: string,
   pattern: RegExp,
@@ -174,6 +198,7 @@ function extractOutlookValue(
 
   return getGrowthOutlookValue(valueText) ??
     getOutlookRangeValue(valueText, valueType) ??
+    ("text" === valueType ? getSingleOutlookValue(valueText, "money") : null) ??
     getSingleOutlookValue(valueText, valueType) ??
     getFallbackOutlookValue(valueText);
 }
@@ -262,7 +287,11 @@ function getSingleOutlookValue(value: string, valueType: OutlookValueType): stri
 
 function getFallbackOutlookValue(value: string): string | null {
   const fallbackValue = value.split(/[.;]/)[0]?.trim() ?? "";
-  if (fallbackValue.length < 2 || fallbackValue.length > 80) {
+  if (fallbackValue.length < 2 ||
+      fallbackValue.length > 80 ||
+      fallbackValue.includes("|") ||
+      /^n\/?a$/i.test(fallbackValue) ||
+      /\$\s*\d/.test(fallbackValue)) {
     return null;
   }
 
@@ -273,7 +302,7 @@ function findNumericValue(
   text: string,
   options: {maxAbsValue?: number; skipPercentages?: boolean;} = {},
 ): number | null {
-  const numberMatches = text.matchAll(/\(?-?\$?\d{1,3}(?:,\d{3})*(?:\.\d+)?\)?|\(?-?\$?\d+(?:\.\d+)?\)?/g);
+  const numberMatches = text.matchAll(/\(?-?\$?\s*(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?/g);
   for (const numberMatch of numberMatches) {
     const token = numberMatch[0];
     const endIndex = numberMatch.index + token.length;
@@ -365,6 +394,10 @@ function formatUsdCompact(value: number): string {
 
   if (absoluteValue >= 1_000_000) {
     return `${sign}$${formatDecimal(absoluteValue / 1_000_000)}M`;
+  }
+
+  if (absoluteValue >= 1_000) {
+    return `${sign}$${formatDecimal(absoluteValue / 1_000)}K`;
   }
 
   return `${sign}$${formatDecimal(absoluteValue)}`;

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -25,6 +25,8 @@ describe("earnings result announcements", () => {
         date: "2026-05-01",
         importance: 1,
         companyName: "Exxon Mobil",
+        marketCap: 475_000_000_000,
+        marketCapText: "$475B",
         epsConsensus: "$0.96",
       }],
     });
@@ -151,6 +153,106 @@ describe("earnings result announcements", () => {
     });
 
     expect(result.announcements).toHaveLength(0);
+  });
+
+  test("skips companies outside the scheduled earnings announcement scope", async () => {
+    getEarningsResultFn.mockResolvedValue({
+      status: "ok",
+      events: [{
+        ticker: "XOM",
+        when: "before_open",
+        date: "2026-05-01",
+        importance: 1,
+        companyName: "Exxon Mobil",
+        marketCap: 9_999_999_999,
+        marketCapText: "$10B",
+        epsConsensus: "$0.96",
+      }],
+    });
+
+    const result = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      },
+    });
+
+    expect(result).toEqual({
+      active: false,
+      announcements: [],
+      watchedCompanies: 0,
+    });
+    expect(getWithRetryFn).toHaveBeenCalledWith(
+      "https://www.sec.gov/files/company_tickers.json",
+      expect.anything(),
+    );
+    expect(getWithRetryFn).not.toHaveBeenCalledWith(
+      expect.stringContaining("browse-edgar"),
+      expect.anything(),
+    );
+  });
+
+  test("skips SEC filings updated on a different US Eastern day", async () => {
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.includes("company_tickers.json")) {
+        return {
+          data: {
+            0: {
+              cik_str: 34088,
+              ticker: "XOM",
+              title: "EXXON MOBIL CORP",
+            },
+          },
+        };
+      }
+
+      if (url.includes("type=8-K")) {
+        return {
+          data: `
+            <feed>
+              <entry>
+                <title>8-K - EXXON MOBIL CORP</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0000034088-26-000042</id>
+                <updated>2026-04-30T23:59:00-04:00</updated>
+                <category term="8-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/0000034088-26-000042-index.htm" />
+                <summary>
+                  &lt;b&gt;CIK:&lt;/b&gt; 0000034088&lt;br/&gt;
+                  &lt;b&gt;Items:&lt;/b&gt; 2.02, 9.01
+                </summary>
+              </entry>
+            </feed>
+          `,
+        };
+      }
+
+      if (url.includes("type=6-K")) {
+        return {
+          data: "<feed></feed>",
+        };
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    const result = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      },
+    });
+
+    expect(result.active).toBe(true);
+    expect(result.watchedCompanies).toBe(1);
+    expect(result.announcements).toEqual([]);
+    expect(getWithRetryFn).not.toHaveBeenCalledWith(
+      expect.stringContaining("/index.json"),
+      expect.anything(),
+    );
   });
 
   test("skips the scan when the SEC ticker map is blocked", async () => {

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -1,5 +1,5 @@
 import moment from "moment-timezone";
-import {type EarningsEvent, getEarningsResult} from "./earnings.ts";
+import {bluechipMinMarketCap, type EarningsEvent, getEarningsResult} from "./earnings.ts";
 import {
   formatUsdCompact,
   getEarningsResultMessage,
@@ -258,6 +258,10 @@ export async function getEarningsResultAnnouncements({
       continue;
     }
 
+    if (false === isFilingUpdatedToday(filing, now)) {
+      continue;
+    }
+
     const filingWatches = watchesByCik.get(filing.cik);
     const filingWatch = filingWatches?.[0];
     if (!filingWatch) {
@@ -392,6 +396,10 @@ function buildEarningsWatches(
   const watches: EarningsWatchEntry[] = [];
 
   for (const event of earningsEvents) {
+    if (false === isEarningsResultAnnouncementScope(event)) {
+      continue;
+    }
+
     const normalizedTicker = normalizeTickerSymbol(event.ticker);
     const secCompany = tickerToCompany.get(normalizedTicker);
     if (!secCompany || true === seenCiks.has(secCompany.cik)) {
@@ -408,6 +416,12 @@ function buildEarningsWatches(
   }
 
   return watches;
+}
+
+function isEarningsResultAnnouncementScope(event: EarningsEvent): boolean {
+  return "number" === typeof event.marketCap &&
+    true === Number.isFinite(event.marketCap) &&
+    event.marketCap >= bluechipMinMarketCap;
 }
 
 function groupWatchesByCik(watches: EarningsWatchEntry[]): Map<string, EarningsWatchEntry[]> {
@@ -432,6 +446,15 @@ function isWatchActive(event: EarningsEvent, now: moment.Moment): boolean {
   }
 
   return minuteOfDay >= 4 * 60 && minuteOfDay <= 23 * 60 + 30;
+}
+
+function isFilingUpdatedToday(filing: SecCurrentFiling, now: moment.Moment): boolean {
+  const updatedAt = moment.parseZone(filing.updated, moment.ISO_8601, true);
+  if (false === updatedAt.isValid()) {
+    return false;
+  }
+
+  return updatedAt.tz(usEasternTimezone).format(dateStampFormat) === now.format(dateStampFormat);
 }
 
 async function buildEarningsResultAnnouncement(


### PR DESCRIPTION
## Summary
- Gate earnings-result announcements to scheduled same-day SEC filings for bluechip-scope companies.
- Tighten SEC metric parsing for local table units, per-share net income traps, false revenue rows, production units, and compact K-format money output.
- Harden outlook extraction so title guidance and raw comparison rows do not leak while real guidance sections still parse.

## Why
Several posted earnings messages included microcaps or stale/unscheduled filings, and some parsed values from SEC exhibits were misleading because the parser used broad document context or grabbed table/comparison values.

## Validation
- npm test -- modules/earnings-results-format.test.ts modules/earnings-results-outlook.test.ts
- npm run typecheck
- npm run test:coverage
- git diff --check

Spot checks against the reported SEC samples showed CNA omits the bogus $18M revenue, SGC uses the real $572M to $585M outlook range, and TWST parses the $442M to $447M outlook range.