### PR TITLE
[codex] Improve earnings result formatting

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -71,7 +71,7 @@ describe("earnings result formatting", () => {
       metrics,
       parsedDocument,
       ticker: "XOM",
-    })).toContain("Adj EPS: `$1.16` vs est. `$0.96` - beat");
+    })).toContain("- **Adj EPS:** $1.16 vs est. $0.96 (🟢 beat)");
     expect(getEarningsResultMessage({
       companyName: "Exxon Mobil",
       filing: {
@@ -141,10 +141,10 @@ describe("earnings result formatting", () => {
       parsedDocument,
       ticker: "EXCO",
     })).toContain([
-      "Outlook:",
-      "Revenue: `$89B to $91B`",
-      "EPS: `$1.42 to $1.48`",
-      "Gross margin: `46.5% to 47.5%`",
+      "🔮 **Outlook**",
+      "- **Revenue:** $89B to $91B",
+      "- **EPS:** $1.42 to $1.48",
+      "- **Gross margin:** 46.5% to 47.5%",
     ].join("\n"));
   });
 
@@ -499,8 +499,10 @@ describe("earnings result formatting", () => {
     });
 
     expect(message).toBe([
-      "💰 **Earnings: Example (`EX`)**",
-      "Production: `1,200 boepd`",
+      "**Example (EX)**",
+      "",
+      "📊 **Results**",
+      "- **Production:** 1,200 boepd",
       "SEC: [10-Q](https://www.sec.gov/example)",
     ].join("\n"));
   });

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -241,22 +241,26 @@ export function getEarningsResultMessage({
   parsedDocument: ParsedEarningsDocument;
   ticker: string;
 }): string {
-  const titleParts = [`💰 **Earnings: ${companyName} (\`${ticker.trim().toUpperCase()}\`)`];
+  const titleParts = [`**${companyName} (${ticker.trim().toUpperCase()})`];
   if (parsedDocument.quarterLabel) {
-    titleParts.push(` ${parsedDocument.quarterLabel}`);
+    titleParts.push(` - ${parsedDocument.quarterLabel}`);
   }
   titleParts.push("**");
 
   const lines = [titleParts.join("")];
-  for (const metric of metrics) {
-    lines.push(getMetricMessageLine(metric));
+  if (0 < metrics.length) {
+    lines.push("");
+    lines.push("📊 **Results**");
+    for (const metric of metrics) {
+      lines.push(getMetricMessageLine(metric));
+    }
   }
 
   if (0 < parsedDocument.outlook.length) {
     lines.push("");
-    lines.push("Outlook:");
+    lines.push("🔮 **Outlook**");
     for (const metric of parsedDocument.outlook) {
-      lines.push(`${metric.label}: \`${metric.value}\``);
+      lines.push(`- **${metric.label}:** ${metric.value}`);
     }
   }
 
@@ -267,9 +271,21 @@ export function getEarningsResultMessage({
 }
 
 function getMetricMessageLine(metric: EarningsResultMetric): string {
-  const estimateText = metric.estimate ? ` vs est. \`${metric.estimate}\`` : "";
-  const outcomeText = metric.outcome ? ` - ${metric.outcome}` : "";
-  return `${metric.label}: \`${metric.value}\`${estimateText}${outcomeText}`;
+  const estimateText = metric.estimate ? ` vs est. ${metric.estimate}` : "";
+  const outcomeText = metric.outcome ? ` (${getOutcomeIndicator(metric.outcome)} ${metric.outcome})` : "";
+  return `- **${metric.label}:** ${metric.value}${estimateText}${outcomeText}`;
+}
+
+function getOutcomeIndicator(outcome: EarningsResultOutcome): string {
+  if ("beat" === outcome) {
+    return "🟢";
+  }
+
+  if ("miss" === outcome) {
+    return "🔴";
+  }
+
+  return "⚪";
 }
 
 function getOutcome(actual: number | undefined, estimate: number): EarningsResultOutcome | undefined {

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -51,7 +51,7 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
-  test("handles growth language, negative money ranges, and fallback text", () => {
+  test("handles qualified growth language and negative money ranges", () => {
     const metrics = extractOutlookMetrics([
       "Fiscal 2026 Outlook",
       "Net sales expected to decline low double-digit.",
@@ -77,11 +77,6 @@ describe("extractOutlookMetrics", () => {
         key: "operating_income",
         label: "Operating income",
         value: "-$200M to -$100M",
-      },
-      {
-        key: "free_cash_flow",
-        label: "Free cash flow",
-        value: "remains positive despite investment cycle",
       },
     ]);
   });
@@ -175,9 +170,9 @@ describe("extractOutlookMetrics", () => {
         value: "$2.4B",
       },
       {
-        key: "tax_rate",
-        label: "Tax rate",
-        value: "not available",
+        key: "capex",
+        label: "Capex",
+        value: "$12M",
       },
     ]);
   });

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -199,8 +199,7 @@ function extractOutlookValue(
   return getGrowthOutlookValue(valueText) ??
     getOutlookRangeValue(valueText, valueType) ??
     ("text" === valueType ? getSingleOutlookValue(valueText, "money") : null) ??
-    getSingleOutlookValue(valueText, valueType) ??
-    getFallbackOutlookValue(valueText, valueType);
+    getSingleOutlookValue(valueText, valueType);
 }
 
 function normalizeOutlookValueText(value: string): string {
@@ -283,33 +282,6 @@ function getSingleOutlookValue(value: string, valueType: OutlookValueType): stri
   }
 
   return null;
-}
-
-function getFallbackOutlookValue(value: string, valueType: OutlookValueType): string | null {
-  const fallbackValue = value.split(/[.;]/)[0]?.trim() ?? "";
-  if (fallbackValue.length < 2 ||
-      fallbackValue.length > 80 ||
-      fallbackValue.includes("|") ||
-      /^n\/?a$/i.test(fallbackValue) ||
-      /\$\s*\d/.test(fallbackValue)) {
-    return null;
-  }
-
-  if ("text" !== valueType && false === isUsefulNonTextFallbackValue(fallbackValue)) {
-    return null;
-  }
-
-  return fallbackValue;
-}
-
-function isUsefulNonTextFallbackValue(value: string): boolean {
-  if (/^(?:and|or)\b/i.test(value) ||
-      /^\(?\s*%/i.test(value) ||
-      /\bpre-tax\s+income\s+attributable\b/i.test(value)) {
-    return false;
-  }
-
-  return /\b(?:positive|negative|not\s+available|unavailable|breakeven|break-even|flat|unchanged|growth|decline|increase|decrease)\b/i.test(value);
 }
 
 function findNumericValue(

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -135,9 +135,10 @@ describe("earnings result announcements", () => {
     expect(result.active).toBe(true);
     expect(result.watchedCompanies).toBe(1);
     expect(result.announcements).toHaveLength(1);
-    expect(result.announcements[0]!.message).toContain("Earnings: Exxon Mobil (`XOM`) Q1 2026");
-    expect(result.announcements[0]!.message).toContain("Adj EPS: `$1.16` vs est. `$0.96` - beat");
-    expect(result.announcements[0]!.message).toContain("Revenue: `$85.14B` vs est. `$80.74B` - beat");
+    expect(result.announcements[0]!.message).toContain("**Exxon Mobil (XOM) - Q1 2026**");
+    expect(result.announcements[0]!.message).toContain("📊 **Results**");
+    expect(result.announcements[0]!.message).toContain("- **Adj EPS:** $1.16 vs est. $0.96 (🟢 beat)");
+    expect(result.announcements[0]!.message).toContain("- **Revenue:** $85.14B vs est. $80.74B (🟢 beat)");
     expect(result.announcements[0]!.message).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm) Item 2.02, 9.01");
   });
 
@@ -474,7 +475,7 @@ describe("earnings result announcements", () => {
     });
 
     expect(send).toHaveBeenCalledWith({
-      content: expect.stringContaining("Earnings: Exxon Mobil (`XOM`) Q1 2026"),
+      content: expect.stringContaining("**Exxon Mobil (XOM) - Q1 2026**"),
       allowedMentions: {
         parse: [],
       },
@@ -547,7 +548,7 @@ describe("earnings result announcements", () => {
       limit: 100,
     });
     expect(threadSend).toHaveBeenCalledWith({
-      content: expect.stringContaining("Earnings: Exxon Mobil (`XOM`) Q1 2026"),
+      content: expect.stringContaining("**Exxon Mobil (XOM) - Q1 2026**"),
       allowedMentions: {
         parse: [],
       },
@@ -648,8 +649,9 @@ describe("earnings result announcements", () => {
   });
 
   test("provides a concrete example output", () => {
-    expect(getExampleEarningsResultOutput()).toContain("Apple Inc. (`AAPL`)");
-    expect(getExampleEarningsResultOutput()).toContain("EPS: `$2.84` vs est. `$2.67` - beat");
+    expect(getExampleEarningsResultOutput()).toContain("**Apple Inc. (AAPL) - Q1 2026**");
+    expect(getExampleEarningsResultOutput()).toContain("📊 **Results**");
+    expect(getExampleEarningsResultOutput()).toContain("- **EPS:** $2.84 vs est. $2.67 (🟢 beat)");
     expect(getExampleEarningsResultOutput()).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01");
   });
 });

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -787,10 +787,12 @@ function parseNasdaqMoney(value: unknown): number | null {
 
 export function getExampleEarningsResultOutput(): string {
   return [
-    "💰 **Earnings: Apple Inc. (`AAPL`) Q1 2026**",
-    `EPS: \`$2.84\` vs est. \`$2.67\` - beat`,
-    `Revenue: \`${formatUsdCompact(143_800_000_000)}\` vs est. \`${formatUsdCompact(138_250_000_000)}\` - beat`,
-    `Net income: \`${formatUsdCompact(42_097_000_000)}\``,
+    "**Apple Inc. (AAPL) - Q1 2026**",
+    "",
+    "📊 **Results**",
+    "- **EPS:** $2.84 vs est. $2.67 (🟢 beat)",
+    `- **Revenue:** ${formatUsdCompact(143_800_000_000)} vs est. ${formatUsdCompact(138_250_000_000)} (🟢 beat)`,
+    `- **Net income:** ${formatUsdCompact(42_097_000_000)}`,
     "SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- simplify earnings result titles for the dedicated earnings channel
- render results and outlook as bullet sections with visual icons
- add beat/miss/inline indicators to comparison metrics
- suppress qualitative-only outlook fragments such as generic growth or improved profitability

## Validation
- npm test -- modules/earnings-results-format.test.ts modules/earnings-results-outlook.test.ts modules/earnings-results.test.ts
- npm run typecheck
- npm run lint