### PR TITLE
Gate Gemini earnings extraction

### DIFF
--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -148,6 +148,112 @@ describe("Gemini earnings helpers", () => {
     );
   });
 
+  test("sends Gemini a bounded SEC release excerpt instead of the whole filing", async () => {
+    const longReleaseHtml = [
+      "<html><body>",
+      "<h1>Example Corp reports first quarter 2026 results</h1>",
+      "<p>Amounts in millions of dollars, except per share amounts.</p>",
+      ...Array.from({length: 400}, (_value, index) =>
+        `<p>Revenue commentary ${index} ${"continued quarterly results discussion ".repeat(3)}</p>`,
+      ),
+      "<p>UNIQUE_TAIL_MARKER Revenue should not be included after truncation.</p>",
+      "</body></html>",
+    ].join("\n");
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: null,
+                metrics: [],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: longReleaseHtml,
+      ticker: "EXM",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    const requestBody = postWithRetryFn.mock.calls[0]?.[1] as {contents?: {parts?: {text?: string}[]}[]};
+    const prompt = requestBody.contents?.[0]?.parts?.find(part => "string" === typeof part.text)?.text ?? "";
+    const filingText = prompt.split("Filing text:\n")[1] ?? "";
+    expect(filingText.length).toBeLessThanOrEqual(10_020);
+    expect(filingText).toContain("Example Corp reports first quarter 2026 results");
+    expect(filingText).toContain("[truncated]");
+    expect(filingText).not.toContain("UNIQUE_TAIL_MARKER");
+  });
+
+  test("bounds single-line SEC release excerpts before calling Gemini", async () => {
+    const longSingleLineHtml = `<html><body>${"Revenue discussion ".repeat(900)}</body></html>`;
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: null,
+                metrics: [],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: longSingleLineHtml,
+      ticker: "EXM",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    const requestBody = postWithRetryFn.mock.calls[0]?.[1] as {contents?: {parts?: {text?: string}[]}[]};
+    const prompt = requestBody.contents?.[0]?.parts?.find(part => "string" === typeof part.text)?.text ?? "";
+    const filingText = prompt.split("Filing text:\n")[1] ?? "";
+    expect(filingText.length).toBeLessThanOrEqual(10_020);
+    expect(filingText).toContain("[truncated]");
+  });
+
+  test("does not call Gemini when SEC release text is empty", async () => {
+    const postWithRetryFn = vi.fn();
+
+    const result = await extractEarningsWithGemini({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: " \n\t ",
+      ticker: "EXM",
+    }, {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBeNull();
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+  });
+
   test("drops AI metrics when their source snippets are not present", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -65,7 +65,9 @@ type AiMetricDefinition = {
   valueType: "eps" | "money";
 };
 
-const maxAiFilingTextLength = 18_000;
+const maxAiFilingTextLength = 10_000;
+const aiRelevantContextBeforeLines = 2;
+const aiRelevantContextAfterLines = 4;
 
 const aiMetricDefinitions = new Map<AiMetricKey, AiMetricDefinition>([
   ["adjusted_eps", {
@@ -626,7 +628,11 @@ function getRelevantFilingText(html: string): string {
       continue;
     }
 
-    for (let index = Math.max(0, lineIndex - 2); index <= Math.min(lines.length - 1, lineIndex + 4); index++) {
+    for (
+      let index = Math.max(0, lineIndex - aiRelevantContextBeforeLines);
+      index <= Math.min(lines.length - 1, lineIndex + aiRelevantContextAfterLines);
+      index++
+    ) {
       selectedLineIndexes.add(index);
     }
   }
@@ -648,7 +654,12 @@ function truncateAiText(value: string): string {
     return value;
   }
 
-  return value.slice(0, maxAiFilingTextLength);
+  const truncatedValue = value.slice(0, maxAiFilingTextLength);
+  const lastLineBreak = truncatedValue.lastIndexOf("\n");
+  const excerpt = lastLineBreak > 0
+    ? truncatedValue.slice(0, lastLineBreak)
+    : truncatedValue;
+  return `${excerpt.trimEnd()}\n[truncated]`;
 }
 
 function getNumericEventEpsConsensus(event: EarningsEvent): number | undefined {

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -587,7 +587,121 @@ describe("earnings result announcements", () => {
     expect(result.announcements).toEqual([]);
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Skipping earnings result announcement for XOM: no filing details could be parsed.",
+      "Skipping earnings result announcement for XOM: no earnings metrics or outlook could be parsed.",
+    );
+  });
+
+  test("does not spend Gemini calls on primary 8-K shells with no parsed metrics", async () => {
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.includes("company_tickers.json")) {
+        return {
+          data: {
+            0: {
+              cik_str: 34088,
+              ticker: "XOM",
+              title: "EXXON MOBIL CORP",
+            },
+          },
+        };
+      }
+
+      if (url.includes("type=8-K")) {
+        return {
+          data: `
+            <feed>
+              <entry>
+                <title>8-K - EXXON MOBIL CORP</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0000034088-26-000042</id>
+                <updated>2026-05-01T08:01:00-04:00</updated>
+                <category term="8-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/0000034088-26-000042-index.htm" />
+                <summary>
+                  &lt;b&gt;CIK:&lt;/b&gt; 0000034088&lt;br/&gt;
+                  &lt;b&gt;Items:&lt;/b&gt; 2.02, 9.01
+                </summary>
+              </entry>
+            </feed>
+          `,
+        };
+      }
+
+      if (url.includes("type=6-K")) {
+        return {
+          data: "<feed></feed>",
+        };
+      }
+
+      if (url.includes("companyfacts/CIK0000034088.json")) {
+        return {
+          data: {
+            facts: {},
+          },
+        };
+      }
+
+      if (url.endsWith("/index.json")) {
+        return {
+          data: {
+            directory: {
+              item: [{
+                name: "xom-20260331.htm",
+                type: "8-K",
+              }],
+            },
+          },
+        };
+      }
+
+      if (url.endsWith("/xom-20260331.htm")) {
+        return {
+          data: `
+            <html>
+              <body>
+                <h1>Item 2.02 Results of Operations and Financial Condition</h1>
+                <p>A copy of the press release is furnished as Exhibit 99.1.</p>
+              </body>
+            </html>
+          `,
+        };
+      }
+
+      if (url.includes("/XOM/earnings-surprise")) {
+        return {
+          data: {
+            data: {
+              earningsSurpriseTable: {
+                rows: [],
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    const result = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+        postWithRetryFn,
+        readSecretFn: vi.fn((secretName: string) => {
+          if ("gemini_api_key" === secretName) {
+            return "gemini-key";
+          }
+
+          throw new Error(`missing ${secretName}`);
+        }),
+      },
+    });
+
+    expect(result.announcements).toEqual([]);
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping earnings result announcement for XOM: no earnings metrics or outlook could be parsed.",
     );
   });
 

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -16,6 +16,8 @@ import {
   normalizeTickerSymbol,
   parseEarningsDocument,
   parseNumber,
+  type EarningsResultMetric,
+  type ParsedEarningsDocument,
   type NasdaqSurprise,
 } from "./earnings-results-format.ts";
 import {
@@ -118,6 +120,11 @@ type EarningsResultAnnouncement = {
   filingUrl: string;
   message: string;
   ticker: string;
+};
+
+type SecFilingDetails = {
+  documentUrl: string;
+  html: string;
 };
 
 export type EarningsResultScanResult = {
@@ -597,7 +604,13 @@ async function buildEarningsResultAnnouncement(
     ...getSuspiciousEarningsReasons(initialMetrics, surprise, watch.event),
     ...getSuspiciousQuarterReasons(parsedDocument.quarterLabel, now),
   ];
-  const aiExtraction = shouldRunAiExtraction(filingDetails?.html ?? "", sourceMetrics, initialSuspiciousReasons)
+  const aiExtraction = shouldRunAiExtraction({
+    filing,
+    filingDetails,
+    parsedDocument,
+    sourceMetrics,
+    suspiciousReasons: initialSuspiciousReasons,
+  })
     ? await extractEarningsWithGemini({
       companyName: watch.companyName,
       filingForm: filing.form,
@@ -626,7 +639,7 @@ async function buildEarningsResultAnnouncement(
   if (0 === metrics.length && 0 === parsedDocument.outlook.length) {
     dependencies.logger.log(
       "warn",
-      `Skipping earnings result announcement for ${watch.event.ticker}: no filing details could be parsed.`,
+      `Skipping earnings result announcement for ${watch.event.ticker}: no earnings metrics or outlook could be parsed.`,
     );
     return null;
   }
@@ -670,12 +683,95 @@ async function buildEarningsResultAnnouncement(
   };
 }
 
-function shouldRunAiExtraction(
-  html: string,
-  sourceMetrics: unknown[],
-  suspiciousReasons: SuspiciousEarningsReason[],
+function shouldRunAiExtraction({
+  filing,
+  filingDetails,
+  parsedDocument,
+  sourceMetrics,
+  suspiciousReasons,
+}: {
+  filing: SecCurrentFiling;
+  filingDetails: SecFilingDetails | null;
+  parsedDocument: ParsedEarningsDocument;
+  sourceMetrics: EarningsResultMetric[];
+  suspiciousReasons: SuspiciousEarningsReason[];
+}): boolean {
+  const html = filingDetails?.html ?? "";
+  if ("" === html.trim()) {
+    return false;
+  }
+
+  if (0 < sourceMetrics.length) {
+    return 0 < suspiciousReasons.length;
+  }
+
+  if (0 < parsedDocument.outlook.length) {
+    return false;
+  }
+
+  return isLikelyUsefulAiExtractionDocument(filing, filingDetails);
+}
+
+function isLikelyUsefulAiExtractionDocument(
+  filing: SecCurrentFiling,
+  filingDetails: SecFilingDetails | null,
 ): boolean {
-  return "" !== html.trim() && (0 === sourceMetrics.length || 0 < suspiciousReasons.length);
+  if (null === filingDetails) {
+    return false;
+  }
+
+  const documentName = getUrlFileName(filingDetails.documentUrl);
+  if (true === isLikelyEarningsReleaseFileName(documentName)) {
+    return true;
+  }
+
+  if ("8-K" === filing.form.toUpperCase()) {
+    return false;
+  }
+
+  return hasEarningsReleaseTextEvidence(filingDetails.html);
+}
+
+function getUrlFileName(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return pathname.slice(pathname.lastIndexOf("/") + 1).toLowerCase();
+  } catch {
+    const normalizedUrl = url.toLowerCase();
+    return normalizedUrl.slice(normalizedUrl.lastIndexOf("/") + 1);
+  }
+}
+
+function isLikelyEarningsReleaseFileName(name: string): boolean {
+  return /(?:^|[^a-z0-9])ex(?:hibit)?[-_\s]?99(?:[-_.\s]?1)?(?:[^a-z0-9]|$)/i.test(name) ||
+    name.includes("ex99") ||
+    name.includes("exhibit991") ||
+    /\b(?:earnings|release|results)\b/i.test(name);
+}
+
+function hasEarningsReleaseTextEvidence(html: string): boolean {
+  const text = normalizeAiPreflightText(html);
+  if ("" === text) {
+    return false;
+  }
+
+  const hasReleaseHeadline = /\b(?:reports?|announces?|released?|issues?)\b.{0,120}\b(?:quarter|fiscal|year|annual)\b.{0,120}\b(?:results?|earnings)\b/i.test(text) ||
+    /\b(?:quarterly|annual)\s+(?:financial\s+)?results?\b/i.test(text);
+  const hasMetricCue = /\b(?:revenue|sales|net\s+income|net\s+earnings|earnings\s+per\s+share|eps|adjusted\s+ebitda)\b/i.test(text);
+  const hasQuantitativeCue = /(?:[$€£¥]\s?\(?\d|\b\d+(?:[,.]\d+)?\s?(?:million|billion|m|bn|%|cents|per\s+share)\b)/i.test(text);
+  return hasReleaseHeadline && hasMetricCue && hasQuantitativeCue;
+}
+
+function normalizeAiPreflightText(html: string): string {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 60_000);
 }
 
 function shouldSuppressAnnouncement(


### PR DESCRIPTION
## Summary
- gate AI earnings extraction so deterministic parsing/XBRL runs first and Gemini is skipped for SEC shells or non-release filings with no useful metrics
- shorten SEC filing text sent to Gemini to bounded relevant-line excerpts
- add regression coverage for skipped primary 8-K shells and bounded Gemini prompt payloads

## Validation
- npx vitest run modules/earnings-results-ai.test.ts modules/earnings-results.test.ts modules/gemini.test.ts
- npm run typecheck
- npm run lint
- npm run test:coverage