### PR TITLE
[codex] Post paywall preview URL separately

### DIFF
--- a/modules/paywall-response.ts
+++ b/modules/paywall-response.ts
@@ -2,18 +2,16 @@ import {EmbedBuilder} from "discord.js";
 import type {PaywallResult} from "./paywall.ts";
 
 export type PaywallResponsePayload = {
-  content: string;
   embeds: EmbedBuilder[];
 };
 
-export function buildPaywallResponsePayload(url: string, result: PaywallResult): PaywallResponsePayload {
+export function buildPaywallResponsePayload(result: PaywallResult): PaywallResponsePayload {
   const embed = new EmbedBuilder();
 
   if (true === result.nofix) {
     embed.setTitle("Paywall Bypass");
     embed.setDescription("Für diese Seite ist leider kein Paywall-Bypass bekannt.");
     return {
-      content: url,
       embeds: [embed],
     };
   }
@@ -39,7 +37,6 @@ export function buildPaywallResponsePayload(url: string, result: PaywallResult):
   embed.addFields({name: "Ergebnisse", value: lines.join("\n")});
 
   return {
-    content: url,
     embeds: [embed],
   };
 }

--- a/modules/slash-commands-interact-paywall.ts
+++ b/modules/slash-commands-interact-paywall.ts
@@ -82,10 +82,17 @@ export async function handlePaywallSlashCommand(
       requesterId: interaction.user.id,
     });
 
-    await interaction.editReply(buildPaywallResponsePayload(url, result)).catch((error: unknown) => {
+    await interaction.editReply({content: url}).catch((error: unknown) => {
       logger.log(
         "error",
-        `Error replying to paywall slashcommand: ${error}`,
+        `Error sending paywall original URL: ${error}`,
+      );
+    });
+
+    await interaction.followUp(buildPaywallResponsePayload(result)).catch((error: unknown) => {
+      logger.log(
+        "error",
+        `Error sending paywall bypass embed: ${error}`,
       );
     });
   } catch (error: unknown) {

--- a/modules/slash-commands.interact-paywall.test.ts
+++ b/modules/slash-commands.interact-paywall.test.ts
@@ -105,8 +105,10 @@ describe("handlePaywallSlashCommand", () => {
     expect(interaction.editReply).toHaveBeenNthCalledWith(1, {
       content: "Suche nach Paywall-Bypass für <https://example.com/article>... Das kann bis zu 60 Sekunden dauern.",
     });
-    const finalPayload = interaction.editReply.mock.calls[1]![0] as {content: string; embeds: EditedEmbed[]};
-    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(interaction.editReply).toHaveBeenNthCalledWith(2, {
+      content: "https://example.com/article",
+    });
+    const finalPayload = interaction.followUp.mock.calls[0]![0] as {embeds: EditedEmbed[]};
     expect(finalPayload.embeds[0]?.toJSON()).toEqual({
       title: "Paywall Bypass",
       description: "Für diese Seite ist leider kein Paywall-Bypass bekannt.",
@@ -136,8 +138,10 @@ describe("handlePaywallSlashCommand", () => {
     expect(getPaywallLinksMock).toHaveBeenCalledWith("https://example.com/article", [], {
       requesterId: "user-id",
     });
-    const finalPayload = interaction.editReply.mock.calls[1]![0] as {content: string; embeds: EditedEmbed[]};
-    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(interaction.editReply).toHaveBeenNthCalledWith(2, {
+      content: "https://example.com/article",
+    });
+    const finalPayload = interaction.followUp.mock.calls[0]![0] as {embeds: EditedEmbed[]};
     expect(finalPayload.embeds[0]?.toJSON()).toEqual({
       title: "Paywall Bypass (unbekannte Seite)",
       description: "Unbekannte Seite — versuche allgemeine Services:",
@@ -170,8 +174,10 @@ describe("handlePaywallSlashCommand", () => {
     expect(getPaywallLinksMock).toHaveBeenCalledWith("https://example.com/article", [], {
       requesterId: "user-id",
     });
-    const finalPayload = interaction.editReply.mock.calls[1]![0] as {content: string; embeds: EditedEmbed[]};
-    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(interaction.editReply).toHaveBeenNthCalledWith(2, {
+      content: "https://example.com/article",
+    });
+    const finalPayload = interaction.followUp.mock.calls[0]![0] as {embeds: EditedEmbed[]};
     expect(finalPayload.embeds[0]?.toJSON()).toEqual({
       title: "Paywall Bypass",
       fields: [
@@ -201,6 +207,28 @@ describe("handlePaywallSlashCommand", () => {
     await expect(handlePaywallSlashCommand(asChatInputInteraction(interaction), "paywall")).resolves.toBe(true);
 
     expect(interaction.editReply).toHaveBeenCalledTimes(2);
+    expect(interaction.followUp).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs and completes when the bypass embed follow-up fails", async () => {
+    getPaywallLinksMock.mockResolvedValueOnce(paywallResult({
+      services: [
+        {
+          name: "archive.today",
+          url: "https://archive.ph/newest/https://example.com/article",
+          available: true,
+        },
+      ],
+    }));
+    const interaction = createPaywallInteraction("https://example.com/article");
+    interaction.followUp.mockRejectedValueOnce(new Error("follow-up failed"));
+
+    await expect(handlePaywallSlashCommand(asChatInputInteraction(interaction), "paywall")).resolves.toBe(true);
+
+    expect(interaction.editReply).toHaveBeenNthCalledWith(2, {
+      content: "https://example.com/article",
+    });
+    expect(interaction.followUp).toHaveBeenCalledTimes(1);
   });
 
   test("edits busy message when lookup capacity is exhausted", async () => {
@@ -214,6 +242,18 @@ describe("handlePaywallSlashCommand", () => {
     });
   });
 
+  test("logs when editing the busy message fails", async () => {
+    getPaywallLinksMock.mockRejectedValueOnce(new PaywallLookupCapacityError("requester"));
+    const interaction = createPaywallInteraction("https://example.com/article");
+    interaction.editReply
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("busy edit failed"));
+
+    await expect(handlePaywallSlashCommand(asChatInputInteraction(interaction), "paywall", [])).resolves.toBe(true);
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(2);
+  });
+
   test("edits generic error message when lookup fails unexpectedly", async () => {
     getPaywallLinksMock.mockRejectedValueOnce(new Error("lookup failed"));
     const interaction = createPaywallInteraction("https://example.com/article");
@@ -223,6 +263,18 @@ describe("handlePaywallSlashCommand", () => {
     expect(interaction.editReply).toHaveBeenLastCalledWith({
       content: "Fehler beim Verarbeiten der Anfrage. Bitte später erneut versuchen.",
     });
+  });
+
+  test("logs when editing the generic error message fails", async () => {
+    getPaywallLinksMock.mockRejectedValueOnce(new Error("lookup failed"));
+    const interaction = createPaywallInteraction("https://example.com/article");
+    interaction.editReply
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("error edit failed"));
+
+    await expect(handlePaywallSlashCommand(asChatInputInteraction(interaction), "paywall", [])).resolves.toBe(true);
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(2);
   });
 
   test("returns after failed defer without running lookup", async () => {

--- a/modules/trigger-response.test.ts
+++ b/modules/trigger-response.test.ts
@@ -378,8 +378,8 @@ describe("addTriggerResponses", () => {
     expect(getPaywallLinksMock).toHaveBeenCalledWith("https://example.com/article", [], {
       requesterId: "requester-id",
     });
-    const finalPayload = edit.mock.calls[0]![0] as SentPayload;
-    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(edit).toHaveBeenCalledWith("https://example.com/article");
+    const finalPayload = message.channel.send.mock.calls[1]![0] as SentPayload;
     expect(finalPayload.embeds?.[0]?.toJSON()).toEqual({
       title: "Paywall Bypass (unbekannte Seite)",
       description: "Unbekannte Seite — versuche allgemeine Services:",
@@ -427,8 +427,8 @@ describe("addTriggerResponses", () => {
       1,
       "Suche nach Paywall-Bypass für <https://example.com/article>... Das kann bis zu 60 Sekunden dauern.",
     );
-    const finalPayload = message.channel.send.mock.calls[1]![0] as SentPayload;
-    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(message.channel.send).toHaveBeenNthCalledWith(2, "https://example.com/article");
+    const finalPayload = message.channel.send.mock.calls[2]![0] as SentPayload;
     expect(finalPayload.embeds?.[0]?.toJSON()).toEqual({
       title: "Paywall Bypass",
       fields: [{
@@ -472,8 +472,8 @@ describe("addTriggerResponses", () => {
 
     await handler(message);
 
-    const finalPayload = edit.mock.calls[0]![0] as SentPayload;
-    expect(finalPayload.content).toBe("https://example.com/article");
+    expect(edit).toHaveBeenCalledWith("https://example.com/article");
+    const finalPayload = message.channel.send.mock.calls[1]![0] as SentPayload;
     expect(finalPayload.embeds?.[0]?.toJSON()).toEqual({
       title: "Paywall Bypass",
       description: "Für diese Seite ist leider kein Paywall-Bypass bekannt.",

--- a/modules/trigger-response.ts
+++ b/modules/trigger-response.ts
@@ -10,7 +10,7 @@ import {
   paywallLookupBusyMessage,
 } from "./paywall.ts";
 import type {PaywallResult} from "./paywall.ts";
-import {buildPaywallResponsePayload, type PaywallResponsePayload} from "./paywall-response.ts";
+import {buildPaywallResponsePayload} from "./paywall-response.ts";
 import {assertSafeRequestUrl, UnsafeUrlError} from "./safe-http.ts";
 import {getRandomAssetByTriggerGroup} from "./random-asset.ts";
 import {getRandomQuote} from "./random-quote.ts";
@@ -24,8 +24,12 @@ type TriggerResponsePayload = string | {
   embeds?: EmbedBuilder[];
   files?: AttachmentBuilder[];
 };
+type TriggerResponseEditPayload = string | {
+  content?: string;
+  embeds?: EmbedBuilder[];
+};
 type TriggerResponseSentMessage = {
-  edit: (content: string | PaywallResponsePayload) => Promise<unknown>;
+  edit: (content: TriggerResponseEditPayload) => Promise<unknown>;
 };
 type TriggerResponseChannel = {
   send: (payload: TriggerResponsePayload) => Promise<TriggerResponseSentMessage | undefined>;
@@ -244,12 +248,13 @@ export function addTriggerResponses(
           const paywallOptions = message.author?.id ? {requesterId: message.author.id} : {};
           const result: PaywallResult = await getPaywallLinks(cleanUrl, paywallAssets ?? [], paywallOptions);
 
-          const response = buildPaywallResponsePayload(cleanUrl, result);
+          const response = buildPaywallResponsePayload(result);
           if (undefined !== workingMessage) {
-            await workingMessage.edit(response);
+            await workingMessage.edit(cleanUrl);
           } else {
-            await message.channel.send(response);
+            await message.channel.send(cleanUrl);
           }
+          await message.channel.send(response);
         } catch (error: unknown) {
           if (error instanceof PaywallLookupCapacityError) {
             if (undefined !== workingMessage) {


### PR DESCRIPTION
## Summary
- Put the original article URL in its own bot message so Discord can generate the native link preview.
- Send the paywall bypass results as a separate follow-up embed below the preview URL.
- Keep the bypass embed focused on the bypass result links only.

## Why
Discord did not unfurl the article URL when the same bot message also included our custom Paywall Bypass embed. Sending the original URL as a standalone message avoids mixing the native article preview with the custom bypass embed.

## Validation
- npm test -- modules/trigger-response.test.ts modules/slash-commands.interact-paywall.test.ts
- npm run typecheck
- npm run test:coverage
- git diff --check