### PR TITLE
[codex] Fix earnings history lint guard

### DIFF
--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -33,6 +33,10 @@ type FetchableMessageManager = {
   fetch: (options: {limit: number}) => Promise<unknown> | unknown;
 };
 
+type FetchedMessageCollection = {
+  values: () => Iterable<unknown>;
+};
+
 type EarningsResultClient = {
   channels?: {
     cache?: {
@@ -383,14 +387,22 @@ async function seedSeenAccessionsFromChannelHistory(
 }
 
 function getFetchedMessageValues(fetchedMessages: unknown): unknown[] {
-  if ("object" === typeof fetchedMessages &&
-      null !== fetchedMessages &&
-      "values" in fetchedMessages &&
-      "function" === typeof fetchedMessages.values) {
-    return Array.from(fetchedMessages.values());
+  if (true === isFetchedMessageCollection(fetchedMessages)) {
+    return [...fetchedMessages.values()];
   }
 
   return [];
+}
+
+function isFetchedMessageCollection(value: unknown): value is FetchedMessageCollection {
+  const values = isObjectLike(value) && "values" in value
+    ? value.values
+    : undefined;
+  return "function" === typeof values;
+}
+
+function isObjectLike(value: unknown): value is object {
+  return Object(value) === value;
 }
 
 function getMessageContent(message: unknown): string | null {


### PR DESCRIPTION
## Summary
- Replace the loose runtime `.values()` check used while seeding earnings result history with a typed collection guard.
- Keep the restart dedupe behavior from #1672 while satisfying `@typescript-eslint/no-unsafe-call` and `no-unsafe-argument`.

## Why
PR #1672 was merged before the CI lint fix landed. CI reported the channel-history message collection helper as unsafe because `.values()` was called from a structurally checked unknown object.

## Validation
- npm run lint
- npm test -- modules/earnings-results.test.ts
- npm run typecheck
- git diff --check