### PR TITLE
[codex] Use selective code formatting in earnings results

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -321,6 +321,75 @@ describe("earnings result formatting", () => {
     ]);
   });
 
+  test("uses split table values instead of date headers or note columns", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>GlobalFoundries reports first quarter 2026 results</h1>
+          <p>(Unaudited, in millions, except per share amounts)</p>
+          <p>Three Months Ended March 31</p>
+          <p>| 2026</p>
+          <p>| 2025</p>
+          <p>Net revenue</p>
+          <p>| $</p>
+          <p>| 1,634</p>
+          <p>| $</p>
+          <p>| 1,585</p>
+          <p>Cost of revenue</p>
+          <p>| 1,183</p>
+          <p>| 1,230</p>
+          <p>Net income</p>
+          <p>| $</p>
+          <p>| 104</p>
+          <p>| $</p>
+          <p>| 211</p>
+          <h2>Note 3. Net Revenue</h2>
+          <p>The following table presents the Company's revenue for the three month periods ended March 31, 2026 and 2025.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 1_634_000_000,
+        value: "$1.63B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 104_000_000,
+        value: "$104M",
+      }),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$31M");
+  });
+
+  test("skips table note references and prefers the period-ended quarter", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <p>BioNTech | Quarterly Report for the three months ended March 31, 2026</p>
+          <p>Q1 2027 program timing remains subject to risks.</p>
+          <table>
+            <tr><td>(in millions €, except per share data)</td><td>Note</td><td>2026</td><td>2025</td></tr>
+            <tr><td>Revenues</td><td>3</td></tr>
+            <tr><td>118.1</td><td>182.8</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q1 2026");
+    expect(parsedDocument.metrics).toEqual([
+      expect.objectContaining({
+        currencyCode: "EUR",
+        key: "revenue",
+        numericValue: 118_100_000,
+        value: "€118.1M",
+      }),
+    ]);
+  });
+
   test("skips generic production mentions without operational units", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>
@@ -499,8 +568,7 @@ describe("earnings result formatting", () => {
     });
 
     expect(message).toBe([
-      "**Example (EX)**",
-      "",
+      "**Example (`EX`)**",
       "📊 **Results**",
       "- **Production:** `1,200 boepd`",
       "SEC: [10-Q](https://www.sec.gov/example)",

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -71,7 +71,7 @@ describe("earnings result formatting", () => {
       metrics,
       parsedDocument,
       ticker: "XOM",
-    })).toContain("- **Adj EPS:** $1.16 vs est. $0.96 (🟢 beat)");
+    })).toContain("- **Adj EPS:** `$1.16` vs est. `$0.96` (🟢 beat)");
     expect(getEarningsResultMessage({
       companyName: "Exxon Mobil",
       filing: {
@@ -142,9 +142,9 @@ describe("earnings result formatting", () => {
       ticker: "EXCO",
     })).toContain([
       "🔮 **Outlook**",
-      "- **Revenue:** $89B to $91B",
-      "- **EPS:** $1.42 to $1.48",
-      "- **Gross margin:** 46.5% to 47.5%",
+      "- **Revenue:** `$89B` to `$91B`",
+      "- **EPS:** `$1.42` to `$1.48`",
+      "- **Gross margin:** `46.5%` to `47.5%`",
     ].join("\n"));
   });
 
@@ -502,7 +502,7 @@ describe("earnings result formatting", () => {
       "**Example (EX)**",
       "",
       "📊 **Results**",
-      "- **Production:** 1,200 boepd",
+      "- **Production:** `1,200 boepd`",
       "SEC: [10-Q](https://www.sec.gov/example)",
     ].join("\n"));
   });

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -260,7 +260,7 @@ export function getEarningsResultMessage({
     lines.push("");
     lines.push("🔮 **Outlook**");
     for (const metric of parsedDocument.outlook) {
-      lines.push(`- **${metric.label}:** ${metric.value}`);
+      lines.push(`- **${metric.label}:** ${formatOutlookValue(metric.value)}`);
     }
   }
 
@@ -271,9 +271,32 @@ export function getEarningsResultMessage({
 }
 
 function getMetricMessageLine(metric: EarningsResultMetric): string {
-  const estimateText = metric.estimate ? ` vs est. ${metric.estimate}` : "";
+  const estimateText = metric.estimate ? ` vs est. ${formatInlineCode(metric.estimate)}` : "";
   const outcomeText = metric.outcome ? ` (${getOutcomeIndicator(metric.outcome)} ${metric.outcome})` : "";
-  return `- **${metric.label}:** ${metric.value}${estimateText}${outcomeText}`;
+  return `- **${metric.label}:** ${formatInlineCode(metric.value)}${estimateText}${outcomeText}`;
+}
+
+function formatOutlookValue(value: string): string {
+  if (false === isQuantitativeText(value)) {
+    return value;
+  }
+
+  return formatQuantitativeTokens(value);
+}
+
+function isQuantitativeText(value: string): boolean {
+  return /[$€£¥]|\d/.test(value);
+}
+
+function formatQuantitativeTokens(value: string): string {
+  return value.replace(
+    /-?(?:[$€£¥]\s*)?\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|billions?|millions?|thousands?|tn|bn|mm|[tbmk]|kbd|koebd|boepd|bpd|mmboe|bcfe|mmcf|mw|gw)\b|\s*%)?/gi,
+    token => formatInlineCode(token.trim()),
+  );
+}
+
+function formatInlineCode(value: string): string {
+  return `\`${value.replaceAll("`", "'")}\``;
 }
 
 function getOutcomeIndicator(outcome: EarningsResultOutcome): string {

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -8,6 +8,7 @@ import {
 export type EarningsResultOutcome = "beat" | "inline" | "miss";
 
 export type EarningsResultMetric = {
+  currencyCode?: string | undefined;
   estimate?: string | undefined;
   key: string;
   label: string;
@@ -37,6 +38,11 @@ type SecCurrentFilingForMessage = {
 };
 
 type MetricValueType = "eps" | "money" | "number";
+
+type MoneyContext = {
+  currencyCode?: string | undefined;
+  scale: number;
+};
 
 type MetricDefinition = {
   key: string;
@@ -141,18 +147,24 @@ export function getMessageMetrics(
 
   const epsMetric = metrics.find(metric => "adjusted_eps" === metric.key) ??
     metrics.find(metric => "nasdaq_eps" === metric.key || "gaap_eps" === metric.key);
-  if (epsMetric && "number" === typeof consensusEps) {
+  if (epsMetric && "number" === typeof consensusEps && true === canCompareAgainstUsdEstimate(epsMetric)) {
     epsMetric.estimate = formatEps(consensusEps);
     epsMetric.outcome = getOutcome(epsMetric.numericValue, consensusEps);
   }
 
   const revenueMetric = metrics.find(metric => "revenue" === metric.key);
-  if (revenueMetric && "number" === typeof surprise?.consensusRevenue) {
+  if (revenueMetric &&
+      "number" === typeof surprise?.consensusRevenue &&
+      true === canCompareAgainstUsdEstimate(revenueMetric)) {
     revenueMetric.estimate = formatUsdCompact(surprise.consensusRevenue);
     revenueMetric.outcome = getOutcome(revenueMetric.numericValue, surprise.consensusRevenue);
   }
 
   return metrics.slice(0, 7);
+}
+
+function canCompareAgainstUsdEstimate(metric: EarningsResultMetric): boolean {
+  return undefined === metric.currencyCode || "USD" === metric.currencyCode;
 }
 
 function normalizeEpsMetrics(
@@ -241,15 +253,14 @@ export function getEarningsResultMessage({
   parsedDocument: ParsedEarningsDocument;
   ticker: string;
 }): string {
-  const titleParts = [`**${companyName} (${ticker.trim().toUpperCase()})`];
+  const normalizedTicker = ticker.trim().toUpperCase().replaceAll("`", "'");
+  const titleParts = [`**${companyName} (\`${normalizedTicker}\`)**`];
   if (parsedDocument.quarterLabel) {
     titleParts.push(` - ${parsedDocument.quarterLabel}`);
   }
-  titleParts.push("**");
 
   const lines = [titleParts.join("")];
   if (0 < metrics.length) {
-    lines.push("");
     lines.push("📊 **Results**");
     for (const metric of metrics) {
       lines.push(getMetricMessageLine(metric));
@@ -257,7 +268,9 @@ export function getEarningsResultMessage({
   }
 
   if (0 < parsedDocument.outlook.length) {
-    lines.push("");
+    if (1 < lines.length) {
+      lines.push("");
+    }
     lines.push("🔮 **Outlook**");
     for (const metric of parsedDocument.outlook) {
       lines.push(`- **${metric.label}:** ${formatOutlookValue(metric.value)}`);
@@ -366,34 +379,51 @@ function getDocumentHeadline(lines: string[]): string | undefined {
 }
 
 function getQuarterLabel(text: string): string | undefined {
-  const directQuarterMatch = text.match(/\b(Q[1-4])\s+(20\d{2})\b/i);
-  if (undefined !== directQuarterMatch?.[1] && undefined !== directQuarterMatch[2]) {
-    return `${directQuarterMatch[1].toUpperCase()} ${directQuarterMatch[2]}`;
+  const periodEndedQuarter = getQuarterLabelFromPeriodEnded(text);
+  if (undefined !== periodEndedQuarter) {
+    return periodEndedQuarter;
   }
 
   const writtenQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter\s+(?:of\s+)?(20\d{2})\b/i);
   if (undefined !== writtenQuarterMatch?.[1] && undefined !== writtenQuarterMatch[2]) {
-    const quarterByName = new Map<string, string>([
-      ["first", "Q1"],
-      ["second", "Q2"],
-      ["third", "Q3"],
-      ["fourth", "Q4"],
-    ]);
-    const quarter = quarterByName.get(writtenQuarterMatch[1].toLowerCase());
+    const quarter = getQuarterFromName(writtenQuarterMatch[1]);
     if (quarter) {
       return `${quarter} ${writtenQuarterMatch[2]}`;
     }
   }
 
-  const quarterEndedMatch = text.match(/\bquarter\s+ended\s+([A-Z][a-z]+)\s+\d{1,2},\s+(20\d{2})\b/);
-  if (undefined !== quarterEndedMatch?.[1] && undefined !== quarterEndedMatch[2]) {
-    const month = moment(quarterEndedMatch[1], "MMMM", true);
-    if (true === month.isValid()) {
-      return `Q${Math.floor(month.month() / 3) + 1} ${quarterEndedMatch[2]}`;
-    }
+  const directQuarterMatch = text.match(/\b(Q[1-4])\s+(20\d{2})\b/i);
+  if (undefined !== directQuarterMatch?.[1] && undefined !== directQuarterMatch[2]) {
+    return `${directQuarterMatch[1].toUpperCase()} ${directQuarterMatch[2]}`;
   }
 
   return undefined;
+}
+
+function getQuarterLabelFromPeriodEnded(text: string): string | undefined {
+  const periodEndedMatch = text.match(
+    /\b(?:three\s+months|quarter)\s+ended\s+([A-Z][a-z]+)\s+\d{1,2},\s+(20\d{2})\b/,
+  );
+  if (undefined === periodEndedMatch?.[1] || undefined === periodEndedMatch[2]) {
+    return undefined;
+  }
+
+  const month = moment(periodEndedMatch[1], "MMMM", true);
+  if (false === month.isValid()) {
+    return undefined;
+  }
+
+  return `Q${Math.floor(month.month() / 3) + 1} ${periodEndedMatch[2]}`;
+}
+
+function getQuarterFromName(name: string): string | undefined {
+  const quarterByName = new Map<string, string>([
+    ["first", "Q1"],
+    ["second", "Q2"],
+    ["third", "Q3"],
+    ["fourth", "Q4"],
+  ]);
+  return quarterByName.get(name.toLowerCase());
 }
 
 function extractEarningsMetrics(lines: string[]): EarningsResultMetric[] {
@@ -440,13 +470,15 @@ function extractMetric(
       metricLine,
       pattern,
       definition.valueType,
-      getContextMoneyScale(lines, lineIndex),
+      getContextMoney(lines, lineIndex),
+      isNearTableNoteColumn(lines, lineIndex),
     );
     if (null === metricValue) {
       continue;
     }
 
     return {
+      currencyCode: metricValue.currencyCode,
       key: definition.key,
       label: definition.label,
       numericValue: metricValue.numericValue,
@@ -463,13 +495,17 @@ function isPerShareOnlyNetIncomeLine(line: string): boolean {
 }
 
 function getMetricLineWithContinuation(lines: string[], lineIndex: number): string {
-  const line = lines[lineIndex] ?? "";
-  const nextLine = lines[lineIndex + 1];
-  if (undefined === nextLine || false === isValueOnlyLine(nextLine)) {
-    return line;
+  const metricLines = [lines[lineIndex] ?? ""];
+  for (let index = lineIndex + 1; index < lines.length && index <= lineIndex + 6; index++) {
+    const nextLine = lines[index];
+    if (undefined === nextLine || false === isValueOnlyLine(nextLine)) {
+      break;
+    }
+
+    metricLines.push(nextLine);
   }
 
-  return `${line} ${nextLine}`;
+  return metricLines.join(" ");
 }
 
 function isValueOnlyLine(line: string): boolean {
@@ -480,8 +516,9 @@ function extractMetricValue(
   line: string,
   pattern: RegExp,
   valueType: MetricValueType,
-  contextMoneyScale: number,
-): {numericValue: number; value: string} | null {
+  contextMoney: MoneyContext,
+  skipTableNoteRefs: boolean,
+): {currencyCode?: string | undefined; numericValue: number; value: string} | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
   const searchText = patternMatch ? line.slice(patternMatch.index + patternMatch[0].length) : line;
@@ -493,7 +530,8 @@ function extractMetricValue(
 
   if ("money" === valueType) {
     const parsedValue = findNumericValue(searchText, {
-      requireMoneyCue: 1 === contextMoneyScale,
+      requireMoneyCue: 1 === contextMoney.scale,
+      skipTableNoteRefs,
       skipPercentages: true,
     });
     if (null === parsedValue) {
@@ -501,10 +539,12 @@ function extractMetricValue(
     }
 
     const explicitScale = getExplicitMoneyScale(searchText);
-    const amount = parsedValue * (explicitScale ?? contextMoneyScale);
+    const currencyCode = getCurrencyCodeFromText(searchText) ?? contextMoney.currencyCode;
+    const amount = parsedValue * (explicitScale ?? contextMoney.scale);
     return {
+      currencyCode,
       numericValue: amount,
-      value: formatUsdCompact(amount),
+      value: formatMoneyCompact(amount, currencyCode),
     };
   }
 
@@ -524,20 +564,39 @@ function extractMetricValue(
   };
 }
 
-function getContextMoneyScale(lines: string[], lineIndex: number): number {
-  for (let index = lineIndex; index >= 0 && index >= lineIndex - 30; index--) {
+function getContextMoney(lines: string[], lineIndex: number): MoneyContext {
+  let currencyCode: string | undefined;
+  for (let index = lineIndex; index >= 0 && index >= lineIndex - 80; index--) {
     const line = lines[index];
     if (undefined === line) {
       continue;
     }
 
+    currencyCode ??= getCurrencyCodeFromText(line);
     const scale = getMoneyScaleFromContextText(line);
     if (null !== scale) {
-      return scale;
+      return {
+        currencyCode,
+        scale,
+      };
     }
   }
 
-  return 1;
+  return {
+    currencyCode,
+    scale: 1,
+  };
+}
+
+function isNearTableNoteColumn(lines: string[], lineIndex: number): boolean {
+  for (let index = lineIndex; index >= 0 && index >= lineIndex - 5; index--) {
+    const line = lines[index];
+    if (undefined !== line && /\bnote\b/i.test(line)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function getMoneyScaleFromContextText(text: string): number | null {
@@ -554,6 +613,26 @@ function getMoneyScaleFromContextText(text: string): number | null {
   }
 
   return null;
+}
+
+function getCurrencyCodeFromText(text: string): string | undefined {
+  if (text.includes("€") || /\bEUR\b/i.test(text)) {
+    return "EUR";
+  }
+
+  if (text.includes("£") || /\bGBP\b/i.test(text)) {
+    return "GBP";
+  }
+
+  if (text.includes("¥") || /\bJPY\b/i.test(text)) {
+    return "JPY";
+  }
+
+  if (text.includes("$") || /\bUSD\b/i.test(text) || /\bdollars?\b/i.test(text)) {
+    return "USD";
+  }
+
+  return undefined;
 }
 
 function getExplicitMoneyScale(text: string): number | null {
@@ -580,13 +659,22 @@ function getExplicitMoneyScale(text: string): number | null {
 
 function findNumericValue(
   text: string,
-  options: {maxAbsValue?: number; requireMoneyCue?: boolean; skipPercentages?: boolean;} = {},
+  options: {
+    maxAbsValue?: number;
+    requireMoneyCue?: boolean;
+    skipPercentages?: boolean;
+    skipTableNoteRefs?: boolean;
+  } = {},
 ): number | null {
-  const numberMatches = text.matchAll(/\(?-?\$?\s*(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?/g);
+  const numberMatches = text.matchAll(/\(?-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?/g);
   for (const numberMatch of numberMatches) {
     const token = numberMatch[0];
     const endIndex = numberMatch.index + token.length;
     if (true === options.skipPercentages && "%" === text.slice(endIndex, endIndex + 1)) {
+      continue;
+    }
+
+    if (true === isCalendarDayValue(text, numberMatch.index, endIndex)) {
       continue;
     }
 
@@ -597,6 +685,11 @@ function findNumericValue(
 
     if (true === options.requireMoneyCue &&
         false === hasMoneyCue(text, numberMatch.index, endIndex, token)) {
+      continue;
+    }
+
+    if (true === options.skipTableNoteRefs &&
+        true === isLikelyTableNoteReference(text, numberMatch.index, endIndex, token)) {
       continue;
     }
 
@@ -614,13 +707,36 @@ function findNumericValue(
   return null;
 }
 
+function isCalendarDayValue(text: string, startIndex: number, endIndex: number): boolean {
+  const beforeToken = text.slice(Math.max(0, startIndex - 16), startIndex);
+  const afterToken = text.slice(endIndex, endIndex + 8);
+  return /\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+$/i.test(beforeToken) &&
+    /^\s*,?\s*(?:20\d{2})?\b/.test(afterToken);
+}
+
+function isLikelyTableNoteReference(text: string, startIndex: number, endIndex: number, token: string): boolean {
+  if (!/^\(?-?\d{1,2}\)?$/.test(token.trim())) {
+    return false;
+  }
+
+  if (true === hasMoneyCue(text, startIndex, endIndex, token)) {
+    return false;
+  }
+
+  const beforeToken = text.slice(Math.max(0, startIndex - 16), startIndex);
+  const afterToken = text.slice(endIndex, endIndex + 80);
+  return /\|[\s|()–-]*$/.test(beforeToken) &&
+    /^\s*(?:\||$)/.test(afterToken) &&
+    /\d/.test(afterToken);
+}
+
 function hasMoneyCue(text: string, startIndex: number, endIndex: number, token: string): boolean {
-  if (token.includes("$")) {
+  if (/[$€£¥]/.test(token)) {
     return true;
   }
 
   const beforeToken = text.slice(Math.max(0, startIndex - 8), startIndex);
-  if (/\$[\s|()–-]*$/.test(beforeToken)) {
+  if (/[$€£¥][\s|()–-]*$/.test(beforeToken)) {
     return true;
   }
 
@@ -640,7 +756,7 @@ export function parseNumber(value: unknown): number | null {
   const normalizedValue = value
     .replace(/^\((.*)\)$/, "-$1")
     .replace(/^\((.*)$/, "-$1")
-    .replaceAll("$", "")
+    .replace(/[$€£¥]/g, "")
     .replaceAll(",", "")
     .replaceAll("%", "")
     .trim()
@@ -665,25 +781,46 @@ export function formatEps(value: number): string {
 }
 
 export function formatUsdCompact(value: number): string {
+  return formatMoneyCompact(value, "USD");
+}
+
+export function formatMoneyCompact(value: number, currencyCode = "USD"): string {
+  const symbol = getCurrencySymbol(currencyCode);
   const absoluteValue = Math.abs(value);
   const sign = value < 0 ? "-" : "";
   if (absoluteValue >= 1_000_000_000_000) {
-    return `${sign}$${formatDecimal(absoluteValue / 1_000_000_000_000)}T`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000_000_000)}T`;
   }
 
   if (absoluteValue >= 1_000_000_000) {
-    return `${sign}$${formatDecimal(absoluteValue / 1_000_000_000)}B`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000_000)}B`;
   }
 
   if (absoluteValue >= 1_000_000) {
-    return `${sign}$${formatDecimal(absoluteValue / 1_000_000)}M`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000)}M`;
   }
 
   if (absoluteValue >= 1_000) {
-    return `${sign}$${formatDecimal(absoluteValue / 1_000)}K`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000)}K`;
   }
 
-  return `${sign}$${formatDecimal(absoluteValue)}`;
+  return `${sign}${symbol}${formatDecimal(absoluteValue)}`;
+}
+
+function getCurrencySymbol(currencyCode: string): string {
+  if ("EUR" === currencyCode) {
+    return "€";
+  }
+
+  if ("GBP" === currencyCode) {
+    return "£";
+  }
+
+  if ("JPY" === currencyCode) {
+    return "¥";
+  }
+
+  return "$";
 }
 
 function formatDecimal(value: number): string {

--- a/modules/earnings-results-xbrl.test.ts
+++ b/modules/earnings-results-xbrl.test.ts
@@ -1,0 +1,149 @@
+import {describe, expect, test} from "vitest";
+import {extractSecXbrlMetrics, type SecCompanyFactsResponse} from "./earnings-results-xbrl.ts";
+
+describe("earnings result XBRL metrics", () => {
+  test("extracts quarterly facts for the matching accession", () => {
+    const companyFacts: SecCompanyFactsResponse = {
+      facts: {
+        "us-gaap": {
+          EarningsPerShareDiluted: {
+            units: {
+              "USD/shares": [{
+                accn: "0000034088-26-000042",
+                end: "2026-03-31",
+                fp: "Q1",
+                form: "8-K",
+                frame: "CY2026Q1",
+                start: "2026-01-01",
+                val: 1,
+              }],
+            },
+          },
+          NetIncomeLoss: {
+            units: {
+              USD: [{
+                accn: "0000034088-26-000042",
+                end: "2026-03-31",
+                fp: "Q1",
+                form: "8-K",
+                frame: "CY2026Q1",
+                start: "2026-01-01",
+                val: 8_100_000_000,
+              }],
+            },
+          },
+          RevenueFromContractWithCustomerExcludingAssessedTax: {
+            units: {
+              USD: [{
+                accn: "0000034088-26-000042",
+                end: "2026-06-30",
+                fp: "Q2",
+                form: "10-Q",
+                start: "2026-01-01",
+                val: 170_000_000_000,
+              }, {
+                accn: "0000034088-26-000042",
+                end: "2026-03-31",
+                fp: "Q1",
+                form: "8-K",
+                frame: "CY2026Q1",
+                start: "2026-01-01",
+                val: 85_140_000_000,
+              }],
+            },
+          },
+        },
+      },
+    };
+
+    expect(extractSecXbrlMetrics(companyFacts, "0000034088-26-000042")).toEqual([
+      {
+        currencyCode: "USD",
+        key: "gaap_eps",
+        label: "EPS",
+        numericValue: 1,
+        value: "$1",
+      },
+      {
+        currencyCode: "USD",
+        key: "revenue",
+        label: "Revenue",
+        numericValue: 85_140_000_000,
+        value: "$85.14B",
+      },
+      {
+        currencyCode: "USD",
+        key: "net_income",
+        label: "Net income",
+        numericValue: 8_100_000_000,
+        value: "$8.1B",
+      },
+    ]);
+  });
+
+  test("supports IFRS currency facts", () => {
+    const companyFacts: SecCompanyFactsResponse = {
+      facts: {
+        "ifrs-full": {
+          DilutedEarningsLossPerShare: {
+            units: {
+              "EUR/shares": [{
+                accn: "0001776985-26-000031",
+                end: "2026-03-31",
+                fp: "Q1",
+                form: "6-K",
+                frame: "CY2026Q1",
+                start: "2026-01-01",
+                val: -1.3,
+              }],
+            },
+          },
+          ProfitLossAttributableToOwnersOfParent: {
+            units: {
+              EUR: [{
+                accn: "0001776985-26-000031",
+                end: "2026-03-31",
+                fp: "Q1",
+                form: "6-K",
+                frame: "CY2026Q1",
+                start: "2026-01-01",
+                val: -415_000_000,
+              }],
+            },
+          },
+          RevenueFromContractsWithCustomers: {
+            units: {
+              EUR: [{
+                accn: "0001776985-26-000031",
+                end: "2026-03-31",
+                fp: "Q1",
+                form: "6-K",
+                frame: "CY2026Q1",
+                start: "2026-01-01",
+                val: 118_100_000,
+              }],
+            },
+          },
+        },
+      },
+    };
+
+    expect(extractSecXbrlMetrics(companyFacts, "0001776985-26-000031")).toEqual([
+      expect.objectContaining({
+        currencyCode: "EUR",
+        key: "gaap_eps",
+        value: "-€1.3",
+      }),
+      expect.objectContaining({
+        currencyCode: "EUR",
+        key: "revenue",
+        value: "€118.1M",
+      }),
+      expect.objectContaining({
+        currencyCode: "EUR",
+        key: "net_income",
+        value: "-€415M",
+      }),
+    ]);
+  });
+});

--- a/modules/earnings-results-xbrl.ts
+++ b/modules/earnings-results-xbrl.ts
@@ -1,0 +1,313 @@
+import {type getWithRetry} from "./http-retry.ts";
+import {
+  formatMoneyCompact,
+  parseNumber,
+  type EarningsResultMetric,
+} from "./earnings-results-format.ts";
+import {type SecCurrentFiling} from "./earnings-results-sec.ts";
+
+type Logger = {
+  log: (level: string, message: unknown) => void;
+};
+
+type SecRequestDependencies = {
+  getWithRetryFn: typeof getWithRetry;
+  logger: Logger;
+};
+
+type SecCompanyFact = {
+  accn?: string;
+  end?: string;
+  filed?: string;
+  form?: string;
+  fp?: string;
+  frame?: string;
+  fy?: number | string;
+  start?: string;
+  val?: number | string;
+};
+
+type SecCompanyFactUnits = Record<string, SecCompanyFact[]>;
+
+type SecCompanyFactConcept = {
+  units?: SecCompanyFactUnits;
+};
+
+export type SecCompanyFactsResponse = {
+  facts?: Record<string, Record<string, SecCompanyFactConcept>>;
+};
+
+type XbrlMetricDefinition = {
+  concepts: {name: string; namespace: string;}[];
+  key: string;
+  label: string;
+  valueType: "eps" | "money";
+};
+
+type XbrlFactCandidate = {
+  currencyCode: string;
+  durationDays: number | null;
+  fact: SecCompanyFact;
+  score: number;
+  unit: string;
+  value: number;
+};
+
+const secCompanyFactsEndpoint = "https://data.sec.gov/api/xbrl/companyfacts";
+const secRequestHeaders = {
+  "User-Agent": "hblwrk discord-bot-ts admin@hblwrk.de",
+  "Accept": "application/json, text/plain, */*",
+  "Accept-Encoding": "gzip, deflate",
+};
+
+const xbrlMetricDefinitions: XbrlMetricDefinition[] = [
+  {
+    key: "gaap_eps",
+    label: "EPS",
+    valueType: "eps",
+    concepts: [
+      {namespace: "us-gaap", name: "EarningsPerShareDiluted"},
+      {namespace: "us-gaap", name: "EarningsPerShareBasicAndDiluted"},
+      {namespace: "ifrs-full", name: "DilutedEarningsLossPerShare"},
+      {namespace: "us-gaap", name: "EarningsPerShareBasic"},
+      {namespace: "ifrs-full", name: "BasicEarningsLossPerShare"},
+    ],
+  },
+  {
+    key: "revenue",
+    label: "Revenue",
+    valueType: "money",
+    concepts: [
+      {namespace: "us-gaap", name: "RevenueFromContractWithCustomerExcludingAssessedTax"},
+      {namespace: "us-gaap", name: "RevenueFromContractWithCustomerIncludingAssessedTax"},
+      {namespace: "us-gaap", name: "Revenues"},
+      {namespace: "us-gaap", name: "SalesRevenueNet"},
+      {namespace: "ifrs-full", name: "RevenueFromContractsWithCustomers"},
+      {namespace: "ifrs-full", name: "Revenue"},
+    ],
+  },
+  {
+    key: "net_income",
+    label: "Net income",
+    valueType: "money",
+    concepts: [
+      {namespace: "us-gaap", name: "NetIncomeLoss"},
+      {namespace: "us-gaap", name: "ProfitLoss"},
+      {namespace: "us-gaap", name: "NetIncomeLossAvailableToCommonStockholdersBasic"},
+      {namespace: "ifrs-full", name: "ProfitLossAttributableToOwnersOfParent"},
+      {namespace: "ifrs-full", name: "ProfitLoss"},
+    ],
+  },
+];
+
+export async function loadSecXbrlMetrics(
+  filing: SecCurrentFiling,
+  dependencies: SecRequestDependencies,
+): Promise<EarningsResultMetric[]> {
+  const response = await dependencies.getWithRetryFn<SecCompanyFactsResponse>(
+    `${secCompanyFactsEndpoint}/CIK${filing.cik}.json`,
+    {
+      headers: secRequestHeaders,
+    },
+  );
+  return extractSecXbrlMetrics(response.data, filing.accessionNumber);
+}
+
+export function extractSecXbrlMetrics(
+  companyFacts: SecCompanyFactsResponse,
+  accessionNumber: string,
+): EarningsResultMetric[] {
+  const metrics: EarningsResultMetric[] = [];
+
+  for (const definition of xbrlMetricDefinitions) {
+    const candidate = getBestFactCandidate(companyFacts, accessionNumber, definition);
+    if (null === candidate) {
+      continue;
+    }
+
+    metrics.push({
+      currencyCode: candidate.currencyCode,
+      key: definition.key,
+      label: definition.label,
+      numericValue: candidate.value,
+      value: formatMoneyCompact(candidate.value, candidate.currencyCode),
+    });
+  }
+
+  return metrics;
+}
+
+export function mergeXbrlAndHtmlMetrics(
+  xbrlMetrics: EarningsResultMetric[],
+  htmlMetrics: EarningsResultMetric[],
+): EarningsResultMetric[] {
+  if (0 === xbrlMetrics.length) {
+    return htmlMetrics;
+  }
+
+  const metricsByKey = new Map<string, EarningsResultMetric>();
+  for (const metric of xbrlMetrics) {
+    metricsByKey.set(metric.key, metric);
+  }
+
+  for (const metric of htmlMetrics) {
+    if (false === metricsByKey.has(metric.key)) {
+      metricsByKey.set(metric.key, metric);
+    }
+  }
+
+  const preferredOrder = [
+    "adjusted_eps",
+    "gaap_eps",
+    "nasdaq_eps",
+    "revenue",
+    "net_income",
+    "refinery_throughput",
+    "production",
+  ];
+  return [
+    ...preferredOrder.flatMap(key => {
+      const metric = metricsByKey.get(key);
+      return undefined === metric ? [] : [metric];
+    }),
+    ...[...metricsByKey.values()].filter(metric => false === preferredOrder.includes(metric.key)),
+  ];
+}
+
+function getBestFactCandidate(
+  companyFacts: SecCompanyFactsResponse,
+  accessionNumber: string,
+  definition: XbrlMetricDefinition,
+): XbrlFactCandidate | null {
+  const candidates: XbrlFactCandidate[] = [];
+
+  for (const concept of definition.concepts) {
+    const units = companyFacts.facts?.[concept.namespace]?.[concept.name]?.units;
+    if (undefined === units) {
+      continue;
+    }
+
+    for (const [unit, facts] of Object.entries(units)) {
+      const currencyCode = getCurrencyCodeFromUnit(unit, definition.valueType);
+      if (null === currencyCode) {
+        continue;
+      }
+
+      for (const fact of facts) {
+        const value = parseNumber(fact.val);
+        if (null === value || false === isMatchingAccession(fact.accn, accessionNumber)) {
+          continue;
+        }
+
+        const durationDays = getDurationDays(fact);
+        if (null !== durationDays && durationDays > 140) {
+          continue;
+        }
+
+        candidates.push({
+          currencyCode,
+          durationDays,
+          fact,
+          score: getFactScore(fact, durationDays),
+          unit,
+          value,
+        });
+      }
+    }
+
+    if (0 < candidates.length) {
+      break;
+    }
+  }
+
+  candidates.sort(compareFactCandidates);
+  return candidates[0] ?? null;
+}
+
+function getCurrencyCodeFromUnit(unit: string, valueType: XbrlMetricDefinition["valueType"]): string | null {
+  const unitMatch = unit.toUpperCase().match(/(?:^|:)([A-Z]{3})(?:\/SHARES)?$/);
+  const currencyCode = unitMatch?.[1] ?? null;
+  if (null === currencyCode) {
+    return null;
+  }
+
+  if ("eps" === valueType) {
+    return /\/SHARES$/i.test(unit) ? currencyCode : null;
+  }
+
+  return /^[A-Z]{3}$/i.test(unit) || /^ISO4217:[A-Z]{3}$/i.test(unit)
+    ? currencyCode
+    : null;
+}
+
+function isMatchingAccession(factAccession: string | undefined, accessionNumber: string): boolean {
+  return normalizeAccessionNumber(factAccession) === normalizeAccessionNumber(accessionNumber);
+}
+
+function normalizeAccessionNumber(value: string | undefined): string {
+  const normalizedValue = value?.trim() ?? "";
+  if (/^\d{18}$/.test(normalizedValue)) {
+    return `${normalizedValue.slice(0, 10)}-${normalizedValue.slice(10, 12)}-${normalizedValue.slice(12)}`;
+  }
+
+  return normalizedValue;
+}
+
+function getDurationDays(fact: SecCompanyFact): number | null {
+  if (undefined === fact.start || undefined === fact.end) {
+    return null;
+  }
+
+  const startMs = Date.parse(fact.start);
+  const endMs = Date.parse(fact.end);
+  if (false === Number.isFinite(startMs) || false === Number.isFinite(endMs) || endMs < startMs) {
+    return null;
+  }
+
+  return Math.round((endMs - startMs) / 86_400_000) + 1;
+}
+
+function getFactScore(fact: SecCompanyFact, durationDays: number | null): number {
+  let score = 0;
+  if (null !== durationDays) {
+    score += Math.max(0, 100 - Math.abs(durationDays - 91));
+  }
+
+  if (/^CY\d{4}Q[1-4]$/i.test(fact.frame ?? "")) {
+    score += 40;
+  }
+
+  if (/^Q[1-4]$/i.test(fact.fp ?? "")) {
+    score += 10;
+  }
+
+  if (/^(8-K|6-K|10-Q)$/i.test(fact.form ?? "")) {
+    score += 5;
+  }
+
+  return score;
+}
+
+function compareFactCandidates(first: XbrlFactCandidate, second: XbrlFactCandidate): number {
+  if (first.score !== second.score) {
+    return second.score - first.score;
+  }
+
+  const durationDistance = getDurationDistance(first) - getDurationDistance(second);
+  if (0 !== durationDistance) {
+    return durationDistance;
+  }
+
+  return getTimestampMs(second.fact.end) - getTimestampMs(first.fact.end);
+}
+
+function getDurationDistance(candidate: XbrlFactCandidate): number {
+  return null === candidate.durationDays
+    ? Number.MAX_SAFE_INTEGER
+    : Math.abs(candidate.durationDays - 91);
+}
+
+function getTimestampMs(value: string | undefined): number {
+  const timestampMs = Date.parse(value ?? "");
+  return Number.isFinite(timestampMs) ? timestampMs : 0;
+}

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -69,6 +69,30 @@ describe("earnings result announcements", () => {
         };
       }
 
+      if (url.includes("companyfacts/CIK0000034088.json")) {
+        return {
+          data: {
+            facts: {
+              "us-gaap": {
+                RevenueFromContractWithCustomerExcludingAssessedTax: {
+                  units: {
+                    USD: [{
+                      accn: "0000034088-26-000042",
+                      end: "2026-03-31",
+                      fp: "Q1",
+                      form: "8-K",
+                      frame: "CY2026Q1",
+                      start: "2026-01-01",
+                      val: 85_140_000_000,
+                    }],
+                  },
+                },
+              },
+            },
+          },
+        };
+      }
+
       if (url.endsWith("/index.json")) {
         return {
           data: {
@@ -135,7 +159,7 @@ describe("earnings result announcements", () => {
     expect(result.active).toBe(true);
     expect(result.watchedCompanies).toBe(1);
     expect(result.announcements).toHaveLength(1);
-    expect(result.announcements[0]!.message).toContain("**Exxon Mobil (XOM) - Q1 2026**");
+    expect(result.announcements[0]!.message).toContain("**Exxon Mobil (`XOM`)** - Q1 2026");
     expect(result.announcements[0]!.message).toContain("📊 **Results**");
     expect(result.announcements[0]!.message).toContain("- **Adj EPS:** `$1.16` vs est. `$0.96` (🟢 beat)");
     expect(result.announcements[0]!.message).toContain("- **Revenue:** `$85.14B` vs est. `$80.74B` (🟢 beat)");
@@ -475,7 +499,7 @@ describe("earnings result announcements", () => {
     });
 
     expect(send).toHaveBeenCalledWith({
-      content: expect.stringContaining("**Exxon Mobil (XOM) - Q1 2026**"),
+      content: expect.stringContaining("**Exxon Mobil (`XOM`)** - Q1 2026"),
       allowedMentions: {
         parse: [],
       },
@@ -548,7 +572,7 @@ describe("earnings result announcements", () => {
       limit: 100,
     });
     expect(threadSend).toHaveBeenCalledWith({
-      content: expect.stringContaining("**Exxon Mobil (XOM) - Q1 2026**"),
+      content: expect.stringContaining("**Exxon Mobil (`XOM`)** - Q1 2026"),
       allowedMentions: {
         parse: [],
       },
@@ -649,7 +673,7 @@ describe("earnings result announcements", () => {
   });
 
   test("provides a concrete example output", () => {
-    expect(getExampleEarningsResultOutput()).toContain("**Apple Inc. (AAPL) - Q1 2026**");
+    expect(getExampleEarningsResultOutput()).toContain("**Apple Inc. (`AAPL`)** - Q1 2026");
     expect(getExampleEarningsResultOutput()).toContain("📊 **Results**");
     expect(getExampleEarningsResultOutput()).toContain("- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)");
     expect(getExampleEarningsResultOutput()).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01");

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -137,8 +137,8 @@ describe("earnings result announcements", () => {
     expect(result.announcements).toHaveLength(1);
     expect(result.announcements[0]!.message).toContain("**Exxon Mobil (XOM) - Q1 2026**");
     expect(result.announcements[0]!.message).toContain("📊 **Results**");
-    expect(result.announcements[0]!.message).toContain("- **Adj EPS:** $1.16 vs est. $0.96 (🟢 beat)");
-    expect(result.announcements[0]!.message).toContain("- **Revenue:** $85.14B vs est. $80.74B (🟢 beat)");
+    expect(result.announcements[0]!.message).toContain("- **Adj EPS:** `$1.16` vs est. `$0.96` (🟢 beat)");
+    expect(result.announcements[0]!.message).toContain("- **Revenue:** `$85.14B` vs est. `$80.74B` (🟢 beat)");
     expect(result.announcements[0]!.message).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm) Item 2.02, 9.01");
   });
 
@@ -651,7 +651,7 @@ describe("earnings result announcements", () => {
   test("provides a concrete example output", () => {
     expect(getExampleEarningsResultOutput()).toContain("**Apple Inc. (AAPL) - Q1 2026**");
     expect(getExampleEarningsResultOutput()).toContain("📊 **Results**");
-    expect(getExampleEarningsResultOutput()).toContain("- **EPS:** $2.84 vs est. $2.67 (🟢 beat)");
+    expect(getExampleEarningsResultOutput()).toContain("- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)");
     expect(getExampleEarningsResultOutput()).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01");
   });
 });

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -9,6 +9,7 @@ import {
   parseNumber,
   type NasdaqSurprise,
 } from "./earnings-results-format.ts";
+import {loadSecXbrlMetrics, mergeXbrlAndHtmlMetrics} from "./earnings-results-xbrl.ts";
 import {
   clearSecEarningsResultCaches,
   isLikelyEarningsFiling,
@@ -663,21 +664,27 @@ async function buildEarningsResultAnnouncement(
   dependencies: EarningsResultDependencies,
   now: moment.Moment,
 ): Promise<EarningsResultAnnouncement | null> {
-  const filingDetails = await loadSecFilingDetails(filing, dependencies).catch(error => {
-    dependencies.logger.log(
-      "warn",
-      `Skipping earnings result announcement for ${watch.event.ticker}: SEC filing details could not be loaded: ${error}`,
-    );
-    return null;
-  });
-  if (null === filingDetails) {
-    return null;
-  }
-
+  const [filingDetails, xbrlMetrics] = await Promise.all([
+    loadSecFilingDetails(filing, dependencies).catch(error => {
+      dependencies.logger.log(
+        "warn",
+        `Skipping earnings result announcement for ${watch.event.ticker}: SEC filing details could not be loaded: ${error}`,
+      );
+      return null;
+    }),
+    loadSecXbrlMetrics(filing, dependencies).catch(error => {
+      dependencies.logger.log(
+        "debug",
+        `SEC XBRL facts could not be loaded for ${watch.event.ticker}; falling back to HTML metrics: ${error}`,
+      );
+      return [];
+    }),
+  ]);
+  const parsedDocument = parseEarningsDocument(filingDetails?.html ?? "");
+  const sourceMetrics = mergeXbrlAndHtmlMetrics(xbrlMetrics, parsedDocument.metrics);
   const surprise = await loadNasdaqSurprise(watch.event.ticker, dependencies, now);
-  const parsedDocument = parseEarningsDocument(filingDetails.html);
-  const metrics = getMessageMetrics(parsedDocument.metrics, surprise, watch.event);
-  const filingUrl = filingDetails.documentUrl || filing.filingUrl;
+  const metrics = getMessageMetrics(sourceMetrics, surprise, watch.event);
+  const filingUrl = filingDetails?.documentUrl || filing.filingUrl;
 
   if (0 === metrics.length && 0 === parsedDocument.outlook.length) {
     dependencies.logger.log(
@@ -787,8 +794,7 @@ function parseNasdaqMoney(value: unknown): number | null {
 
 export function getExampleEarningsResultOutput(): string {
   return [
-    "**Apple Inc. (AAPL) - Q1 2026**",
-    "",
+    "**Apple Inc. (`AAPL`)** - Q1 2026",
     "📊 **Results**",
     "- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)",
     `- **Revenue:** \`${formatUsdCompact(143_800_000_000)}\` vs est. \`${formatUsdCompact(138_250_000_000)}\` (🟢 beat)`,

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -790,9 +790,9 @@ export function getExampleEarningsResultOutput(): string {
     "**Apple Inc. (AAPL) - Q1 2026**",
     "",
     "📊 **Results**",
-    "- **EPS:** $2.84 vs est. $2.67 (🟢 beat)",
-    `- **Revenue:** ${formatUsdCompact(143_800_000_000)} vs est. ${formatUsdCompact(138_250_000_000)} (🟢 beat)`,
-    `- **Net income:** ${formatUsdCompact(42_097_000_000)}`,
+    "- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)",
+    `- **Revenue:** \`${formatUsdCompact(143_800_000_000)}\` vs est. \`${formatUsdCompact(138_250_000_000)}\` (🟢 beat)`,
+    `- **Net income:** \`${formatUsdCompact(42_097_000_000)}\``,
     "SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- restore inline code boxes for numeric result values and estimates
- format outlook ranges as separate code-formatted endpoints, e.g. EPS: `` to ``
- keep labels, bullets, section headers, and beat/miss indicators outside code formatting

## Validation
- npm test -- modules/earnings-results-format.test.ts modules/earnings-results-outlook.test.ts modules/earnings-results.test.ts
- npm run typecheck
- npm run lint