### PR TITLE
[codex] Route earnings announcements to threads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ Coding guidance for this repo. Extracts the rules a contributor (human or agent)
 - Separate workflows run CodeQL, njsscan, and Semgrep. Treat their findings as blocking.
 - Don't loosen any of: `coverageThreshold`, `npm audit --audit-level=high`, Trivy severity filters, Checkov framework scope, image signing, or the staging readiness gate. If one is genuinely the wrong fit, raise it explicitly rather than editing it through.
 
+## Codex sandbox
+
+- Codex sessions for this repo commonly require `require_escalated` for commands that write git metadata or access GitHub credentials. Use escalation proactively for `git add`, `git commit`, `git switch -c`, `git push`, and GitHub CLI commands such as `gh auth status`, `gh repo view`, and `gh pr create`, because sandboxed runs cannot reliably create `.git/*.lock` files or access keyring-backed GitHub tokens.
+
 ## Dependencies
 
 - `package.json` pins `engines.node` and uses `overrides` to force-resolve `undici`. Preserve that override when bumping deps unless you've verified the underlying advisory no longer applies.

--- a/modules/earnings-format-render.ts
+++ b/modules/earnings-format-render.ts
@@ -254,14 +254,14 @@ function getEarningsEventLine(
   );
   const marketCapText = getFormattedMarketCapText(earningsEvent.marketCap, earningsEvent.marketCapText);
   const epsConsensus = getFormattedEpsConsensusText(earningsEvent.epsConsensus);
-  const paddedMarketCapText = getPaddedEarningsColumnText(
+  const marketCapPadding = getEarningsColumnPadding(
     marketCapText,
     lineWidths.marketCap
   );
   const expectedMoveText = getFormattedExpectedMoveText(earningsEvent);
   const underlyingPriceText = getFormattedExpectedMoveUnderlyingPriceText(earningsEvent);
 
-  return `${ticker} 💰 MCap: \`${paddedMarketCapText}\`${underlyingPriceText} 🔮 EPS: \`${epsConsensus}\`${expectedMoveText}`;
+  return `${ticker} 💰 MCap: \`${marketCapText}\`${marketCapPadding}${underlyingPriceText} 🔮 EPS: \`${epsConsensus}\`${expectedMoveText}`;
 }
 
 function getFormattedMarketCapText(
@@ -291,11 +291,11 @@ function getFormattedEpsConsensusText(
   return getNormalizedString(epsConsensus) ?? unknownValueLabel;
 }
 
-function getPaddedEarningsColumnText(
+function getEarningsColumnPadding(
   text: string,
   width: number
 ): string {
-  return text.padEnd(width, " ");
+  return " ".repeat(Math.max(0, width - text.length));
 }
 
 function getFormattedTicker(
@@ -303,12 +303,12 @@ function getFormattedTicker(
   highlightedTickerSymbols: Set<string>,
   width: number
 ): string {
-  const tickerText = `\`${getPaddedEarningsColumnText(ticker, width)}\``;
+  const tickerPadding = getEarningsColumnPadding(ticker, width);
   if (true === highlightedTickerSymbols.has(ticker)) {
-    return `**${tickerText}**`;
+    return `**${ticker}**${tickerPadding}`;
   }
 
-  return tickerText;
+  return `\`${ticker}\`${tickerPadding}`;
 }
 
 function getEarningsWhenLabel(earningsWhen: EarningsWhen): string {

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -184,6 +184,27 @@ describe("earnings result formatting", () => {
     ]);
   });
 
+  test("drops noisy non-text outlook values", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h2>Financial Outlook</h2>
+          <p>Operating income and net income in each quarter this year are expected to improve.</p>
+          <p>Tax rate (% Pre-Tax Income Attributable to the Company) (1)</p>
+          <p>Free cash flow is expected to be between $4.2 billion and $4.4 billion.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.outlook).toEqual([
+      {
+        key: "free_cash_flow",
+        label: "Free cash flow",
+        value: "$4.2B to $4.4B",
+      },
+    ]);
+  });
+
   test("does not emit outlook metrics without an outlook section", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>
@@ -403,6 +424,58 @@ describe("earnings result formatting", () => {
       estimate: "$100B",
       outcome: "miss",
     });
+  });
+
+  test("uses Nasdaq EPS when parsed SEC EPS is implausible and drops bogus secondary GAAP EPS", () => {
+    const event: EarningsEvent = {
+      ticker: "RBA",
+      when: "after_close",
+      date: "2026-05-04",
+      importance: 1,
+      epsConsensus: "$0.89",
+    };
+
+    const metrics = getMessageMetrics([
+      {
+        key: "adjusted_eps",
+        label: "Adj EPS",
+        numericValue: 13,
+        value: "$13",
+      },
+      {
+        key: "gaap_eps",
+        label: "EPS",
+        numericValue: 20,
+        value: "$20",
+      },
+      {
+        key: "revenue",
+        label: "Revenue",
+        numericValue: 1_200_000_000,
+        value: "$1.2B",
+      },
+    ], {
+      actualEps: 1.13,
+      consensusEps: 0.89,
+    }, event);
+
+    expect(metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "adjusted_eps",
+        estimate: "$0.89",
+        outcome: "beat",
+        value: "$1.13",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        value: "$1.2B",
+      }),
+    ]));
+    expect(metrics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "gaap_eps",
+      }),
+    ]));
   });
 
   test("formats message without quarter, filing items, estimate or outlook", () => {

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -123,10 +123,10 @@ export function getMessageMetrics(
   surprise: NasdaqSurprise | null,
   event: EarningsEvent,
 ): EarningsResultMetric[] {
-  const metrics = [...secMetrics];
+  const consensusEps = surprise?.consensusEps ?? parseNumber(event.epsConsensus) ?? undefined;
+  const metrics = normalizeEpsMetrics([...secMetrics], surprise, consensusEps);
   const hasAdjustedEps = metrics.some(metric => "adjusted_eps" === metric.key);
   const hasGaapEps = metrics.some(metric => "gaap_eps" === metric.key);
-  const consensusEps = surprise?.consensusEps ?? parseNumber(event.epsConsensus);
 
   if ("number" === typeof surprise?.actualEps &&
       false === hasAdjustedEps &&
@@ -153,6 +153,77 @@ export function getMessageMetrics(
   }
 
   return metrics.slice(0, 7);
+}
+
+function normalizeEpsMetrics(
+  metrics: EarningsResultMetric[],
+  surprise: NasdaqSurprise | null,
+  consensusEps: number | undefined,
+): EarningsResultMetric[] {
+  const actualEps = surprise?.actualEps;
+  const adjustedEpsMetric = metrics.find(metric => "adjusted_eps" === metric.key);
+  const gaapEpsMetric = metrics.find(metric => "gaap_eps" === metric.key);
+  const primaryEpsMetric = adjustedEpsMetric ?? gaapEpsMetric;
+
+  if ("number" === typeof actualEps &&
+      undefined !== primaryEpsMetric &&
+      true === isImplausibleSecEps(primaryEpsMetric.numericValue, actualEps, consensusEps)) {
+    primaryEpsMetric.numericValue = actualEps;
+    primaryEpsMetric.value = formatEps(actualEps);
+  }
+
+  if (adjustedEpsMetric &&
+      gaapEpsMetric &&
+      true === isImplausibleSecondaryGaapEps(gaapEpsMetric.numericValue, adjustedEpsMetric.numericValue)) {
+    return metrics.filter(metric => "gaap_eps" !== metric.key);
+  }
+
+  return metrics;
+}
+
+function isImplausibleSecEps(
+  secValue: number | undefined,
+  actualEps: number,
+  consensusEps: number | undefined,
+): boolean {
+  if ("number" !== typeof secValue || false === Number.isFinite(secValue)) {
+    return false;
+  }
+
+  const referenceEps = consensusEps ?? actualEps;
+  const closeEnoughTolerance = Math.max(0.25, Math.abs(actualEps) * 0.25);
+  if (Math.abs(secValue - actualEps) <= closeEnoughTolerance) {
+    return false;
+  }
+
+  if (Math.abs(secValue) >= 10 && Math.abs(referenceEps) < 5) {
+    return true;
+  }
+
+  if (Math.sign(secValue) !== Math.sign(actualEps) &&
+      Math.abs(secValue - actualEps) > 0.5) {
+    return true;
+  }
+
+  return Math.abs(secValue - actualEps) > Math.max(1, Math.abs(referenceEps) * 2);
+}
+
+function isImplausibleSecondaryGaapEps(
+  gaapValue: number | undefined,
+  adjustedValue: number | undefined,
+): boolean {
+  if ("number" !== typeof gaapValue ||
+      "number" !== typeof adjustedValue ||
+      false === Number.isFinite(gaapValue) ||
+      false === Number.isFinite(adjustedValue)) {
+    return false;
+  }
+
+  if (Math.abs(gaapValue) >= 10 && Math.abs(adjustedValue) < 5) {
+    return true;
+  }
+
+  return Math.abs(gaapValue - adjustedValue) > Math.max(10, Math.abs(adjustedValue) * 5);
 }
 
 export function getEarningsResultMessage({

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -200,7 +200,7 @@ function extractOutlookValue(
     getOutlookRangeValue(valueText, valueType) ??
     ("text" === valueType ? getSingleOutlookValue(valueText, "money") : null) ??
     getSingleOutlookValue(valueText, valueType) ??
-    getFallbackOutlookValue(valueText);
+    getFallbackOutlookValue(valueText, valueType);
 }
 
 function normalizeOutlookValueText(value: string): string {
@@ -285,7 +285,7 @@ function getSingleOutlookValue(value: string, valueType: OutlookValueType): stri
   return null;
 }
 
-function getFallbackOutlookValue(value: string): string | null {
+function getFallbackOutlookValue(value: string, valueType: OutlookValueType): string | null {
   const fallbackValue = value.split(/[.;]/)[0]?.trim() ?? "";
   if (fallbackValue.length < 2 ||
       fallbackValue.length > 80 ||
@@ -295,7 +295,21 @@ function getFallbackOutlookValue(value: string): string | null {
     return null;
   }
 
+  if ("text" !== valueType && false === isUsefulNonTextFallbackValue(fallbackValue)) {
+    return null;
+  }
+
   return fallbackValue;
+}
+
+function isUsefulNonTextFallbackValue(value: string): boolean {
+  if (/^(?:and|or)\b/i.test(value) ||
+      /^\(?\s*%/i.test(value) ||
+      /\bpre-tax\s+income\s+attributable\b/i.test(value)) {
+    return false;
+  }
+
+  return /\b(?:positive|negative|not\s+available|unavailable|breakeven|break-even|flat|unchanged|growth|decline|increase|decrease)\b/i.test(value);
 }
 
 function findNumericValue(

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -349,6 +349,96 @@ describe("earnings result announcements", () => {
     );
   });
 
+  test("skips SEC-only filings when no earnings metrics or outlook can be parsed", async () => {
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.includes("company_tickers.json")) {
+        return {
+          data: {
+            0: {
+              cik_str: 34088,
+              ticker: "XOM",
+              title: "EXXON MOBIL CORP",
+            },
+          },
+        };
+      }
+
+      if (url.includes("type=8-K")) {
+        return {
+          data: `
+            <feed>
+              <entry>
+                <title>8-K - EXXON MOBIL CORP</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0000034088-26-000042</id>
+                <updated>2026-05-01T08:01:00-04:00</updated>
+                <category term="8-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/0000034088-26-000042-index.htm" />
+                <summary>
+                  &lt;b&gt;CIK:&lt;/b&gt; 0000034088&lt;br/&gt;
+                  &lt;b&gt;Items:&lt;/b&gt; 2.02, 9.01
+                </summary>
+              </entry>
+            </feed>
+          `,
+        };
+      }
+
+      if (url.includes("type=6-K")) {
+        return {
+          data: "<feed></feed>",
+        };
+      }
+
+      if (url.endsWith("/index.json")) {
+        return {
+          data: {
+            directory: {
+              item: [{
+                name: "xom-ex991.htm",
+                type: "EX-99.1",
+              }],
+            },
+          },
+        };
+      }
+
+      if (url.endsWith("/xom-ex991.htm")) {
+        return {
+          data: "<html><body><h1>Exxon Mobil reports first quarter 2026 results</h1></body></html>",
+        };
+      }
+
+      if (url.includes("/XOM/earnings-surprise")) {
+        return {
+          data: {
+            data: {
+              earningsSurpriseTable: {
+                rows: [],
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    const result = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      },
+    });
+
+    expect(result.announcements).toEqual([]);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping earnings result announcement for XOM: no filing details could be parsed.",
+    );
+  });
+
   test("watcher sends new announcements once, schedules active polling, and clears its timer on stop", async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const timeoutHandle = {
@@ -402,6 +492,69 @@ describe("earnings result announcements", () => {
     watcher.stop();
 
     expect(clearTimeoutFn).toHaveBeenCalledWith(timeoutHandle);
+  });
+
+  test("watcher sends announcements to the optional results thread and seeds thread plus parent history", async () => {
+    const parentSend = vi.fn().mockResolvedValue(undefined);
+    const threadSend = vi.fn().mockResolvedValue(undefined);
+    const parentFetchMessages = vi.fn().mockResolvedValue(new Map());
+    const threadFetchMessages = vi.fn().mockResolvedValue(new Map());
+    const timeoutHandle = {
+      unref: vi.fn(),
+    } as unknown as ReturnType<typeof setTimeout>;
+    const setTimeoutMock = vi.fn((_callback: () => void, _delayMs: number) => timeoutHandle);
+
+    const watcher = startEarningsResultWatcher({
+      channels: {
+        cache: {
+          get: vi.fn((channelID: string) => {
+            if ("earnings-results-thread-id" === channelID) {
+              return {
+                messages: {
+                  fetch: threadFetchMessages,
+                },
+                send: threadSend,
+              };
+            }
+
+            return {
+              messages: {
+                fetch: parentFetchMessages,
+              },
+              send: parentSend,
+            };
+          }),
+        },
+      },
+    }, "breaking-news-channel-id", {
+      announcementThreadID: "earnings-results-thread-id",
+      getEarningsResultFn,
+      getWithRetryFn,
+      logger,
+      now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      pollIntervalMs: 123,
+      setTimeoutFn: setTimeoutMock as unknown as typeof setTimeout,
+    });
+
+    await vi.waitFor(() => {
+      expect(threadSend).toHaveBeenCalledTimes(1);
+    });
+
+    expect(threadFetchMessages).toHaveBeenCalledWith({
+      limit: 100,
+    });
+    expect(parentFetchMessages).toHaveBeenCalledWith({
+      limit: 100,
+    });
+    expect(threadSend).toHaveBeenCalledWith({
+      content: expect.stringContaining("Earnings: Exxon Mobil (`XOM`) Q1 2026"),
+      allowedMentions: {
+        parse: [],
+      },
+    });
+    expect(parentSend).not.toHaveBeenCalled();
+
+    watcher.stop();
   });
 
   test("watcher seeds announced accessions from channel history before scanning", async () => {

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -42,12 +42,14 @@ type EarningsResultClient = {
     cache?: {
       get?: (channelID: string) => unknown;
     };
+    fetch?: (channelID: string) => Promise<unknown> | unknown;
   };
 };
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 
 type EarningsResultWatcherOptions = {
+  announcementThreadID?: string | undefined;
   clearTimeoutFn?: typeof clearTimeout;
   getEarningsResultFn?: typeof getEarningsResult;
   getWithRetryFn?: typeof getWithRetry;
@@ -154,6 +156,7 @@ export function startEarningsResultWatcher(
   const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
   const pollIntervalMs = options.pollIntervalMs ?? defaultPollIntervalMs;
   const inactivePollIntervalMs = options.inactivePollIntervalMs ?? defaultInactivePollIntervalMs;
+  const announcementThreadID = getOptionalChannelID(options.announcementThreadID);
   const seenAccessions = new Set<string>();
   const dependencies = getDependencies(options);
   let seenAccessionsSeeded = false;
@@ -162,9 +165,10 @@ export function startEarningsResultWatcher(
 
   const runOnce = async (): Promise<EarningsResultScanResult> => {
     if (false === seenAccessionsSeeded) {
-      const seeded = await seedSeenAccessionsFromChannelHistory(
+      const seeded = await seedSeenAccessionsFromAnnouncementHistory(
         client,
         channelID,
+        announcementThreadID,
         seenAccessions,
         dependencies.logger,
       );
@@ -201,6 +205,7 @@ export function startEarningsResultWatcher(
       const sent = await sendEarningsResultAnnouncement(
         client,
         channelID,
+        announcementThreadID,
         announcement.message,
         dependencies.logger,
       );
@@ -328,17 +333,75 @@ function getDependencies(options: EarningsResultWatcherOptions = {}): EarningsRe
 }
 
 function isSendableChannel(channel: unknown): channel is SendableChannel {
-  return "object" === typeof channel &&
-    null !== channel &&
+  return isObjectLike(channel) &&
     "send" in channel &&
     "function" === typeof channel.send;
 }
 
 function isFetchableMessageManager(value: unknown): value is FetchableMessageManager {
-  return "object" === typeof value &&
-    null !== value &&
+  return isObjectLike(value) &&
     "fetch" in value &&
     "function" === typeof value.fetch;
+}
+
+function getOptionalChannelID(channelID: string | undefined): string | undefined {
+  const normalizedChannelID = channelID?.trim();
+  return normalizedChannelID ? normalizedChannelID : undefined;
+}
+
+async function fetchChannel(
+  client: EarningsResultClient,
+  channelID: string,
+  loggerInstance: Logger,
+): Promise<unknown> {
+  const cachedChannel = client.channels?.cache?.get?.(channelID);
+  if (undefined !== cachedChannel) {
+    return cachedChannel;
+  }
+
+  const fetchChannelFn = client.channels?.fetch;
+  if ("function" !== typeof fetchChannelFn) {
+    return undefined;
+  }
+
+  return Promise.resolve(fetchChannelFn(channelID)).catch(error => {
+    loggerInstance.log(
+      "warn",
+      `Could not fetch earnings result channel ${channelID}: ${error}`,
+    );
+    return undefined;
+  });
+}
+
+async function seedSeenAccessionsFromAnnouncementHistory(
+  client: EarningsResultClient,
+  channelID: string,
+  announcementThreadID: string | undefined,
+  seenAccessions: Set<string>,
+  loggerInstance: Logger,
+): Promise<boolean> {
+  const targetChannelID = announcementThreadID ?? channelID;
+  const seededTarget = await seedSeenAccessionsFromChannelHistory(
+    client,
+    targetChannelID,
+    seenAccessions,
+    loggerInstance,
+  );
+  if (false === seededTarget) {
+    return false;
+  }
+
+  if (undefined !== announcementThreadID && announcementThreadID !== channelID) {
+    await seedSeenAccessionsFromChannelHistory(
+      client,
+      channelID,
+      seenAccessions,
+      loggerInstance,
+      false,
+    );
+  }
+
+  return true;
 }
 
 async function seedSeenAccessionsFromChannelHistory(
@@ -346,17 +409,20 @@ async function seedSeenAccessionsFromChannelHistory(
   channelID: string,
   seenAccessions: Set<string>,
   loggerInstance: Logger,
+  required = true,
 ): Promise<boolean> {
-  const channel = client.channels?.cache?.get?.(channelID);
-  const messages = "object" === typeof channel && null !== channel && "messages" in channel
+  const channel = await fetchChannel(client, channelID, loggerInstance);
+  const messages = isObjectLike(channel) && "messages" in channel
     ? channel.messages
     : undefined;
   if (false === isFetchableMessageManager(messages)) {
     loggerInstance.log(
       "warn",
-      `Skipping earnings result scan: channel ${channelID} message history is not fetchable.`,
+      true === required
+        ? `Skipping earnings result scan: channel ${channelID} message history is not fetchable.`
+        : `Could not seed earnings result announcements from optional channel ${channelID}: message history is not fetchable.`,
     );
-    return false;
+    return false === required;
   }
 
   const fetchedMessages = await Promise.resolve(messages.fetch({
@@ -369,7 +435,7 @@ async function seedSeenAccessionsFromChannelHistory(
     return null;
   });
   if (null === fetchedMessages) {
-    return false;
+    return false === required;
   }
 
   for (const message of getFetchedMessageValues(fetchedMessages)) {
@@ -438,14 +504,16 @@ function formatCompactAccessionNumber(value: string): string {
 async function sendEarningsResultAnnouncement(
   client: EarningsResultClient,
   channelID: string,
+  announcementThreadID: string | undefined,
   message: string,
   loggerInstance: Logger,
 ): Promise<boolean> {
-  const channel = client.channels?.cache?.get?.(channelID);
+  const targetChannelID = announcementThreadID ?? channelID;
+  const channel = await fetchChannel(client, targetChannelID, loggerInstance);
   if (false === isSendableChannel(channel)) {
     loggerInstance.log(
       "error",
-      `Skipping earnings result announcement: channel ${channelID} not found or not send-capable.`,
+      `Skipping earnings result announcement: channel ${targetChannelID} not found or not send-capable.`,
     );
     return false;
   }
@@ -608,7 +676,7 @@ async function buildEarningsResultAnnouncement(
   const metrics = getMessageMetrics(parsedDocument.metrics, surprise, watch.event);
   const filingUrl = filingDetails.documentUrl || filing.filingUrl;
 
-  if (0 === metrics.length && "" === filingUrl) {
+  if (0 === metrics.length && 0 === parsedDocument.outlook.length) {
     dependencies.logger.log(
       "warn",
       `Skipping earnings result announcement for ${watch.event.ticker}: no filing details could be parsed.`,

--- a/modules/earnings.test.ts
+++ b/modules/earnings.test.ts
@@ -54,15 +54,15 @@ function getEarningsEvent(overrides: Partial<EarningsEvent> = {}): EarningsEvent
 function parseEarningsLine(
   line: string
 ): {ticker: string; marketCap: string; eps: string} {
-  const match = line.match(/^(?:\*\*)?`([^`]+)`(?:\*\*)? 💰 MCap: `([^`]+)`(?: 📈 Last: `\$[^`]+`)? 🔮 EPS: `([^`]+)`(?: .*)?$/);
+  const match = line.match(/^(?:(?:\*\*)?`([^`]+)`(?:\*\*)?|\*\*([^*]+)\*\*)( *) 💰 MCap: `([^`]+)`( *)(?: 📈 Last: `\$[^`]+`)? 🔮 EPS: `([^`]+)`(?: .*)?$/);
   if (null === match) {
     throw new Error(`Unexpected earnings line format: ${line}`);
   }
 
   return {
-    ticker: match[1]!,
-    marketCap: match[2]!,
-    eps: match[3]!,
+    ticker: `${match[1] ?? match[2]}${match[3]}`,
+    marketCap: `${match[4]}${match[5]}`,
+    eps: match[6]!,
   };
 }
 
@@ -398,7 +398,9 @@ describe("getEarningsText", () => {
 
     const lines = text.split("\n").filter(line => line.includes(" MCap: "));
     const parsedLines = lines.map(parseEarningsLine);
-    expect(lines[0]!.startsWith("**`BIG")).toBe(true);
+    expect(lines[0]!.startsWith("**BIG**")).toBe(true);
+    expect(lines[0]!).not.toContain("`BIG ");
+    expect(lines[0]!).not.toContain("$1B ");
     expect(parsedLines[0]!).toEqual(expect.objectContaining({
       ticker: "BIG  ",
       marketCap: expect.stringMatching(/^\$1B +$/),
@@ -458,7 +460,9 @@ describe("getEarningsMessages", () => {
 
     const lines = batch.messages[0]!.split("\n").filter(line => line.includes(" MCap: "));
     const parsedLines = lines.map(parseEarningsLine);
-    expect(lines[0]!.startsWith("**`BIG")).toBe(true);
+    expect(lines[0]!.startsWith("**BIG**")).toBe(true);
+    expect(lines[0]!).not.toContain("`BIG ");
+    expect(lines[0]!).not.toContain("$1.5B ");
     expect(parsedLines[0]!.ticker.trim()).toBe("BIG");
     expect(parsedLines[1]!.ticker.trim()).toBe("SMALL");
     expect(parsedLines[2]!.ticker.trim()).toBe("MID");

--- a/modules/startup-orchestrator.test.ts
+++ b/modules/startup-orchestrator.test.ts
@@ -154,6 +154,9 @@ describe("startBot", () => {
     expect(mocks.startEarningsResultWatcher).toHaveBeenCalledWith(
       expect.anything(),
       "other",
+      {
+        announcementThreadID: undefined,
+      },
     );
     expect(mocks.addInlineResponses).toHaveBeenCalledTimes(1);
     expect(mocks.addTriggerResponses).toHaveBeenCalledTimes(1);
@@ -211,6 +214,55 @@ describe("startBot", () => {
       [],
       calendarReminderAssets,
       earningsReminderAssets,
+      undefined,
+    );
+  });
+
+  test("passes optional earnings thread targets when configured", async () => {
+    const readSecret = vi.fn((secretName: string) => {
+      const defaults: Record<string, string> = {
+        environment: "staging",
+        discord_token: "token",
+        hblwrk_channel_NYSEAnnouncement_ID: "nyse",
+        hblwrk_gainslosses_thread_ID: "gains-losses-thread",
+        hblwrk_channel_MNCAnnouncement_ID: "mnc",
+        hblwrk_channel_OtherAnnouncement_ID: "other",
+        hblwrk_earnings_expectations_thread_ID: "earnings-expectations-thread",
+        hblwrk_earnings_results_thread_ID: "earnings-results-thread",
+        hblwrk_channel_clownboard_ID: "clownboard",
+        discord_client_ID: "bot-client-id",
+        discord_guild_ID: "guild-id",
+        hblwrk_role_assignment_channel_ID: "",
+        hblwrk_role_assignment_broker_message_ID: "",
+        hblwrk_role_assignment_special_message_ID: "",
+        hblwrk_role_muted_ID: "",
+        hblwrk_role_broker_yes_ID: "",
+      };
+
+      return defaults[secretName] ?? "";
+    });
+    const {dependencies, mocks} = createDependencies({
+      readSecret,
+    });
+
+    const runtime = await startBot(dependencies);
+    await waitFor(() => true === runtime.getStartupState().ready);
+
+    expect(mocks.startEarningsResultWatcher).toHaveBeenCalledWith(
+      expect.anything(),
+      "other",
+      {
+        announcementThreadID: "earnings-results-thread",
+      },
+    );
+    expect(mocks.startOtherTimers).toHaveBeenCalledWith(
+      expect.anything(),
+      "other",
+      [],
+      [],
+      [],
+      [],
+      "earnings-expectations-thread",
     );
   });
 

--- a/modules/startup-orchestrator.ts
+++ b/modules/startup-orchestrator.ts
@@ -82,6 +82,15 @@ function createDependencies(options: StartupOptions): StartupDependencies {
   };
 }
 
+function readOptionalSecretValue(readSecretFn: typeof readSecret, secretName: string): string | undefined {
+  try {
+    const value = readSecretFn(secretName).trim();
+    return "" === value ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}
+
 async function waitForDiscordReady(
   client: Client,
   token: string,
@@ -149,6 +158,8 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
   const gainsLossesThreadId = dependencies.readSecret("hblwrk_gainslosses_thread_ID").trim();
   const channelMncId = dependencies.readSecret("hblwrk_channel_MNCAnnouncement_ID").trim();
   const channelOtherId = dependencies.readSecret("hblwrk_channel_OtherAnnouncement_ID").trim();
+  const earningsExpectationsThreadId = readOptionalSecretValue(dependencies.readSecret, "hblwrk_earnings_expectations_thread_ID");
+  const earningsResultsThreadId = readOptionalSecretValue(dependencies.readSecret, "hblwrk_earnings_results_thread_ID");
   const channelClownboardId = dependencies.readSecret("hblwrk_channel_clownboard_ID").trim();
   const roleAssignmentChannelId = dependencies.readSecret("hblwrk_role_assignment_channel_ID").trim();
   const roleAssignmentBrokerMessageId = dependencies.readSecret("hblwrk_role_assignment_broker_message_ID").trim();
@@ -223,7 +234,9 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     dependencies.clownboard(client, channelClownboardId);
     dependencies.startNyseTimers(client, channelNyseId, gainsLossesThreadId);
     dependencies.startMncTimers(client, channelMncId);
-    dependencies.startEarningsResultWatcher(client, channelOtherId);
+    dependencies.startEarningsResultWatcher(client, channelOtherId, {
+      announcementThreadID: earningsResultsThreadId,
+    });
     dependencies.addInlineResponses(client, sharedData.assets, sharedData.assetCommands);
     dependencies.addTriggerResponses(client, sharedData.assets, sharedData.assetCommandsWithPrefix, sharedData.whatIsAssets, sharedData.paywallAssets);
     dependencies.interactSlashCommands(client, sharedData.assets, sharedData.assetCommands, sharedData.whatIsAssets, sharedData.tickers, sharedData.paywallAssets);
@@ -260,6 +273,7 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     dependencies,
     startupState,
     channelOtherId,
+    earningsExpectationsThreadId,
     environment,
   });
 

--- a/modules/startup-warmup.ts
+++ b/modules/startup-warmup.ts
@@ -70,6 +70,7 @@ export async function warmRemoteData({
   dependencies,
   startupState,
   channelOtherId,
+  earningsExpectationsThreadId,
   environment,
 }: {
   client: Client;
@@ -77,6 +78,7 @@ export async function warmRemoteData({
   dependencies: StartupDependencies;
   startupState: ReturnType<typeof createStartupState>;
   channelOtherId: string;
+  earningsExpectationsThreadId?: string | undefined;
   environment: string;
 }) {
   const logger = dependencies.logger;
@@ -122,6 +124,7 @@ export async function warmRemoteData({
       sharedData.tickers,
       sharedData.calendarReminderAssets,
       sharedData.earningsReminderAssets,
+      earningsExpectationsThreadId,
     );
     otherTimersStarted = true;
     logger.log(

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -479,6 +479,40 @@ describe("timers: other announcements", () => {
     });
   });
 
+  test("startOtherTimers sends upcoming earnings to the optional expectations thread", async () => {
+    const channelSend = vi.fn().mockResolvedValue(undefined);
+    const threadSend = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      channels: {
+        cache: {
+          get: vi.fn((channelId: string) => {
+            if ("earnings-expectations-thread" === channelId) {
+              return {
+                send: threadSend,
+              };
+            }
+
+            return {
+              send: channelSend,
+            };
+          }),
+        },
+      },
+    };
+
+    startOtherTimers(client, "channel-id", [], [], [], [], "earnings-expectations-thread");
+    const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
+    await dailyEarningsJob.callback();
+
+    expect(threadSend).toHaveBeenCalledWith({
+      content: "earnings-text",
+      allowedMentions: {
+        parse: [],
+      },
+    });
+    expect(channelSend).not.toHaveBeenCalled();
+  });
+
   test("startOtherTimers sends weekly earnings with dedicated headline on Friday evening", async () => {
     const {client, send} = createClientWithChannel();
     getEarningsMessagesMock.mockReturnValue({

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -66,6 +66,7 @@ type TimerClient = {
     cache?: {
       get?: (channelId: string) => unknown;
     };
+    fetch?: (channelId: string) => Promise<unknown> | unknown;
   };
 };
 type NyseSentimentPollMessage = {
@@ -253,8 +254,72 @@ function getSendableChannel(client: TimerClient, channelID: string, source: stri
   return channel;
 }
 
+function getOptionalChannelID(channelID: string | undefined): string | undefined {
+  const normalizedChannelID = channelID?.trim();
+  return normalizedChannelID ? normalizedChannelID : undefined;
+}
+
+async function fetchChannel(client: TimerClient, channelID: string, source: string): Promise<unknown> {
+  const cachedChannel = client.channels?.cache?.get?.(channelID);
+  if (undefined !== cachedChannel) {
+    return cachedChannel;
+  }
+
+  const fetchChannelFn = client.channels?.fetch;
+  if ("function" !== typeof fetchChannelFn) {
+    return undefined;
+  }
+
+  return Promise.resolve(fetchChannelFn(channelID)).catch(error => {
+    logger.log(
+      "warn",
+      `Could not fetch ${source} channel ${channelID}: ${error}`,
+    );
+    return undefined;
+  });
+}
+
+async function getFetchableSendableChannel(client: TimerClient, channelID: string, source: string): Promise<SendableChannel | null> {
+  const channel = await fetchChannel(client, channelID, source);
+  if (false === isSendableChannel(channel)) {
+    logger.log(
+      "error",
+      `Skipping ${source} announcement: channel ${channelID} not found or not send-capable.`,
+    );
+    return null;
+  }
+
+  return channel;
+}
+
+async function getOptionalThreadTargetChannel(
+  client: TimerClient,
+  channelID: string,
+  threadID: string | undefined,
+  source: string,
+): Promise<SendableChannel | null> {
+  const normalizedThreadID = getOptionalChannelID(threadID);
+  if (undefined !== normalizedThreadID) {
+    const thread = await getFetchableSendableChannel(client, normalizedThreadID, `${source} thread`);
+    if (null !== thread) {
+      return thread;
+    }
+
+    logger.log(
+      "warn",
+      `Configured ${source} thread ${normalizedThreadID} is unavailable; falling back to channel ${channelID}.`,
+    );
+  }
+
+  return getSendableChannel(client, channelID, source);
+}
+
 async function sendAnnouncement(client: TimerClient, channelID: string, payload: unknown, source: string) {
   const channel = getSendableChannel(client, channelID, source);
+  return sendToChannel(channel, payload, source);
+}
+
+async function sendToChannel(channel: SendableChannel | null, payload: unknown, source: string) {
   if (!channel) {
     return undefined;
   }
@@ -273,6 +338,7 @@ async function runEarningsAnnouncement(
   channelID: string,
   tickers: Ticker[],
   config: EarningsAnnouncementConfig,
+  earningsExpectationsThreadID?: string,
 ) {
   const earningsResult = await getEarningsResult(config.days, config.date);
   const earningsEvents = await addExpectedMovesToEarningsEvents(earningsResult.events, {
@@ -301,7 +367,7 @@ async function runEarningsAnnouncement(
     return;
   }
 
-  const channel = getSendableChannel(client, channelID, "earnings");
+  const channel = await getOptionalThreadTargetChannel(client, channelID, earningsExpectationsThreadID, "earnings");
   const messages = config.headline
     ? prependHeadlineToFirstMessage(earningsBatch.messages, config.headline, EARNINGS_MAX_MESSAGE_LENGTH)
     : earningsBatch.messages;
@@ -544,6 +610,7 @@ export function startOtherTimers(
   tickers: Ticker[],
   calendarReminderAssets: CalendarReminderAsset[] = [],
   earningsReminderAssets: EarningsReminderAsset[] = [],
+  earningsExpectationsThreadID?: string,
 ) {
   const ruleFriday = createRecurrenceRule({
     hour: 8,
@@ -615,7 +682,7 @@ export function startOtherTimers(
       filter: "bluechips",
       source: "timer-earnings",
       when: "all",
-    });
+    }, earningsExpectationsThreadID);
   });
 
   const ruleEarningsWeekly = createRecurrenceRule({
@@ -652,7 +719,7 @@ export function startOtherTimers(
       headline: weeklyEarningsHeadline,
       source: "timer-earnings-weekly",
       when: "all",
-    });
+    }, earningsExpectationsThreadID);
   });
 
   const ruleEarningsReminder = createRecurrenceRule({
@@ -691,9 +758,9 @@ export function startOtherTimers(
         continue;
       }
 
-      await sendAnnouncement(
-        client,
-        channelID,
+      const channel = await getOptionalThreadTargetChannel(client, channelID, earningsExpectationsThreadID, earningsReminderSource);
+      await sendToChannel(
+        channel,
         {
           content: getEarningsReminderMessage(roleId, matchedEvents),
           allowedMentions: getAllowedRoleMentions(roleId),


### PR DESCRIPTION
## Summary
- route upcoming earnings posts and earnings reminders to optional expectations thread hblwrk_earnings_expectations_thread_ID
- route actual SEC earnings results to optional results thread hblwrk_earnings_results_thread_ID, with parent-channel history seeding during migration
- fix scheduled earnings Markdown padding and tighten earnings-result parsing for empty/buggy result posts

## Impact
- staging can omit both optional thread secrets and keeps posting to the existing breaking-news channel
- production can separate upcoming earnings from actual result filings by configuring the two thread IDs
- SEC result announcements skip filings where no useful metric or outlook can be parsed

## Validation
- npm run test:coverage
- npm run typecheck
- npm run lint
- git diff --check