### PR TITLE
[codex] Adjust paywall previews and earnings links

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -72,6 +72,17 @@ describe("earnings result formatting", () => {
       parsedDocument,
       ticker: "XOM",
     })).toContain("Adj EPS: `$1.16` vs est. `$0.96` - beat");
+    expect(getEarningsResultMessage({
+      companyName: "Exxon Mobil",
+      filing: {
+        form: "8-K",
+        items: ["2.02", "9.01"],
+      },
+      filingUrl: "https://www.sec.gov/Archives/edgar/data/34088/example/ex-991.htm",
+      metrics,
+      parsedDocument,
+      ticker: "XOM",
+    })).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/34088/example/ex-991.htm) Item 2.02, 9.01");
   });
 
   test("parses and renders table-based outlook metrics", () => {
@@ -417,7 +428,7 @@ describe("earnings result formatting", () => {
     expect(message).toBe([
       "💰 **Earnings: Example (`EX`)**",
       "Production: `1,200 boepd`",
-      "SEC: 10-Q https://www.sec.gov/example",
+      "SEC: [10-Q](https://www.sec.gov/example)",
     ].join("\n"));
   });
 

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -190,7 +190,8 @@ export function getEarningsResultMessage({
   }
 
   const filingItems = filing.items.length > 0 ? ` Item ${filing.items.join(", ")}` : "";
-  lines.push(`SEC: ${filing.form}${filingItems} ${filingUrl}`);
+  const filingForm = "" === filingUrl ? filing.form : `[${filing.form}](${filingUrl})`;
+  lines.push(`SEC: ${filingForm}${filingItems}`);
   return lines.join("\n");
 }
 

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -138,7 +138,7 @@ describe("earnings result announcements", () => {
     expect(result.announcements[0]!.message).toContain("Earnings: Exxon Mobil (`XOM`) Q1 2026");
     expect(result.announcements[0]!.message).toContain("Adj EPS: `$1.16` vs est. `$0.96` - beat");
     expect(result.announcements[0]!.message).toContain("Revenue: `$85.14B` vs est. `$80.74B` - beat");
-    expect(result.announcements[0]!.message).toContain("SEC: 8-K Item 2.02, 9.01");
+    expect(result.announcements[0]!.message).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm) Item 2.02, 9.01");
   });
 
   test("skips accessions that were already announced", async () => {
@@ -400,5 +400,6 @@ describe("earnings result announcements", () => {
   test("provides a concrete example output", () => {
     expect(getExampleEarningsResultOutput()).toContain("Apple Inc. (`AAPL`)");
     expect(getExampleEarningsResultOutput()).toContain("EPS: `$2.84` vs est. `$2.67` - beat");
+    expect(getExampleEarningsResultOutput()).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01");
   });
 });

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -591,6 +591,6 @@ export function getExampleEarningsResultOutput(): string {
     `EPS: \`$2.84\` vs est. \`$2.67\` - beat`,
     `Revenue: \`${formatUsdCompact(143_800_000_000)}\` vs est. \`${formatUsdCompact(138_250_000_000)}\` - beat`,
     `Net income: \`${formatUsdCompact(42_097_000_000)}\``,
-    "SEC: 8-K Item 2.02, 9.01 https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm",
+    "SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01",
   ].join("\n");
 }

--- a/modules/paywall-response.ts
+++ b/modules/paywall-response.ts
@@ -1,0 +1,45 @@
+import {EmbedBuilder} from "discord.js";
+import type {PaywallResult} from "./paywall.ts";
+
+export type PaywallResponsePayload = {
+  content: string;
+  embeds: EmbedBuilder[];
+};
+
+export function buildPaywallResponsePayload(url: string, result: PaywallResult): PaywallResponsePayload {
+  const embed = new EmbedBuilder();
+
+  if (true === result.nofix) {
+    embed.setTitle("Paywall Bypass");
+    embed.setDescription("Für diese Seite ist leider kein Paywall-Bypass bekannt.");
+    return {
+      content: url,
+      embeds: [embed],
+    };
+  }
+
+  const title = true === result.isDefault
+    ? "Paywall Bypass (unbekannte Seite)"
+    : "Paywall Bypass";
+  embed.setTitle(title);
+
+  if (true === result.isDefault) {
+    embed.setDescription("Unbekannte Seite — versuche allgemeine Services:");
+  }
+
+  const lines: string[] = [];
+  for (const service of result.services) {
+    if (true === service.available) {
+      lines.push(`✅ **${service.name}**: <${service.url}>`);
+    } else {
+      lines.push(`❓ **${service.name}**: <${service.url}>`);
+    }
+  }
+
+  embed.addFields({name: "Ergebnisse", value: lines.join("\n")});
+
+  return {
+    content: url,
+    embeds: [embed],
+  };
+}

--- a/modules/slash-commands-interact-paywall.ts
+++ b/modules/slash-commands-interact-paywall.ts
@@ -1,4 +1,4 @@
-import {type ChatInputCommandInteraction, EmbedBuilder} from "discord.js";
+import {type ChatInputCommandInteraction} from "discord.js";
 import validator from "validator";
 import {type PaywallAsset} from "./assets.ts";
 import {getLogger} from "./logging.ts";
@@ -8,6 +8,7 @@ import {
   paywallLookupBusyMessage,
   type PaywallResult,
 } from "./paywall.ts";
+import {buildPaywallResponsePayload} from "./paywall-response.ts";
 import {assertSafeRequestUrl, UnsafeUrlError} from "./safe-http.ts";
 
 const logger = getLogger();
@@ -80,40 +81,8 @@ export async function handlePaywallSlashCommand(
     const result: PaywallResult = await getPaywallLinks(url, paywallAssets ?? [], {
       requesterId: interaction.user.id,
     });
-    const embed = new EmbedBuilder();
 
-    if (true === result.nofix) {
-      embed.setTitle("Paywall Bypass");
-      embed.setDescription(
-        `Für diese Seite ist leider kein Paywall-Bypass bekannt.`,
-      );
-      embed.addFields({name: "URL", value: `<${url}>`});
-    } else {
-      const title = true === result.isDefault
-        ? "Paywall Bypass (unbekannte Seite)"
-        : "Paywall Bypass";
-      embed.setTitle(title);
-
-      if (true === result.isDefault) {
-        embed.setDescription("Unbekannte Seite — versuche allgemeine Services:");
-      }
-
-      const lines: string[] = [];
-      for (const service of result.services) {
-        if (true === service.available) {
-          lines.push(`✅ **${service.name}**: <${service.url}>`);
-        } else {
-          lines.push(`❓ **${service.name}**: <${service.url}>`);
-        }
-      }
-
-      embed.addFields(
-        {name: "Original", value: `<${url}>`},
-        {name: "Ergebnisse", value: lines.join("\n")},
-      );
-    }
-
-    await interaction.editReply({content: "", embeds: [embed]}).catch((error: unknown) => {
+    await interaction.editReply(buildPaywallResponsePayload(url, result)).catch((error: unknown) => {
       logger.log(
         "error",
         `Error replying to paywall slashcommand: ${error}`,

--- a/modules/slash-commands.interact-paywall.test.ts
+++ b/modules/slash-commands.interact-paywall.test.ts
@@ -106,14 +106,10 @@ describe("handlePaywallSlashCommand", () => {
       content: "Suche nach Paywall-Bypass für <https://example.com/article>... Das kann bis zu 60 Sekunden dauern.",
     });
     const finalPayload = interaction.editReply.mock.calls[1]![0] as {content: string; embeds: EditedEmbed[]};
-    expect(finalPayload.content).toBe("");
+    expect(finalPayload.content).toBe("https://example.com/article");
     expect(finalPayload.embeds[0]?.toJSON()).toEqual({
       title: "Paywall Bypass",
       description: "Für diese Seite ist leider kein Paywall-Bypass bekannt.",
-      fields: [{
-        name: "URL",
-        value: "<https://example.com/article>",
-      }],
     });
   });
 
@@ -141,14 +137,11 @@ describe("handlePaywallSlashCommand", () => {
       requesterId: "user-id",
     });
     const finalPayload = interaction.editReply.mock.calls[1]![0] as {content: string; embeds: EditedEmbed[]};
+    expect(finalPayload.content).toBe("https://example.com/article");
     expect(finalPayload.embeds[0]?.toJSON()).toEqual({
       title: "Paywall Bypass (unbekannte Seite)",
       description: "Unbekannte Seite — versuche allgemeine Services:",
       fields: [
-        {
-          name: "Original",
-          value: "<https://example.com/article>",
-        },
         {
           name: "Ergebnisse",
           value: [
@@ -178,19 +171,36 @@ describe("handlePaywallSlashCommand", () => {
       requesterId: "user-id",
     });
     const finalPayload = interaction.editReply.mock.calls[1]![0] as {content: string; embeds: EditedEmbed[]};
+    expect(finalPayload.content).toBe("https://example.com/article");
     expect(finalPayload.embeds[0]?.toJSON()).toEqual({
       title: "Paywall Bypass",
       fields: [
-        {
-          name: "Original",
-          value: "<https://example.com/article>",
-        },
         {
           name: "Ergebnisse",
           value: "✅ **archive.today**: <https://archive.ph/newest/https://example.com/article>",
         },
       ],
     });
+  });
+
+  test("logs and completes when the final paywall edit fails", async () => {
+    getPaywallLinksMock.mockResolvedValueOnce(paywallResult({
+      services: [
+        {
+          name: "archive.today",
+          url: "https://archive.ph/newest/https://example.com/article",
+          available: true,
+        },
+      ],
+    }));
+    const interaction = createPaywallInteraction("https://example.com/article");
+    interaction.editReply
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("edit failed"));
+
+    await expect(handlePaywallSlashCommand(asChatInputInteraction(interaction), "paywall")).resolves.toBe(true);
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(2);
   });
 
   test("edits busy message when lookup capacity is exhausted", async () => {

--- a/modules/trigger-response.test.ts
+++ b/modules/trigger-response.test.ts
@@ -25,13 +25,16 @@ type SentAttachment = {
 };
 type SentEmbed = {
   toJSON: () => {
+    description?: string;
     fields?: {name: string; value: string}[];
     image?: {
       url?: string;
     };
+    title?: string;
   };
 };
 type SentPayload = {
+  content?: string;
   embeds?: SentEmbed[];
   files?: SentAttachment[];
 };
@@ -375,11 +378,19 @@ describe("addTriggerResponses", () => {
     expect(getPaywallLinksMock).toHaveBeenCalledWith("https://example.com/article", [], {
       requesterId: "requester-id",
     });
-    expect(edit).toHaveBeenCalledWith([
-      "Unbekannte Seite — versuche allgemeine Services:\n",
-      "✅ **archive.today**: <https://archive.ph/newest/https://example.com/article>",
-      "❓ **backup**: <https://backup.example/article>",
-    ].join("\n"));
+    const finalPayload = edit.mock.calls[0]![0] as SentPayload;
+    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(finalPayload.embeds?.[0]?.toJSON()).toEqual({
+      title: "Paywall Bypass (unbekannte Seite)",
+      description: "Unbekannte Seite — versuche allgemeine Services:",
+      fields: [{
+        name: "Ergebnisse",
+        value: [
+          "✅ **archive.today**: <https://archive.ph/newest/https://example.com/article>",
+          "❓ **backup**: <https://backup.example/article>",
+        ].join("\n"),
+      }],
+    });
   });
 
   test("paywall rejects unsafe private-network URLs before lookup", async () => {
@@ -393,6 +404,38 @@ describe("addTriggerResponses", () => {
 
     expect(message.channel.send).toHaveBeenCalledWith("Ungültige URL. Bitte eine öffentliche http(s)-URL angeben.");
     expect(getPaywallLinksMock).not.toHaveBeenCalled();
+  });
+
+  test("paywall sends final payload when the working message cannot be created", async () => {
+    getPaywallLinksMock.mockResolvedValueOnce(paywallResult({
+      services: [{
+        name: "archive.today",
+        url: "https://archive.ph/newest/https://example.com/article",
+        available: true,
+      }],
+    }));
+    const {client, getHandler} = createEventClient();
+    addTriggerResponses(client, [], [], []);
+
+    const handler = getHandler("messageCreate");
+    const message = createMessage("!paywall https://example.com/article");
+    message.channel.send.mockRejectedValueOnce(new Error("send failed"));
+
+    await handler(message);
+
+    expect(message.channel.send).toHaveBeenNthCalledWith(
+      1,
+      "Suche nach Paywall-Bypass für <https://example.com/article>... Das kann bis zu 60 Sekunden dauern.",
+    );
+    const finalPayload = message.channel.send.mock.calls[1]![0] as SentPayload;
+    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(finalPayload.embeds?.[0]?.toJSON()).toEqual({
+      title: "Paywall Bypass",
+      fields: [{
+        name: "Ergebnisse",
+        value: "✅ **archive.today**: <https://archive.ph/newest/https://example.com/article>",
+      }],
+    });
   });
 
   test("paywall edits busy fallback when lookup capacity is exhausted", async () => {
@@ -429,7 +472,12 @@ describe("addTriggerResponses", () => {
 
     await handler(message);
 
-    expect(edit).toHaveBeenCalledWith("Für diese Seite ist leider kein Paywall-Bypass bekannt.");
+    const finalPayload = edit.mock.calls[0]![0] as SentPayload;
+    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(finalPayload.embeds?.[0]?.toJSON()).toEqual({
+      title: "Paywall Bypass",
+      description: "Für diese Seite ist leider kein Paywall-Bypass bekannt.",
+    });
   });
 
   test("replies with sara attachment for yes and shrug", async () => {

--- a/modules/trigger-response.ts
+++ b/modules/trigger-response.ts
@@ -10,6 +10,7 @@ import {
   paywallLookupBusyMessage,
 } from "./paywall.ts";
 import type {PaywallResult} from "./paywall.ts";
+import {buildPaywallResponsePayload, type PaywallResponsePayload} from "./paywall-response.ts";
 import {assertSafeRequestUrl, UnsafeUrlError} from "./safe-http.ts";
 import {getRandomAssetByTriggerGroup} from "./random-asset.ts";
 import {getRandomQuote} from "./random-quote.ts";
@@ -19,11 +20,12 @@ const noQuoteMessage = "Keine passenden Zitate gefunden.";
 const unavailableMessage = "Dieser Inhalt ist gerade nicht verfügbar. Bitte später erneut versuchen.";
 
 type TriggerResponsePayload = string | {
+  content?: string;
   embeds?: EmbedBuilder[];
   files?: AttachmentBuilder[];
 };
 type TriggerResponseSentMessage = {
-  edit: (content: string) => Promise<unknown>;
+  edit: (content: string | PaywallResponsePayload) => Promise<unknown>;
 };
 type TriggerResponseChannel = {
   send: (payload: TriggerResponsePayload) => Promise<TriggerResponseSentMessage | undefined>;
@@ -242,33 +244,11 @@ export function addTriggerResponses(
           const paywallOptions = message.author?.id ? {requesterId: message.author.id} : {};
           const result: PaywallResult = await getPaywallLinks(cleanUrl, paywallAssets ?? [], paywallOptions);
 
-          if (true === result.nofix) {
-            const noFixResponse = `Für diese Seite ist leider kein Paywall-Bypass bekannt.`;
-            if (undefined !== workingMessage) {
-              await workingMessage.edit(noFixResponse);
-            } else {
-              await message.channel.send(noFixResponse);
-            }
+          const response = buildPaywallResponsePayload(cleanUrl, result);
+          if (undefined !== workingMessage) {
+            await workingMessage.edit(response);
           } else {
-            const lines: string[] = [];
-            if (true === result.isDefault) {
-              lines.push("Unbekannte Seite — versuche allgemeine Services:\n");
-            }
-
-            for (const service of result.services) {
-              if (true === service.available) {
-                lines.push(`✅ **${service.name}**: <${service.url}>`);
-              } else {
-                lines.push(`❓ **${service.name}**: <${service.url}>`);
-              }
-            }
-
-            const response = lines.join("\n");
-            if (undefined !== workingMessage) {
-              await workingMessage.edit(response);
-            } else {
-              await message.channel.send(response);
-            }
+            await message.channel.send(response);
           }
         } catch (error: unknown) {
           if (error instanceof PaywallLookupCapacityError) {


### PR DESCRIPTION
## Summary
- Post the original paywall URL as message content so Discord can render the normal link preview image.
- Move paywall bypass results into the bot embed and remove the original URL field from that embed.
- Format earnings SEC footers as Markdown links on the filing form, e.g. `SEC: [8-K](...) Item 2.02, 9.01`, instead of appending a bare SEC URL.

## Why
Discord only creates the article preview when the original URL appears as normal message content. The bot embed should focus on the bypass result link, while earnings messages should avoid noisy bare SEC URLs.

## Validation
- npm test -- modules/trigger-response.test.ts modules/slash-commands.interact-paywall.test.ts modules/earnings-results-format.test.ts modules/earnings-results.test.ts
- npm run typecheck
- npm run test:coverage
- git diff --check