### PR TITLE
Add optional Gemini earnings and MNC summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ echo -n "hunter7" | docker secret create production_hblwrk_channel_MNCAnnounceme
 echo -n "hunter8" | docker secret create production_hblwrk_channel_OtherAnnouncement_ID -
 echo -n "hunter9" | docker secret create production_discord_btcusd_token -
 echo -n "hunter10" | docker secret create production_discord_btcusd_client_ID -
+echo -n "hunter11" | docker secret create production_gemini_api_key -
 ...
 ```
 
@@ -148,6 +149,9 @@ The health-check server port can be overridden via the `HEALTHCHECK_PORT` enviro
   "discord_30y_client_ID": "",
   "tastytrade_client_secret": "",
   "tastytrade_refresh_token": "",
+  "gemini_api_key": "",
+  "gemini_model": "gemini-2.5-flash-lite",
+  "gemini_calls_per_minute": "14",
   "dracoon_password": "",
   "hblwrk_channel_NYSEAnnouncement_ID": "",
   "hblwrk_gainslosses_thread_ID": "",
@@ -196,7 +200,7 @@ If DRACOON downloads fail during startup, the bot keeps those assets marked as t
 
 ### Reminder assets
 
-Calendar reminders, earnings reminders, and earnings result announcements post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements are sent after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. They ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
+Calendar reminders, earnings reminders, and earnings result announcements post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements are sent after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. Gemini-assisted SEC extraction and suspicious-post checks run when `gemini_api_key` is configured; the bot keeps XBRL and HTML parsing as the primary source and validates AI metrics against source snippets before posting. MNC announcements use the same optional Gemini access to add a one-minute Discord Markdown summary above the PDF attachment. `gemini_calls_per_minute` caps local Gemini calls and defaults to `14`, below the free-tier `gemini-2.5-flash-lite` hard limit of 15 requests per minute. They ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
 
 Calendar reminder assets are matched against the current day and sent at `08:30 Europe/Berlin`, immediately after the general daily calendar post. If multiple matching calendar items share the same release minute, the bot bundles them into a single reminder ping:
 

--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -1,0 +1,591 @@
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {
+  checkEarningsQualityWithGemini,
+  clearEarningsAiState,
+  extractEarningsWithGemini,
+  getSuspiciousEarningsReasons,
+  hasHighSeveritySuspicion,
+  mergeAiMetrics,
+} from "./earnings-results-ai.ts";
+import type {EarningsResultMetric} from "./earnings-results-format.ts";
+
+describe("Gemini earnings helpers", () => {
+  const logger = {
+    log: vi.fn(),
+  };
+  const readSecretFn = vi.fn((secretName: string) => {
+    if ("gemini_api_key" === secretName) {
+      return "gemini-key";
+    }
+
+    if ("gemini_calls_per_minute" === secretName) {
+      return "1";
+    }
+
+    throw new Error(`missing ${secretName}`);
+  });
+  const html = `
+    <html>
+      <body>
+        <h1>Example Corp reports first quarter 2026 results</h1>
+        <p>Amounts in millions of dollars, except per share amounts.</p>
+        <table>
+          <tr><td>Adjusted EPS</td><td>$1.25</td></tr>
+          <tr><td>Revenue</td><td>42.0</td></tr>
+        </table>
+      </body>
+    </html>
+  `;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearEarningsAiState();
+  });
+
+  test("extracts schema-constrained metrics with verified source snippets", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: "Q1 2026",
+                metrics: [{
+                  key: "revenue",
+                  numericValue: 42_000_000,
+                  currencyCode: "USD",
+                  sourceSnippet: "Revenue | 42.0",
+                }],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      ticker: "EXM",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result?.quarterLabel).toBe("Q1 2026");
+    expect(result?.metrics).toEqual([{
+      currencyCode: "USD",
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 42_000_000,
+      sourceSnippet: "Revenue | 42.0",
+      value: "$42M",
+    }]);
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent",
+      expect.objectContaining({
+        generationConfig: expect.objectContaining({
+          responseMimeType: "application/json",
+          responseJsonSchema: expect.any(Object),
+          temperature: 0,
+        }),
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-goog-api-key": "gemini-key",
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  test("uses default model and rate limit when optional Gemini secrets are missing", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: null,
+                metrics: [],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      ticker: "EXM",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn: vi.fn((secretName: string) => {
+        if ("gemini_api_key" === secretName) {
+          return "gemini-key";
+        }
+
+        throw new Error(`missing ${secretName}`);
+      }),
+    });
+
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test("drops AI metrics when their source snippets are not present", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: null,
+                metrics: [{
+                  key: "revenue",
+                  numericValue: 42_000_000,
+                  currencyCode: "USD",
+                  sourceSnippet: "Revenue was 42 million",
+                }],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      ticker: "EXM",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result?.metrics).toEqual([]);
+  });
+
+  test("caps Gemini calls with the local per-minute limiter", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: null,
+                metrics: [],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const input = {
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      ticker: "EXM",
+    };
+
+    await extractEarningsWithGemini(input, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+    const secondResult = await extractEarningsWithGemini(input, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(secondResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping Gemini earnings extraction for EXM: local 1/minute rate limit is exhausted.",
+    );
+  });
+
+  test("releases local Gemini call capacity after one minute", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: null,
+                metrics: [],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+    const input = {
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      ticker: "EXM",
+    };
+
+    await extractEarningsWithGemini(input, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+    await extractEarningsWithGemini(input, {
+      logger,
+      nowMs: () => 62_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+  });
+
+  test("stays disabled when the Gemini API key secret is missing", async () => {
+    const postWithRetryFn = vi.fn();
+
+    const result = await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      ticker: "EXM",
+    }, {
+      logger,
+      postWithRetryFn,
+      readSecretFn: vi.fn(() => {
+        throw new Error("missing secret");
+      }),
+    });
+
+    expect(result).toBeNull();
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+  });
+
+  test("returns null when Gemini extraction output is invalid JSON", async () => {
+    const result = await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      ticker: "EXM",
+    }, {
+      logger,
+      postWithRetryFn: vi.fn().mockResolvedValue({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: "{not-json",
+              }],
+            },
+          }],
+        },
+      }),
+      readSecretFn,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini earnings extraction returned invalid JSON for EXM.",
+    );
+  });
+
+  test("allows quality checks without calling Gemini when there are no suspicious reasons", async () => {
+    const postWithRetryFn = vi.fn();
+
+    const result = await checkEarningsQualityWithGemini({
+      companyName: "Example Corp",
+      event: getEvent(),
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      message: "message",
+      metrics: [],
+      reasons: [],
+      surprise: null,
+      ticker: "EXM",
+    }, {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toEqual({
+      confidence: 1,
+      decision: "allow",
+      issues: [],
+      reason: "No suspicious earnings metrics detected.",
+    });
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+  });
+
+  test("parses quality gate suppression with validated source snippets", async () => {
+    const result = await checkEarningsQualityWithGemini({
+      companyName: "Example Corp",
+      event: getEvent(),
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      message: "message",
+      metrics: [{
+        key: "gaap_eps",
+        label: "EPS",
+        numericValue: 20.8,
+        value: "$20.80",
+      }],
+      reasons: [{
+        message: "EPS is suspicious.",
+        metricKey: "gaap_eps",
+        severity: "high",
+      }],
+      surprise: {
+        consensusEps: 0.9,
+      },
+      ticker: "EXM",
+    }, {
+      logger,
+      postWithRetryFn: vi.fn().mockResolvedValue({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: JSON.stringify({
+                  decision: "suppress",
+                  confidence: 0.8,
+                  reason: "The filing supports a parsing issue.",
+                  issues: [{
+                    severity: "high",
+                    metricKey: null,
+                    message: "EPS came from a bad table row.",
+                    sourceSnippet: "Adjusted EPS | $1.25",
+                  }],
+                }),
+              }],
+            },
+          }],
+        },
+      }),
+      readSecretFn,
+    });
+
+    expect(result).toEqual({
+      confidence: 0.8,
+      decision: "suppress",
+      issues: [{
+        message: "EPS came from a bad table row.",
+        severity: "high",
+        sourceSnippet: "Adjusted EPS | $1.25",
+      }],
+      reason: "The filing supports a parsing issue.",
+    });
+  });
+
+  test("rejects quality gate suppression without validated issues", async () => {
+    const result = await checkEarningsQualityWithGemini({
+      companyName: "Example Corp",
+      event: getEvent(),
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html,
+      message: "message",
+      metrics: [],
+      reasons: [{
+        message: "Revenue is suspicious.",
+        metricKey: "revenue",
+        severity: "high",
+      }],
+      surprise: null,
+      ticker: "EXM",
+    }, {
+      logger,
+      postWithRetryFn: vi.fn().mockResolvedValue({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: JSON.stringify({
+                  decision: "suppress",
+                  confidence: 0.9,
+                  reason: "No evidence.",
+                  issues: [],
+                }),
+              }],
+            },
+          }],
+        },
+      }),
+      readSecretFn,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("merges AI metrics only for missing or suspicious deterministic metrics", () => {
+    const deterministicMetrics: EarningsResultMetric[] = [{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 20.8,
+      value: "$20.80",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 267_000_000,
+      value: "$267M",
+    }];
+    const aiMetrics: EarningsResultMetric[] = [{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 1.3,
+      value: "$1.30",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 14_550_000_000,
+      value: "$14.55B",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: 2_000_000_000,
+      value: "$2B",
+    }];
+
+    expect(mergeAiMetrics(deterministicMetrics, aiMetrics, [{
+      message: "EPS is suspicious.",
+      metricKey: "gaap_eps",
+      severity: "high",
+    }])).toEqual([{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 1.3,
+      value: "$1.30",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 267_000_000,
+      value: "$267M",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: 2_000_000_000,
+      value: "$2B",
+    }]);
+    expect(mergeAiMetrics(deterministicMetrics, [], [])).toBe(deterministicMetrics);
+  });
+
+  test("identifies suspicious EPS, revenue, and net income values", () => {
+    const event = getEvent({
+      epsConsensus: "$0.90",
+      marketCap: 10_000_000_000,
+    });
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 20.8,
+      value: "$20.80",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 400_000,
+      value: "$400K",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: 25_000_000_000,
+      value: "$25B",
+    }], {
+      consensusEps: 0.9,
+      consensusRevenue: 14_000_000_000,
+    }, event);
+
+    expect(reasons.map(reason => reason.metricKey)).toEqual([
+      "gaap_eps",
+      "revenue",
+      "revenue",
+      "net_income",
+    ]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(true);
+  });
+
+  test("identifies medium EPS and revenue suspicion without high severity", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 10,
+      value: "$10.00",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 100,
+      value: "$100",
+    }], {
+      consensusRevenue: 1_000,
+    }, getEvent({
+      epsConsensus: "$1.00",
+      marketCap: 1_000_000_000,
+    }));
+
+    expect(reasons).toEqual([{
+      message: "EPS $10.00 is unusually far from consensus $1.00.",
+      metricKey: "gaap_eps",
+      severity: "medium",
+    }, {
+      message: "Revenue $100 is unusually far from consensus $1K.",
+      metricKey: "revenue",
+      severity: "medium",
+    }]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(false);
+  });
+});
+
+function getEvent(overrides: Partial<ReturnType<typeof getEventBase>> = {}) {
+  return {
+    ...getEventBase(),
+    ...overrides,
+  };
+}
+
+function getEventBase() {
+  return {
+    ticker: "EXM",
+    when: "before_open" as const,
+    date: "2026-05-01",
+    importance: 1,
+    companyName: "Example Corp",
+    marketCap: 20_000_000_000,
+    marketCapText: "$20B",
+    epsConsensus: "$1.00",
+  };
+}

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -1,0 +1,711 @@
+import {type EarningsEvent} from "./earnings.ts";
+import {
+  formatEps,
+  formatMoneyCompact,
+  htmlToText,
+  type EarningsResultMetric,
+  type NasdaqSurprise,
+} from "./earnings-results-format.ts";
+import {callGeminiJson, clearGeminiState, type GeminiDependencies} from "./gemini.ts";
+
+type EarningsAiDependencies = GeminiDependencies;
+
+export type EarningsAiExtractionInput = {
+  companyName: string;
+  filingForm: string;
+  filingUrl: string;
+  html: string;
+  ticker: string;
+};
+
+export type EarningsAiExtraction = {
+  issues: string[];
+  metrics: EarningsResultMetric[];
+  quarterLabel?: string | undefined;
+};
+
+export type SuspiciousEarningsReason = {
+  message: string;
+  metricKey?: string | undefined;
+  severity: "high" | "medium";
+};
+
+export type EarningsAiQualityGateInput = {
+  companyName: string;
+  event: EarningsEvent;
+  filingForm: string;
+  filingUrl: string;
+  html: string;
+  message: string;
+  metrics: EarningsResultMetric[];
+  reasons: SuspiciousEarningsReason[];
+  surprise: NasdaqSurprise | null;
+  ticker: string;
+};
+
+export type EarningsAiQualityGateResult = {
+  confidence: number;
+  decision: "allow" | "suppress";
+  issues: EarningsAiQualityIssue[];
+  reason: string;
+};
+
+type EarningsAiQualityIssue = {
+  message: string;
+  metricKey?: string | undefined;
+  severity: "high" | "medium" | "low";
+  sourceSnippet: string;
+};
+
+type AiMetricKey = "adjusted_eps" | "gaap_eps" | "revenue" | "net_income";
+
+type AiMetricDefinition = {
+  key: AiMetricKey;
+  label: string;
+  valueType: "eps" | "money";
+};
+
+const maxAiFilingTextLength = 18_000;
+
+const aiMetricDefinitions = new Map<AiMetricKey, AiMetricDefinition>([
+  ["adjusted_eps", {
+    key: "adjusted_eps",
+    label: "Adj EPS",
+    valueType: "eps",
+  }],
+  ["gaap_eps", {
+    key: "gaap_eps",
+    label: "EPS",
+    valueType: "eps",
+  }],
+  ["revenue", {
+    key: "revenue",
+    label: "Revenue",
+    valueType: "money",
+  }],
+  ["net_income", {
+    key: "net_income",
+    label: "Net income",
+    valueType: "money",
+  }],
+]);
+
+const earningsExtractionSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    quarterLabel: {
+      type: ["string", "null"],
+      description: "Reported quarter as Q1 2026, Q2 2026, Q3 2026, or Q4 2026 when explicit in the filing.",
+    },
+    metrics: {
+      type: "array",
+      maxItems: 4,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          key: {
+            type: "string",
+            enum: ["adjusted_eps", "gaap_eps", "revenue", "net_income"],
+          },
+          numericValue: {
+            type: "number",
+            description: "EPS in currency units per share. Revenue and net income in full currency units after applying table scale.",
+          },
+          currencyCode: {
+            type: "string",
+            description: "ISO currency code. Use USD when the filing says dollars or uses $.",
+          },
+          sourceSnippet: {
+            type: "string",
+            description: "Short exact snippet from the provided filing text proving the value and scale.",
+          },
+        },
+        required: ["key", "numericValue", "currencyCode", "sourceSnippet"],
+      },
+    },
+    issues: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+  },
+  required: ["quarterLabel", "metrics", "issues"],
+} satisfies Record<string, unknown>;
+
+const qualityGateSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    decision: {
+      type: "string",
+      enum: ["allow", "suppress"],
+    },
+    confidence: {
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+    },
+    reason: {
+      type: "string",
+    },
+    issues: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["high", "medium", "low"],
+          },
+          metricKey: {
+            type: ["string", "null"],
+            enum: ["adjusted_eps", "gaap_eps", "revenue", "net_income", "nasdaq_eps", null],
+          },
+          message: {
+            type: "string",
+          },
+          sourceSnippet: {
+            type: "string",
+            description: "Short exact snippet from the provided filing text supporting the issue or allow decision.",
+          },
+        },
+        required: ["severity", "metricKey", "message", "sourceSnippet"],
+      },
+    },
+  },
+  required: ["decision", "confidence", "reason", "issues"],
+} satisfies Record<string, unknown>;
+
+export function clearEarningsAiState() {
+  clearGeminiState();
+}
+
+export async function extractEarningsWithGemini(
+  input: EarningsAiExtractionInput,
+  dependencies: EarningsAiDependencies,
+): Promise<EarningsAiExtraction | null> {
+  const sourceText = getRelevantFilingText(input.html);
+  if ("" === sourceText) {
+    return null;
+  }
+
+  const prompt = getExtractionPrompt(input, sourceText);
+  const jsonText = await callGeminiJson(
+    prompt,
+    earningsExtractionSchema,
+    dependencies,
+    `earnings extraction for ${input.ticker}`,
+  )
+    .catch(error => {
+      dependencies.logger.log(
+        "warn",
+        `Gemini earnings extraction failed for ${input.ticker}: ${error}`,
+      );
+      return null;
+    });
+  if (null === jsonText) {
+    return null;
+  }
+
+  const parsedJson = parseJson(jsonText);
+  if (null === parsedJson) {
+    dependencies.logger.log(
+      "warn",
+      `Gemini earnings extraction returned invalid JSON for ${input.ticker}.`,
+    );
+    return null;
+  }
+
+  return parseAiExtraction(parsedJson, htmlToText(input.html));
+}
+
+export async function checkEarningsQualityWithGemini(
+  input: EarningsAiQualityGateInput,
+  dependencies: EarningsAiDependencies,
+): Promise<EarningsAiQualityGateResult | null> {
+  if (0 === input.reasons.length) {
+    return {
+      confidence: 1,
+      decision: "allow",
+      issues: [],
+      reason: "No suspicious earnings metrics detected.",
+    };
+  }
+
+  const sourceText = getRelevantFilingText(input.html);
+  if ("" === sourceText) {
+    return null;
+  }
+
+  const prompt = getQualityGatePrompt(input, sourceText);
+  const jsonText = await callGeminiJson(
+    prompt,
+    qualityGateSchema,
+    dependencies,
+    `earnings quality gate for ${input.ticker}`,
+  )
+    .catch(error => {
+      dependencies.logger.log(
+        "warn",
+        `Gemini earnings quality gate failed for ${input.ticker}: ${error}`,
+      );
+      return null;
+    });
+  if (null === jsonText) {
+    return null;
+  }
+
+  const parsedJson = parseJson(jsonText);
+  if (null === parsedJson) {
+    dependencies.logger.log(
+      "warn",
+      `Gemini earnings quality gate returned invalid JSON for ${input.ticker}.`,
+    );
+    return null;
+  }
+
+  return parseQualityGate(parsedJson, htmlToText(input.html));
+}
+
+export function mergeAiMetrics(
+  deterministicMetrics: EarningsResultMetric[],
+  aiMetrics: EarningsResultMetric[],
+  suspiciousReasons: SuspiciousEarningsReason[],
+): EarningsResultMetric[] {
+  if (0 === aiMetrics.length) {
+    return deterministicMetrics;
+  }
+
+  const suspiciousMetricKeys = new Set(suspiciousReasons.flatMap(reason =>
+    undefined === reason.metricKey ? [] : [reason.metricKey],
+  ));
+  const metricsByKey = new Map<string, EarningsResultMetric>();
+  for (const metric of deterministicMetrics) {
+    metricsByKey.set(metric.key, metric);
+  }
+
+  for (const metric of aiMetrics) {
+    if (false === metricsByKey.has(metric.key) || true === suspiciousMetricKeys.has(metric.key)) {
+      metricsByKey.set(metric.key, metric);
+    }
+  }
+
+  return sortEarningsMetrics([...metricsByKey.values()]);
+}
+
+export function getSuspiciousEarningsReasons(
+  metrics: EarningsResultMetric[],
+  surprise: NasdaqSurprise | null,
+  event: EarningsEvent,
+): SuspiciousEarningsReason[] {
+  const reasons: SuspiciousEarningsReason[] = [];
+  const consensusEps = surprise?.consensusEps ?? getNumericEventEpsConsensus(event);
+  const epsMetric = metrics.find(metric => "adjusted_eps" === metric.key) ??
+    metrics.find(metric => "gaap_eps" === metric.key || "nasdaq_eps" === metric.key);
+  if (undefined !== epsMetric &&
+      "number" === typeof epsMetric.numericValue &&
+      true === Number.isFinite(epsMetric.numericValue) &&
+      "number" === typeof consensusEps &&
+      true === Number.isFinite(consensusEps)) {
+    const absoluteConsensus = Math.abs(consensusEps);
+    const absoluteEps = Math.abs(epsMetric.numericValue);
+    if (absoluteEps >= 20 && absoluteConsensus < 5) {
+      reasons.push({
+        message: `${epsMetric.label} ${epsMetric.value} is extremely far from consensus ${formatEps(consensusEps)}.`,
+        metricKey: epsMetric.key,
+        severity: "high",
+      });
+    } else if (absoluteEps >= 10 && absoluteConsensus < 5) {
+      reasons.push({
+        message: `${epsMetric.label} ${epsMetric.value} is unusually far from consensus ${formatEps(consensusEps)}.`,
+        metricKey: epsMetric.key,
+        severity: "medium",
+      });
+    }
+  }
+
+  const revenueMetric = metrics.find(metric => "revenue" === metric.key);
+  if (undefined !== revenueMetric &&
+      "number" === typeof revenueMetric.numericValue &&
+      "number" === typeof surprise?.consensusRevenue &&
+      surprise.consensusRevenue > 0) {
+    const ratio = revenueMetric.numericValue / surprise.consensusRevenue;
+    if (ratio >= 20 || ratio <= 0.05) {
+      reasons.push({
+        message: `Revenue ${revenueMetric.value} is far from consensus ${formatMoneyCompact(surprise.consensusRevenue)}.`,
+        metricKey: "revenue",
+        severity: "high",
+      });
+    } else if (ratio >= 10 || ratio <= 0.1) {
+      reasons.push({
+        message: `Revenue ${revenueMetric.value} is unusually far from consensus ${formatMoneyCompact(surprise.consensusRevenue)}.`,
+        metricKey: "revenue",
+        severity: "medium",
+      });
+    }
+  }
+
+  if (undefined !== revenueMetric &&
+      "number" === typeof revenueMetric.numericValue &&
+      "number" === typeof event.marketCap &&
+      event.marketCap >= 10_000_000_000 &&
+      revenueMetric.numericValue > 0 &&
+      revenueMetric.numericValue < 1_000_000) {
+    reasons.push({
+      message: `Revenue ${revenueMetric.value} is below $1M for a large-cap scheduled earnings event.`,
+      metricKey: "revenue",
+      severity: "medium",
+    });
+  }
+
+  const netIncomeMetric = metrics.find(metric => "net_income" === metric.key);
+  if (undefined !== netIncomeMetric &&
+      "number" === typeof netIncomeMetric.numericValue &&
+      "number" === typeof event.marketCap &&
+      Math.abs(netIncomeMetric.numericValue) > event.marketCap * 2) {
+    reasons.push({
+      message: `Net income ${netIncomeMetric.value} is larger than two times the company's market cap.`,
+      metricKey: "net_income",
+      severity: "high",
+    });
+  }
+
+  return reasons;
+}
+
+export function hasHighSeveritySuspicion(reasons: SuspiciousEarningsReason[]): boolean {
+  return reasons.some(reason => "high" === reason.severity);
+}
+
+function getExtractionPrompt(input: EarningsAiExtractionInput, sourceText: string): string {
+  return [
+    "Extract the main quarterly earnings metrics from this public SEC earnings release.",
+    "Return only JSON matching the schema. Do not include markdown.",
+    "Rules:",
+    "- Extract only values for the reported quarter, not year-to-date totals, prior-year periods, dates, footnotes, page numbers, share counts, percentages, or outlook.",
+    "- Revenue and net income numericValue must be full currency units after applying table scale such as thousands, millions, or billions.",
+    "- EPS numericValue must be currency units per share. Convert cents to dollars, e.g. 77 cents becomes 0.77.",
+    "- Include adjusted EPS only when explicitly non-GAAP/adjusted. Include GAAP EPS only when explicitly GAAP/diluted/basic EPS.",
+    "- Every metric must include a short exact sourceSnippet from the filing text that proves the metric and scale.",
+    `Company: ${input.companyName}`,
+    `Ticker: ${input.ticker}`,
+    `Filing: ${input.filingForm} ${input.filingUrl}`,
+    "Filing text:",
+    sourceText,
+  ].join("\n");
+}
+
+function getQualityGatePrompt(input: EarningsAiQualityGateInput, sourceText: string): string {
+  const metricLines = input.metrics.map(metric =>
+    `${metric.key}: ${metric.value}${metric.estimate ? ` vs estimate ${metric.estimate}` : ""}`,
+  );
+  const reasonLines = input.reasons.map(reason => `${reason.severity}: ${reason.message}`);
+  return [
+    "Review this pending Discord earnings post against the SEC filing text.",
+    "Return only JSON matching the schema. Do not include markdown.",
+    "Suppress only when a main metric is likely a parsing bug, such as a footnote/date fragment, a cents value treated as dollars, a table scale mistake, or a value copied from the wrong period.",
+    "Allow when the post is plausible or the filing text supports the values.",
+    "Every issue must include a short exact sourceSnippet from the filing text.",
+    `Company: ${input.companyName}`,
+    `Ticker: ${input.ticker}`,
+    `Filing: ${input.filingForm} ${input.filingUrl}`,
+    "Suspicious checks:",
+    ...reasonLines,
+    "Pending metrics:",
+    ...metricLines,
+    "Pending message:",
+    input.message,
+    "Filing text:",
+    sourceText,
+  ].join("\n");
+}
+
+function parseJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function parseAiExtraction(value: unknown, sourceText: string): EarningsAiExtraction | null {
+  if (false === isRecord(value)) {
+    return null;
+  }
+
+  const metrics = getArray(value["metrics"]).flatMap(metricValue => {
+    const metric = parseAiMetric(metricValue, sourceText);
+    return null === metric ? [] : [metric];
+  });
+  const issues = getArray(value["issues"]).flatMap(issue =>
+    "string" === typeof issue && "" !== issue.trim() ? [issue.trim()] : [],
+  );
+  const quarterLabel = parseQuarterLabel(value["quarterLabel"]);
+  const result: EarningsAiExtraction = {
+    issues,
+    metrics: sortEarningsMetrics(dedupeMetrics(metrics)),
+  };
+  if (undefined !== quarterLabel) {
+    result.quarterLabel = quarterLabel;
+  }
+
+  return result;
+}
+
+function parseAiMetric(value: unknown, sourceText: string): EarningsResultMetric | null {
+  if (false === isRecord(value)) {
+    return null;
+  }
+
+  const key = parseMetricKey(value["key"]);
+  const numericValue = value["numericValue"];
+  const currencyCode = normalizeCurrencyCode(value["currencyCode"]);
+  const sourceSnippet = "string" === typeof value["sourceSnippet"]
+    ? value["sourceSnippet"].trim()
+    : "";
+  if (null === key ||
+      "number" !== typeof numericValue ||
+      false === Number.isFinite(numericValue) ||
+      undefined === currencyCode ||
+      false === hasSourceSnippet(sourceText, sourceSnippet)) {
+    return null;
+  }
+
+  const definition = aiMetricDefinitions.get(key);
+  if (undefined === definition) {
+    return null;
+  }
+
+  if ("eps" === definition.valueType && Math.abs(numericValue) > 100) {
+    return null;
+  }
+
+  if ("money" === definition.valueType && Math.abs(numericValue) > 20_000_000_000_000) {
+    return null;
+  }
+
+  return {
+    currencyCode,
+    key: definition.key,
+    label: definition.label,
+    numericValue,
+    sourceSnippet,
+    value: "eps" === definition.valueType
+      ? formatEps(numericValue, currencyCode)
+      : formatMoneyCompact(numericValue, currencyCode),
+  };
+}
+
+function parseQualityGate(value: unknown, sourceText: string): EarningsAiQualityGateResult | null {
+  if (false === isRecord(value)) {
+    return null;
+  }
+
+  const decision = value["decision"];
+  const confidence = value["confidence"];
+  const reason = value["reason"];
+  if (("allow" !== decision && "suppress" !== decision) ||
+      "number" !== typeof confidence ||
+      false === Number.isFinite(confidence) ||
+      confidence < 0 ||
+      confidence > 1 ||
+      "string" !== typeof reason ||
+      "" === reason.trim()) {
+    return null;
+  }
+
+  const issues = getArray(value["issues"]).flatMap(issueValue => {
+    const issue = parseQualityIssue(issueValue, sourceText);
+    return null === issue ? [] : [issue];
+  });
+  if ("suppress" === decision && 0 === issues.length) {
+    return null;
+  }
+
+  return {
+    confidence,
+    decision,
+    issues,
+    reason: reason.trim(),
+  };
+}
+
+function parseQualityIssue(value: unknown, sourceText: string): EarningsAiQualityIssue | null {
+  if (false === isRecord(value)) {
+    return null;
+  }
+
+  const severity = value["severity"];
+  const metricKey = value["metricKey"];
+  const message = value["message"];
+  const sourceSnippet = value["sourceSnippet"];
+  if (("high" !== severity && "medium" !== severity && "low" !== severity) ||
+      "string" !== typeof message ||
+      "" === message.trim() ||
+      "string" !== typeof sourceSnippet ||
+      false === hasSourceSnippet(sourceText, sourceSnippet)) {
+    return null;
+  }
+
+  const issue: EarningsAiQualityIssue = {
+    message: message.trim(),
+    severity,
+    sourceSnippet: sourceSnippet.trim(),
+  };
+  if ("string" === typeof metricKey && "" !== metricKey.trim()) {
+    issue.metricKey = metricKey.trim();
+  }
+
+  return issue;
+}
+
+function parseMetricKey(value: unknown): AiMetricKey | null {
+  if ("string" !== typeof value) {
+    return null;
+  }
+
+  return aiMetricDefinitions.has(value as AiMetricKey)
+    ? value as AiMetricKey
+    : null;
+}
+
+function parseQuarterLabel(value: unknown): string | undefined {
+  if ("string" !== typeof value) {
+    return undefined;
+  }
+
+  const normalizedValue = value.trim().toUpperCase();
+  return /^Q[1-4]\s+20\d{2}$/.test(normalizedValue)
+    ? normalizedValue.replace(/\s+/, " ")
+    : undefined;
+}
+
+function normalizeCurrencyCode(value: unknown): string | undefined {
+  if ("string" !== typeof value) {
+    return undefined;
+  }
+
+  const normalizedValue = value.trim().toUpperCase();
+  return /^[A-Z]{3}$/.test(normalizedValue) ? normalizedValue : undefined;
+}
+
+function hasSourceSnippet(sourceText: string, sourceSnippet: string): boolean {
+  const normalizedSnippet = normalizeEvidenceText(sourceSnippet);
+  if (normalizedSnippet.length < 12) {
+    return false;
+  }
+
+  return normalizeEvidenceText(sourceText).includes(normalizedSnippet);
+}
+
+function normalizeEvidenceText(value: string): string {
+  return value
+    .replace(/\s*\|\s*/g, " | ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function getRelevantFilingText(html: string): string {
+  const text = htmlToText(html);
+  const lines = text
+    .split("\n")
+    .map(line => line.replace(/\s*\|\s*/g, " | ").replace(/\s+/g, " ").trim())
+    .filter(line => line.length >= 3);
+  if (0 === lines.length) {
+    return "";
+  }
+
+  const selectedLineIndexes = new Set<number>();
+  for (const [lineIndex, line] of lines.entries()) {
+    if (false === isAiRelevantLine(line)) {
+      continue;
+    }
+
+    for (let index = Math.max(0, lineIndex - 2); index <= Math.min(lines.length - 1, lineIndex + 4); index++) {
+      selectedLineIndexes.add(index);
+    }
+  }
+
+  const selectedLines = [...selectedLineIndexes]
+    .sort((first, second) => first - second)
+    .map(lineIndex => lines[lineIndex])
+    .filter((line): line is string => undefined !== line);
+  const selectedText = selectedLines.join("\n").trim();
+  return truncateAiText("" === selectedText ? lines.join("\n") : selectedText);
+}
+
+function isAiRelevantLine(line: string): boolean {
+  return /\b(?:earnings|results?|revenue|sales|net\s+income|net\s+earnings|eps|per\s+share|guidance|outlook|forecast|quarter|fiscal)\b/i.test(line);
+}
+
+function truncateAiText(value: string): string {
+  if (value.length <= maxAiFilingTextLength) {
+    return value;
+  }
+
+  return value.slice(0, maxAiFilingTextLength);
+}
+
+function getNumericEventEpsConsensus(event: EarningsEvent): number | undefined {
+  if ("number" === typeof event.epsConsensus) {
+    return Number.isFinite(event.epsConsensus) ? event.epsConsensus : undefined;
+  }
+
+  if ("string" !== typeof event.epsConsensus) {
+    return undefined;
+  }
+
+  const normalizedValue = event.epsConsensus
+    .replace(/[$€£¥]/g, "")
+    .replaceAll(",", "")
+    .trim();
+  const parsedValue = Number.parseFloat(normalizedValue);
+  return Number.isFinite(parsedValue) ? parsedValue : undefined;
+}
+
+function sortEarningsMetrics(metrics: EarningsResultMetric[]): EarningsResultMetric[] {
+  const preferredOrder = [
+    "adjusted_eps",
+    "gaap_eps",
+    "nasdaq_eps",
+    "revenue",
+    "net_income",
+    "refinery_throughput",
+    "production",
+  ];
+  return [...metrics].sort((first, second) => {
+    const firstIndex = preferredOrder.indexOf(first.key);
+    const secondIndex = preferredOrder.indexOf(second.key);
+    const firstRank = -1 === firstIndex ? Number.MAX_SAFE_INTEGER : firstIndex;
+    const secondRank = -1 === secondIndex ? Number.MAX_SAFE_INTEGER : secondIndex;
+    if (firstRank !== secondRank) {
+      return firstRank - secondRank;
+    }
+
+    return first.label.localeCompare(second.label);
+  });
+}
+
+function dedupeMetrics(metrics: EarningsResultMetric[]): EarningsResultMetric[] {
+  const dedupedMetrics = new Map<string, EarningsResultMetric>();
+  for (const metric of metrics) {
+    if (false === dedupedMetrics.has(metric.key)) {
+      dedupedMetrics.set(metric.key, metric);
+    }
+  }
+
+  return [...dedupedMetrics.values()];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
+}
+
+function getArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -14,6 +14,7 @@ export type EarningsResultMetric = {
   label: string;
   numericValue?: number | undefined;
   outcome?: EarningsResultOutcome | undefined;
+  sourceSnippet?: string | undefined;
   value: string;
 };
 

--- a/modules/earnings-results-history.ts
+++ b/modules/earnings-results-history.ts
@@ -1,0 +1,256 @@
+import moment from "moment-timezone";
+import {normalizeTickerSymbol} from "./earnings-results-format.ts";
+
+type Logger = {
+  log: (level: string, message: unknown) => void;
+};
+
+type EarningsResultClient = {
+  channels?: {
+    cache?: {
+      get?: (channelID: string) => unknown;
+    };
+    fetch?: (channelID: string) => Promise<unknown> | unknown;
+  };
+};
+
+type FetchableMessageManager = {
+  fetch: (options: {limit: number}) => Promise<unknown> | unknown;
+};
+
+type FetchedMessageCollection = {
+  values: () => Iterable<unknown>;
+};
+
+const defaultRecentMessageFetchLimit = 100;
+const usEasternTimezone = "US/Eastern";
+const dateStampFormat = "YYYY-MM-DD";
+
+export async function seedSeenEarningsResultAnnouncementsFromHistory({
+  announcementThreadID,
+  channelID,
+  client,
+  dateStamp,
+  logger,
+  seenAccessions,
+  seenResultKeys,
+}: {
+  announcementThreadID: string | undefined;
+  channelID: string;
+  client: EarningsResultClient;
+  dateStamp: string;
+  logger: Logger;
+  seenAccessions: Set<string>;
+  seenResultKeys: Set<string>;
+}): Promise<boolean> {
+  const targetChannelID = announcementThreadID ?? channelID;
+  const seededTarget = await seedSeenAccessionsFromChannelHistory(
+    client,
+    targetChannelID,
+    seenAccessions,
+    seenResultKeys,
+    logger,
+    dateStamp,
+  );
+  if (false === seededTarget) {
+    return false;
+  }
+
+  if (undefined !== announcementThreadID && announcementThreadID !== channelID) {
+    await seedSeenAccessionsFromChannelHistory(
+      client,
+      channelID,
+      seenAccessions,
+      seenResultKeys,
+      logger,
+      dateStamp,
+      false,
+    );
+  }
+
+  return true;
+}
+
+export function getEarningsResultKey(ticker: string, dateStamp: string): string {
+  return `${dateStamp}:${normalizeTickerSymbol(ticker)}`;
+}
+
+async function seedSeenAccessionsFromChannelHistory(
+  client: EarningsResultClient,
+  channelID: string,
+  seenAccessions: Set<string>,
+  seenResultKeys: Set<string>,
+  logger: Logger,
+  dateStamp: string,
+  required = true,
+): Promise<boolean> {
+  const channel = await fetchChannel(client, channelID, logger);
+  const messages = isObjectLike(channel) && "messages" in channel
+    ? channel.messages
+    : undefined;
+  if (false === isFetchableMessageManager(messages)) {
+    logger.log(
+      "warn",
+      true === required
+        ? `Skipping earnings result scan: channel ${channelID} message history is not fetchable.`
+        : `Could not seed earnings result announcements from optional channel ${channelID}: message history is not fetchable.`,
+    );
+    return false === required;
+  }
+
+  const fetchedMessages = await Promise.resolve(messages.fetch({
+    limit: defaultRecentMessageFetchLimit,
+  })).catch(error => {
+    logger.log(
+      "warn",
+      `Could not seed earnings result announcements from channel history: ${error}`,
+    );
+    return null;
+  });
+  if (null === fetchedMessages) {
+    return false === required;
+  }
+
+  for (const message of getFetchedMessageValues(fetchedMessages)) {
+    const content = getMessageContent(message);
+    if (null === content) {
+      continue;
+    }
+
+    for (const accessionNumber of extractSecAccessionNumbers(content)) {
+      seenAccessions.add(accessionNumber);
+    }
+
+    if (true === isMessageFromDate(message, dateStamp)) {
+      for (const ticker of extractEarningsResultTickers(content)) {
+        seenResultKeys.add(getEarningsResultKey(ticker, dateStamp));
+      }
+    }
+  }
+
+  return true;
+}
+
+async function fetchChannel(
+  client: EarningsResultClient,
+  channelID: string,
+  logger: Logger,
+): Promise<unknown> {
+  const cachedChannel = client.channels?.cache?.get?.(channelID);
+  if (undefined !== cachedChannel) {
+    return cachedChannel;
+  }
+
+  const fetchChannelFn = client.channels?.fetch;
+  if ("function" !== typeof fetchChannelFn) {
+    return undefined;
+  }
+
+  return Promise.resolve(fetchChannelFn(channelID)).catch(error => {
+    logger.log(
+      "warn",
+      `Could not fetch earnings result channel ${channelID}: ${error}`,
+    );
+    return undefined;
+  });
+}
+
+function getFetchedMessageValues(fetchedMessages: unknown): unknown[] {
+  if (true === isFetchedMessageCollection(fetchedMessages)) {
+    return [...fetchedMessages.values()];
+  }
+
+  return [];
+}
+
+function isFetchableMessageManager(value: unknown): value is FetchableMessageManager {
+  return isObjectLike(value) &&
+    "fetch" in value &&
+    "function" === typeof value.fetch;
+}
+
+function isFetchedMessageCollection(value: unknown): value is FetchedMessageCollection {
+  const values = isObjectLike(value) && "values" in value
+    ? value.values
+    : undefined;
+  return "function" === typeof values;
+}
+
+function isObjectLike(value: unknown): value is object {
+  return Object(value) === value;
+}
+
+function getMessageContent(message: unknown): string | null {
+  if ("object" !== typeof message || null === message || false === "content" in message) {
+    return null;
+  }
+
+  return "string" === typeof message.content ? message.content : null;
+}
+
+function extractSecAccessionNumbers(content: string): string[] {
+  const accessions = new Set<string>();
+  for (const match of content.matchAll(/\b\d{10}-\d{2}-\d{6}\b/g)) {
+    accessions.add(match[0]);
+  }
+
+  for (const match of content.matchAll(/\/Archives\/edgar\/data\/\d+\/(\d{18})\//gi)) {
+    const compactAccession = match[1];
+    if (undefined === compactAccession) {
+      continue;
+    }
+
+    accessions.add(formatCompactAccessionNumber(compactAccession));
+  }
+
+  return [...accessions];
+}
+
+function extractEarningsResultTickers(content: string): string[] {
+  const tickers = new Set<string>();
+  for (const match of content.matchAll(/\(`([A-Z0-9./-]{1,16})`\)/g)) {
+    const ticker = match[1];
+    if (undefined !== ticker) {
+      tickers.add(normalizeTickerSymbol(ticker));
+    }
+  }
+
+  return [...tickers];
+}
+
+function isMessageFromDate(message: unknown, dateStamp: string): boolean {
+  const createdAtMs = getMessageCreatedAtMs(message);
+  if (undefined === createdAtMs) {
+    return false;
+  }
+
+  return moment(createdAtMs).tz(usEasternTimezone).format(dateStampFormat) === dateStamp;
+}
+
+function getMessageCreatedAtMs(message: unknown): number | undefined {
+  if (false === isObjectLike(message)) {
+    return undefined;
+  }
+
+  const messageRecord = message as Record<string, unknown>;
+  const createdTimestamp = messageRecord["createdTimestamp"];
+  if ("number" === typeof createdTimestamp && true === Number.isFinite(createdTimestamp)) {
+    return createdTimestamp;
+  }
+
+  const createdAt = messageRecord["createdAt"];
+  if (createdAt instanceof Date) {
+    return createdAt.getTime();
+  }
+
+  if ("string" === typeof createdAt) {
+    const parsedDate = Date.parse(createdAt);
+    return Number.isFinite(parsedDate) ? parsedDate : undefined;
+  }
+
+  return undefined;
+}
+
+function formatCompactAccessionNumber(value: string): string {
+  return `${value.slice(0, 10)}-${value.slice(10, 12)}-${value.slice(12)}`;
+}

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -13,6 +13,7 @@ describe("earnings result announcements", () => {
   };
   const getEarningsResultFn = vi.fn();
   const getWithRetryFn = vi.fn();
+  const postWithRetryFn = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -144,6 +145,131 @@ describe("earnings result announcements", () => {
 
       throw new Error(`Unexpected URL ${url}`);
     });
+  });
+
+  test("posts only one result per ticker and day when multiple current filings match", async () => {
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.includes("company_tickers.json")) {
+        return {
+          data: {
+            0: {
+              cik_str: 34088,
+              ticker: "XOM",
+              title: "EXXON MOBIL CORP",
+            },
+          },
+        };
+      }
+
+      if (url.includes("type=8-K")) {
+        return {
+          data: `
+            <feed>
+              <entry>
+                <title>8-K - EXXON MOBIL CORP</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0000034088-26-000042</id>
+                <updated>2026-05-01T08:01:00-04:00</updated>
+                <category term="8-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/0000034088-26-000042-index.htm" />
+                <summary>
+                  &lt;b&gt;CIK:&lt;/b&gt; 0000034088&lt;br/&gt;
+                  &lt;b&gt;Items:&lt;/b&gt; 2.02, 9.01
+                </summary>
+              </entry>
+              <entry>
+                <title>8-K - EXXON MOBIL CORP</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0000034088-26-000043</id>
+                <updated>2026-05-01T08:03:00-04:00</updated>
+                <category term="8-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/34088/000003408826000043/0000034088-26-000043-index.htm" />
+                <summary>
+                  &lt;b&gt;CIK:&lt;/b&gt; 0000034088&lt;br/&gt;
+                  &lt;b&gt;Items:&lt;/b&gt; 2.02, 9.01
+                </summary>
+              </entry>
+            </feed>
+          `,
+        };
+      }
+
+      if (url.includes("type=6-K")) {
+        return {
+          data: "<feed></feed>",
+        };
+      }
+
+      if (url.includes("000003408826000042/index.json")) {
+        return {
+          data: {
+            directory: {
+              item: [{
+                name: "xom-ex991.htm",
+                type: "EX-99.1",
+              }],
+            },
+          },
+        };
+      }
+
+      if (url.includes("000003408826000042/xom-ex991.htm")) {
+        return {
+          data: `
+            <html>
+              <body>
+                <h1>Exxon Mobil reports first quarter 2026 results</h1>
+                <p>Financial data in millions of dollars, except per share amounts.</p>
+                <table>
+                  <tr><td>Adjusted EPS</td><td>$1.16</td></tr>
+                  <tr><td>Total revenues and other income</td><td>85,140</td></tr>
+                </table>
+              </body>
+            </html>
+          `,
+        };
+      }
+
+      if (url.includes("companyfacts/CIK0000034088.json")) {
+        return {
+          data: {
+            facts: {},
+          },
+        };
+      }
+
+      if (url.includes("/XOM/earnings-surprise")) {
+        return {
+          data: {
+            data: {
+              earningsSurpriseTable: {
+                rows: [{
+                  dateReported: "5/1/2026",
+                  eps: "$1.16",
+                  consensusForecast: "$0.96",
+                  revenueEstimate: "$80.74B",
+                }],
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    const result = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      },
+    });
+
+    expect(result.announcements).toHaveLength(1);
+    expect(getWithRetryFn).not.toHaveBeenCalledWith(
+      expect.stringContaining("000003408826000043/index.json"),
+      expect.anything(),
+    );
   });
 
   test("builds an earnings result announcement from a watched SEC filing", async () => {
@@ -629,6 +755,230 @@ describe("earnings result announcements", () => {
     );
 
     watcher.stop();
+  });
+
+  test("watcher seeds same-day result tickers from channel history before scanning", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const timeoutHandle = {
+      unref: vi.fn(),
+    } as unknown as ReturnType<typeof setTimeout>;
+    const setTimeoutMock = vi.fn((_callback: () => void, _delayMs: number) => timeoutHandle);
+    const fetchMessages = vi.fn().mockResolvedValue(new Map([
+      ["message-id", {
+        content: "**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/000003408826000041/xom-ex991.htm)",
+        createdTimestamp: moment.tz("2026-05-01 08:04", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
+      }],
+    ]));
+
+    const watcher = startEarningsResultWatcher({
+      channels: {
+        cache: {
+          get: vi.fn(() => ({
+            messages: {
+              fetch: fetchMessages,
+            },
+            send,
+          })),
+        },
+      },
+    }, "breaking-news-channel-id", {
+      getEarningsResultFn,
+      getWithRetryFn,
+      logger,
+      now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      pollIntervalMs: 123,
+      setTimeoutFn: setTimeoutMock as unknown as typeof setTimeout,
+    });
+
+    await vi.waitFor(() => {
+      expect(setTimeoutMock).toHaveBeenCalled();
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(getWithRetryFn).not.toHaveBeenCalledWith(
+      expect.stringContaining("/index.json"),
+      expect.anything(),
+    );
+
+    watcher.stop();
+  });
+
+  test("uses Gemini extraction and suppresses suspicious earnings metrics when quality gate rejects them", async () => {
+    getEarningsResultFn.mockResolvedValue({
+      status: "ok",
+      events: [{
+        ticker: "BUD",
+        when: "before_open",
+        date: "2026-05-01",
+        importance: 1,
+        companyName: "Anheuser-Busch Inbev SA",
+        marketCap: 100_000_000_000,
+        marketCapText: "$100B",
+        epsConsensus: "$0.90",
+      }],
+    });
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.includes("company_tickers.json")) {
+        return {
+          data: {
+            0: {
+              cik_str: 1668717,
+              ticker: "BUD",
+              title: "ANHEUSER-BUSCH INBEV SA/NV",
+            },
+          },
+        };
+      }
+
+      if (url.includes("type=8-K")) {
+        return {
+          data: "<feed></feed>",
+        };
+      }
+
+      if (url.includes("type=6-K")) {
+        return {
+          data: `
+            <feed>
+              <entry>
+                <title>6-K - ANHEUSER-BUSCH INBEV SA/NV</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0001193125-26-123456</id>
+                <updated>2026-05-01T08:01:00-04:00</updated>
+                <category term="6-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/1668717/000119312526123456/0001193125-26-123456-index.htm" />
+                <summary>&lt;b&gt;CIK:&lt;/b&gt; 0001668717</summary>
+              </entry>
+            </feed>
+          `,
+        };
+      }
+
+      if (url.endsWith("/index.json")) {
+        return {
+          data: {
+            directory: {
+              item: [{
+                name: "bud-ex991.htm",
+                type: "EX-99.1",
+              }],
+            },
+          },
+        };
+      }
+
+      if (url.endsWith("/bud-ex991.htm")) {
+        return {
+          data: `
+            <html>
+              <body>
+                <h1>Anheuser-Busch InBev reports first quarter 2026 results</h1>
+                <p>Revenue increased to 14.55 billion USD.</p>
+                <table>
+                  <tr><td>EPS</td><td>20.80</td></tr>
+                  <tr><td>Revenue</td><td>267</td></tr>
+                </table>
+              </body>
+            </html>
+          `,
+        };
+      }
+
+      if (url.includes("companyfacts/CIK0001668717.json")) {
+        return {
+          data: {
+            facts: {},
+          },
+        };
+      }
+
+      if (url.includes("/BUD/earnings-surprise")) {
+        return {
+          data: {
+            data: {
+              earningsSurpriseTable: {
+                rows: [{
+                  dateReported: "5/1/2026",
+                  consensusForecast: "$0.90",
+                  revenueEstimate: "$14.4B",
+                }],
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    postWithRetryFn
+      .mockResolvedValueOnce({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: JSON.stringify({
+                  quarterLabel: "Q1 2026",
+                  metrics: [{
+                    key: "revenue",
+                    numericValue: 14_550_000_000,
+                    currencyCode: "USD",
+                    sourceSnippet: "Revenue increased to 14.55 billion USD.",
+                  }],
+                  issues: [],
+                }),
+              }],
+            },
+          }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: JSON.stringify({
+                  decision: "suppress",
+                  confidence: 0.91,
+                  reason: "EPS was parsed from a table fragment and does not match the supported filing text.",
+                  issues: [{
+                    severity: "high",
+                    metricKey: "gaap_eps",
+                    message: "The EPS value is likely a parsing artifact.",
+                    sourceSnippet: "EPS | 20.80",
+                  }],
+                }),
+              }],
+            },
+          }],
+        },
+      });
+
+    const result = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+        postWithRetryFn,
+        readSecretFn: vi.fn((secretName: string) => {
+          if ("gemini_api_key" === secretName) {
+            return "gemini-key";
+          }
+
+          if ("gemini_calls_per_minute" === secretName) {
+            return "14";
+          }
+
+          throw new Error(`missing ${secretName}`);
+        }),
+      },
+    });
+
+    expect(result.announcements).toEqual([]);
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping earnings result announcement for BUD: suspicious metrics were not verified.",
+    );
   });
 
   test("watcher skips scans until channel history can be checked", async () => {

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -1,6 +1,15 @@
 import moment from "moment-timezone";
 import {bluechipMinMarketCap, clearEarningsScheduleCache, type EarningsEvent, getEarningsResult} from "./earnings.ts";
 import {
+  checkEarningsQualityWithGemini,
+  clearEarningsAiState,
+  extractEarningsWithGemini,
+  getSuspiciousEarningsReasons,
+  hasHighSeveritySuspicion,
+  mergeAiMetrics,
+  type SuspiciousEarningsReason,
+} from "./earnings-results-ai.ts";
+import {
   formatUsdCompact,
   getEarningsResultMessage,
   getMessageMetrics,
@@ -9,6 +18,10 @@ import {
   parseNumber,
   type NasdaqSurprise,
 } from "./earnings-results-format.ts";
+import {
+  getEarningsResultKey,
+  seedSeenEarningsResultAnnouncementsFromHistory,
+} from "./earnings-results-history.ts";
 import {loadSecXbrlMetrics, mergeXbrlAndHtmlMetrics} from "./earnings-results-xbrl.ts";
 import {
   clearSecEarningsResultCaches,
@@ -19,8 +32,9 @@ import {
   type SecCompany,
   type SecCurrentFiling,
 } from "./earnings-results-sec.ts";
-import {getWithRetry} from "./http-retry.ts";
+import {getWithRetry, type postWithRetry} from "./http-retry.ts";
 import {getLogger} from "./logging.ts";
+import {type readSecret} from "./secrets.ts";
 
 type Logger = {
   log: (level: string, message: unknown) => void;
@@ -28,14 +42,6 @@ type Logger = {
 
 type SendableChannel = {
   send: (payload: unknown) => Promise<unknown> | unknown;
-};
-
-type FetchableMessageManager = {
-  fetch: (options: {limit: number}) => Promise<unknown> | unknown;
-};
-
-type FetchedMessageCollection = {
-  values: () => Iterable<unknown>;
 };
 
 type EarningsResultClient = {
@@ -57,8 +63,11 @@ type EarningsResultWatcherOptions = {
   inactivePollIntervalMs?: number;
   logger?: Logger;
   maxAnnouncementsPerScan?: number;
+  nowMs?: () => number;
   now?: () => moment.Moment;
   pollIntervalMs?: number;
+  postWithRetryFn?: typeof postWithRetry;
+  readSecretFn?: typeof readSecret;
   secCurrentFilingsLimit?: number;
   setTimeoutFn?: typeof setTimeout;
 };
@@ -66,7 +75,7 @@ type EarningsResultWatcherOptions = {
 type EarningsResultDependencies = Required<Pick<
   EarningsResultWatcherOptions,
   "getEarningsResultFn" | "getWithRetryFn" | "logger" | "now"
->>;
+>> & Pick<EarningsResultWatcherOptions, "nowMs" | "postWithRetryFn" | "readSecretFn">;
 
 type EarningsWatchEntry = {
   cik: string;
@@ -129,7 +138,6 @@ const defaultPollIntervalMs = 60_000;
 const defaultInactivePollIntervalMs = 15 * 60_000;
 const defaultSecCurrentFilingsLimit = 100;
 const defaultMaxAnnouncementsPerScan = 10;
-const defaultRecentMessageFetchLimit = 100;
 const earningsWatchTtlMs = 15 * 60_000;
 const nasdaqEarningsSurpriseEndpoint = "https://api.nasdaq.com/api/company";
 const noMentions = {
@@ -147,6 +155,7 @@ export function clearEarningsResultCaches() {
   earningsWatchCache = undefined;
   clearEarningsScheduleCache();
   clearSecEarningsResultCaches();
+  clearEarningsAiState();
 }
 
 export function startEarningsResultWatcher(
@@ -160,6 +169,7 @@ export function startEarningsResultWatcher(
   const inactivePollIntervalMs = options.inactivePollIntervalMs ?? defaultInactivePollIntervalMs;
   const announcementThreadID = getOptionalChannelID(options.announcementThreadID);
   const seenAccessions = new Set<string>();
+  const seenResultKeys = new Set<string>();
   const dependencies = getDependencies(options);
   let seenAccessionsSeeded = false;
   let stopped = false;
@@ -167,13 +177,15 @@ export function startEarningsResultWatcher(
 
   const runOnce = async (): Promise<EarningsResultScanResult> => {
     if (false === seenAccessionsSeeded) {
-      const seeded = await seedSeenAccessionsFromAnnouncementHistory(
-        client,
-        channelID,
+      const seeded = await seedSeenEarningsResultAnnouncementsFromHistory({
         announcementThreadID,
+        channelID,
+        client,
+        dateStamp: dependencies.now().clone().tz(usEasternTimezone).format(dateStampFormat),
+        logger: dependencies.logger,
         seenAccessions,
-        dependencies.logger,
-      );
+        seenResultKeys,
+      });
       if (false === seeded) {
         return {
           active: true,
@@ -190,9 +202,11 @@ export function startEarningsResultWatcher(
       maxAnnouncementsPerScan?: number;
       secCurrentFilingsLimit?: number;
       seenAccessions: Set<string>;
+      seenResultKeys: Set<string>;
     } = {
       dependencies,
       seenAccessions,
+      seenResultKeys,
     };
     if (undefined !== options.maxAnnouncementsPerScan) {
       announcementOptions.maxAnnouncementsPerScan = options.maxAnnouncementsPerScan;
@@ -213,6 +227,7 @@ export function startEarningsResultWatcher(
       );
       if (true === sent) {
         seenAccessions.add(announcement.accessionNumber);
+        seenResultKeys.add(getEarningsResultKey(announcement.ticker, nowDateStamp(dependencies)));
       }
     }
 
@@ -263,11 +278,13 @@ export async function getEarningsResultAnnouncements({
   maxAnnouncementsPerScan = defaultMaxAnnouncementsPerScan,
   secCurrentFilingsLimit = defaultSecCurrentFilingsLimit,
   seenAccessions = new Set<string>(),
+  seenResultKeys = new Set<string>(),
 }: {
   dependencies?: EarningsResultDependencies;
   maxAnnouncementsPerScan?: number;
   secCurrentFilingsLimit?: number;
   seenAccessions?: Set<string>;
+  seenResultKeys?: Set<string>;
 } = {}): Promise<EarningsResultScanResult> {
   const now = dependencies.now().clone().tz(usEasternTimezone);
   const watches = await getTodaysEarningsWatches(dependencies, now);
@@ -283,6 +300,7 @@ export async function getEarningsResultAnnouncements({
   const watchesByCik = groupWatchesByCik(activeWatches);
   const filings = await loadSecCurrentFilings(dependencies, secCurrentFilingsLimit);
   const announcements: EarningsResultAnnouncement[] = [];
+  const announcedResultKeys = new Set(seenResultKeys);
 
   for (const filing of filings) {
     if (announcements.length >= maxAnnouncementsPerScan) {
@@ -303,6 +321,11 @@ export async function getEarningsResultAnnouncements({
       continue;
     }
 
+    const resultKey = getEarningsResultKey(filingWatch.event.ticker, now.format(dateStampFormat));
+    if (true === announcedResultKeys.has(resultKey)) {
+      continue;
+    }
+
     if (false === isLikelyEarningsFiling(filing)) {
       continue;
     }
@@ -315,6 +338,7 @@ export async function getEarningsResultAnnouncements({
     );
     if (null !== announcement) {
       announcements.push(announcement);
+      announcedResultKeys.add(resultKey);
     }
   }
 
@@ -326,24 +350,29 @@ export async function getEarningsResultAnnouncements({
 }
 
 function getDependencies(options: EarningsResultWatcherOptions = {}): EarningsResultDependencies {
-  return {
+  const dependencies: EarningsResultDependencies = {
     getEarningsResultFn: options.getEarningsResultFn ?? getEarningsResult,
     getWithRetryFn: options.getWithRetryFn ?? getWithRetry,
     logger: options.logger ?? logger,
     now: options.now ?? (() => moment.tz(usEasternTimezone)),
   };
+  if (undefined !== options.nowMs) {
+    dependencies.nowMs = options.nowMs;
+  }
+  if (undefined !== options.postWithRetryFn) {
+    dependencies.postWithRetryFn = options.postWithRetryFn;
+  }
+  if (undefined !== options.readSecretFn) {
+    dependencies.readSecretFn = options.readSecretFn;
+  }
+
+  return dependencies;
 }
 
 function isSendableChannel(channel: unknown): channel is SendableChannel {
   return isObjectLike(channel) &&
     "send" in channel &&
     "function" === typeof channel.send;
-}
-
-function isFetchableMessageManager(value: unknown): value is FetchableMessageManager {
-  return isObjectLike(value) &&
-    "fetch" in value &&
-    "function" === typeof value.fetch;
 }
 
 function getOptionalChannelID(channelID: string | undefined): string | undefined {
@@ -375,132 +404,12 @@ async function fetchChannel(
   });
 }
 
-async function seedSeenAccessionsFromAnnouncementHistory(
-  client: EarningsResultClient,
-  channelID: string,
-  announcementThreadID: string | undefined,
-  seenAccessions: Set<string>,
-  loggerInstance: Logger,
-): Promise<boolean> {
-  const targetChannelID = announcementThreadID ?? channelID;
-  const seededTarget = await seedSeenAccessionsFromChannelHistory(
-    client,
-    targetChannelID,
-    seenAccessions,
-    loggerInstance,
-  );
-  if (false === seededTarget) {
-    return false;
-  }
-
-  if (undefined !== announcementThreadID && announcementThreadID !== channelID) {
-    await seedSeenAccessionsFromChannelHistory(
-      client,
-      channelID,
-      seenAccessions,
-      loggerInstance,
-      false,
-    );
-  }
-
-  return true;
-}
-
-async function seedSeenAccessionsFromChannelHistory(
-  client: EarningsResultClient,
-  channelID: string,
-  seenAccessions: Set<string>,
-  loggerInstance: Logger,
-  required = true,
-): Promise<boolean> {
-  const channel = await fetchChannel(client, channelID, loggerInstance);
-  const messages = isObjectLike(channel) && "messages" in channel
-    ? channel.messages
-    : undefined;
-  if (false === isFetchableMessageManager(messages)) {
-    loggerInstance.log(
-      "warn",
-      true === required
-        ? `Skipping earnings result scan: channel ${channelID} message history is not fetchable.`
-        : `Could not seed earnings result announcements from optional channel ${channelID}: message history is not fetchable.`,
-    );
-    return false === required;
-  }
-
-  const fetchedMessages = await Promise.resolve(messages.fetch({
-    limit: defaultRecentMessageFetchLimit,
-  })).catch(error => {
-    loggerInstance.log(
-      "warn",
-      `Could not seed earnings result announcements from channel history: ${error}`,
-    );
-    return null;
-  });
-  if (null === fetchedMessages) {
-    return false === required;
-  }
-
-  for (const message of getFetchedMessageValues(fetchedMessages)) {
-    const content = getMessageContent(message);
-    if (null === content) {
-      continue;
-    }
-
-    for (const accessionNumber of extractSecAccessionNumbers(content)) {
-      seenAccessions.add(accessionNumber);
-    }
-  }
-
-  return true;
-}
-
-function getFetchedMessageValues(fetchedMessages: unknown): unknown[] {
-  if (true === isFetchedMessageCollection(fetchedMessages)) {
-    return [...fetchedMessages.values()];
-  }
-
-  return [];
-}
-
-function isFetchedMessageCollection(value: unknown): value is FetchedMessageCollection {
-  const values = isObjectLike(value) && "values" in value
-    ? value.values
-    : undefined;
-  return "function" === typeof values;
-}
-
 function isObjectLike(value: unknown): value is object {
   return Object(value) === value;
 }
 
-function getMessageContent(message: unknown): string | null {
-  if ("object" !== typeof message || null === message || false === "content" in message) {
-    return null;
-  }
-
-  return "string" === typeof message.content ? message.content : null;
-}
-
-function extractSecAccessionNumbers(content: string): string[] {
-  const accessions = new Set<string>();
-  for (const match of content.matchAll(/\b\d{10}-\d{2}-\d{6}\b/g)) {
-    accessions.add(match[0]);
-  }
-
-  for (const match of content.matchAll(/\/Archives\/edgar\/data\/\d+\/(\d{18})\//gi)) {
-    const compactAccession = match[1];
-    if (undefined === compactAccession) {
-      continue;
-    }
-
-    accessions.add(formatCompactAccessionNumber(compactAccession));
-  }
-
-  return [...accessions];
-}
-
-function formatCompactAccessionNumber(value: string): string {
-  return `${value.slice(0, 10)}-${value.slice(10, 12)}-${value.slice(12)}`;
+function nowDateStamp(dependencies: EarningsResultDependencies): string {
+  return dependencies.now().clone().tz(usEasternTimezone).format(dateStampFormat);
 }
 
 async function sendEarningsResultAnnouncement(
@@ -680,10 +589,38 @@ async function buildEarningsResultAnnouncement(
       return [];
     }),
   ]);
-  const parsedDocument = parseEarningsDocument(filingDetails?.html ?? "");
-  const sourceMetrics = mergeXbrlAndHtmlMetrics(xbrlMetrics, parsedDocument.metrics);
+  let parsedDocument = parseEarningsDocument(filingDetails?.html ?? "");
+  let sourceMetrics = mergeXbrlAndHtmlMetrics(xbrlMetrics, parsedDocument.metrics);
   const surprise = await loadNasdaqSurprise(watch.event.ticker, dependencies, now);
+  const initialMetrics = getMessageMetrics(sourceMetrics, surprise, watch.event);
+  const initialSuspiciousReasons = [
+    ...getSuspiciousEarningsReasons(initialMetrics, surprise, watch.event),
+    ...getSuspiciousQuarterReasons(parsedDocument.quarterLabel, now),
+  ];
+  const aiExtraction = shouldRunAiExtraction(filingDetails?.html ?? "", sourceMetrics, initialSuspiciousReasons)
+    ? await extractEarningsWithGemini({
+      companyName: watch.companyName,
+      filingForm: filing.form,
+      filingUrl: filingDetails?.documentUrl || filing.filingUrl,
+      html: filingDetails?.html ?? "",
+      ticker: watch.event.ticker,
+    }, dependencies)
+    : null;
+  if (null !== aiExtraction) {
+    sourceMetrics = mergeAiMetrics(sourceMetrics, aiExtraction.metrics, initialSuspiciousReasons);
+    if (undefined === parsedDocument.quarterLabel && undefined !== aiExtraction.quarterLabel) {
+      parsedDocument = {
+        ...parsedDocument,
+        quarterLabel: aiExtraction.quarterLabel,
+      };
+    }
+  }
+
   const metrics = getMessageMetrics(sourceMetrics, surprise, watch.event);
+  const suspiciousReasons = [
+    ...getSuspiciousEarningsReasons(metrics, surprise, watch.event),
+    ...getSuspiciousQuarterReasons(parsedDocument.quarterLabel, now),
+  ];
   const filingUrl = filingDetails?.documentUrl || filing.filingUrl;
 
   if (0 === metrics.length && 0 === parsedDocument.outlook.length) {
@@ -694,21 +631,100 @@ async function buildEarningsResultAnnouncement(
     return null;
   }
 
+  const message = getEarningsResultMessage({
+    companyName: watch.companyName,
+    filing,
+    filingUrl,
+    metrics,
+    parsedDocument,
+    ticker: watch.event.ticker,
+  });
+  const qualityGate = await checkEarningsQualityWithGemini({
+    companyName: watch.companyName,
+    event: watch.event,
+    filingForm: filing.form,
+    filingUrl,
+    html: filingDetails?.html ?? "",
+    message,
+    metrics,
+    reasons: suspiciousReasons,
+    surprise,
+    ticker: watch.event.ticker,
+  }, dependencies);
+  if (true === shouldSuppressAnnouncement(qualityGate, suspiciousReasons)) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping earnings result announcement for ${watch.event.ticker}: suspicious metrics were not verified.`,
+    );
+    return null;
+  }
+
   return {
     accessionNumber: filing.accessionNumber,
     cik: filing.cik,
     companyName: watch.companyName,
     filing,
     filingUrl,
-    message: getEarningsResultMessage({
-      companyName: watch.companyName,
-      filing,
-      filingUrl,
-      metrics,
-      parsedDocument,
-      ticker: watch.event.ticker,
-    }),
+    message,
     ticker: watch.event.ticker,
+  };
+}
+
+function shouldRunAiExtraction(
+  html: string,
+  sourceMetrics: unknown[],
+  suspiciousReasons: SuspiciousEarningsReason[],
+): boolean {
+  return "" !== html.trim() && (0 === sourceMetrics.length || 0 < suspiciousReasons.length);
+}
+
+function shouldSuppressAnnouncement(
+  qualityGate: {confidence: number; decision: "allow" | "suppress";} | null,
+  suspiciousReasons: SuspiciousEarningsReason[],
+): boolean {
+  if (null !== qualityGate) {
+    return "suppress" === qualityGate.decision && qualityGate.confidence >= 0.75;
+  }
+
+  return hasHighSeveritySuspicion(suspiciousReasons);
+}
+
+function getSuspiciousQuarterReasons(
+  quarterLabel: string | undefined,
+  now: moment.Moment,
+): SuspiciousEarningsReason[] {
+  const reportedQuarter = parseQuarterLabel(quarterLabel);
+  if (null === reportedQuarter) {
+    return [];
+  }
+
+  const currentQuarterStart = now.clone().startOf("quarter");
+  const previousQuarterStart = currentQuarterStart.clone().subtract(1, "quarter");
+  const reportedQuarterStart = moment.tz(
+    `${reportedQuarter.year}-${String((reportedQuarter.quarter - 1) * 3 + 1).padStart(2, "0")}-01`,
+    dateStampFormat,
+    usEasternTimezone,
+  );
+  if (false === reportedQuarterStart.isBefore(previousQuarterStart, "day")) {
+    return [];
+  }
+
+  const daysIntoCurrentQuarter = now.clone().startOf("day").diff(currentQuarterStart, "days");
+  return [{
+    message: `Filing period ${quarterLabel} is older than the previous calendar quarter for this earnings date.`,
+    severity: daysIntoCurrentQuarter >= 21 ? "high" : "medium",
+  }];
+}
+
+function parseQuarterLabel(quarterLabel: string | undefined): {quarter: number; year: number;} | null {
+  const quarterMatch = quarterLabel?.match(/^Q([1-4])\s+(20\d{2})$/i);
+  if (undefined === quarterMatch?.[1] || undefined === quarterMatch[2]) {
+    return null;
+  }
+
+  return {
+    quarter: Number.parseInt(quarterMatch[1], 10),
+    year: Number.parseInt(quarterMatch[2], 10),
   };
 }
 

--- a/modules/gemini.ts
+++ b/modules/gemini.ts
@@ -1,0 +1,202 @@
+import {postWithRetry} from "./http-retry.ts";
+import {readSecret} from "./secrets.ts";
+
+type Logger = {
+  log: (level: string, message: unknown) => void;
+};
+
+export type GeminiDependencies = {
+  logger: Logger;
+  nowMs?: () => number;
+  postWithRetryFn?: typeof postWithRetry;
+  readSecretFn?: typeof readSecret;
+};
+
+export type GeminiInlineData = {
+  data: string;
+  mimeType: string;
+};
+
+export type GeminiCallOptions = {
+  timeoutMs?: number | undefined;
+};
+
+type GeminiConfig = {
+  apiKey: string;
+  callsPerMinute: number;
+  model: string;
+};
+
+type GeminiContentPart = {
+  text: string;
+} | {
+  inline_data: {
+    data: string;
+    mime_type: string;
+  };
+};
+
+type GeminiGenerateContentResponse = {
+  candidates?: {
+    content?: {
+      parts?: {
+        text?: string;
+      }[];
+    };
+  }[];
+};
+
+const geminiApiEndpoint = "https://generativelanguage.googleapis.com/v1beta";
+const geminiApiKeySecret = "gemini_api_key";
+const geminiModelSecret = "gemini_model";
+const geminiCallsPerMinuteSecret = "gemini_calls_per_minute";
+const defaultGeminiModel = "gemini-2.5-flash-lite";
+const defaultGeminiCallsPerMinute = 14;
+const maxGeminiCallsPerMinute = 30;
+const geminiWindowMs = 60_000;
+
+const geminiCallTimestampsMs: number[] = [];
+
+export function clearGeminiState() {
+  geminiCallTimestampsMs.splice(0, geminiCallTimestampsMs.length);
+}
+
+export async function callGeminiJson(
+  prompt: string,
+  responseJsonSchema: Record<string, unknown>,
+  dependencies: GeminiDependencies,
+  task: string,
+  inlineData?: GeminiInlineData,
+  options: GeminiCallOptions = {},
+): Promise<string | null> {
+  const config = getGeminiConfig(dependencies);
+  if (null === config) {
+    return null;
+  }
+
+  if (false === reserveGeminiCall(config, dependencies, task)) {
+    return null;
+  }
+
+  const postWithRetryFn = dependencies.postWithRetryFn ?? postWithRetry;
+  const parts = getGeminiContentParts(prompt, inlineData);
+  const response = await postWithRetryFn<GeminiGenerateContentResponse>(
+    `${geminiApiEndpoint}/${getGeminiModelPath(config.model)}:generateContent`,
+    {
+      contents: [{
+        parts,
+      }],
+      generationConfig: {
+        responseMimeType: "application/json",
+        responseJsonSchema,
+        temperature: 0,
+      },
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": config.apiKey,
+      },
+    },
+    {
+      maxAttempts: 1,
+      timeoutMs: options.timeoutMs ?? 15_000,
+    },
+  );
+
+  const firstCandidate = response.data.candidates?.[0];
+  const textPart = firstCandidate?.content?.parts?.find(part => "string" === typeof part.text);
+  return textPart?.text ?? null;
+}
+
+function getGeminiContentParts(
+  prompt: string,
+  inlineData: GeminiInlineData | undefined,
+): GeminiContentPart[] {
+  if (undefined === inlineData) {
+    return [{
+      text: prompt,
+    }];
+  }
+
+  return [{
+    inline_data: {
+      data: inlineData.data,
+      mime_type: inlineData.mimeType,
+    },
+  }, {
+    text: prompt,
+  }];
+}
+
+function getGeminiConfig(dependencies: GeminiDependencies): GeminiConfig | null {
+  const readSecretFn = dependencies.readSecretFn ?? readSecret;
+  const apiKey = readOptionalSecret(readSecretFn, geminiApiKeySecret);
+  if (undefined === apiKey) {
+    return null;
+  }
+
+  const model = readOptionalSecret(readSecretFn, geminiModelSecret) ?? defaultGeminiModel;
+  const callsPerMinute = getGeminiCallsPerMinute(readOptionalSecret(readSecretFn, geminiCallsPerMinuteSecret));
+  return {
+    apiKey,
+    callsPerMinute,
+    model,
+  };
+}
+
+function readOptionalSecret(readSecretFn: typeof readSecret, secretName: string): string | undefined {
+  try {
+    const value = readSecretFn(secretName).trim();
+    return "" === value ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}
+
+function getGeminiCallsPerMinute(value: string | undefined): number {
+  if (undefined === value) {
+    return defaultGeminiCallsPerMinute;
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+  if (false === Number.isFinite(parsedValue)) {
+    return defaultGeminiCallsPerMinute;
+  }
+
+  return Math.min(Math.max(parsedValue, 1), maxGeminiCallsPerMinute);
+}
+
+function reserveGeminiCall(
+  config: GeminiConfig,
+  dependencies: GeminiDependencies,
+  task: string,
+): boolean {
+  const nowMs = dependencies.nowMs?.() ?? Date.now();
+  const windowStartMs = nowMs - geminiWindowMs;
+  while (0 < geminiCallTimestampsMs.length && (geminiCallTimestampsMs[0] ?? 0) <= windowStartMs) {
+    geminiCallTimestampsMs.shift();
+  }
+
+  if (geminiCallTimestampsMs.length >= config.callsPerMinute) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping Gemini ${task}: local ${config.callsPerMinute}/minute rate limit is exhausted.`,
+    );
+    return false;
+  }
+
+  geminiCallTimestampsMs.push(nowMs);
+  return true;
+}
+
+function getGeminiModelPath(model: string): string {
+  const normalizedModel = model.trim();
+  if ("" === normalizedModel || /[^a-z0-9._/-]/i.test(normalizedModel)) {
+    return `models/${defaultGeminiModel}`;
+  }
+
+  return normalizedModel.startsWith("models/")
+    ? normalizedModel
+    : `models/${normalizedModel}`;
+}

--- a/modules/mnc-summary.test.ts
+++ b/modules/mnc-summary.test.ts
@@ -1,0 +1,156 @@
+import {Buffer} from "node:buffer";
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {clearGeminiState} from "./gemini.ts";
+import {getMncSummary} from "./mnc-summary.ts";
+
+describe("MNC Gemini summary", () => {
+  const logger = {
+    log: vi.fn(),
+  };
+  const readSecretFn = vi.fn((secretName: string) => {
+    if ("gemini_api_key" === secretName) {
+      return "gemini-key";
+    }
+
+    throw new Error(`missing ${secretName}`);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearGeminiState();
+  });
+
+  test("summarizes the PDF with inline Gemini PDF data", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summaryMarkdown: "**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBe("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      expect.stringContaining("gemini-2.5-flash-lite:generateContent"),
+      expect.objectContaining({
+        contents: [{
+          parts: [{
+            inline_data: {
+              data: Buffer.from("pdf-bytes").toString("base64"),
+              mime_type: "application/pdf",
+            },
+          }, {
+            text: expect.stringContaining("otherwise format the company name itself as inline code"),
+          }],
+        }],
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-goog-api-key": "gemini-key",
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  test("stays disabled when the Gemini API key is missing", async () => {
+    const postWithRetryFn = vi.fn();
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn: vi.fn(() => {
+        throw new Error("missing secret");
+      }),
+    });
+
+    expect(summary).toBeUndefined();
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+  });
+
+  test("skips inline summaries for oversized PDFs", async () => {
+    const postWithRetryFn = vi.fn();
+
+    const summary = await getMncSummary(Buffer.alloc(14_000_001), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBeUndefined();
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping MNC Gemini summary: PDF is too large for inline Gemini processing.",
+    );
+  });
+
+  test("normalizes markdown fences and truncates long summaries", async () => {
+    const longSummary = [
+      "```markdown",
+      "**Morning News Call - TL;DR**",
+      ...Array.from({length: 40}, (_value, index) => `- Market item ${index} with enough text to make the generated summary too long for Discord posting.`),
+      "```",
+    ].join("\n");
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summaryMarkdown: longSummary,
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBeDefined();
+    expect(summary).not.toContain("```");
+    expect(summary!.length).toBeLessThanOrEqual(1_700);
+    expect(summary).toContain("\n- ...");
+  });
+
+  test("returns no summary for invalid Gemini JSON", async () => {
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn: vi.fn().mockResolvedValue({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: "{not-json",
+              }],
+            },
+          }],
+        },
+      }),
+      readSecretFn,
+    });
+
+    expect(summary).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini MNC summary returned invalid JSON.",
+    );
+  });
+});

--- a/modules/mnc-summary.ts
+++ b/modules/mnc-summary.ts
@@ -1,0 +1,136 @@
+import type {Buffer} from "node:buffer";
+import {callGeminiJson, type GeminiDependencies} from "./gemini.ts";
+
+export type MncSummaryDependencies = GeminiDependencies;
+
+const maxInlinePdfBytes = 14_000_000;
+const maxDiscordSummaryLength = 1_700;
+
+const mncSummarySchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    summaryMarkdown: {
+      type: "string",
+      description: "A concise one-minute Morning News Call summary formatted in Discord-compatible Markdown.",
+    },
+  },
+  required: ["summaryMarkdown"],
+} satisfies Record<string, unknown>;
+
+export async function getMncSummary(
+  pdfBuffer: Buffer,
+  dependencies: MncSummaryDependencies,
+): Promise<string | undefined> {
+  if (pdfBuffer.length > maxInlinePdfBytes) {
+    dependencies.logger.log(
+      "warn",
+      "Skipping MNC Gemini summary: PDF is too large for inline Gemini processing.",
+    );
+    return undefined;
+  }
+
+  const jsonText = await callGeminiJson(
+    getMncSummaryPrompt(),
+    mncSummarySchema,
+    dependencies,
+    "MNC summary",
+    {
+      data: pdfBuffer.toString("base64"),
+      mimeType: "application/pdf",
+    },
+    {
+      timeoutMs: 60_000,
+    },
+  ).catch(error => {
+    dependencies.logger.log(
+      "warn",
+      `Gemini MNC summary failed: ${error}`,
+    );
+    return null;
+  });
+  if (null === jsonText) {
+    return undefined;
+  }
+
+  const parsedJson = parseJson(jsonText);
+  if (false === isRecord(parsedJson)) {
+    dependencies.logger.log(
+      "warn",
+      "Gemini MNC summary returned invalid JSON.",
+    );
+    return undefined;
+  }
+
+  const summaryMarkdown = parsedJson["summaryMarkdown"];
+  if ("string" !== typeof summaryMarkdown) {
+    dependencies.logger.log(
+      "warn",
+      "Gemini MNC summary response did not contain summaryMarkdown.",
+    );
+    return undefined;
+  }
+
+  const normalizedSummary = normalizeMarkdownSummary(summaryMarkdown);
+  return "" === normalizedSummary ? undefined : truncateMarkdownSummary(normalizedSummary);
+}
+
+function getMncSummaryPrompt(): string {
+  return [
+    "Summarize this Refinitiv Morning News Call PDF for a Discord trading channel.",
+    "Return only JSON matching the schema. Do not include markdown outside the JSON string.",
+    "Write summaryMarkdown as a one-minute read in concise Discord Markdown.",
+    "Required shape:",
+    "**Morning News Call - TL;DR**",
+    "- 2-3 bullets with the market setup and most important macro drivers.",
+    "",
+    "**Stocks in focus**",
+    "- 4-6 bullets with company/ticker-specific news, earnings, guidance, analyst calls, or deal headlines.",
+    "",
+    "**Watchlist**",
+    "- 1-3 bullets for events, data releases, sectors, or risks traders should monitor.",
+    "Rules:",
+    "- Keep the full summary under 1,500 characters.",
+    "- Use 8-12 bullets total; each bullet should fit one Discord line.",
+    "- Prioritize concrete, market-moving information from the PDF.",
+    "- Format ticker symbols and quantitative metrics as inline code, e.g. `AAPL`, `$2.14`, `3.1%`, `10Y`, `250K`.",
+    "- In stock-specific bullets, start with an inline-code ticker only when the PDF explicitly provides the ticker; otherwise format the company name itself as inline code.",
+    "- Do not infer or invent tickers, prices, percentages, or attributions.",
+    "- Do not use code blocks, tables, links, emojis, or disclaimers.",
+  ].join("\n");
+}
+
+function normalizeMarkdownSummary(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map(line => line.trimEnd())
+    .filter(line => false === /^```/.test(line.trim()))
+    .join("\n")
+    .trim();
+}
+
+function truncateMarkdownSummary(value: string): string {
+  if (value.length <= maxDiscordSummaryLength) {
+    return value;
+  }
+
+  const truncatedValue = value.slice(0, maxDiscordSummaryLength - 20);
+  const lastLineBreak = truncatedValue.lastIndexOf("\n");
+  const summary = lastLineBreak > 0
+    ? truncatedValue.slice(0, lastLineBreak)
+    : truncatedValue;
+  return `${summary.trimEnd()}\n- ...`;
+}
+
+function parseJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
+}

--- a/modules/test-utils/timers.ts
+++ b/modules/test-utils/timers.ts
@@ -38,6 +38,7 @@ const warmExpectedMoveCacheForEarningsEventsMock = vi.fn();
 const getEarningsResultMock = vi.fn();
 const getEarningsMessagesMock = vi.fn();
 const getMncMock = vi.fn();
+const getMncSummaryMock = vi.fn();
 const loggerMock = {
   log: vi.fn(),
 };
@@ -93,6 +94,10 @@ vi.mock("../earnings-expected-move.ts", () => ({
 
 vi.mock("../mnc-downloader.ts", () => ({
   getMnc: (...args: unknown[]) => getMncMock(...args),
+}));
+
+vi.mock("../mnc-summary.ts", () => ({
+  getMncSummary: (...args: unknown[]) => getMncSummaryMock(...args),
 }));
 
 vi.mock("../logging.ts", () => ({
@@ -212,6 +217,7 @@ export function resetTimerMocks() {
 
   isHolidayMock.mockReturnValue(false);
   getMncMock.mockResolvedValue(Buffer.from("mnc-pdf"));
+  getMncSummaryMock.mockResolvedValue(undefined);
   getAssetByNameMock.mockReturnValue({
     fileContent: Buffer.from("freitag"),
     fileName: "freitag.png",
@@ -261,6 +267,7 @@ export {
   getEarningsResultMock,
   getHolidaysMock,
   getMncMock,
+  getMncSummaryMock,
   getScheduledDateJobs,
   getScheduledJobByTime,
   isHolidayMock,

--- a/modules/timers.test.ts
+++ b/modules/timers.test.ts
@@ -5,6 +5,7 @@ import {
   createClientWithoutChannel,
   getHolidaysMock,
   getMncMock,
+  getMncSummaryMock,
   getScheduledJobByTime,
   isHolidayMock,
   loggerMock,
@@ -221,11 +222,31 @@ describe("timers: NYSE and MNC", () => {
     await Promise.resolve();
 
     expect(getMncMock).toHaveBeenCalledTimes(1);
+    expect(getMncSummaryMock).toHaveBeenCalledWith(Buffer.from("mnc-pdf"), expect.objectContaining({
+      logger: expect.any(Object),
+    }));
     expect(attachmentBuilderMock).toHaveBeenCalledWith(Buffer.from("mnc-pdf"), expect.objectContaining({
       name: expect.stringMatching(/^MNC-\d{4}-\d{2}-\d{2}\.pdf$/),
     }));
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringContaining("Morning News Call"),
+      files: expect.any(Array),
+    }));
+  });
+
+  test("startMncTimers includes a Gemini summary when available", async () => {
+    const {client, send} = createClientWithChannel();
+    getMncSummaryMock.mockResolvedValueOnce("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
+
+    startMncTimers(client, "channel-id");
+    const mncJob = getScheduledJobByTime(9, 0, "US/Eastern");
+
+    await mncJob.callback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining("**Morning News Call - TL;DR**"),
       files: expect.any(Array),
     }));
   });
@@ -239,6 +260,7 @@ describe("timers: NYSE and MNC", () => {
     await mncJob.callback();
 
     expect(attachmentBuilderMock).not.toHaveBeenCalled();
+    expect(getMncSummaryMock).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(loggerMock.log).toHaveBeenCalledWith("warn", "Skipping MNC announcement: no file downloaded.");
   });

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -25,6 +25,7 @@ import {
 import {addExpectedMovesToEarningsEvents, warmExpectedMoveCacheForEarningsEvents} from "./earnings-expected-move.ts";
 import {getLogger} from "./logging.ts";
 import {getMnc} from "./mnc-downloader.ts";
+import {getMncSummary} from "./mnc-summary.ts";
 import {type Ticker} from "./tickers.ts";
 import {
   getAllowedRoleMentions,
@@ -598,13 +599,21 @@ export function startMncTimers(client: TimerClient, channelID: string) {
     const shortDate = moment().format("YYYY-MM-DD");
     const fileName = `MNC-${shortDate}.pdf`;
     const mncFile = new AttachmentBuilder(buffer, {name: fileName});
+    const summary = await getMncSummary(buffer, {logger});
     await sendAnnouncement(
       client,
       channelID,
-      {content: `Morning News Call (${date})`, files: [mncFile]},
+      {content: getMncAnnouncementContent(date, summary), files: [mncFile]},
       "MNC",
     );
   });
+}
+
+function getMncAnnouncementContent(date: string, summary: string | undefined): string {
+  const title = `Morning News Call (${date})`;
+  return undefined === summary
+    ? title
+    : `${title}\n\n${summary}`;
 }
 
 export function startOtherTimers(

--- a/tools/docker-compose-production.yml
+++ b/tools/docker-compose-production.yml
@@ -49,6 +49,7 @@ services:
       - production_discord_10y_client_ID
       - production_discord_30y_token
       - production_discord_30y_client_ID
+      - production_gemini_api_key
       - production_dracoon_password
       - production_hblwrk_channel_NYSEAnnouncement_ID
       - production_hblwrk_channel_MNCAnnouncement_ID
@@ -146,6 +147,8 @@ secrets:
   production_discord_30y_token:
     external: true
   production_discord_30y_client_ID:
+    external: true
+  production_gemini_api_key:
     external: true
   production_dracoon_password:
     external: true


### PR DESCRIPTION
## Summary
- add optional Gemini client with JSON-schema responses, API-key secret support, and a default 14 calls/minute local limiter
- add AI-assisted SEC earnings extraction fallback plus suspicious-post quality gate and source-snippet validation
- add same-day ticker de-dupe for earnings results and optional Gemini MNC one-minute Discord summary

## Tests
- npm run typecheck
- npm run lint
- npm run test:coverage
- live MNC Gemini e2e with approved non-confidential MNC PDF