### PR TITLE
Add Gemini market close recap

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ echo -n "hunter8" | docker secret create production_hblwrk_channel_OtherAnnounce
 echo -n "hunter9" | docker secret create production_discord_btcusd_token -
 echo -n "hunter10" | docker secret create production_discord_btcusd_client_ID -
 echo -n "hunter11" | docker secret create production_gemini_api_key -
+echo -n "120" | docker secret create production_gemini_calls_per_minute -
+echo -n "5000" | docker secret create production_gemini_calls_per_day -
 ...
 ```
 
@@ -151,7 +153,8 @@ The health-check server port can be overridden via the `HEALTHCHECK_PORT` enviro
   "tastytrade_refresh_token": "",
   "gemini_api_key": "",
   "gemini_model": "gemini-2.5-flash-lite",
-  "gemini_calls_per_minute": "14",
+  "gemini_calls_per_minute": "9",
+  "gemini_calls_per_day": "18",
   "dracoon_password": "",
   "hblwrk_channel_NYSEAnnouncement_ID": "",
   "hblwrk_gainslosses_thread_ID": "",
@@ -200,7 +203,7 @@ If DRACOON downloads fail during startup, the bot keeps those assets marked as t
 
 ### Reminder assets
 
-Calendar reminders, earnings reminders, and earnings result announcements post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements are sent after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. Gemini-assisted SEC extraction and suspicious-post checks run when `gemini_api_key` is configured; the bot keeps XBRL and HTML parsing as the primary source and validates AI metrics against source snippets before posting. MNC announcements use the same optional Gemini access to add a one-minute Discord Markdown summary above the PDF attachment. `gemini_calls_per_minute` caps local Gemini calls and defaults to `14`, below the free-tier `gemini-2.5-flash-lite` hard limit of 15 requests per minute. They ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
+Calendar reminders, earnings reminders, and earnings result announcements post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements are sent after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. Gemini-assisted SEC extraction and suspicious-post checks run when `gemini_api_key` is configured; the bot keeps XBRL and HTML parsing as the primary source and validates AI metrics against source snippets before posting. MNC announcements use the same optional Gemini access to add a one-minute Discord Markdown summary above the PDF attachment. NYSE close announcements use optional Gemini search grounding to add a German close recap and match the day to the opening sentiment poll; if the bot restarts during the session, it recovers the poll from recent channel history when possible. `gemini_calls_per_minute` caps local Gemini calls and defaults to `9`; `gemini_calls_per_day` defaults to `18`. Deployments with a higher Gemini quota set `production_gemini_calls_per_minute` and `production_gemini_calls_per_day` to raise those local caps. Calendar and earnings reminders ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
 
 Calendar reminder assets are matched against the current day and sent at `08:30 Europe/Berlin`, immediately after the general daily calendar post. If multiple matching calendar items share the same release minute, the bot bundles them into a single reminder ping:
 

--- a/modules/gemini.test.ts
+++ b/modules/gemini.test.ts
@@ -1,0 +1,262 @@
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {callGeminiJson, clearGeminiState} from "./gemini.ts";
+
+describe("Gemini client", () => {
+  const logger = {
+    log: vi.fn(),
+  };
+  const responseJsonSchema = {
+    type: "object",
+    properties: {},
+  };
+  const readSecretFn = vi.fn((secretName: string) => {
+    if ("gemini_api_key" === secretName) {
+      return "gemini-key";
+    }
+
+    throw new Error(`missing ${secretName}`);
+  });
+  const successfulGeminiResponse = {
+    data: {
+      candidates: [{
+        content: {
+          parts: [{
+            text: "{}",
+          }],
+        },
+      }],
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearGeminiState();
+  });
+
+  test("activates a shared cooldown after API rate limiting", async () => {
+    const rateLimitError = {
+      response: {
+        headers: {
+          "retry-after": "30",
+        },
+        status: 429,
+      },
+    };
+    const postWithRetryFn = vi.fn().mockRejectedValue(rateLimitError);
+
+    await expect(callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(rateLimitError);
+
+    const skippedResult = await callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 2_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task");
+
+    expect(skippedResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini API returned 429; cooling down Gemini calls for 30s.",
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping Gemini test task: API rate-limit cooldown is active for 29s.",
+    );
+  });
+
+  test("uses a default cooldown when rate-limit responses omit retry-after", async () => {
+    const rateLimitError = {
+      response: {
+        headers: {},
+        status: 429,
+      },
+    };
+    const postWithRetryFn = vi.fn().mockRejectedValue(rateLimitError);
+
+    await expect(callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 10_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(rateLimitError);
+
+    const skippedResult = await callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 69_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task");
+
+    expect(skippedResult).toBeNull();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini API returned 429; cooling down Gemini calls for 60s.",
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping Gemini test task: API rate-limit cooldown is active for 1s.",
+    );
+  });
+
+  test("does not activate cooldown for non-rate-limit failures", async () => {
+    const serverError = {
+      response: {
+        headers: {},
+        status: 500,
+      },
+    };
+    const postWithRetryFn = vi.fn()
+      .mockRejectedValueOnce(serverError)
+      .mockResolvedValueOnce(successfulGeminiResponse);
+
+    await expect(callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(serverError);
+    const result = await callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 2_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task");
+
+    expect(result).toBe("{}");
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("cooling down"),
+    );
+  });
+
+  test("caps Gemini calls with the local per-day limiter", async () => {
+    const limitedReadSecretFn = vi.fn((secretName: string) => {
+      if ("gemini_api_key" === secretName) {
+        return "gemini-key";
+      }
+
+      if ("gemini_calls_per_day" === secretName) {
+        return "2";
+      }
+
+      if ("gemini_calls_per_minute" === secretName) {
+        return "10";
+      }
+
+      throw new Error(`missing ${secretName}`);
+    });
+    const postWithRetryFn = vi.fn().mockResolvedValue(successfulGeminiResponse);
+
+    await callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+    await callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 62_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+    const skippedResult = await callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 123_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+
+    expect(skippedResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping Gemini test task: local 2/day rate limit is exhausted.",
+    );
+  });
+
+  test("allows configured Gemini limits above the conservative defaults", async () => {
+    const limitedReadSecretFn = vi.fn((secretName: string) => {
+      if ("gemini_api_key" === secretName) {
+        return "gemini-key";
+      }
+
+      if ("gemini_calls_per_day" === secretName) {
+        return "25";
+      }
+
+      if ("gemini_calls_per_minute" === secretName) {
+        return "11";
+      }
+
+      throw new Error(`missing ${secretName}`);
+    });
+    const postWithRetryFn = vi.fn().mockResolvedValue(successfulGeminiResponse);
+
+    for (let index = 0; index < 11; index++) {
+      await callGeminiJson("prompt", responseJsonSchema, {
+        logger,
+        nowMs: () => 1_000,
+        postWithRetryFn,
+        readSecretFn: limitedReadSecretFn,
+      }, "test task");
+    }
+
+    expect(postWithRetryFn).toHaveBeenCalledTimes(11);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("rate limit is exhausted"),
+    );
+  });
+
+  test("parses numeric and HTTP-date retry-after headers", async () => {
+    const numericRateLimitError = {
+      response: {
+        headers: {
+          "Retry-After": 2,
+        },
+        status: 429,
+      },
+    };
+    const dateRateLimitError = {
+      response: {
+        headers: {
+          "retry-after": new Date(Date.now() + 5_000).toUTCString(),
+        },
+        status: 429,
+      },
+    };
+    const postWithRetryFn = vi.fn()
+      .mockRejectedValueOnce(numericRateLimitError)
+      .mockRejectedValueOnce(dateRateLimitError);
+
+    await expect(callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(numericRateLimitError);
+    clearGeminiState();
+    await expect(callGeminiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 2_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(dateRateLimitError);
+
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini API returned 429; cooling down Gemini calls for 2s.",
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      expect.stringMatching(/^Gemini API returned 429; cooling down Gemini calls for [1-5]s\.$/),
+    );
+  });
+});

--- a/modules/gemini.ts
+++ b/modules/gemini.ts
@@ -19,9 +19,11 @@ export type GeminiInlineData = {
 
 export type GeminiCallOptions = {
   timeoutMs?: number | undefined;
+  useGoogleSearch?: boolean | undefined;
 };
 
 type GeminiConfig = {
+  callsPerDay: number;
   apiKey: string;
   callsPerMinute: number;
   model: string;
@@ -50,15 +52,24 @@ const geminiApiEndpoint = "https://generativelanguage.googleapis.com/v1beta";
 const geminiApiKeySecret = "gemini_api_key";
 const geminiModelSecret = "gemini_model";
 const geminiCallsPerMinuteSecret = "gemini_calls_per_minute";
+const geminiCallsPerDaySecret = "gemini_calls_per_day";
 const defaultGeminiModel = "gemini-2.5-flash-lite";
-const defaultGeminiCallsPerMinute = 14;
-const maxGeminiCallsPerMinute = 30;
+const defaultGeminiCallsPerMinute = 9;
+const defaultGeminiCallsPerDay = 18;
+const maxGeminiCallsPerMinute = 1_000;
+const maxGeminiCallsPerDay = 100_000;
 const geminiWindowMs = 60_000;
+const geminiDayWindowMs = 24 * 60 * 60_000;
+const defaultGeminiRateLimitCooldownMs = 60_000;
 
 const geminiCallTimestampsMs: number[] = [];
+const geminiDailyCallTimestampsMs: number[] = [];
+let geminiCooldownUntilMs = 0;
 
 export function clearGeminiState() {
   geminiCallTimestampsMs.splice(0, geminiCallTimestampsMs.length);
+  geminiDailyCallTimestampsMs.splice(0, geminiDailyCallTimestampsMs.length);
+  geminiCooldownUntilMs = 0;
 }
 
 export async function callGeminiJson(
@@ -80,18 +91,24 @@ export async function callGeminiJson(
 
   const postWithRetryFn = dependencies.postWithRetryFn ?? postWithRetry;
   const parts = getGeminiContentParts(prompt, inlineData);
+  const requestBody = {
+    contents: [{
+      parts,
+    }],
+    generationConfig: {
+      responseMimeType: "application/json",
+      responseJsonSchema,
+      temperature: 0,
+    },
+    ...(true === options.useGoogleSearch ? {
+      tools: [{
+        google_search: {},
+      }],
+    } : {}),
+  };
   const response = await postWithRetryFn<GeminiGenerateContentResponse>(
     `${geminiApiEndpoint}/${getGeminiModelPath(config.model)}:generateContent`,
-    {
-      contents: [{
-        parts,
-      }],
-      generationConfig: {
-        responseMimeType: "application/json",
-        responseJsonSchema,
-        temperature: 0,
-      },
-    },
+    requestBody,
     {
       headers: {
         "Content-Type": "application/json",
@@ -102,7 +119,10 @@ export async function callGeminiJson(
       maxAttempts: 1,
       timeoutMs: options.timeoutMs ?? 15_000,
     },
-  );
+  ).catch(error => {
+    activateGeminiCooldownOnRateLimit(error, dependencies);
+    throw error;
+  });
 
   const firstCandidate = response.data.candidates?.[0];
   const textPart = firstCandidate?.content?.parts?.find(part => "string" === typeof part.text);
@@ -138,8 +158,10 @@ function getGeminiConfig(dependencies: GeminiDependencies): GeminiConfig | null 
 
   const model = readOptionalSecret(readSecretFn, geminiModelSecret) ?? defaultGeminiModel;
   const callsPerMinute = getGeminiCallsPerMinute(readOptionalSecret(readSecretFn, geminiCallsPerMinuteSecret));
+  const callsPerDay = getGeminiCallsPerDay(readOptionalSecret(readSecretFn, geminiCallsPerDaySecret));
   return {
     apiKey,
+    callsPerDay,
     callsPerMinute,
     model,
   };
@@ -167,15 +189,41 @@ function getGeminiCallsPerMinute(value: string | undefined): number {
   return Math.min(Math.max(parsedValue, 1), maxGeminiCallsPerMinute);
 }
 
+function getGeminiCallsPerDay(value: string | undefined): number {
+  if (undefined === value) {
+    return defaultGeminiCallsPerDay;
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+  if (false === Number.isFinite(parsedValue)) {
+    return defaultGeminiCallsPerDay;
+  }
+
+  return Math.min(Math.max(parsedValue, 1), maxGeminiCallsPerDay);
+}
+
 function reserveGeminiCall(
   config: GeminiConfig,
   dependencies: GeminiDependencies,
   task: string,
 ): boolean {
   const nowMs = dependencies.nowMs?.() ?? Date.now();
+  if (nowMs < geminiCooldownUntilMs) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping Gemini ${task}: API rate-limit cooldown is active for ${Math.ceil((geminiCooldownUntilMs - nowMs) / 1000)}s.`,
+    );
+    return false;
+  }
+
   const windowStartMs = nowMs - geminiWindowMs;
   while (0 < geminiCallTimestampsMs.length && (geminiCallTimestampsMs[0] ?? 0) <= windowStartMs) {
     geminiCallTimestampsMs.shift();
+  }
+
+  const dayWindowStartMs = nowMs - geminiDayWindowMs;
+  while (0 < geminiDailyCallTimestampsMs.length && (geminiDailyCallTimestampsMs[0] ?? 0) <= dayWindowStartMs) {
+    geminiDailyCallTimestampsMs.shift();
   }
 
   if (geminiCallTimestampsMs.length >= config.callsPerMinute) {
@@ -186,8 +234,82 @@ function reserveGeminiCall(
     return false;
   }
 
+  if (geminiDailyCallTimestampsMs.length >= config.callsPerDay) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping Gemini ${task}: local ${config.callsPerDay}/day rate limit is exhausted.`,
+    );
+    return false;
+  }
+
   geminiCallTimestampsMs.push(nowMs);
+  geminiDailyCallTimestampsMs.push(nowMs);
   return true;
+}
+
+function activateGeminiCooldownOnRateLimit(error: unknown, dependencies: GeminiDependencies) {
+  if (429 !== getHttpStatus(error)) {
+    return;
+  }
+
+  const nowMs = dependencies.nowMs?.() ?? Date.now();
+  const retryAfterMs = getRetryAfterMs(error) ?? defaultGeminiRateLimitCooldownMs;
+  geminiCooldownUntilMs = Math.max(geminiCooldownUntilMs, nowMs + retryAfterMs);
+  dependencies.logger.log(
+    "warn",
+    `Gemini API returned 429; cooling down Gemini calls for ${Math.ceil(retryAfterMs / 1000)}s.`,
+  );
+}
+
+function getHttpStatus(error: unknown): number | undefined {
+  if (false === isRecord(error)) {
+    return undefined;
+  }
+
+  const response = error["response"];
+  if (false === isRecord(response)) {
+    return undefined;
+  }
+
+  const status = response["status"];
+  return "number" === typeof status ? status : undefined;
+}
+
+function getRetryAfterMs(error: unknown): number | undefined {
+  if (false === isRecord(error)) {
+    return undefined;
+  }
+
+  const response = error["response"];
+  if (false === isRecord(response)) {
+    return undefined;
+  }
+
+  const headers = response["headers"];
+  if (false === isRecord(headers)) {
+    return undefined;
+  }
+
+  const retryAfter = headers["retry-after"] ?? headers["Retry-After"];
+  if ("number" === typeof retryAfter && Number.isFinite(retryAfter)) {
+    return Math.max(1, retryAfter) * 1_000;
+  }
+
+  if ("string" !== typeof retryAfter || "" === retryAfter.trim()) {
+    return undefined;
+  }
+
+  const retryAfterSeconds = Number.parseInt(retryAfter, 10);
+  if (Number.isFinite(retryAfterSeconds)) {
+    return Math.max(1, retryAfterSeconds) * 1_000;
+  }
+
+  const retryAfterTimestampMs = Date.parse(retryAfter);
+  if (false === Number.isFinite(retryAfterTimestampMs)) {
+    return undefined;
+  }
+
+  return Math.max(1_000, retryAfterTimestampMs - Date.now());
 }
 
 function getGeminiModelPath(model: string): string {
@@ -199,4 +321,8 @@ function getGeminiModelPath(model: string): string {
   return normalizedModel.startsWith("models/")
     ? normalizedModel
     : `models/${normalizedModel}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
 }

--- a/modules/market-close-recap.test.ts
+++ b/modules/market-close-recap.test.ts
@@ -1,0 +1,417 @@
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {clearGeminiState} from "./gemini.ts";
+import {
+  findMarketOpenSentimentPollMessage,
+  getMarketCloseRecap,
+} from "./market-close-recap.ts";
+
+describe("market close recap", () => {
+  const logger = {
+    log: vi.fn(),
+  };
+  const readSecretFn = vi.fn((secretName: string) => {
+    if ("gemini_api_key" === secretName) {
+      return "gemini-key";
+    }
+
+    throw new Error(`missing ${secretName}`);
+  });
+  const validRecapJson = {
+    sentimentTitle: "ruhiger Risikoappetit",
+    summaryMarkdown: "`SPX` schloss über dem Open. Der `VIX` fiel um `1,1 Punkte`.",
+    winningPollAnswer: "Risk-on",
+  };
+
+  function createPostWithRecap(overrides: Record<string, unknown> = {}) {
+    return vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                ...validRecapJson,
+                ...overrides,
+              }),
+            }],
+          },
+        }],
+      },
+    });
+  }
+
+  function createPollMessage(answerText: string, fetch: ReturnType<typeof vi.fn>) {
+    return {
+      poll: {
+        answers: new Map([
+          [1, {id: 1, text: answerText, voters: {fetch}}],
+        ]),
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearGeminiState();
+  });
+
+  test("generates a German grounded close recap and mentions voters who picked the matching sentiment", async () => {
+    const chaosVotersFetch = vi.fn().mockResolvedValue(new Map([
+      ["123", {id: "123"}],
+      ["456", {id: "456"}],
+    ]));
+    const pollMessage = {
+      poll: {
+        answers: new Map([
+          [1, {id: 1, text: "Risk-on", voters: {fetch: vi.fn()}}],
+          [2, {id: 2, text: "Risk-off", voters: {fetch: vi.fn()}}],
+          [3, {id: 3, text: "Cash", voters: {fetch: vi.fn()}}],
+          [4, {id: 4, text: "Chaos", voters: {fetch: chaosVotersFetch}}],
+        ]),
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                sentimentTitle: "wildes Hin und Her mit bullischem Finish",
+                summaryMarkdown: [
+                  "`SPX` und `RTY` schlossen über dem Open, während `NQ` nur knapp behauptet war.",
+                  "Der `VIX` fiel von `19,2` auf `17,8` und damit um `1,4 Punkte`.",
+                ].join("\n"),
+                winningPollAnswer: "Chaos",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const recap = await getMarketCloseRecap(pollMessage, {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    }, {
+      date: new Date("2026-05-05T20:10:00Z"),
+    });
+
+    expect(recap).toEqual({
+      allowedUserIds: ["123", "456"],
+      content: expect.stringContaining("**Börsenschluss - Kurzüberblick**"),
+    });
+    expect(recap?.content).toContain("Das heutige Sentiment war: **🎢 Chaos**");
+    expect(recap?.content).toContain("<@123> <@456>");
+    expect(recap?.content).not.toContain("Gemini");
+    expect(chaosVotersFetch).toHaveBeenCalledWith({
+      limit: 100,
+    });
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      expect.stringContaining("gemini-2.5-flash-lite:generateContent"),
+      expect.objectContaining({
+        tools: [{
+          google_search: {},
+        }],
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-goog-api-key": "gemini-key",
+        }),
+      }),
+      expect.objectContaining({
+        timeoutMs: 45_000,
+      }),
+    );
+    const requestBody = postWithRetryFn.mock.calls[0]?.[1] as {contents?: {parts?: {text?: string}[]}[]};
+    expect(requestBody.contents?.[0]?.parts?.[0]?.text).toContain("Der `VIX` darf niemals als Prozentwert beschrieben werden.");
+  });
+
+  test("stays disabled when the Gemini API key is missing", async () => {
+    const postWithRetryFn = vi.fn();
+
+    const recap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn,
+      readSecretFn: vi.fn(() => {
+        throw new Error("missing secret");
+      }),
+    });
+
+    expect(recap).toBeUndefined();
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+  });
+
+  test("omits voter mentions when no poll can be recovered", async () => {
+    const recap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    expect(recap?.allowedUserIds).toEqual([]);
+    expect(recap?.content).toContain("Das heutige Sentiment war: **🟢 Risk-on**");
+    expect(recap?.content).not.toContain("Richtig gelegen");
+  });
+
+  test("handles an empty sentiment title and truncates long summaries", async () => {
+    const longSummary = [
+      "`VIX` fiel um `1,1 Punkte`.",
+      ...Array.from({length: 40}, (_value, index) => `Zeile ${index} mit genug Text, damit die Zusammenfassung sicher gekürzt werden muss.`),
+    ].join("\n");
+
+    const recap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        sentimentTitle: "",
+        summaryMarkdown: longSummary,
+      }),
+      readSecretFn,
+    });
+
+    expect(recap?.content).toContain("Das heutige Sentiment war: **🟢 Risk-on**");
+    expect(recap?.content).not.toContain("**🟢 Risk-on** -");
+    expect(recap?.content).toContain("\n...");
+  });
+
+  test("renders an empty winner section only when voter fetching succeeds", async () => {
+    const votersFetch = vi.fn().mockResolvedValue(new Map());
+    const recap = await getMarketCloseRecap(createPollMessage("Risk-on", votersFetch), {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    expect(recap?.allowedUserIds).toEqual([]);
+    expect(recap?.content).toContain("Richtig gelegen hat heute niemand im Opening-Poll.");
+  });
+
+  test("limits mentions while counting additional fetched voters", async () => {
+    const firstPageUsers = Array.from({length: 100}, (_value, index) => {
+      const id = String(index + 1).padStart(3, "0");
+      return [id, {id}] as const;
+    });
+    const votersFetch = vi.fn()
+      .mockResolvedValueOnce(new Map(firstPageUsers))
+      .mockResolvedValueOnce(new Map([["101", {id: "101"}]]));
+
+    const recap = await getMarketCloseRecap(createPollMessage("Risk-on", votersFetch), {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    }, {
+      maxFetchedWinners: 101,
+      maxMentionedWinners: 1,
+    });
+
+    expect(recap?.allowedUserIds).toEqual(["001"]);
+    expect(recap?.content).toContain("<@001>");
+    expect(recap?.content).toContain("und `100` weitere.");
+    expect(votersFetch).toHaveBeenNthCalledWith(2, {
+      after: "100",
+      limit: 1,
+    });
+  });
+
+  test("omits voter mentions when the matching answer has no fetchable voters", async () => {
+    const recap = await getMarketCloseRecap({
+      poll: {
+        answers: [{id: 1, text: "Risk-on"}],
+      },
+    }, {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    expect(recap?.content).not.toContain("Richtig gelegen");
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping market close recap voter mentions: poll answer Risk-on is not fetchable.",
+    );
+  });
+
+  test("omits voter mentions when voter fetching fails", async () => {
+    const votersFetch = vi.fn().mockRejectedValue(new Error("discord down"));
+    const recap = await getMarketCloseRecap(createPollMessage("Risk-on", votersFetch), {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    expect(recap?.content).not.toContain("Richtig gelegen");
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("Could not fetch market close recap poll voters"),
+    );
+  });
+
+  test("rejects recaps that quote VIX in percent", async () => {
+    const postWithRetryFn = createPostWithRecap({
+      sentimentTitle: "risk-off",
+      summaryMarkdown: "`SPX` fiel vom Open. Der `VIX` stieg um `8%`.",
+      winningPollAnswer: "Risk-off",
+    });
+
+    const recap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(recap).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini market close recap failed output validation.",
+    );
+  });
+
+  test("rejects invalid or incomplete Gemini responses", async () => {
+    const invalidJsonRecap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: vi.fn().mockResolvedValue({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: "{not-json",
+              }],
+            },
+          }],
+        },
+      }),
+      readSecretFn,
+    });
+    const missingFieldRecap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        winningPollAnswer: "Unknown",
+      }),
+      readSecretFn,
+    });
+
+    expect(invalidJsonRecap).toBeUndefined();
+    expect(missingFieldRecap).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini market close recap returned invalid JSON.",
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini market close recap response missed required fields.",
+    );
+  });
+
+  test("rejects output that mentions the provider or omits VIX", async () => {
+    const providerMentionRecap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        summaryMarkdown: "Gemini sagt: `SPX` war fest und der `VIX` fiel um `1 Punkt`.",
+      }),
+      readSecretFn,
+    });
+    const missingVixRecap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        summaryMarkdown: "`SPX` war fest und `QQQ` erholte sich.",
+      }),
+      readSecretFn,
+    });
+
+    expect(providerMentionRecap).toBeUndefined();
+    expect(missingVixRecap).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Gemini market close recap failed output validation.",
+    );
+  });
+
+  test("recovers today's opening sentiment poll from message history", async () => {
+    const yesterdayPoll = {
+      createdTimestamp: new Date("2026-05-04T13:30:00Z").getTime(),
+      poll: {
+        answers: new Map([[1, {id: 1, text: "Risk-on"}]]),
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+    const todayPoll = {
+      createdTimestamp: new Date("2026-05-05T13:30:00Z").getTime(),
+      poll: {
+        answers: new Map([[1, {id: 1, text: "Risk-on"}]]),
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+    const channel = {
+      messages: {
+        fetch: vi.fn().mockResolvedValue(new Map([
+          ["old", yesterdayPoll],
+          ["new", todayPoll],
+        ])),
+      },
+    };
+
+    const poll = await findMarketOpenSentimentPollMessage(channel, {
+      logger,
+    }, {
+      date: new Date("2026-05-05T20:10:00Z"),
+    });
+
+    expect(poll).toBe(todayPoll);
+    expect(channel.messages.fetch).toHaveBeenCalledWith({
+      limit: 50,
+    });
+  });
+
+  test("recovers an opening sentiment poll from array history with createdAt", async () => {
+    const todayPoll = {
+      createdAt: new Date("2026-05-05T13:30:00Z"),
+      poll: {
+        answers: [{id: 1, text: "Risk-on"}],
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+
+    const poll = await findMarketOpenSentimentPollMessage({
+      messages: {
+        fetch: vi.fn().mockResolvedValue([todayPoll]),
+      },
+    }, {
+      logger,
+    }, {
+      date: new Date("2026-05-05T20:10:00Z"),
+    });
+
+    expect(poll).toBe(todayPoll);
+  });
+
+  test("handles missing or failing poll history lookup", async () => {
+    const missingPoll = await findMarketOpenSentimentPollMessage({}, {
+      logger,
+    });
+    const failingPoll = await findMarketOpenSentimentPollMessage({
+      messages: {
+        fetch: vi.fn().mockRejectedValue(new Error("missing history")),
+      },
+    }, {
+      logger,
+    });
+
+    expect(missingPoll).toBeUndefined();
+    expect(failingPoll).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("Could not recover NYSE opening sentiment poll"),
+    );
+  });
+});

--- a/modules/market-close-recap.ts
+++ b/modules/market-close-recap.ts
@@ -1,0 +1,531 @@
+import moment from "moment-timezone";
+import {callGeminiJson, type GeminiDependencies} from "./gemini.ts";
+
+export type MarketCloseSentimentAnswer = "Risk-on" | "Risk-off" | "Cash" | "Chaos";
+
+export type MarketCloseRecapPayload = {
+  allowedUserIds: string[];
+  content: string;
+};
+
+export type MarketCloseRecapDependencies = GeminiDependencies;
+
+export type MarketCloseRecapOptions = {
+  date?: Date | undefined;
+  maxFetchedWinners?: number | undefined;
+  maxMentionedWinners?: number | undefined;
+};
+
+type PollAnswerFetchOptions = {
+  after?: string | undefined;
+  limit?: number | undefined;
+};
+
+type PollAnswerVoters = {
+  fetch?: (options?: PollAnswerFetchOptions) => Promise<unknown> | unknown;
+};
+
+type PollAnswerLike = {
+  id?: number | undefined;
+  text?: string | null | undefined;
+  voters?: PollAnswerVoters | undefined;
+};
+
+type PollLike = {
+  answers?: unknown;
+  question?: {
+    text?: string | null | undefined;
+  } | undefined;
+};
+
+type PollMessageLike = {
+  createdAt?: Date | undefined;
+  createdTimestamp?: number | undefined;
+  poll?: PollLike | null | undefined;
+};
+
+type GeminiMarketCloseRecap = {
+  sentimentTitle?: string | undefined;
+  summaryMarkdown: string;
+  winningPollAnswer: MarketCloseSentimentAnswer;
+};
+
+const usEasternTimezone = "US/Eastern";
+const defaultMaxFetchedWinners = 200;
+const defaultMaxMentionedWinners = 20;
+const marketOpenSentimentPollQuestion = "Opening Sentiment: Wie geht ihr in den Handel?";
+const marketOpenPollHistoryLimit = 50;
+const maxSummaryMarkdownLength = 1_100;
+const maxRecapContentLength = 1_950;
+
+const sentimentLabels = {
+  "Risk-on": "🟢 Risk-on",
+  "Risk-off": "🔴 Risk-off",
+  "Cash": "💵 Cash",
+  "Chaos": "🎢 Chaos",
+} satisfies Record<MarketCloseSentimentAnswer, string>;
+
+const marketCloseRecapSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    summaryMarkdown: {
+      type: "string",
+      description: "A short German market-close summary in Discord-compatible Markdown.",
+    },
+    winningPollAnswer: {
+      type: "string",
+      enum: ["Risk-on", "Risk-off", "Cash", "Chaos"],
+      description: "The opening sentiment poll answer that best matched the US cash session from open to close.",
+    },
+    sentimentTitle: {
+      type: "string",
+      description: "A concise German label for the session, without mentioning any AI provider.",
+    },
+  },
+  required: ["summaryMarkdown", "winningPollAnswer", "sentimentTitle"],
+} satisfies Record<string, unknown>;
+
+export async function getMarketCloseRecap(
+  pollMessage: unknown,
+  dependencies: MarketCloseRecapDependencies,
+  options: MarketCloseRecapOptions = {},
+): Promise<MarketCloseRecapPayload | undefined> {
+  const jsonText = await callGeminiJson(
+    getMarketCloseRecapPrompt(options.date ?? new Date()),
+    marketCloseRecapSchema,
+    dependencies,
+    "market close recap",
+    undefined,
+    {
+      timeoutMs: 45_000,
+      useGoogleSearch: true,
+    },
+  ).catch(error => {
+    dependencies.logger.log(
+      "warn",
+      `Gemini market close recap failed: ${error}`,
+    );
+    return null;
+  });
+  if (null === jsonText) {
+    return undefined;
+  }
+
+  const recap = parseGeminiMarketCloseRecap(jsonText, dependencies);
+  if (undefined === recap) {
+    return undefined;
+  }
+
+  const rightVoterIds = await getRightVoterIds(pollMessage, recap.winningPollAnswer, dependencies, options);
+  const mentionedUserIds = rightVoterIds?.slice(0, options.maxMentionedWinners ?? defaultMaxMentionedWinners) ?? [];
+  const content = buildMarketCloseRecapContent(recap, rightVoterIds?.length, mentionedUserIds);
+  return {
+    allowedUserIds: mentionedUserIds,
+    content,
+  };
+}
+
+export async function findMarketOpenSentimentPollMessage(
+  channel: unknown,
+  dependencies: Pick<MarketCloseRecapDependencies, "logger">,
+  options: Pick<MarketCloseRecapOptions, "date"> = {},
+): Promise<PollMessageLike | undefined> {
+  const messages = getMessageManager(channel);
+  const fetchMessages = messages?.fetch;
+  if ("function" !== typeof fetchMessages) {
+    return undefined;
+  }
+
+  const fetchedMessages = await Promise.resolve(fetchMessages({
+    limit: marketOpenPollHistoryLimit,
+  })).catch(error => {
+    dependencies.logger.log(
+      "warn",
+      `Could not recover NYSE opening sentiment poll from message history: ${error}`,
+    );
+    return undefined;
+  });
+  const targetDate = options.date ?? new Date();
+  return getMessages(fetchedMessages)
+    .filter(message => true === isSentimentPollMessage(message))
+    .filter(message => true === isSameUsEasternDate(message, targetDate))
+    .sort((left, right) => getMessageTimestamp(right) - getMessageTimestamp(left))[0];
+}
+
+function getMessageManager(channel: unknown): {fetch?: (options?: {limit?: number | undefined}) => Promise<unknown> | unknown} | undefined {
+  if (false === isRecord(channel)) {
+    return undefined;
+  }
+
+  const messages = channel["messages"];
+  if (false === isRecord(messages)) {
+    return undefined;
+  }
+
+  const fetch = messages["fetch"];
+  if ("function" !== typeof fetch) {
+    return {};
+  }
+
+  const fetchFn = fetch as (this: unknown, options?: {limit?: number | undefined}) => Promise<unknown> | unknown;
+  return {
+    fetch: options => fetchFn.call(messages, options),
+  };
+}
+
+function getMarketCloseRecapPrompt(date: Date): string {
+  const usEasternDate = moment(date).tz(usEasternTimezone).format("YYYY-MM-DD");
+  return [
+    `Heute ist nach US-Börsenschluss am ${usEasternDate} (US/Eastern).`,
+    "Nutze Google Search, um den US-Cash-Handelstag realitätsnah einzuordnen.",
+    "Bewerte den Handelstag vom regulären US-Open bis zum regulären US-Close.",
+    "Berücksichtige `SPX` oder `SPY`, `NQ` oder `QQQ`, `RTY` oder `IWM` sowie zwingend den `VIX`.",
+    "Der `VIX` darf niemals als Prozentwert beschrieben werden. Beschreibe ihn nur als Stand, Veränderung in Punkten oder Richtung, z.B. `18,4` auf `20,1` oder `+1,7 Punkte`.",
+    "Wähle genau eine passende Antwort aus dem Opening-Sentiment-Poll:",
+    "- Risk-on: breite Stärke, fallender oder ruhiger `VIX`, Risikoappetit.",
+    "- Risk-off: breite Schwäche, steigender `VIX`, Defensive/Absicherung dominiert.",
+    "- Cash: wenig Richtung, dünne Signale, abwartender Handel.",
+    "- Chaos: starke Reversals, gemischte Indizes, hohe Intraday-Spanne, headline-getriebener oder schwer lesbarer Handel.",
+    "Return only JSON matching the schema. Do not include Markdown outside JSON strings.",
+    "Schreibe `summaryMarkdown` auf Deutsch für einen Discord-Trading-Channel.",
+    "Halte `summaryMarkdown` unter 1.000 Zeichen.",
+    "Nutze 2-4 kurze Absätze oder Bulletpoints.",
+    "Formatiere Ticker und konkrete Kennzahlen als Inline-Code, z.B. `SPX`, `QQQ`, `+0,4%`, `1,7 Punkte`.",
+    "Erwähne weder Gemini noch KI, Modell, Google Search, Quellen, Grounding oder Rechercheprozess.",
+    "Keine Disclaimer, keine Links, keine Tabellen, keine Codeblöcke.",
+  ].join("\n");
+}
+
+function parseGeminiMarketCloseRecap(
+  jsonText: string,
+  dependencies: MarketCloseRecapDependencies,
+): GeminiMarketCloseRecap | undefined {
+  const parsedJson = parseJson(jsonText);
+  if (false === isRecord(parsedJson)) {
+    dependencies.logger.log(
+      "warn",
+      "Gemini market close recap returned invalid JSON.",
+    );
+    return undefined;
+  }
+
+  const summaryMarkdown = parsedJson["summaryMarkdown"];
+  const winningPollAnswer = parsedJson["winningPollAnswer"];
+  const sentimentTitle = parsedJson["sentimentTitle"];
+  if ("string" !== typeof summaryMarkdown ||
+      false === isMarketCloseSentimentAnswer(winningPollAnswer) ||
+      "string" !== typeof sentimentTitle) {
+    dependencies.logger.log(
+      "warn",
+      "Gemini market close recap response missed required fields.",
+    );
+    return undefined;
+  }
+
+  const normalizedSummary = truncateSummary(normalizeMarkdown(summaryMarkdown));
+  const normalizedTitle = normalizeSingleLine(sentimentTitle);
+  const combinedText = `${normalizedSummary}\n${normalizedTitle}`;
+  if ("" === normalizedSummary ||
+      false === /\bVIX\b/i.test(combinedText) ||
+      true === hasForbiddenProviderMention(combinedText) ||
+      true === hasVixPercent(combinedText)) {
+    dependencies.logger.log(
+      "warn",
+      "Gemini market close recap failed output validation.",
+    );
+    return undefined;
+  }
+
+  return {
+    sentimentTitle: normalizedTitle,
+    summaryMarkdown: normalizedSummary,
+    winningPollAnswer,
+  };
+}
+
+function buildMarketCloseRecapContent(
+  recap: GeminiMarketCloseRecap,
+  totalRightVoterCount: number | undefined,
+  mentionedUserIds: string[],
+): string {
+  const sentimentLine = getSentimentLine(recap);
+  const voterSection = getVoterSection(totalRightVoterCount, mentionedUserIds);
+  return truncateRecapContent([
+    "**Börsenschluss - Kurzüberblick**",
+    recap.summaryMarkdown,
+    sentimentLine,
+    voterSection,
+  ].filter(line => "" !== line).join("\n\n"));
+}
+
+function getSentimentLine(recap: GeminiMarketCloseRecap): string {
+  const answerLabel = sentimentLabels[recap.winningPollAnswer];
+  if (undefined === recap.sentimentTitle || "" === recap.sentimentTitle) {
+    return `Das heutige Sentiment war: **${answerLabel}**`;
+  }
+
+  return `Das heutige Sentiment war: **${answerLabel}** - ${recap.sentimentTitle}`;
+}
+
+function getVoterSection(totalRightVoterCount: number | undefined, mentionedUserIds: string[]): string {
+  if (undefined === totalRightVoterCount) {
+    return "";
+  }
+
+  if (0 === totalRightVoterCount) {
+    return "Richtig gelegen hat heute niemand im Opening-Poll.";
+  }
+
+  const suffix = totalRightVoterCount > mentionedUserIds.length
+    ? `\nund \`${totalRightVoterCount - mentionedUserIds.length}\` weitere.`
+    : "";
+  return `Richtig gelegen haben:\n${mentionedUserIds.map(userId => `<@${userId}>`).join(" ")}${suffix}`;
+}
+
+async function getRightVoterIds(
+  pollMessage: unknown,
+  winningPollAnswer: MarketCloseSentimentAnswer,
+  dependencies: MarketCloseRecapDependencies,
+  options: MarketCloseRecapOptions,
+): Promise<string[] | undefined> {
+  const answer = getPollAnswerByText(pollMessage, winningPollAnswer);
+  if (undefined === answer) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping market close recap voter mentions: poll answer ${winningPollAnswer} was not found.`,
+    );
+    return undefined;
+  }
+
+  const fetchVoters = answer.voters?.fetch;
+  if ("function" !== typeof fetchVoters) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping market close recap voter mentions: poll answer ${winningPollAnswer} is not fetchable.`,
+    );
+    return undefined;
+  }
+
+  const maxFetchedWinners = options.maxFetchedWinners ?? defaultMaxFetchedWinners;
+  const voterIds: string[] = [];
+  let after: string | undefined;
+  while (voterIds.length < maxFetchedWinners) {
+    const limit = Math.min(100, maxFetchedWinners - voterIds.length);
+    const voters = await Promise.resolve(fetchVoters.call(answer.voters, {
+      ...(undefined === after ? {} : {after}),
+      limit,
+    })).catch(error => {
+      dependencies.logger.log(
+        "warn",
+        `Could not fetch market close recap poll voters: ${error}`,
+      );
+      return undefined;
+    });
+    if (undefined === voters) {
+      return undefined;
+    }
+
+    const pageUserIds = getUserIds(voters).filter(userId => false === voterIds.includes(userId));
+    if (0 === pageUserIds.length) {
+      break;
+    }
+
+    voterIds.push(...pageUserIds);
+    if (pageUserIds.length < limit) {
+      break;
+    }
+
+    after = pageUserIds[pageUserIds.length - 1];
+  }
+
+  return voterIds;
+}
+
+function getPollAnswerByText(
+  pollMessage: unknown,
+  answerText: MarketCloseSentimentAnswer,
+): PollAnswerLike | undefined {
+  return getPollAnswers(pollMessage).find(answer => answer.text === answerText);
+}
+
+function isSentimentPollMessage(message: PollMessageLike): boolean {
+  return message.poll?.question?.text === marketOpenSentimentPollQuestion &&
+    0 < getPollAnswers(message).length;
+}
+
+function isSameUsEasternDate(message: PollMessageLike, date: Date): boolean {
+  const timestamp = getMessageTimestamp(message);
+  if (0 === timestamp) {
+    return true;
+  }
+
+  return moment(timestamp).tz(usEasternTimezone).format("YYYY-MM-DD") ===
+    moment(date).tz(usEasternTimezone).format("YYYY-MM-DD");
+}
+
+function getMessageTimestamp(message: PollMessageLike): number {
+  if ("number" === typeof message.createdTimestamp && Number.isFinite(message.createdTimestamp)) {
+    return message.createdTimestamp;
+  }
+
+  const createdAtTime = message.createdAt?.getTime();
+  return "number" === typeof createdAtTime && Number.isFinite(createdAtTime) ? createdAtTime : 0;
+}
+
+function getMessages(value: unknown): PollMessageLike[] {
+  if (undefined === value || null === value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter(isPollMessageLike);
+  }
+
+  if (isRecord(value)) {
+    const values = value["values"];
+    if ("function" === typeof values) {
+      const valuesFn = values as (this: unknown) => Iterable<unknown>;
+      return Array.from(valuesFn.call(value)).filter(isPollMessageLike);
+    }
+
+    return Object.values(value).filter(isPollMessageLike);
+  }
+
+  return [];
+}
+
+function getPollAnswers(pollMessage: unknown): PollAnswerLike[] {
+  if (false === isPollMessageLike(pollMessage)) {
+    return [];
+  }
+
+  const answers = pollMessage.poll?.answers;
+  if (undefined === answers || null === answers) {
+    return [];
+  }
+
+  if (Array.isArray(answers)) {
+    return answers.filter(isPollAnswerLike);
+  }
+
+  if (isRecord(answers)) {
+    const values = answers["values"];
+    if ("function" === typeof values) {
+      const valuesFn = values as (this: unknown) => Iterable<unknown>;
+      return Array.from(valuesFn.call(answers)).filter(isPollAnswerLike);
+    }
+
+    return Object.values(answers).filter(isPollAnswerLike);
+  }
+
+  return [];
+}
+
+function getUserIds(value: unknown): string[] {
+  if (undefined === value || null === value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(getUserIds);
+  }
+
+  if (isRecord(value)) {
+    const id = value["id"];
+    if ("string" === typeof id && "" !== id.trim()) {
+      return [id.trim()];
+    }
+
+    const values = value["values"];
+    if ("function" === typeof values) {
+      const valuesFn = values as (this: unknown) => Iterable<unknown>;
+      return Array.from(valuesFn.call(value)).flatMap(getUserIds);
+    }
+
+    const users = value["users"];
+    if (Array.isArray(users)) {
+      return users.flatMap(getUserIds);
+    }
+  }
+
+  return [];
+}
+
+function normalizeMarkdown(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map(line => line.trimEnd())
+    .filter(line => false === /^```/.test(line.trim()))
+    .join("\n")
+    .trim();
+}
+
+function normalizeSingleLine(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+}
+
+function truncateSummary(value: string): string {
+  if (value.length <= maxSummaryMarkdownLength) {
+    return value;
+  }
+
+  const truncatedValue = value.slice(0, maxSummaryMarkdownLength - 8);
+  const lastLineBreak = truncatedValue.lastIndexOf("\n");
+  const summary = lastLineBreak > 0
+    ? truncatedValue.slice(0, lastLineBreak)
+    : truncatedValue;
+  return `${summary.trimEnd()}\n...`;
+}
+
+function truncateRecapContent(value: string): string {
+  if (value.length <= maxRecapContentLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxRecapContentLength - 4).trimEnd()}\n...`;
+}
+
+function hasForbiddenProviderMention(value: string): boolean {
+  return /\b(Gemini|KI|Künstliche Intelligenz|Modell|Google Search|Grounding)\b/iu.test(value);
+}
+
+function hasVixPercent(value: string): boolean {
+  return /\bVIX\b[^\n.?!;:]*[+-]?\d+(?:[,.]\d+)?\s*%/iu.test(value);
+}
+
+function isMarketCloseSentimentAnswer(value: unknown): value is MarketCloseSentimentAnswer {
+  return "Risk-on" === value ||
+    "Risk-off" === value ||
+    "Cash" === value ||
+    "Chaos" === value;
+}
+
+function isPollAnswerLike(value: unknown): value is PollAnswerLike {
+  if (false === isRecord(value)) {
+    return false;
+  }
+
+  const text = value["text"];
+  return "string" === typeof text && isMarketCloseSentimentAnswer(text);
+}
+
+function isPollMessageLike(value: unknown): value is PollMessageLike {
+  return isRecord(value) && "poll" in value;
+}
+
+function parseJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
+}

--- a/modules/test-utils/timers.ts
+++ b/modules/test-utils/timers.ts
@@ -37,6 +37,8 @@ const addExpectedMovesToEarningsEventsMock = vi.fn();
 const warmExpectedMoveCacheForEarningsEventsMock = vi.fn();
 const getEarningsResultMock = vi.fn();
 const getEarningsMessagesMock = vi.fn();
+const findMarketOpenSentimentPollMessageMock = vi.fn();
+const getMarketCloseRecapMock = vi.fn();
 const getMncMock = vi.fn();
 const getMncSummaryMock = vi.fn();
 const loggerMock = {
@@ -94,6 +96,11 @@ vi.mock("../earnings-expected-move.ts", () => ({
 
 vi.mock("../mnc-downloader.ts", () => ({
   getMnc: (...args: unknown[]) => getMncMock(...args),
+}));
+
+vi.mock("../market-close-recap.ts", () => ({
+  findMarketOpenSentimentPollMessage: (...args: unknown[]) => findMarketOpenSentimentPollMessageMock(...args),
+  getMarketCloseRecap: (...args: unknown[]) => getMarketCloseRecapMock(...args),
 }));
 
 vi.mock("../mnc-summary.ts", () => ({
@@ -234,6 +241,8 @@ export function resetTimerMocks() {
     totalEvents: 1,
     includedEvents: 1,
   });
+  findMarketOpenSentimentPollMessageMock.mockResolvedValue(undefined);
+  getMarketCloseRecapMock.mockResolvedValue(undefined);
   getCalendarEventsMock.mockResolvedValue([]);
   getCalendarEventsResultMock.mockResolvedValue({
     events: [],
@@ -258,6 +267,7 @@ export {
   attachmentBuilderMock,
   createClientWithChannel,
   createClientWithoutChannel,
+  findMarketOpenSentimentPollMessageMock,
   getAssetByNameMock,
   getCalendarEventsMock,
   getCalendarEventsResultMock,
@@ -267,6 +277,7 @@ export {
   getEarningsResultMock,
   getHolidaysMock,
   getMncMock,
+  getMarketCloseRecapMock,
   getMncSummaryMock,
   getScheduledDateJobs,
   getScheduledJobByTime,

--- a/modules/timers.test.ts
+++ b/modules/timers.test.ts
@@ -3,7 +3,9 @@ import {
   attachmentBuilderMock,
   createClientWithChannel,
   createClientWithoutChannel,
+  findMarketOpenSentimentPollMessageMock,
   getHolidaysMock,
+  getMarketCloseRecapMock,
   getMncMock,
   getMncSummaryMock,
   getScheduledJobByTime,
@@ -32,7 +34,7 @@ describe("timers: NYSE and MNC", () => {
     startNyseTimers(client, "channel-id");
     const premarketJob = getScheduledJobByTime(4, 0, "US/Eastern");
 
-    expect(scheduleJobMock).toHaveBeenCalledTimes(8);
+    expect(scheduleJobMock).toHaveBeenCalledTimes(10);
     expect(premarketJob.rule).toEqual(expect.objectContaining({
       hour: 4,
       minute: 0,
@@ -191,6 +193,88 @@ describe("timers: NYSE and MNC", () => {
     closeJob.callback();
 
     expect(send).toHaveBeenCalledWith(expect.stringContaining("<#thread-id>"));
+  });
+
+  test("startNyseTimers posts optional market close recap with poll winners", async () => {
+    const {client, send} = createClientWithChannel();
+    const pollMessage = {
+      poll: {
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+    send.mockResolvedValueOnce(pollMessage);
+    getMarketCloseRecapMock.mockResolvedValueOnce({
+      allowedUserIds: ["123", "456"],
+      content: "**Börsenschluss - Kurzüberblick**\n`VIX` fiel um `1,2 Punkte`.",
+    });
+
+    startNyseTimers(client, "channel-id");
+    const openJob = getScheduledJobByTime(9, 30, "US/Eastern");
+    openJob.callback();
+    await flushAsyncJobs();
+
+    const recapJob = getScheduledJobByTime(16, 10, "US/Eastern");
+    await recapJob.callback();
+    await flushAsyncJobs();
+
+    expect(getMarketCloseRecapMock).toHaveBeenCalledWith(pollMessage, expect.objectContaining({
+      logger: expect.any(Object),
+    }), expect.objectContaining({
+      date: expect.any(Date),
+    }));
+    expect(send).toHaveBeenLastCalledWith(expect.objectContaining({
+      allowedMentions: {
+        parse: [],
+        users: ["123", "456"],
+      },
+      content: expect.stringContaining("Börsenschluss"),
+    }));
+  });
+
+  test("startNyseTimers recovers the opening poll from history after a restart", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const channel = {
+      messages: {
+        fetch: vi.fn(),
+      },
+      send,
+    };
+    const client = {
+      channels: {
+        cache: {
+          get: vi.fn(() => channel),
+        },
+      },
+    };
+    const recoveredPollMessage = {
+      poll: {
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+    findMarketOpenSentimentPollMessageMock.mockResolvedValueOnce(recoveredPollMessage);
+    getMarketCloseRecapMock.mockResolvedValueOnce({
+      allowedUserIds: [],
+      content: "**Börsenschluss - Kurzüberblick**\n`VIX` stieg um `0,8 Punkte`.",
+    });
+
+    startNyseTimers(client, "channel-id");
+    const recapJob = getScheduledJobByTime(16, 10, "US/Eastern");
+    await recapJob.callback();
+    await flushAsyncJobs();
+
+    expect(findMarketOpenSentimentPollMessageMock).toHaveBeenCalledWith(channel, expect.objectContaining({
+      logger: expect.any(Object),
+    }), expect.objectContaining({
+      date: expect.any(Date),
+    }));
+    expect(getMarketCloseRecapMock).toHaveBeenCalledWith(recoveredPollMessage, expect.any(Object), expect.any(Object));
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining("Börsenschluss"),
+    }));
   });
 
   test("startNyseTimers skips announcement when channel is missing", () => {

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -24,6 +24,7 @@ import {
 } from "./earnings.ts";
 import {addExpectedMovesToEarningsEvents, warmExpectedMoveCacheForEarningsEvents} from "./earnings-expected-move.ts";
 import {getLogger} from "./logging.ts";
+import {findMarketOpenSentimentPollMessage, getMarketCloseRecap} from "./market-close-recap.ts";
 import {getMnc} from "./mnc-downloader.ts";
 import {getMncSummary} from "./mnc-summary.ts";
 import {type Ticker} from "./tickers.ts";
@@ -212,8 +213,11 @@ async function endNyseSentimentPoll(sentimentPollState: NyseSentimentPollState, 
   }
 
   if ("function" === typeof pollMessage.poll?.end) {
-    await Promise.resolve(pollMessage.poll.end()).then(() => {
+    await Promise.resolve(pollMessage.poll.end()).then(message => {
       sentimentPollState.ended = true;
+      if ("object" === typeof message && null !== message) {
+        sentimentPollState.message = message;
+      }
     }).catch(error => {
       logger.log(
         "error",
@@ -224,8 +228,11 @@ async function endNyseSentimentPoll(sentimentPollState: NyseSentimentPollState, 
   }
 
   if (pollMessage.id && "function" === typeof pollMessage.channel?.messages?.endPoll) {
-    await Promise.resolve(pollMessage.channel.messages.endPoll(pollMessage.id)).then(() => {
+    await Promise.resolve(pollMessage.channel.messages.endPoll(pollMessage.id)).then(message => {
       sentimentPollState.ended = true;
+      if ("object" === typeof message && null !== message) {
+        sentimentPollState.message = message;
+      }
     }).catch(error => {
       logger.log(
         "error",
@@ -332,6 +339,44 @@ async function sendToChannel(channel: SendableChannel | null, payload: unknown, 
     );
     return undefined;
   });
+}
+
+async function runNyseMarketCloseRecap(
+  client: TimerClient,
+  channelID: string,
+  sentimentPollState: NyseSentimentPollState,
+) {
+  const channel = await fetchChannel(client, channelID, "NYSE close recap");
+  if (false === isSendableChannel(channel)) {
+    logger.log(
+      "error",
+      `Skipping NYSE close recap: channel ${channelID} not found or not send-capable.`,
+    );
+    return;
+  }
+
+  const date = getCurrentNyseDate();
+  const pollMessage = sentimentPollState.message ?? await findMarketOpenSentimentPollMessage(channel, {
+    logger,
+  }, {
+    date,
+  });
+  const recap = await getMarketCloseRecap(pollMessage, {
+    logger,
+  }, {
+    date,
+  });
+  if (undefined === recap) {
+    return;
+  }
+
+  await sendToChannel(channel, {
+    allowedMentions: {
+      parse: [],
+      users: recap.allowedUserIds,
+    },
+    content: recap.content,
+  }, "NYSE close recap");
 }
 
 async function runEarningsAnnouncement(
@@ -446,6 +491,20 @@ export function startNyseTimers(client: TimerClient, channelID: string, gainsLos
     tz: usEasternTimezone,
   });
 
+  const ruleNyseCloseRecap = createRecurrenceRule({
+    hour: 16,
+    minute: 10,
+    dayOfWeek: usEasternWeekdays,
+    tz: usEasternTimezone,
+  });
+
+  const ruleNyseCloseRecapEarly = createRecurrenceRule({
+    hour: 13,
+    minute: 10,
+    dayOfWeek: usEasternWeekdays,
+    tz: usEasternTimezone,
+  });
+
   const ruleNyseAftermarketClose = createRecurrenceRule({
     hour: 20,
     minute: 0,
@@ -539,6 +598,20 @@ export function startNyseTimers(client: TimerClient, channelID: string, gainsLos
         getNyseCloseAnnouncement(gainsLossesThreadID),
         "NYSE",
       );
+    }
+  });
+
+  Schedule.scheduleJob(ruleNyseCloseRecap, () => {
+    const thanksgivingEarlyClose = isDayAfterThanksgiving();
+    if (false === isNyseHolidayToday() &&
+        false === thanksgivingEarlyClose) {
+      void runNyseMarketCloseRecap(client, channelID, sentimentPollState);
+    }
+  });
+
+  Schedule.scheduleJob(ruleNyseCloseRecapEarly, () => {
+    if (true === isDayAfterThanksgiving()) {
+      void runNyseMarketCloseRecap(client, channelID, sentimentPollState);
     }
   });
 

--- a/tools/docker-compose-production.yml
+++ b/tools/docker-compose-production.yml
@@ -50,6 +50,8 @@ services:
       - production_discord_30y_token
       - production_discord_30y_client_ID
       - production_gemini_api_key
+      - production_gemini_calls_per_minute
+      - production_gemini_calls_per_day
       - production_dracoon_password
       - production_hblwrk_channel_NYSEAnnouncement_ID
       - production_hblwrk_channel_MNCAnnouncement_ID
@@ -149,6 +151,10 @@ secrets:
   production_discord_30y_client_ID:
     external: true
   production_gemini_api_key:
+    external: true
+  production_gemini_calls_per_minute:
+    external: true
+  production_gemini_calls_per_day:
     external: true
   production_dracoon_password:
     external: true


### PR DESCRIPTION
## Summary
- add optional German NYSE close recap using Gemini JSON output with Google Search grounding
- match the recap verdict to the opening sentiment poll, fetch matching voters, and recover the poll from recent history after restarts
- add shared Gemini API 429 cooldown plus configurable per-minute and per-day local caps for higher-quota accounts

## Tests
- npm run lint
- npm run typecheck
- npm run test:coverage