### PR TITLE
[codex] Move earnings filing link into title

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,10 @@ Example Discord output:
 @alerts Heute wichtig: `14:30` 🇺🇸 Consumer Price Index (CPI)
 @alerts Heute Earnings: `AAPL` (nach Handelsschluss)
 @alerts Heute Earnings: `NVDA`, `MSFT` (nach Handelsschluss)
-💰 **Earnings: Apple Inc. (`AAPL`) Q1 2026**
-EPS: `$2.84` vs est. `$2.67` - beat
-Revenue: `$143.8B` vs est. `$138.25B` - beat
-SEC: 8-K Item 2.02, 9.01 https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm
+**Apple Inc. (`AAPL`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm)
+📊 **Results**
+- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)
+- **Revenue:** `$143.8B` vs est. `$138.25B` (🟢 beat)
 ```
 
 ## Market data

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -82,7 +82,7 @@ describe("earnings result formatting", () => {
       metrics,
       parsedDocument,
       ticker: "XOM",
-    })).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/34088/example/ex-991.htm) Item 2.02, 9.01");
+    })).toContain("**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/example/ex-991.htm)");
   });
 
   test("parses and renders table-based outlook metrics", () => {
@@ -485,9 +485,9 @@ describe("earnings result formatting", () => {
 
     expect(metrics[0]).toMatchObject({
       key: "nasdaq_eps",
-      estimate: "$1",
+      estimate: "$1.00",
       outcome: "inline",
-      value: "$1",
+      value: "$1.00",
     });
     expect(metrics.find(metric => "revenue" === metric.key)).toMatchObject({
       estimate: "$100B",
@@ -568,10 +568,9 @@ describe("earnings result formatting", () => {
     });
 
     expect(message).toBe([
-      "**Example (`EX`)**",
+      "**Example (`EX`)** - [10-Q](https://www.sec.gov/example)",
       "📊 **Results**",
       "- **Production:** `1,200 boepd`",
-      "SEC: [10-Q](https://www.sec.gov/example)",
     ].join("\n"));
   });
 
@@ -622,7 +621,8 @@ describe("earnings result formatting", () => {
     expect(parseNumber("--")).toBeNull();
     expect(parseNumber({})).toBeNull();
 
-    expect(formatEps(-1.2)).toBe("-$1.2");
+    expect(formatEps(5.6)).toBe("$5.60");
+    expect(formatEps(-1.2)).toBe("-$1.20");
     expect(formatUsdCompact(-1_250_000_000_000)).toBe("-$1.25T");
     expect(formatUsdCompact(12_300_000)).toBe("$12.3M");
     expect(formatUsdCompact(750_000)).toBe("$750K");

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -258,6 +258,7 @@ export function getEarningsResultMessage({
   if (parsedDocument.quarterLabel) {
     titleParts.push(` - ${parsedDocument.quarterLabel}`);
   }
+  titleParts.push(` - ${getFilingFormText(filing, filingUrl)}`);
 
   const lines = [titleParts.join("")];
   if (0 < metrics.length) {
@@ -277,10 +278,11 @@ export function getEarningsResultMessage({
     }
   }
 
-  const filingItems = filing.items.length > 0 ? ` Item ${filing.items.join(", ")}` : "";
-  const filingForm = "" === filingUrl ? filing.form : `[${filing.form}](${filingUrl})`;
-  lines.push(`SEC: ${filingForm}${filingItems}`);
   return lines.join("\n");
+}
+
+function getFilingFormText(filing: SecCurrentFilingForMessage, filingUrl: string): string {
+  return "" === filingUrl ? filing.form : `[${filing.form}](${filingUrl})`;
 }
 
 function getMetricMessageLine(metric: EarningsResultMetric): string {
@@ -775,9 +777,9 @@ export function parseNumber(value: unknown): number | null {
   return Number.isFinite(parsedValue) ? parsedValue : null;
 }
 
-export function formatEps(value: number): string {
+export function formatEps(value: number, currencyCode = "USD"): string {
   const sign = value < 0 ? "-" : "";
-  return `${sign}$${Math.abs(value).toFixed(2).replace(/\.?0+$/, "")}`;
+  return `${sign}${getCurrencySymbol(currencyCode)}${Math.abs(value).toFixed(2)}`;
 }
 
 export function formatUsdCompact(value: number): string {

--- a/modules/earnings-results-xbrl.test.ts
+++ b/modules/earnings-results-xbrl.test.ts
@@ -62,7 +62,7 @@ describe("earnings result XBRL metrics", () => {
         key: "gaap_eps",
         label: "EPS",
         numericValue: 1,
-        value: "$1",
+        value: "$1.00",
       },
       {
         currencyCode: "USD",
@@ -132,7 +132,7 @@ describe("earnings result XBRL metrics", () => {
       expect.objectContaining({
         currencyCode: "EUR",
         key: "gaap_eps",
-        value: "-€1.3",
+        value: "-€1.30",
       }),
       expect.objectContaining({
         currencyCode: "EUR",

--- a/modules/earnings-results-xbrl.ts
+++ b/modules/earnings-results-xbrl.ts
@@ -1,5 +1,6 @@
 import {type getWithRetry} from "./http-retry.ts";
 import {
+  formatEps,
   formatMoneyCompact,
   parseNumber,
   type EarningsResultMetric,
@@ -130,7 +131,9 @@ export function extractSecXbrlMetrics(
       key: definition.key,
       label: definition.label,
       numericValue: candidate.value,
-      value: formatMoneyCompact(candidate.value, candidate.currencyCode),
+      value: "eps" === definition.valueType
+        ? formatEps(candidate.value, candidate.currencyCode)
+        : formatMoneyCompact(candidate.value, candidate.currencyCode),
     });
   }
 

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -159,11 +159,12 @@ describe("earnings result announcements", () => {
     expect(result.active).toBe(true);
     expect(result.watchedCompanies).toBe(1);
     expect(result.announcements).toHaveLength(1);
-    expect(result.announcements[0]!.message).toContain("**Exxon Mobil (`XOM`)** - Q1 2026");
+    expect(result.announcements[0]!.message).toContain(
+      "**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm)",
+    );
     expect(result.announcements[0]!.message).toContain("📊 **Results**");
     expect(result.announcements[0]!.message).toContain("- **Adj EPS:** `$1.16` vs est. `$0.96` (🟢 beat)");
     expect(result.announcements[0]!.message).toContain("- **Revenue:** `$85.14B` vs est. `$80.74B` (🟢 beat)");
-    expect(result.announcements[0]!.message).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm) Item 2.02, 9.01");
   });
 
   test("skips accessions that were already announced", async () => {
@@ -499,7 +500,7 @@ describe("earnings result announcements", () => {
     });
 
     expect(send).toHaveBeenCalledWith({
-      content: expect.stringContaining("**Exxon Mobil (`XOM`)** - Q1 2026"),
+      content: expect.stringContaining("**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm)"),
       allowedMentions: {
         parse: [],
       },
@@ -572,7 +573,7 @@ describe("earnings result announcements", () => {
       limit: 100,
     });
     expect(threadSend).toHaveBeenCalledWith({
-      content: expect.stringContaining("**Exxon Mobil (`XOM`)** - Q1 2026"),
+      content: expect.stringContaining("**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm)"),
       allowedMentions: {
         parse: [],
       },
@@ -590,7 +591,7 @@ describe("earnings result announcements", () => {
     const setTimeoutMock = vi.fn((_callback: () => void, _delayMs: number) => timeoutHandle);
     const fetchMessages = vi.fn().mockResolvedValue(new Map([
       ["message-id", {
-        content: "SEC: [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm) Item 2.02, 9.01",
+        content: "**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/xom-ex991.htm)",
       }],
     ]));
 
@@ -673,9 +674,10 @@ describe("earnings result announcements", () => {
   });
 
   test("provides a concrete example output", () => {
-    expect(getExampleEarningsResultOutput()).toContain("**Apple Inc. (`AAPL`)** - Q1 2026");
+    expect(getExampleEarningsResultOutput()).toContain(
+      "**Apple Inc. (`AAPL`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm)",
+    );
     expect(getExampleEarningsResultOutput()).toContain("📊 **Results**");
     expect(getExampleEarningsResultOutput()).toContain("- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)");
-    expect(getExampleEarningsResultOutput()).toContain("SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01");
   });
 });

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -794,11 +794,10 @@ function parseNasdaqMoney(value: unknown): number | null {
 
 export function getExampleEarningsResultOutput(): string {
   return [
-    "**Apple Inc. (`AAPL`)** - Q1 2026",
+    "**Apple Inc. (`AAPL`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm)",
     "📊 **Results**",
     "- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)",
     `- **Revenue:** \`${formatUsdCompact(143_800_000_000)}\` vs est. \`${formatUsdCompact(138_250_000_000)}\` (🟢 beat)`,
     `- **Net income:** \`${formatUsdCompact(42_097_000_000)}\``,
-    "SEC: [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm) Item 2.02, 9.01",
   ].join("\n");
 }


### PR DESCRIPTION
Moves the earnings filing link into the title line, keeps EPS values at two decimals, and updates the example output/tests. Validated with npm run test:coverage, npm run typecheck, and npm run lint.