### PR TITLE
[codex] Cache Nasdaq earnings schedules

### DIFF
--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -1,5 +1,5 @@
 import moment from "moment-timezone";
-import {bluechipMinMarketCap, type EarningsEvent, getEarningsResult} from "./earnings.ts";
+import {bluechipMinMarketCap, clearEarningsScheduleCache, type EarningsEvent, getEarningsResult} from "./earnings.ts";
 import {
   formatUsdCompact,
   getEarningsResultMessage,
@@ -144,6 +144,7 @@ let earningsWatchCache: EarningsWatchCache | undefined;
 
 export function clearEarningsResultCaches() {
   earningsWatchCache = undefined;
+  clearEarningsScheduleCache();
   clearSecEarningsResultCaches();
 }
 
@@ -545,7 +546,9 @@ async function getTodaysEarningsWatches(
   }
 
   const [earningsResult, tickerToCompany] = await Promise.all([
-    dependencies.getEarningsResultFn(0, dateStamp),
+    dependencies.getEarningsResultFn(0, dateStamp, {
+      source: "earnings-results-watch",
+    }),
     loadSecTickerMap(dependencies).catch(error => {
       dependencies.logger.log(
         "warn",

--- a/modules/earnings-source.ts
+++ b/modules/earnings-source.ts
@@ -45,6 +45,18 @@ type NasdaqEarningsResponse = {
   };
   message?: string | null;
 };
+type EarningsLoadOptions = {
+  source?: string;
+};
+type NasdaqEarningsCacheEntry = {
+  loadedAtMs: number;
+  response: NasdaqEarningsResponse;
+};
+type NasdaqEarningsLoadStatus = "cache-hit" | "cache-miss" | "in-flight";
+type NasdaqEarningsLoadResult = {
+  response: NasdaqEarningsResponse;
+  status: NasdaqEarningsLoadStatus;
+};
 
 const nasdaqEarningsEndpoint = "https://api.nasdaq.com/api/calendar/earnings";
 const nasdaqRequestHeaders = {
@@ -52,18 +64,28 @@ const nasdaqRequestHeaders = {
   "Accept": "application/json, text/plain, */*",
   "Referer": "https://www.nasdaq.com/",
 };
+const nasdaqEarningsCacheTtlMs = 90 * 60_000;
+const nasdaqEarningsCache = new Map<string, NasdaqEarningsCacheEntry>();
+const nasdaqEarningsInFlightRequests = new Map<string, Promise<NasdaqEarningsResponse>>();
+
+export function clearEarningsScheduleCache() {
+  nasdaqEarningsCache.clear();
+  nasdaqEarningsInFlightRequests.clear();
+}
 
 export async function getEarnings(
   days: number,
-  date: "today" | "tomorrow" | string
+  date: "today" | "tomorrow" | string,
+  options: EarningsLoadOptions = {},
 ): Promise<EarningsEvent[]> {
-  const earningsResult = await getEarningsResult(days, date);
+  const earningsResult = await getEarningsResult(days, date, options);
   return earningsResult.events;
 }
 
 export async function getEarningsResult(
   days: number,
-  date: "today" | "tomorrow" | string
+  date: "today" | "tomorrow" | string,
+  options: EarningsLoadOptions = {},
 ): Promise<EarningsLoadResult> {
   const usEasternTime = getCurrentUsEasternTime();
   const isMultiDayRangeRequest = false === (null === days || 0 === days);
@@ -79,10 +101,14 @@ export async function getEarningsResult(
       skipWeekends: isMultiDayRangeRequest,
     }
   );
+  const requestSource = getEarningsRequestSource(options);
   const settledRequests = await Promise.allSettled(
-    dateStamps.map(dateStamp => loadNasdaqEarnings(dateStamp))
+    dateStamps.map(dateStamp => loadNasdaqEarningsWithCache(dateStamp))
   );
   let successfulRequestCount = 0;
+  let cacheHitCount = 0;
+  let cacheMissCount = 0;
+  let inFlightHitCount = 0;
 
   for (const [requestIndex, settledRequest] of settledRequests.entries()) {
     const dateStamp = dateStamps[requestIndex];
@@ -91,9 +117,16 @@ export async function getEarningsResult(
     }
     if ("fulfilled" === settledRequest.status) {
       successfulRequestCount++;
+      if ("cache-hit" === settledRequest.value.status) {
+        cacheHitCount++;
+      } else if ("in-flight" === settledRequest.value.status) {
+        inFlightHitCount++;
+      } else {
+        cacheMissCount++;
+      }
       appendNasdaqEarningsEvents(
         earningsEvents,
-        settledRequest.value,
+        settledRequest.value.response,
         dateStamp
       );
       continue;
@@ -111,10 +144,30 @@ export async function getEarningsResult(
       "error",
       `Loading earnings failed: Nasdaq requests were unsuccessful for ${getDateRangeLabel(dateFromStamp, dateToStamp)}.`
     );
-  } else {
+  } else if (0 < cacheMissCount) {
     logger.log(
       "info",
-      `Loaded ${earningsEvents.length} earnings from Nasdaq for ${getDateRangeLabel(dateFromStamp, dateToStamp)}.`
+      {
+        source: requestSource,
+        cacheHits: cacheHitCount,
+        cacheMisses: cacheMissCount,
+        dateRange: getDateRangeLabel(dateFromStamp, dateToStamp),
+        inFlightHits: inFlightHitCount,
+        totalEvents: earningsEvents.length,
+        message: `Loaded ${earningsEvents.length} earnings from Nasdaq for ${getDateRangeLabel(dateFromStamp, dateToStamp)}.`,
+      }
+    );
+  } else {
+    logger.log(
+      "debug",
+      {
+        source: requestSource,
+        cacheHits: cacheHitCount,
+        dateRange: getDateRangeLabel(dateFromStamp, dateToStamp),
+        inFlightHits: inFlightHitCount,
+        totalEvents: earningsEvents.length,
+        message: `Used cached Nasdaq earnings for ${getDateRangeLabel(dateFromStamp, dateToStamp)}.`,
+      }
     );
   }
 
@@ -136,6 +189,11 @@ function getCurrentUsEasternTime(): moment.Moment {
     second: 0,
     */
   });
+}
+
+function getEarningsRequestSource(options: EarningsLoadOptions): string {
+  const normalizedSource = options.source?.trim();
+  return normalizedSource ? normalizedSource : "earnings";
 }
 
 function resolveRequestedDateRange(
@@ -268,6 +326,45 @@ async function loadNasdaqEarnings(
   }
 
   return response.data;
+}
+
+async function loadNasdaqEarningsWithCache(
+  dateStamp: string
+): Promise<NasdaqEarningsLoadResult> {
+  const loadedAtMs = Date.now();
+  const cacheEntry = nasdaqEarningsCache.get(dateStamp);
+  if (cacheEntry && loadedAtMs - cacheEntry.loadedAtMs < nasdaqEarningsCacheTtlMs) {
+    return {
+      response: cacheEntry.response,
+      status: "cache-hit",
+    };
+  }
+
+  const inFlightRequest = nasdaqEarningsInFlightRequests.get(dateStamp);
+  if (undefined !== inFlightRequest) {
+    return {
+      response: await inFlightRequest,
+      status: "in-flight",
+    };
+  }
+
+  const request = loadNasdaqEarnings(dateStamp)
+    .then(response => {
+      nasdaqEarningsCache.set(dateStamp, {
+        loadedAtMs: Date.now(),
+        response,
+      });
+      return response;
+    })
+    .finally(() => {
+      nasdaqEarningsInFlightRequests.delete(dateStamp);
+    });
+  nasdaqEarningsInFlightRequests.set(dateStamp, request);
+
+  return {
+    response: await request,
+    status: "cache-miss",
+  };
 }
 
 function getDateStampsInRange(

--- a/modules/earnings.test.ts
+++ b/modules/earnings.test.ts
@@ -1,5 +1,5 @@
 import type {MockedFunction} from "vitest";
-import {type EarningsEvent, getEarnings, getEarningsMessages, getEarningsResult, getEarningsText} from "./earnings.ts";
+import {clearEarningsScheduleCache, type EarningsEvent, getEarnings, getEarningsMessages, getEarningsResult, getEarningsText} from "./earnings.ts";
 import {Ticker} from "./tickers.ts";
 import axios from "axios";
 import {beforeEach, describe, expect, test, vi} from "vitest";
@@ -68,6 +68,7 @@ function parseEarningsLine(
 
 describe("getEarnings/getEarningsResult", () => {
   beforeEach(() => {
+    clearEarningsScheduleCache();
     vi.clearAllMocks();
     vi.setSystemTime(defaultNow);
   });
@@ -329,6 +330,63 @@ describe("getEarnings/getEarningsResult", () => {
       events: [],
       status: "error",
     });
+  });
+
+  test("reuses cached Nasdaq earnings for repeated same-day requests", async () => {
+    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValueOnce({
+      data: getNasdaqResponse([
+        getNasdaqRow({
+          symbol: "FC",
+          name: "Franklin Covey",
+          marketCap: "1.2B",
+          epsForecast: "0.95",
+        }),
+      ]),
+    });
+
+    const firstResult = await getEarningsResult(0, "today", {
+      source: "first-source",
+    });
+    const secondResult = await getEarningsResult(0, "today", {
+      source: "second-source",
+    });
+
+    expect(firstResult).toEqual(secondResult);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  test("shares an in-flight Nasdaq earnings request for the same date", async () => {
+    let resolveNasdaqRequest: ((value: unknown) => void) | undefined;
+    (axios.get as MockedFunction<typeof axios.get>).mockReturnValue(new Promise(resolve => {
+      resolveNasdaqRequest = resolve;
+    }));
+
+    const firstResultPromise = getEarningsResult(0, "today", {
+      source: "first-source",
+    });
+    const secondResultPromise = getEarningsResult(0, "today", {
+      source: "second-source",
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    resolveNasdaqRequest?.({
+      data: getNasdaqResponse([
+        getNasdaqRow({
+          symbol: "FC",
+          name: "Franklin Covey",
+          marketCap: "1.2B",
+          epsForecast: "0.95",
+        }),
+      ]),
+    });
+
+    const [firstResult, secondResult] = await Promise.all([
+      firstResultPromise,
+      secondResultPromise,
+    ]);
+
+    expect(firstResult).toEqual(secondResult);
+    expect(axios.get).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/modules/earnings.ts
+++ b/modules/earnings.ts
@@ -1,3 +1,3 @@
 export * from "./earnings-types.ts";
-export {getEarnings, getEarningsResult} from "./earnings-source.ts";
+export {clearEarningsScheduleCache, getEarnings, getEarningsResult} from "./earnings-source.ts";
 export {getEarningsMessages, getEarningsText} from "./earnings-format.ts";

--- a/modules/slash-commands-interact-events.ts
+++ b/modules/slash-commands-interact-events.ts
@@ -52,7 +52,9 @@ export async function handleEarningsSlashCommand(
     return true;
   }
 
-  const earningsResult = await getEarningsResult(days, date);
+  const earningsResult = await getEarningsResult(days, date, {
+    source: "slash-earnings",
+  });
   const earningsEvents = earningsResult.events;
   const earningsStatus = earningsResult.status;
 

--- a/modules/slash-commands.interact.test.ts
+++ b/modules/slash-commands.interact.test.ts
@@ -903,7 +903,9 @@ describe("interactSlashCommands", () => {
 
     await handler(interaction);
 
-    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "today");
+    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "today", {
+      source: "slash-earnings",
+    });
     expect(getEarningsMessagesMock).toHaveBeenCalledWith([], "all", [], {
       maxMessageLength: 1800,
       maxMessages: 6,

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -337,7 +337,9 @@ describe("timers: other announcements", () => {
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
     await dailyEarningsJob.callback();
 
-    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "tomorrow");
+    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "tomorrow", {
+      source: "timer-earnings",
+    });
     expect(send).not.toHaveBeenCalled();
   });
 
@@ -385,7 +387,9 @@ describe("timers: other announcements", () => {
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
     await dailyEarningsJob.callback();
 
-    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "tomorrow");
+    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "tomorrow", {
+      source: "timer-earnings",
+    });
     expect(addExpectedMovesToEarningsEventsMock).toHaveBeenCalledWith([], {
       marketCapFilter: "bluechips",
       when: "all",
@@ -458,7 +462,9 @@ describe("timers: other announcements", () => {
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
     await dailyEarningsJob.callback();
 
-    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "tomorrow");
+    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "tomorrow", {
+      source: "timer-earnings",
+    });
     expect(send).toHaveBeenNthCalledWith(1, {
       content: "earnings-1",
       allowedMentions: {
@@ -526,7 +532,9 @@ describe("timers: other announcements", () => {
     const weeklyEarningsJob = getScheduledJobByTime(23, 30, "Europe/Berlin");
     await weeklyEarningsJob.callback();
 
-    expect(getEarningsResultMock).toHaveBeenCalledWith(5, "tomorrow");
+    expect(getEarningsResultMock).toHaveBeenCalledWith(5, "tomorrow", {
+      source: "timer-earnings-weekly",
+    });
     expect(getEarningsMessagesMock).toHaveBeenCalledWith([], "all", [], {
       maxMessageLength: 1800,
       maxMessages: 8,
@@ -573,7 +581,9 @@ describe("timers: other announcements", () => {
     })]);
     await getEarningsReminderJob().callback();
 
-    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "today");
+    expect(getEarningsResultMock).toHaveBeenCalledWith(0, "today", {
+      source: "earnings-reminder",
+    });
     expect(send).toHaveBeenCalledWith({
       content: "<@&role-456> Heute Earnings: `NVDA`, `MSFT` (nach Handelsschluss)",
       allowedMentions: {

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -340,7 +340,9 @@ async function runEarningsAnnouncement(
   config: EarningsAnnouncementConfig,
   earningsExpectationsThreadID?: string,
 ) {
-  const earningsResult = await getEarningsResult(config.days, config.date);
+  const earningsResult = await getEarningsResult(config.days, config.date, {
+    source: config.source,
+  });
   const earningsEvents = await addExpectedMovesToEarningsEvents(earningsResult.events, {
     marketCapFilter: config.filter,
     when: config.when,
@@ -375,7 +377,9 @@ async function runEarningsAnnouncement(
 }
 
 async function warmExpectedMovesForAnnouncement(config: EarningsAnnouncementConfig) {
-  const earningsResult = await getEarningsResult(config.days, config.date);
+  const earningsResult = await getEarningsResult(config.days, config.date, {
+    source: `${config.source}-expected-move-warmup`,
+  });
   if ("error" === earningsResult.status) {
     logger.log(
       "warn",
@@ -734,7 +738,9 @@ export function startOtherTimers(
       return;
     }
 
-    const earningsResult = await getEarningsResult(0, "today");
+    const earningsResult = await getEarningsResult(0, "today", {
+      source: earningsReminderSource,
+    });
     if ("error" === earningsResult.status) {
       logger.log(
         "warn",


### PR DESCRIPTION
## Summary
- add a shared 90-minute Nasdaq earnings schedule cache keyed per date
- share in-flight same-date requests across watcher, reminders, timers, and slash command calls
- add source-aware cache miss logging so repeated loads can be attributed

## Validation
- npm test -- modules/earnings.test.ts modules/earnings-results.test.ts modules/timers-other.test.ts modules/slash-commands.interact.test.ts
- npm run typecheck
- npm run lint
- npm run test:coverage