### PR TITLE
[codex] Parse cents-denominated EPS values

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -439,6 +439,47 @@ describe("earnings result formatting", () => {
     ]);
   });
 
+  test("parses cents-denominated EPS as dollars per share", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Ball Reports Strong First Quarter 2026 Results</h1>
+          <p>First quarter U.S. GAAP total diluted earnings per share of 77 cents vs. 63 cents in 2025.</p>
+          <p>On a U.S. GAAP basis, net earnings were $205 million or total diluted earnings per share of 77 cents, on sales of $3.60 billion.</p>
+        </body>
+      </html>
+    `);
+    const event: EarningsEvent = {
+      ticker: "BALL",
+      when: "before_open",
+      date: "2026-05-05",
+      importance: 1,
+      epsConsensus: "$0.85",
+    };
+    const metrics = getMessageMetrics(parsedDocument.metrics, null, event);
+
+    expect(parsedDocument.quarterLabel).toBe("Q1 2026");
+    expect(metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "gaap_eps",
+        estimate: "$0.85",
+        numericValue: 0.77,
+        outcome: "miss",
+        value: "$0.77",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 3_600_000_000,
+        value: "$3.6B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 205_000_000,
+        value: "$205M",
+      }),
+    ]));
+  });
+
   test("removes script/style blocks with spaced closing tags", () => {
     const text = htmlToText(`
       <p>Revenue $10 billion</p>

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -381,17 +381,17 @@ function getDocumentHeadline(lines: string[]): string | undefined {
 }
 
 function getQuarterLabel(text: string): string | undefined {
-  const periodEndedQuarter = getQuarterLabelFromPeriodEnded(text);
-  if (undefined !== periodEndedQuarter) {
-    return periodEndedQuarter;
-  }
-
   const writtenQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter\s+(?:of\s+)?(20\d{2})\b/i);
   if (undefined !== writtenQuarterMatch?.[1] && undefined !== writtenQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenQuarterMatch[1]);
     if (quarter) {
       return `${quarter} ${writtenQuarterMatch[2]}`;
     }
+  }
+
+  const periodEndedQuarter = getQuarterLabelFromPeriodEnded(text);
+  if (undefined !== periodEndedQuarter) {
+    return periodEndedQuarter;
   }
 
   const directQuarterMatch = text.match(/\b(Q[1-4])\s+(20\d{2})\b/i);
@@ -526,7 +526,10 @@ function extractMetricValue(
   const searchText = patternMatch ? line.slice(patternMatch.index + patternMatch[0].length) : line;
 
   if ("eps" === valueType) {
-    const value = findNumericValue(searchText, {maxAbsValue: 100});
+    const value = findNumericValue(searchText, {
+      maxAbsValue: 100,
+      parseCents: true,
+    });
     return null === value ? null : {numericValue: value, value: formatEps(value)};
   }
 
@@ -663,6 +666,7 @@ function findNumericValue(
   text: string,
   options: {
     maxAbsValue?: number;
+    parseCents?: boolean;
     requireMoneyCue?: boolean;
     skipPercentages?: boolean;
     skipTableNoteRefs?: boolean;
@@ -680,7 +684,10 @@ function findNumericValue(
       continue;
     }
 
-    const value = parseNumber(token);
+    const parsedNumber = parseNumber(token);
+    const value = true === options.parseCents && null !== parsedNumber
+      ? normalizeCentsValue(text, endIndex, token, parsedNumber)
+      : parsedNumber;
     if (null === value) {
       continue;
     }
@@ -707,6 +714,17 @@ function findNumericValue(
   }
 
   return null;
+}
+
+function normalizeCentsValue(text: string, endIndex: number, token: string, value: number): number {
+  if (/[$€£¥]/.test(token) || Math.abs(value) < 1) {
+    return value;
+  }
+
+  const afterToken = text.slice(endIndex, endIndex + 24);
+  return /^\s*(?:cents?|¢|c\b)/i.test(afterToken)
+    ? value / 100
+    : value;
 }
 
 function isCalendarDayValue(text: string, startIndex: number, endIndex: number): boolean {


### PR DESCRIPTION
Fixes earnings HTML fallback parsing for releases that state EPS in cents, such as Ball's first-quarter 2026 release. The parser now treats EPS-only values followed by cents/¢ as dollars per share, so 77 cents becomes /bin/zsh.77 instead of .00. Also prefers explicit first-quarter result titles over period-ended text when determining the quarter label.\n\nValidated with:\n- npm test -- modules/earnings-results-format.test.ts modules/earnings-results-xbrl.test.ts modules/earnings-results-outlook.test.ts modules/earnings-results.test.ts\n- npm run typecheck\n- npm run lint