### PR TITLE
[codex] prepare AI provider swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,15 @@ The health-check server port can be overridden via the `HEALTHCHECK_PORT` enviro
   "discord_30y_client_ID": "",
   "tastytrade_client_secret": "",
   "tastytrade_refresh_token": "",
+  "ai_provider": "gemini",
   "gemini_api_key": "",
   "gemini_model": "gemini-2.5-flash-lite",
   "gemini_calls_per_minute": "9",
   "gemini_calls_per_day": "18",
+  "openai_api_key": "",
+  "openai_model": "gpt-5.4-mini",
+  "openai_calls_per_minute": "20",
+  "openai_calls_per_day": "200",
   "dracoon_password": "",
   "hblwrk_channel_NYSEAnnouncement_ID": "",
   "hblwrk_gainslosses_thread_ID": "",
@@ -203,7 +208,7 @@ If DRACOON downloads fail during startup, the bot keeps those assets marked as t
 
 ### Reminder assets
 
-Calendar reminders, earnings reminders, and earnings result announcements post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements are sent after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. Gemini-assisted SEC extraction and suspicious-post checks run when `gemini_api_key` is configured; the bot keeps XBRL and HTML parsing as the primary source and validates AI metrics against source snippets before posting. MNC announcements use the same optional Gemini access to add a one-minute Discord Markdown summary above the PDF attachment. NYSE close announcements use optional Gemini search grounding to add a German close recap and match the day to the opening sentiment poll; if the bot restarts during the session, it recovers the poll from recent channel history when possible. `gemini_calls_per_minute` caps local Gemini calls and defaults to `9`; `gemini_calls_per_day` defaults to `18`. Deployments with a higher Gemini quota set `production_gemini_calls_per_minute` and `production_gemini_calls_per_day` to raise those local caps. Calendar and earnings reminders ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
+Calendar reminders, earnings reminders, and earnings result announcements post into `hblwrk_channel_OtherAnnouncement_ID`. Earnings result announcements are sent after a matching SEC EDGAR filing appears. Result announcements include an `Outlook` block when the filing has an explicit outlook or guidance section. AI-assisted SEC extraction and suspicious-post checks run through the AI provider boundary; `ai_provider` defaults to `gemini`, which runs when `gemini_api_key` is configured. The bot keeps XBRL and HTML parsing as the primary source and validates AI metrics against source snippets before posting. MNC announcements use the same optional AI provider access to add a one-minute Discord Markdown summary above the PDF attachment. NYSE close announcements use optional provider web-search grounding to add a German close recap and match the day to the opening sentiment poll; if the bot restarts during the session, it recovers the poll from recent channel history when possible. The provider boundary also supports `ai_provider=openai` with `openai_api_key` and defaults `openai_model` to `gpt-5.4-mini`. Gemini local call caps default to `9` per minute and `18` per day through `gemini_calls_per_minute` and `gemini_calls_per_day`; OpenAI local call caps default to `20` per minute and `200` per day through `openai_calls_per_minute` and `openai_calls_per_day`. Deployments with a higher Gemini quota set `production_gemini_calls_per_minute` and `production_gemini_calls_per_day` to raise those local caps. Calendar and earnings reminders ping the `alerts` special role, which is self-assignable from the roles channel via the `🛎️` bellhop bell reaction on the special roles message.
 
 Calendar reminder assets are matched against the current day and sent at `08:30 Europe/Berlin`, immediately after the general daily calendar post. If multiple matching calendar items share the same release minute, the bot bundles them into a single reminder ping:
 

--- a/modules/ai-provider.test.ts
+++ b/modules/ai-provider.test.ts
@@ -1,0 +1,135 @@
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {callAiProviderJson, clearAiProviderState} from "./ai-provider.ts";
+
+describe("AI provider facade", () => {
+  const logger = {
+    log: vi.fn(),
+  };
+  const responseJsonSchema = {
+    properties: {},
+    type: "object",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearAiProviderState();
+  });
+
+  test("uses Gemini when no provider is configured", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: "{}",
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await callAiProviderJson("prompt", responseJsonSchema, {
+      logger,
+      postWithRetryFn,
+      readSecretFn: vi.fn((secretName: string) => {
+        if ("gemini_api_key" === secretName) {
+          return "gemini-key";
+        }
+
+        throw new Error(`missing ${secretName}`);
+      }),
+    }, "test task");
+
+    expect(result).toBe("{}");
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      expect.stringContaining("generativelanguage.googleapis.com"),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test("routes to OpenAI when ai_provider is openai", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        output_text: "{}",
+      },
+    });
+
+    const result = await callAiProviderJson("prompt", responseJsonSchema, {
+      logger,
+      postWithRetryFn,
+      readSecretFn: vi.fn((secretName: string) => {
+        if ("ai_provider" === secretName) {
+          return "openai";
+        }
+
+        if ("openai_api_key" === secretName) {
+          return "openai-key";
+        }
+
+        throw new Error(`missing ${secretName}`);
+      }),
+    }, "test task", undefined, {
+      timeoutMs: 60_000,
+      useWebSearch: true,
+    });
+
+    expect(result).toBe("{}");
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/responses",
+      expect.objectContaining({
+        tools: [{
+          search_context_size: "low",
+          type: "web_search",
+        }],
+      }),
+      expect.anything(),
+      expect.objectContaining({
+        timeoutMs: 60_000,
+      }),
+    );
+  });
+
+  test("falls back to Gemini for unsupported provider names", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: "{}",
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await callAiProviderJson("prompt", responseJsonSchema, {
+      logger,
+      postWithRetryFn,
+      readSecretFn: vi.fn((secretName: string) => {
+        if ("ai_provider" === secretName) {
+          return "anthropic";
+        }
+
+        if ("gemini_api_key" === secretName) {
+          return "gemini-key";
+        }
+
+        throw new Error(`missing ${secretName}`);
+      }),
+    }, "test task");
+
+    expect(result).toBe("{}");
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Unsupported AI provider \"anthropic\"; using Gemini.",
+    );
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      expect.stringContaining("generativelanguage.googleapis.com"),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/modules/ai-provider.ts
+++ b/modules/ai-provider.ts
@@ -1,0 +1,107 @@
+import {
+  callGeminiJson,
+  clearGeminiState,
+  type GeminiCallOptions,
+  type GeminiDependencies,
+} from "./gemini.ts";
+import {callOpenAiJson, clearOpenAiState, type OpenAiCallOptions, type OpenAiDependencies} from "./openai.ts";
+import {readSecret} from "./secrets.ts";
+
+export type AiProviderDependencies = GeminiDependencies & OpenAiDependencies;
+
+export type AiProviderInlineData = {
+  data: string;
+  filename?: string | undefined;
+  mimeType: string;
+};
+
+export type AiProviderCallOptions = {
+  timeoutMs?: number | undefined;
+  useWebSearch?: boolean | undefined;
+};
+
+type AiProviderName = "gemini" | "openai";
+
+const aiProviderSecret = "ai_provider";
+
+export function clearAiProviderState() {
+  clearGeminiState();
+  clearOpenAiState();
+}
+
+export async function callAiProviderJson(
+  prompt: string,
+  responseJsonSchema: Record<string, unknown>,
+  dependencies: AiProviderDependencies,
+  task: string,
+  inlineData?: AiProviderInlineData,
+  options: AiProviderCallOptions = {},
+): Promise<string | null> {
+  if ("openai" === getAiProviderName(dependencies)) {
+    const openAiOptions: OpenAiCallOptions = {};
+    if (undefined !== options.timeoutMs) {
+      openAiOptions.timeoutMs = options.timeoutMs;
+    }
+
+    if (true === options.useWebSearch) {
+      openAiOptions.useWebSearch = true;
+    }
+
+    return callOpenAiJson(
+      prompt,
+      responseJsonSchema,
+      dependencies,
+      task,
+      inlineData,
+      openAiOptions,
+    );
+  }
+
+  const geminiOptions: GeminiCallOptions = {};
+  if (undefined !== options.timeoutMs) {
+    geminiOptions.timeoutMs = options.timeoutMs;
+  }
+
+  if (true === options.useWebSearch) {
+    geminiOptions.useGoogleSearch = true;
+  }
+
+  return callGeminiJson(
+    prompt,
+    responseJsonSchema,
+    dependencies,
+    task,
+    undefined === inlineData ? undefined : {
+      data: inlineData.data,
+      mimeType: inlineData.mimeType,
+    },
+    geminiOptions,
+  );
+}
+
+function getAiProviderName(dependencies: AiProviderDependencies): AiProviderName {
+  const readSecretFn = dependencies.readSecretFn ?? readSecret;
+  const configuredProvider = readOptionalSecret(readSecretFn, aiProviderSecret)?.toLowerCase();
+  if (undefined === configuredProvider || "" === configuredProvider || "gemini" === configuredProvider) {
+    return "gemini";
+  }
+
+  if ("openai" === configuredProvider) {
+    return "openai";
+  }
+
+  dependencies.logger.log(
+    "warn",
+    `Unsupported AI provider "${configuredProvider}"; using Gemini.`,
+  );
+  return "gemini";
+}
+
+function readOptionalSecret(readSecretFn: typeof readSecret, secretName: string): string | undefined {
+  try {
+    const value = readSecretFn(secretName).trim();
+    return "" === value ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}

--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -1,15 +1,15 @@
 import {beforeEach, describe, expect, test, vi} from "vitest";
 import {
-  checkEarningsQualityWithGemini,
+  checkEarningsQualityWithAi,
   clearEarningsAiState,
-  extractEarningsWithGemini,
+  extractEarningsWithAi,
   getSuspiciousEarningsReasons,
   hasHighSeveritySuspicion,
   mergeAiMetrics,
 } from "./earnings-results-ai.ts";
 import type {EarningsResultMetric} from "./earnings-results-format.ts";
 
-describe("Gemini earnings helpers", () => {
+describe("AI earnings helpers", () => {
   const logger = {
     log: vi.fn(),
   };
@@ -64,7 +64,7 @@ describe("Gemini earnings helpers", () => {
       },
     });
 
-    const result = await extractEarningsWithGemini({
+    const result = await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -104,7 +104,7 @@ describe("Gemini earnings helpers", () => {
     );
   });
 
-  test("uses default model and rate limit when optional Gemini secrets are missing", async () => {
+  test("uses default provider model and rate limit when optional provider secrets are missing", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {
         candidates: [{
@@ -121,7 +121,7 @@ describe("Gemini earnings helpers", () => {
       },
     });
 
-    await extractEarningsWithGemini({
+    await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -148,7 +148,7 @@ describe("Gemini earnings helpers", () => {
     );
   });
 
-  test("sends Gemini a bounded SEC release excerpt instead of the whole filing", async () => {
+  test("sends the provider a bounded SEC release excerpt instead of the whole filing", async () => {
     const longReleaseHtml = [
       "<html><body>",
       "<h1>Example Corp reports first quarter 2026 results</h1>",
@@ -175,7 +175,7 @@ describe("Gemini earnings helpers", () => {
       },
     });
 
-    await extractEarningsWithGemini({
+    await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -197,7 +197,7 @@ describe("Gemini earnings helpers", () => {
     expect(filingText).not.toContain("UNIQUE_TAIL_MARKER");
   });
 
-  test("bounds single-line SEC release excerpts before calling Gemini", async () => {
+  test("bounds single-line SEC release excerpts before calling the provider", async () => {
     const longSingleLineHtml = `<html><body>${"Revenue discussion ".repeat(900)}</body></html>`;
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {
@@ -215,7 +215,7 @@ describe("Gemini earnings helpers", () => {
       },
     });
 
-    await extractEarningsWithGemini({
+    await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -235,10 +235,10 @@ describe("Gemini earnings helpers", () => {
     expect(filingText).toContain("[truncated]");
   });
 
-  test("does not call Gemini when SEC release text is empty", async () => {
+  test("does not call the provider when SEC release text is empty", async () => {
     const postWithRetryFn = vi.fn();
 
-    const result = await extractEarningsWithGemini({
+    const result = await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -276,7 +276,7 @@ describe("Gemini earnings helpers", () => {
       },
     });
 
-    const result = await extractEarningsWithGemini({
+    const result = await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -292,7 +292,7 @@ describe("Gemini earnings helpers", () => {
     expect(result?.metrics).toEqual([]);
   });
 
-  test("caps Gemini calls with the local per-minute limiter", async () => {
+  test("caps AI calls with the local per-minute limiter", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {
         candidates: [{
@@ -317,13 +317,13 @@ describe("Gemini earnings helpers", () => {
       ticker: "EXM",
     };
 
-    await extractEarningsWithGemini(input, {
+    await extractEarningsWithAi(input, {
       logger,
       nowMs: () => 1_000,
       postWithRetryFn,
       readSecretFn,
     });
-    const secondResult = await extractEarningsWithGemini(input, {
+    const secondResult = await extractEarningsWithAi(input, {
       logger,
       nowMs: () => 1_000,
       postWithRetryFn,
@@ -334,11 +334,11 @@ describe("Gemini earnings helpers", () => {
     expect(postWithRetryFn).toHaveBeenCalledTimes(1);
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Skipping Gemini earnings extraction for EXM: local 1/minute rate limit is exhausted.",
+      expect.stringContaining("earnings extraction for EXM: local 1/minute rate limit is exhausted."),
     );
   });
 
-  test("releases local Gemini call capacity after one minute", async () => {
+  test("releases local AI call capacity after one minute", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {
         candidates: [{
@@ -362,13 +362,13 @@ describe("Gemini earnings helpers", () => {
       ticker: "EXM",
     };
 
-    await extractEarningsWithGemini(input, {
+    await extractEarningsWithAi(input, {
       logger,
       nowMs: () => 1_000,
       postWithRetryFn,
       readSecretFn,
     });
-    await extractEarningsWithGemini(input, {
+    await extractEarningsWithAi(input, {
       logger,
       nowMs: () => 62_000,
       postWithRetryFn,
@@ -378,10 +378,10 @@ describe("Gemini earnings helpers", () => {
     expect(postWithRetryFn).toHaveBeenCalledTimes(2);
   });
 
-  test("stays disabled when the Gemini API key secret is missing", async () => {
+  test("stays disabled when the active provider API key secret is missing", async () => {
     const postWithRetryFn = vi.fn();
 
-    const result = await extractEarningsWithGemini({
+    const result = await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -399,8 +399,8 @@ describe("Gemini earnings helpers", () => {
     expect(postWithRetryFn).not.toHaveBeenCalled();
   });
 
-  test("returns null when Gemini extraction output is invalid JSON", async () => {
-    const result = await extractEarningsWithGemini({
+  test("returns null when AI extraction output is invalid JSON", async () => {
+    const result = await extractEarningsWithAi({
       companyName: "Example Corp",
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
@@ -425,14 +425,14 @@ describe("Gemini earnings helpers", () => {
     expect(result).toBeNull();
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Gemini earnings extraction returned invalid JSON for EXM.",
+      "AI earnings extraction returned invalid JSON for EXM.",
     );
   });
 
-  test("allows quality checks without calling Gemini when there are no suspicious reasons", async () => {
+  test("allows quality checks without calling the provider when there are no suspicious reasons", async () => {
     const postWithRetryFn = vi.fn();
 
-    const result = await checkEarningsQualityWithGemini({
+    const result = await checkEarningsQualityWithAi({
       companyName: "Example Corp",
       event: getEvent(),
       filingForm: "8-K",
@@ -459,7 +459,7 @@ describe("Gemini earnings helpers", () => {
   });
 
   test("parses quality gate suppression with validated source snippets", async () => {
-    const result = await checkEarningsQualityWithGemini({
+    const result = await checkEarningsQualityWithAi({
       companyName: "Example Corp",
       event: getEvent(),
       filingForm: "8-K",
@@ -520,7 +520,7 @@ describe("Gemini earnings helpers", () => {
   });
 
   test("rejects quality gate suppression without validated issues", async () => {
-    const result = await checkEarningsQualityWithGemini({
+    const result = await checkEarningsQualityWithAi({
       companyName: "Example Corp",
       event: getEvent(),
       filingForm: "8-K",

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -6,9 +6,9 @@ import {
   type EarningsResultMetric,
   type NasdaqSurprise,
 } from "./earnings-results-format.ts";
-import {callGeminiJson, clearGeminiState, type GeminiDependencies} from "./gemini.ts";
+import {callAiProviderJson, clearAiProviderState, type AiProviderDependencies} from "./ai-provider.ts";
 
-type EarningsAiDependencies = GeminiDependencies;
+type EarningsAiDependencies = AiProviderDependencies;
 
 export type EarningsAiExtractionInput = {
   companyName: string;
@@ -183,10 +183,10 @@ const qualityGateSchema = {
 } satisfies Record<string, unknown>;
 
 export function clearEarningsAiState() {
-  clearGeminiState();
+  clearAiProviderState();
 }
 
-export async function extractEarningsWithGemini(
+export async function extractEarningsWithAi(
   input: EarningsAiExtractionInput,
   dependencies: EarningsAiDependencies,
 ): Promise<EarningsAiExtraction | null> {
@@ -196,7 +196,7 @@ export async function extractEarningsWithGemini(
   }
 
   const prompt = getExtractionPrompt(input, sourceText);
-  const jsonText = await callGeminiJson(
+  const jsonText = await callAiProviderJson(
     prompt,
     earningsExtractionSchema,
     dependencies,
@@ -205,7 +205,7 @@ export async function extractEarningsWithGemini(
     .catch(error => {
       dependencies.logger.log(
         "warn",
-        `Gemini earnings extraction failed for ${input.ticker}: ${error}`,
+        `AI earnings extraction failed for ${input.ticker}: ${error}`,
       );
       return null;
     });
@@ -217,7 +217,7 @@ export async function extractEarningsWithGemini(
   if (null === parsedJson) {
     dependencies.logger.log(
       "warn",
-      `Gemini earnings extraction returned invalid JSON for ${input.ticker}.`,
+      `AI earnings extraction returned invalid JSON for ${input.ticker}.`,
     );
     return null;
   }
@@ -225,7 +225,7 @@ export async function extractEarningsWithGemini(
   return parseAiExtraction(parsedJson, htmlToText(input.html));
 }
 
-export async function checkEarningsQualityWithGemini(
+export async function checkEarningsQualityWithAi(
   input: EarningsAiQualityGateInput,
   dependencies: EarningsAiDependencies,
 ): Promise<EarningsAiQualityGateResult | null> {
@@ -244,7 +244,7 @@ export async function checkEarningsQualityWithGemini(
   }
 
   const prompt = getQualityGatePrompt(input, sourceText);
-  const jsonText = await callGeminiJson(
+  const jsonText = await callAiProviderJson(
     prompt,
     qualityGateSchema,
     dependencies,
@@ -253,7 +253,7 @@ export async function checkEarningsQualityWithGemini(
     .catch(error => {
       dependencies.logger.log(
         "warn",
-        `Gemini earnings quality gate failed for ${input.ticker}: ${error}`,
+        `AI earnings quality gate failed for ${input.ticker}: ${error}`,
       );
       return null;
     });
@@ -265,7 +265,7 @@ export async function checkEarningsQualityWithGemini(
   if (null === parsedJson) {
     dependencies.logger.log(
       "warn",
-      `Gemini earnings quality gate returned invalid JSON for ${input.ticker}.`,
+      `AI earnings quality gate returned invalid JSON for ${input.ticker}.`,
     );
     return null;
   }

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -575,6 +575,7 @@ describe("earnings result announcements", () => {
       throw new Error(`Unexpected URL ${url}`);
     });
 
+    const skippedNoMetricsAccessions = new Set<string>();
     const result = await getEarningsResultAnnouncements({
       dependencies: {
         getEarningsResultFn,
@@ -582,16 +583,41 @@ describe("earnings result announcements", () => {
         logger,
         now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
       },
+      skippedNoMetricsAccessions,
     });
 
     expect(result.announcements).toEqual([]);
+    expect(skippedNoMetricsAccessions.has("0000034088-26-000042")).toBe(true);
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
       "Skipping earnings result announcement for XOM: no earnings metrics or outlook could be parsed.",
     );
+
+    getWithRetryFn.mockClear();
+    logger.log.mockClear();
+
+    const secondResult = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:06", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      },
+      skippedNoMetricsAccessions,
+    });
+
+    expect(secondResult.announcements).toEqual([]);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      "Skipping earnings result announcement for XOM: no earnings metrics or outlook could be parsed.",
+    );
+    expect(getWithRetryFn).not.toHaveBeenCalledWith(
+      expect.stringContaining("/index.json"),
+      expect.anything(),
+    );
   });
 
-  test("does not spend Gemini calls on primary 8-K shells with no parsed metrics", async () => {
+  test("does not spend AI calls on primary 8-K shells with no parsed metrics", async () => {
     getWithRetryFn.mockImplementation(async (url: string) => {
       if (url.includes("company_tickers.json")) {
         return {
@@ -917,7 +943,7 @@ describe("earnings result announcements", () => {
     watcher.stop();
   });
 
-  test("uses Gemini extraction and suppresses suspicious earnings metrics when quality gate rejects them", async () => {
+  test("uses AI extraction and suppresses suspicious earnings metrics when quality gate rejects them", async () => {
     getEarningsResultFn.mockResolvedValue({
       status: "ok",
       events: [{

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -1,9 +1,9 @@
 import moment from "moment-timezone";
 import {bluechipMinMarketCap, clearEarningsScheduleCache, type EarningsEvent, getEarningsResult} from "./earnings.ts";
 import {
-  checkEarningsQualityWithGemini,
+  checkEarningsQualityWithAi,
   clearEarningsAiState,
-  extractEarningsWithGemini,
+  extractEarningsWithAi,
   getSuspiciousEarningsReasons,
   hasHighSeveritySuspicion,
   mergeAiMetrics,
@@ -13,6 +13,7 @@ import {
   formatUsdCompact,
   getEarningsResultMessage,
   getMessageMetrics,
+  htmlToText,
   normalizeTickerSymbol,
   parseEarningsDocument,
   parseNumber,
@@ -177,6 +178,7 @@ export function startEarningsResultWatcher(
   const announcementThreadID = getOptionalChannelID(options.announcementThreadID);
   const seenAccessions = new Set<string>();
   const seenResultKeys = new Set<string>();
+  const skippedNoMetricsAccessions = new Set<string>();
   const dependencies = getDependencies(options);
   let seenAccessionsSeeded = false;
   let stopped = false;
@@ -210,10 +212,12 @@ export function startEarningsResultWatcher(
       secCurrentFilingsLimit?: number;
       seenAccessions: Set<string>;
       seenResultKeys: Set<string>;
+      skippedNoMetricsAccessions: Set<string>;
     } = {
       dependencies,
       seenAccessions,
       seenResultKeys,
+      skippedNoMetricsAccessions,
     };
     if (undefined !== options.maxAnnouncementsPerScan) {
       announcementOptions.maxAnnouncementsPerScan = options.maxAnnouncementsPerScan;
@@ -286,12 +290,14 @@ export async function getEarningsResultAnnouncements({
   secCurrentFilingsLimit = defaultSecCurrentFilingsLimit,
   seenAccessions = new Set<string>(),
   seenResultKeys = new Set<string>(),
+  skippedNoMetricsAccessions = new Set<string>(),
 }: {
   dependencies?: EarningsResultDependencies;
   maxAnnouncementsPerScan?: number;
   secCurrentFilingsLimit?: number;
   seenAccessions?: Set<string>;
   seenResultKeys?: Set<string>;
+  skippedNoMetricsAccessions?: Set<string>;
 } = {}): Promise<EarningsResultScanResult> {
   const now = dependencies.now().clone().tz(usEasternTimezone);
   const watches = await getTodaysEarningsWatches(dependencies, now);
@@ -315,6 +321,10 @@ export async function getEarningsResultAnnouncements({
     }
 
     if (true === seenAccessions.has(filing.accessionNumber)) {
+      continue;
+    }
+
+    if (true === skippedNoMetricsAccessions.has(filing.accessionNumber)) {
       continue;
     }
 
@@ -342,6 +352,7 @@ export async function getEarningsResultAnnouncements({
       filingWatch,
       dependencies,
       now,
+      skippedNoMetricsAccessions,
     );
     if (null !== announcement) {
       announcements.push(announcement);
@@ -579,6 +590,7 @@ async function buildEarningsResultAnnouncement(
   watch: EarningsWatchEntry,
   dependencies: EarningsResultDependencies,
   now: moment.Moment,
+  skippedNoMetricsAccessions: Set<string>,
 ): Promise<EarningsResultAnnouncement | null> {
   const [filingDetails, xbrlMetrics] = await Promise.all([
     loadSecFilingDetails(filing, dependencies).catch(error => {
@@ -611,7 +623,7 @@ async function buildEarningsResultAnnouncement(
     sourceMetrics,
     suspiciousReasons: initialSuspiciousReasons,
   })
-    ? await extractEarningsWithGemini({
+    ? await extractEarningsWithAi({
       companyName: watch.companyName,
       filingForm: filing.form,
       filingUrl: filingDetails?.documentUrl || filing.filingUrl,
@@ -637,6 +649,7 @@ async function buildEarningsResultAnnouncement(
   const filingUrl = filingDetails?.documentUrl || filing.filingUrl;
 
   if (0 === metrics.length && 0 === parsedDocument.outlook.length) {
+    skippedNoMetricsAccessions.add(filing.accessionNumber);
     dependencies.logger.log(
       "warn",
       `Skipping earnings result announcement for ${watch.event.ticker}: no earnings metrics or outlook could be parsed.`,
@@ -652,7 +665,7 @@ async function buildEarningsResultAnnouncement(
     parsedDocument,
     ticker: watch.event.ticker,
   });
-  const qualityGate = await checkEarningsQualityWithGemini({
+  const qualityGate = await checkEarningsQualityWithAi({
     companyName: watch.companyName,
     event: watch.event,
     filingForm: filing.form,
@@ -763,12 +776,7 @@ function hasEarningsReleaseTextEvidence(html: string): boolean {
 }
 
 function normalizeAiPreflightText(html: string): string {
-  return html
-    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
+  return htmlToText(html)
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, 60_000);

--- a/modules/market-close-recap.test.ts
+++ b/modules/market-close-recap.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, describe, expect, test, vi} from "vitest";
-import {clearGeminiState} from "./gemini.ts";
+import {clearAiProviderState} from "./ai-provider.ts";
 import {
   findMarketOpenSentimentPollMessage,
   getMarketCloseRecap,
@@ -54,7 +54,7 @@ describe("market close recap", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    clearGeminiState();
+    clearAiProviderState();
   });
 
   test("generates a German grounded close recap and mentions voters who picked the matching sentiment", async () => {
@@ -109,6 +109,7 @@ describe("market close recap", () => {
     expect(recap?.content).toContain("Das heutige Sentiment war: **🎢 Chaos**");
     expect(recap?.content).toContain("<@123> <@456>");
     expect(recap?.content).not.toContain("Gemini");
+    expect(recap?.content).not.toContain("GPT");
     expect(chaosVotersFetch).toHaveBeenCalledWith({
       limit: 100,
     });
@@ -132,7 +133,7 @@ describe("market close recap", () => {
     expect(requestBody.contents?.[0]?.parts?.[0]?.text).toContain("Der `VIX` darf niemals als Prozentwert beschrieben werden.");
   });
 
-  test("stays disabled when the Gemini API key is missing", async () => {
+  test("stays disabled when the active provider API key is missing", async () => {
     const postWithRetryFn = vi.fn();
 
     const recap = await getMarketCloseRecap(undefined, {
@@ -267,11 +268,11 @@ describe("market close recap", () => {
     expect(recap).toBeUndefined();
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Gemini market close recap failed output validation.",
+      "AI market close recap failed output validation.",
     );
   });
 
-  test("rejects invalid or incomplete Gemini responses", async () => {
+  test("rejects invalid or incomplete AI responses", async () => {
     const invalidJsonRecap = await getMarketCloseRecap(undefined, {
       logger,
       postWithRetryFn: vi.fn().mockResolvedValue({
@@ -299,11 +300,11 @@ describe("market close recap", () => {
     expect(missingFieldRecap).toBeUndefined();
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Gemini market close recap returned invalid JSON.",
+      "AI market close recap returned invalid JSON.",
     );
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Gemini market close recap response missed required fields.",
+      "AI market close recap response missed required fields.",
     );
   });
 
@@ -312,6 +313,13 @@ describe("market close recap", () => {
       logger,
       postWithRetryFn: createPostWithRecap({
         summaryMarkdown: "Gemini sagt: `SPX` war fest und der `VIX` fiel um `1 Punkt`.",
+      }),
+      readSecretFn,
+    });
+    const gptMentionRecap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        summaryMarkdown: "GPT sagt: `SPX` war fest und der `VIX` fiel um `1 Punkt`.",
       }),
       readSecretFn,
     });
@@ -324,10 +332,11 @@ describe("market close recap", () => {
     });
 
     expect(providerMentionRecap).toBeUndefined();
+    expect(gptMentionRecap).toBeUndefined();
     expect(missingVixRecap).toBeUndefined();
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Gemini market close recap failed output validation.",
+      "AI market close recap failed output validation.",
     );
   });
 

--- a/modules/market-close-recap.ts
+++ b/modules/market-close-recap.ts
@@ -1,5 +1,5 @@
 import moment from "moment-timezone";
-import {callGeminiJson, type GeminiDependencies} from "./gemini.ts";
+import {callAiProviderJson, type AiProviderDependencies} from "./ai-provider.ts";
 
 export type MarketCloseSentimentAnswer = "Risk-on" | "Risk-off" | "Cash" | "Chaos";
 
@@ -8,7 +8,7 @@ export type MarketCloseRecapPayload = {
   content: string;
 };
 
-export type MarketCloseRecapDependencies = GeminiDependencies;
+export type MarketCloseRecapDependencies = AiProviderDependencies;
 
 export type MarketCloseRecapOptions = {
   date?: Date | undefined;
@@ -44,7 +44,7 @@ type PollMessageLike = {
   poll?: PollLike | null | undefined;
 };
 
-type GeminiMarketCloseRecap = {
+type AiMarketCloseRecap = {
   sentimentTitle?: string | undefined;
   summaryMarkdown: string;
   winningPollAnswer: MarketCloseSentimentAnswer;
@@ -91,7 +91,7 @@ export async function getMarketCloseRecap(
   dependencies: MarketCloseRecapDependencies,
   options: MarketCloseRecapOptions = {},
 ): Promise<MarketCloseRecapPayload | undefined> {
-  const jsonText = await callGeminiJson(
+  const jsonText = await callAiProviderJson(
     getMarketCloseRecapPrompt(options.date ?? new Date()),
     marketCloseRecapSchema,
     dependencies,
@@ -99,12 +99,12 @@ export async function getMarketCloseRecap(
     undefined,
     {
       timeoutMs: 45_000,
-      useGoogleSearch: true,
+      useWebSearch: true,
     },
   ).catch(error => {
     dependencies.logger.log(
       "warn",
-      `Gemini market close recap failed: ${error}`,
+      `AI market close recap failed: ${error}`,
     );
     return null;
   });
@@ -112,7 +112,7 @@ export async function getMarketCloseRecap(
     return undefined;
   }
 
-  const recap = parseGeminiMarketCloseRecap(jsonText, dependencies);
+  const recap = parseAiMarketCloseRecap(jsonText, dependencies);
   if (undefined === recap) {
     return undefined;
   }
@@ -178,7 +178,7 @@ function getMarketCloseRecapPrompt(date: Date): string {
   const usEasternDate = moment(date).tz(usEasternTimezone).format("YYYY-MM-DD");
   return [
     `Heute ist nach US-Börsenschluss am ${usEasternDate} (US/Eastern).`,
-    "Nutze Google Search, um den US-Cash-Handelstag realitätsnah einzuordnen.",
+    "Nutze Websuche, um den US-Cash-Handelstag realitätsnah einzuordnen.",
     "Bewerte den Handelstag vom regulären US-Open bis zum regulären US-Close.",
     "Berücksichtige `SPX` oder `SPY`, `NQ` oder `QQQ`, `RTY` oder `IWM` sowie zwingend den `VIX`.",
     "Der `VIX` darf niemals als Prozentwert beschrieben werden. Beschreibe ihn nur als Stand, Veränderung in Punkten oder Richtung, z.B. `18,4` auf `20,1` oder `+1,7 Punkte`.",
@@ -192,20 +192,20 @@ function getMarketCloseRecapPrompt(date: Date): string {
     "Halte `summaryMarkdown` unter 1.000 Zeichen.",
     "Nutze 2-4 kurze Absätze oder Bulletpoints.",
     "Formatiere Ticker und konkrete Kennzahlen als Inline-Code, z.B. `SPX`, `QQQ`, `+0,4%`, `1,7 Punkte`.",
-    "Erwähne weder Gemini noch KI, Modell, Google Search, Quellen, Grounding oder Rechercheprozess.",
+    "Erwähne weder KI-Anbieter, KI, Modell, Websuche, Quellen, Grounding noch Rechercheprozess.",
     "Keine Disclaimer, keine Links, keine Tabellen, keine Codeblöcke.",
   ].join("\n");
 }
 
-function parseGeminiMarketCloseRecap(
+function parseAiMarketCloseRecap(
   jsonText: string,
   dependencies: MarketCloseRecapDependencies,
-): GeminiMarketCloseRecap | undefined {
+): AiMarketCloseRecap | undefined {
   const parsedJson = parseJson(jsonText);
   if (false === isRecord(parsedJson)) {
     dependencies.logger.log(
       "warn",
-      "Gemini market close recap returned invalid JSON.",
+      "AI market close recap returned invalid JSON.",
     );
     return undefined;
   }
@@ -218,7 +218,7 @@ function parseGeminiMarketCloseRecap(
       "string" !== typeof sentimentTitle) {
     dependencies.logger.log(
       "warn",
-      "Gemini market close recap response missed required fields.",
+      "AI market close recap response missed required fields.",
     );
     return undefined;
   }
@@ -232,7 +232,7 @@ function parseGeminiMarketCloseRecap(
       true === hasVixPercent(combinedText)) {
     dependencies.logger.log(
       "warn",
-      "Gemini market close recap failed output validation.",
+      "AI market close recap failed output validation.",
     );
     return undefined;
   }
@@ -245,7 +245,7 @@ function parseGeminiMarketCloseRecap(
 }
 
 function buildMarketCloseRecapContent(
-  recap: GeminiMarketCloseRecap,
+  recap: AiMarketCloseRecap,
   totalRightVoterCount: number | undefined,
   mentionedUserIds: string[],
 ): string {
@@ -259,7 +259,7 @@ function buildMarketCloseRecapContent(
   ].filter(line => "" !== line).join("\n\n"));
 }
 
-function getSentimentLine(recap: GeminiMarketCloseRecap): string {
+function getSentimentLine(recap: AiMarketCloseRecap): string {
   const answerLabel = sentimentLabels[recap.winningPollAnswer];
   if (undefined === recap.sentimentTitle || "" === recap.sentimentTitle) {
     return `Das heutige Sentiment war: **${answerLabel}**`;
@@ -491,7 +491,7 @@ function truncateRecapContent(value: string): string {
 }
 
 function hasForbiddenProviderMention(value: string): boolean {
-  return /\b(Gemini|KI|Künstliche Intelligenz|Modell|Google Search|Grounding)\b/iu.test(value);
+  return /\b(Gemini|OpenAI|GPT|ChatGPT|KI|Künstliche Intelligenz|Modell|Google Search|Websuche|Grounding)\b/iu.test(value);
 }
 
 function hasVixPercent(value: string): boolean {

--- a/modules/mnc-summary.test.ts
+++ b/modules/mnc-summary.test.ts
@@ -1,9 +1,9 @@
 import {Buffer} from "node:buffer";
 import {beforeEach, describe, expect, test, vi} from "vitest";
-import {clearGeminiState} from "./gemini.ts";
+import {clearAiProviderState} from "./ai-provider.ts";
 import {getMncSummary} from "./mnc-summary.ts";
 
-describe("MNC Gemini summary", () => {
+describe("MNC AI summary", () => {
   const logger = {
     log: vi.fn(),
   };
@@ -17,10 +17,10 @@ describe("MNC Gemini summary", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    clearGeminiState();
+    clearAiProviderState();
   });
 
-  test("summarizes the PDF with inline Gemini PDF data", async () => {
+  test("summarizes the PDF with inline provider PDF data", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {
         candidates: [{
@@ -65,7 +65,7 @@ describe("MNC Gemini summary", () => {
     );
   });
 
-  test("stays disabled when the Gemini API key is missing", async () => {
+  test("stays disabled when the active provider API key is missing", async () => {
     const postWithRetryFn = vi.fn();
 
     const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
@@ -93,7 +93,7 @@ describe("MNC Gemini summary", () => {
     expect(postWithRetryFn).not.toHaveBeenCalled();
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Skipping MNC Gemini summary: PDF is too large for inline Gemini processing.",
+      "Skipping MNC AI summary: PDF is too large for inline provider processing.",
     );
   });
 
@@ -130,7 +130,7 @@ describe("MNC Gemini summary", () => {
     expect(summary).toContain("\n- ...");
   });
 
-  test("returns no summary for invalid Gemini JSON", async () => {
+  test("returns no summary for invalid AI JSON", async () => {
     const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
       logger,
       postWithRetryFn: vi.fn().mockResolvedValue({
@@ -150,7 +150,7 @@ describe("MNC Gemini summary", () => {
     expect(summary).toBeUndefined();
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
-      "Gemini MNC summary returned invalid JSON.",
+      "AI MNC summary returned invalid JSON.",
     );
   });
 });

--- a/modules/mnc-summary.ts
+++ b/modules/mnc-summary.ts
@@ -1,7 +1,7 @@
 import type {Buffer} from "node:buffer";
-import {callGeminiJson, type GeminiDependencies} from "./gemini.ts";
+import {callAiProviderJson, type AiProviderDependencies} from "./ai-provider.ts";
 
-export type MncSummaryDependencies = GeminiDependencies;
+export type MncSummaryDependencies = AiProviderDependencies;
 
 const maxInlinePdfBytes = 14_000_000;
 const maxDiscordSummaryLength = 1_700;
@@ -25,18 +25,19 @@ export async function getMncSummary(
   if (pdfBuffer.length > maxInlinePdfBytes) {
     dependencies.logger.log(
       "warn",
-      "Skipping MNC Gemini summary: PDF is too large for inline Gemini processing.",
+      "Skipping MNC AI summary: PDF is too large for inline provider processing.",
     );
     return undefined;
   }
 
-  const jsonText = await callGeminiJson(
+  const jsonText = await callAiProviderJson(
     getMncSummaryPrompt(),
     mncSummarySchema,
     dependencies,
     "MNC summary",
     {
       data: pdfBuffer.toString("base64"),
+      filename: "morning-news-call.pdf",
       mimeType: "application/pdf",
     },
     {
@@ -45,7 +46,7 @@ export async function getMncSummary(
   ).catch(error => {
     dependencies.logger.log(
       "warn",
-      `Gemini MNC summary failed: ${error}`,
+      `AI MNC summary failed: ${error}`,
     );
     return null;
   });
@@ -57,7 +58,7 @@ export async function getMncSummary(
   if (false === isRecord(parsedJson)) {
     dependencies.logger.log(
       "warn",
-      "Gemini MNC summary returned invalid JSON.",
+      "AI MNC summary returned invalid JSON.",
     );
     return undefined;
   }
@@ -66,7 +67,7 @@ export async function getMncSummary(
   if ("string" !== typeof summaryMarkdown) {
     dependencies.logger.log(
       "warn",
-      "Gemini MNC summary response did not contain summaryMarkdown.",
+      "AI MNC summary response did not contain summaryMarkdown.",
     );
     return undefined;
   }

--- a/modules/openai.test.ts
+++ b/modules/openai.test.ts
@@ -1,0 +1,490 @@
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {callOpenAiJson, clearOpenAiState} from "./openai.ts";
+
+describe("OpenAI client", () => {
+  const logger = {
+    log: vi.fn(),
+  };
+  const responseJsonSchema = {
+    additionalProperties: false,
+    properties: {
+      summary: {
+        type: "string",
+      },
+    },
+    required: ["summary"],
+    type: "object",
+  };
+  const readSecretFn = vi.fn((secretName: string) => {
+    if ("openai_api_key" === secretName) {
+      return "openai-key";
+    }
+
+    if ("openai_model" === secretName) {
+      return "gpt-5.4-mini";
+    }
+
+    throw new Error(`missing ${secretName}`);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearOpenAiState();
+  });
+
+  test("posts Responses API structured output requests with optional file and web search", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        output: [{
+          content: [{
+            text: "{\"summary\":\"ok\"}",
+            type: "output_text",
+          }],
+        }],
+      },
+    });
+
+    const result = await callOpenAiJson(
+      "Summarize the PDF.",
+      responseJsonSchema,
+      {
+        logger,
+        nowMs: () => 1_000,
+        postWithRetryFn,
+        readSecretFn,
+      },
+      "MNC summary",
+      {
+        data: "cGRmLWJ5dGVz",
+        filename: "mnc.pdf",
+        mimeType: "application/pdf",
+      },
+      {
+        timeoutMs: 45_000,
+        useWebSearch: true,
+      },
+    );
+
+    expect(result).toBe("{\"summary\":\"ok\"}");
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/responses",
+      expect.objectContaining({
+        input: [{
+          content: [{
+            file_data: "data:application/pdf;base64,cGRmLWJ5dGVz",
+            filename: "mnc.pdf",
+            type: "input_file",
+          }, {
+            text: "Summarize the PDF.",
+            type: "input_text",
+          }],
+          role: "user",
+        }],
+        model: "gpt-5.4-mini",
+        text: {
+          format: {
+            name: "bot_response",
+            schema: responseJsonSchema,
+            strict: true,
+            type: "json_schema",
+          },
+        },
+        tool_choice: "required",
+        tools: [{
+          search_context_size: "low",
+          type: "web_search",
+        }],
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Authorization": "Bearer openai-key",
+          "Content-Type": "application/json",
+        }),
+      }),
+      expect.objectContaining({
+        maxAttempts: 1,
+        timeoutMs: 45_000,
+      }),
+    );
+  });
+
+  test("uses default model when optional OpenAI secrets are missing", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        output_text: "{\"summary\":\"ok\"}",
+      },
+    });
+
+    const result = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn: vi.fn((secretName: string) => {
+        if ("openai_api_key" === secretName) {
+          return "openai-key";
+        }
+
+        throw new Error(`missing ${secretName}`);
+      }),
+    }, "test task");
+
+    expect(result).toBe("{\"summary\":\"ok\"}");
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/responses",
+      expect.objectContaining({
+        model: "gpt-5.4-mini",
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test("uses higher default OpenAI local call caps", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        output_text: "{\"summary\":\"ok\"}",
+      },
+    });
+    const defaultCapReadSecretFn = vi.fn((secretName: string) => {
+      if ("openai_api_key" === secretName) {
+        return "openai-key";
+      }
+
+      throw new Error(`missing ${secretName}`);
+    });
+
+    for (let callIndex = 0; callIndex < 20; callIndex += 1) {
+      await callOpenAiJson("prompt", responseJsonSchema, {
+        logger,
+        nowMs: () => 1_000,
+        postWithRetryFn,
+        readSecretFn: defaultCapReadSecretFn,
+      }, "test task");
+    }
+    const perMinuteSkippedResult = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn: defaultCapReadSecretFn,
+    }, "test task");
+
+    expect(perMinuteSkippedResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(20);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping OpenAI test task: local 20/minute rate limit is exhausted.",
+    );
+
+    clearOpenAiState();
+    postWithRetryFn.mockClear();
+    logger.log.mockClear();
+
+    for (let callIndex = 0; callIndex < 200; callIndex += 1) {
+      await callOpenAiJson("prompt", responseJsonSchema, {
+        logger,
+        nowMs: () => 1_000 + (callIndex * 61_000),
+        postWithRetryFn,
+        readSecretFn: defaultCapReadSecretFn,
+      }, "test task");
+    }
+    const perDaySkippedResult = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000 + (200 * 61_000),
+      postWithRetryFn,
+      readSecretFn: defaultCapReadSecretFn,
+    }, "test task");
+
+    expect(perDaySkippedResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(200);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping OpenAI test task: local 200/day rate limit is exhausted.",
+    );
+  });
+
+  test("returns null when the OpenAI API key is missing", async () => {
+    const postWithRetryFn = vi.fn();
+
+    const result = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      postWithRetryFn,
+      readSecretFn: vi.fn(() => {
+        throw new Error("missing secret");
+      }),
+    }, "test task");
+
+    expect(result).toBeNull();
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+  });
+
+  test("uses default inline filenames by MIME type", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        output_text: "{\"summary\":\"ok\"}",
+      },
+    });
+
+    await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "PDF task", {
+      data: "cGRm",
+      mimeType: "application/pdf",
+    });
+    clearOpenAiState();
+    await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 2_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "binary task", {
+      data: "Ymlu",
+      mimeType: "application/octet-stream",
+    });
+
+    const pdfRequestBody = postWithRetryFn.mock.calls[0]?.[1] as {input?: {content?: {filename?: string}[]}[]};
+    const binaryRequestBody = postWithRetryFn.mock.calls[1]?.[1] as {input?: {content?: {filename?: string}[]}[]};
+    expect(pdfRequestBody.input?.[0]?.content?.[0]?.filename).toBe("attachment.pdf");
+    expect(binaryRequestBody.input?.[0]?.content?.[0]?.filename).toBe("attachment.bin");
+  });
+
+  test("caps OpenAI calls with the local per-minute limiter", async () => {
+    const limitedReadSecretFn = vi.fn((secretName: string) => {
+      if ("openai_api_key" === secretName) {
+        return "openai-key";
+      }
+
+      if ("openai_calls_per_minute" === secretName) {
+        return "1";
+      }
+
+      throw new Error(`missing ${secretName}`);
+    });
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        output_text: "{\"summary\":\"ok\"}",
+      },
+    });
+
+    await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+    const skippedResult = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+
+    expect(skippedResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping OpenAI test task: local 1/minute rate limit is exhausted.",
+    );
+  });
+
+  test("caps OpenAI calls with the local per-day limiter", async () => {
+    const limitedReadSecretFn = vi.fn((secretName: string) => {
+      if ("openai_api_key" === secretName) {
+        return "openai-key";
+      }
+
+      if ("openai_calls_per_day" === secretName) {
+        return "2";
+      }
+
+      if ("openai_calls_per_minute" === secretName) {
+        return "10";
+      }
+
+      throw new Error(`missing ${secretName}`);
+    });
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        output_text: "{\"summary\":\"ok\"}",
+      },
+    });
+
+    await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+    await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 62_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+    const skippedResult = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 123_000,
+      postWithRetryFn,
+      readSecretFn: limitedReadSecretFn,
+    }, "test task");
+
+    expect(skippedResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping OpenAI test task: local 2/day rate limit is exhausted.",
+    );
+  });
+
+  test("activates a shared cooldown after OpenAI rate limiting", async () => {
+    const rateLimitError = {
+      response: {
+        headers: {
+          "retry-after": "30",
+        },
+        status: 429,
+      },
+    };
+    const postWithRetryFn = vi.fn().mockRejectedValue(rateLimitError);
+
+    await expect(callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(rateLimitError);
+
+    const skippedResult = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 2_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task");
+
+    expect(skippedResult).toBeNull();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "OpenAI API returned 429; cooling down OpenAI calls for 30s.",
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping OpenAI test task: API rate-limit cooldown is active for 29s.",
+    );
+  });
+
+  test("uses default OpenAI cooldown when rate-limit responses omit retry-after", async () => {
+    const rateLimitError = {
+      response: {
+        headers: {},
+        status: 429,
+      },
+    };
+    const postWithRetryFn = vi.fn().mockRejectedValue(rateLimitError);
+
+    await expect(callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 10_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(rateLimitError);
+
+    const skippedResult = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 69_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task");
+
+    expect(skippedResult).toBeNull();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "OpenAI API returned 429; cooling down OpenAI calls for 60s.",
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping OpenAI test task: API rate-limit cooldown is active for 1s.",
+    );
+  });
+
+  test("does not activate OpenAI cooldown for non-rate-limit failures", async () => {
+    const serverError = {
+      response: {
+        headers: {},
+        status: 500,
+      },
+    };
+    const postWithRetryFn = vi.fn()
+      .mockRejectedValueOnce(serverError)
+      .mockResolvedValueOnce({
+        data: {
+          output_text: "{\"summary\":\"ok\"}",
+        },
+      });
+
+    await expect(callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(serverError);
+    const result = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 2_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task");
+
+    expect(result).toBe("{\"summary\":\"ok\"}");
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("cooling down"),
+    );
+  });
+
+  test("parses retry-after date headers and returns null for responses without text", async () => {
+    const dateRateLimitError = {
+      response: {
+        headers: {
+          "retry-after": new Date(7_000).toUTCString(),
+        },
+        status: 429,
+      },
+    };
+    const postWithRetryFn = vi.fn()
+      .mockRejectedValueOnce(dateRateLimitError)
+      .mockResolvedValueOnce({
+        data: {
+          output: [{
+            content: [{
+              text: "ignored",
+              type: "tool_call",
+            }],
+          }],
+        },
+      });
+
+    await expect(callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 2_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task")).rejects.toBe(dateRateLimitError);
+    clearOpenAiState();
+    const result = await callOpenAiJson("prompt", responseJsonSchema, {
+      logger,
+      nowMs: () => 8_000,
+      postWithRetryFn,
+      readSecretFn,
+    }, "test task");
+
+    expect(result).toBeNull();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "OpenAI API returned 429; cooling down OpenAI calls for 5s.",
+    );
+  });
+});

--- a/modules/openai.ts
+++ b/modules/openai.ts
@@ -1,0 +1,338 @@
+import {postWithRetry} from "./http-retry.ts";
+import {readSecret} from "./secrets.ts";
+
+type Logger = {
+  log: (level: string, message: unknown) => void;
+};
+
+export type OpenAiDependencies = {
+  logger: Logger;
+  nowMs?: () => number;
+  postWithRetryFn?: typeof postWithRetry;
+  readSecretFn?: typeof readSecret;
+};
+
+export type OpenAiInlineData = {
+  data: string;
+  filename?: string | undefined;
+  mimeType: string;
+};
+
+export type OpenAiCallOptions = {
+  timeoutMs?: number | undefined;
+  useWebSearch?: boolean | undefined;
+};
+
+type OpenAiConfig = {
+  apiKey: string;
+  callsPerDay: number;
+  callsPerMinute: number;
+  model: string;
+};
+
+type OpenAiInputPart = {
+  text: string;
+  type: "input_text";
+} | {
+  file_data: string;
+  filename: string;
+  type: "input_file";
+};
+
+type OpenAiResponse = {
+  output?: {
+    content?: {
+      text?: string;
+      type?: string;
+    }[];
+  }[];
+  output_text?: string;
+};
+
+const openAiResponsesEndpoint = "https://api.openai.com/v1/responses";
+const openAiApiKeySecret = "openai_api_key";
+const openAiModelSecret = "openai_model";
+const openAiCallsPerMinuteSecret = "openai_calls_per_minute";
+const openAiCallsPerDaySecret = "openai_calls_per_day";
+const defaultOpenAiModel = "gpt-5.4-mini";
+const defaultOpenAiCallsPerMinute = 20;
+const defaultOpenAiCallsPerDay = 200;
+const maxOpenAiCallsPerMinute = 1_000;
+const maxOpenAiCallsPerDay = 100_000;
+const openAiWindowMs = 60_000;
+const openAiDayWindowMs = 24 * 60 * 60_000;
+const defaultOpenAiRateLimitCooldownMs = 60_000;
+
+const openAiCallTimestampsMs: number[] = [];
+const openAiDailyCallTimestampsMs: number[] = [];
+let openAiCooldownUntilMs = 0;
+
+export function clearOpenAiState() {
+  openAiCallTimestampsMs.splice(0, openAiCallTimestampsMs.length);
+  openAiDailyCallTimestampsMs.splice(0, openAiDailyCallTimestampsMs.length);
+  openAiCooldownUntilMs = 0;
+}
+
+export async function callOpenAiJson(
+  prompt: string,
+  responseJsonSchema: Record<string, unknown>,
+  dependencies: OpenAiDependencies,
+  task: string,
+  inlineData?: OpenAiInlineData,
+  options: OpenAiCallOptions = {},
+): Promise<string | null> {
+  const config = getOpenAiConfig(dependencies);
+  if (null === config) {
+    return null;
+  }
+
+  if (false === reserveOpenAiCall(config, dependencies, task)) {
+    return null;
+  }
+
+  const postWithRetryFn = dependencies.postWithRetryFn ?? postWithRetry;
+  const requestBody = {
+    input: [{
+      content: getOpenAiInputParts(prompt, inlineData),
+      role: "user",
+    }],
+    model: config.model,
+    text: {
+      format: {
+        name: "bot_response",
+        schema: responseJsonSchema,
+        strict: true,
+        type: "json_schema",
+      },
+    },
+    ...(true === options.useWebSearch ? {
+      tool_choice: "required",
+      tools: [{
+        search_context_size: "low",
+        type: "web_search",
+      }],
+    } : {}),
+  };
+
+  const response = await postWithRetryFn<OpenAiResponse>(
+    openAiResponsesEndpoint,
+    requestBody,
+    {
+      headers: {
+        "Authorization": `Bearer ${config.apiKey}`,
+        "Content-Type": "application/json",
+      },
+    },
+    {
+      maxAttempts: 1,
+      timeoutMs: options.timeoutMs ?? 15_000,
+    },
+  ).catch(error => {
+    activateOpenAiCooldownOnRateLimit(error, dependencies);
+    throw error;
+  });
+
+  return getOpenAiOutputText(response.data);
+}
+
+function getOpenAiInputParts(prompt: string, inlineData: OpenAiInlineData | undefined): OpenAiInputPart[] {
+  const promptPart: OpenAiInputPart = {
+    text: prompt,
+    type: "input_text",
+  };
+  if (undefined === inlineData) {
+    return [promptPart];
+  }
+
+  return [{
+    file_data: `data:${inlineData.mimeType};base64,${inlineData.data}`,
+    filename: inlineData.filename ?? getDefaultInlineFileName(inlineData.mimeType),
+    type: "input_file",
+  }, promptPart];
+}
+
+function getDefaultInlineFileName(mimeType: string): string {
+  if ("application/pdf" === mimeType) {
+    return "attachment.pdf";
+  }
+
+  return "attachment.bin";
+}
+
+function getOpenAiConfig(dependencies: OpenAiDependencies): OpenAiConfig | null {
+  const readSecretFn = dependencies.readSecretFn ?? readSecret;
+  const apiKey = readOptionalSecret(readSecretFn, openAiApiKeySecret);
+  if (undefined === apiKey) {
+    return null;
+  }
+
+  const model = readOptionalSecret(readSecretFn, openAiModelSecret) ?? defaultOpenAiModel;
+  const callsPerMinute = getOpenAiCallsPerMinute(readOptionalSecret(readSecretFn, openAiCallsPerMinuteSecret));
+  const callsPerDay = getOpenAiCallsPerDay(readOptionalSecret(readSecretFn, openAiCallsPerDaySecret));
+  return {
+    apiKey,
+    callsPerDay,
+    callsPerMinute,
+    model,
+  };
+}
+
+function readOptionalSecret(readSecretFn: typeof readSecret, secretName: string): string | undefined {
+  try {
+    const value = readSecretFn(secretName).trim();
+    return "" === value ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}
+
+function getOpenAiCallsPerMinute(value: string | undefined): number {
+  if (undefined === value) {
+    return defaultOpenAiCallsPerMinute;
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+  if (false === Number.isFinite(parsedValue)) {
+    return defaultOpenAiCallsPerMinute;
+  }
+
+  return Math.min(Math.max(parsedValue, 1), maxOpenAiCallsPerMinute);
+}
+
+function getOpenAiCallsPerDay(value: string | undefined): number {
+  if (undefined === value) {
+    return defaultOpenAiCallsPerDay;
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+  if (false === Number.isFinite(parsedValue)) {
+    return defaultOpenAiCallsPerDay;
+  }
+
+  return Math.min(Math.max(parsedValue, 1), maxOpenAiCallsPerDay);
+}
+
+function reserveOpenAiCall(
+  config: OpenAiConfig,
+  dependencies: OpenAiDependencies,
+  task: string,
+): boolean {
+  const nowMs = dependencies.nowMs?.() ?? Date.now();
+  if (nowMs < openAiCooldownUntilMs) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping OpenAI ${task}: API rate-limit cooldown is active for ${Math.ceil((openAiCooldownUntilMs - nowMs) / 1000)}s.`,
+    );
+    return false;
+  }
+
+  const windowStartMs = nowMs - openAiWindowMs;
+  while (0 < openAiCallTimestampsMs.length && (openAiCallTimestampsMs[0] ?? 0) <= windowStartMs) {
+    openAiCallTimestampsMs.shift();
+  }
+
+  const dayWindowStartMs = nowMs - openAiDayWindowMs;
+  while (0 < openAiDailyCallTimestampsMs.length && (openAiDailyCallTimestampsMs[0] ?? 0) <= dayWindowStartMs) {
+    openAiDailyCallTimestampsMs.shift();
+  }
+
+  if (openAiCallTimestampsMs.length >= config.callsPerMinute) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping OpenAI ${task}: local ${config.callsPerMinute}/minute rate limit is exhausted.`,
+    );
+    return false;
+  }
+
+  if (openAiDailyCallTimestampsMs.length >= config.callsPerDay) {
+    dependencies.logger.log(
+      "warn",
+      `Skipping OpenAI ${task}: local ${config.callsPerDay}/day rate limit is exhausted.`,
+    );
+    return false;
+  }
+
+  openAiCallTimestampsMs.push(nowMs);
+  openAiDailyCallTimestampsMs.push(nowMs);
+  return true;
+}
+
+function activateOpenAiCooldownOnRateLimit(error: unknown, dependencies: OpenAiDependencies) {
+  if (429 !== getHttpStatus(error)) {
+    return;
+  }
+
+  const nowMs = dependencies.nowMs?.() ?? Date.now();
+  const retryAfterMs = getRetryAfterMs(error, nowMs) ?? defaultOpenAiRateLimitCooldownMs;
+  openAiCooldownUntilMs = Math.max(openAiCooldownUntilMs, nowMs + retryAfterMs);
+  dependencies.logger.log(
+    "warn",
+    `OpenAI API returned 429; cooling down OpenAI calls for ${Math.ceil(retryAfterMs / 1000)}s.`,
+  );
+}
+
+function getOpenAiOutputText(response: OpenAiResponse): string | null {
+  if ("string" === typeof response.output_text) {
+    return response.output_text;
+  }
+
+  const outputTexts = response.output
+    ?.flatMap(outputItem => outputItem.content ?? [])
+    .flatMap(contentPart => "output_text" === contentPart.type && "string" === typeof contentPart.text ? [contentPart.text] : []) ?? [];
+  return 0 === outputTexts.length ? null : outputTexts.join("\n");
+}
+
+function getHttpStatus(error: unknown): number | undefined {
+  if (false === isRecord(error)) {
+    return undefined;
+  }
+
+  const response = error["response"];
+  if (false === isRecord(response)) {
+    return undefined;
+  }
+
+  const status = response["status"];
+  return "number" === typeof status ? status : undefined;
+}
+
+function getRetryAfterMs(error: unknown, nowMs: number): number | undefined {
+  if (false === isRecord(error)) {
+    return undefined;
+  }
+
+  const response = error["response"];
+  if (false === isRecord(response)) {
+    return undefined;
+  }
+
+  const headers = response["headers"];
+  if (false === isRecord(headers)) {
+    return undefined;
+  }
+
+  const retryAfter = headers["retry-after"] ?? headers["Retry-After"];
+  if ("number" === typeof retryAfter && Number.isFinite(retryAfter)) {
+    return Math.max(1, retryAfter) * 1_000;
+  }
+
+  if ("string" !== typeof retryAfter || "" === retryAfter.trim()) {
+    return undefined;
+  }
+
+  const retryAfterSeconds = Number.parseInt(retryAfter, 10);
+  if (Number.isFinite(retryAfterSeconds)) {
+    return Math.max(1, retryAfterSeconds) * 1_000;
+  }
+
+  const retryAfterTimestampMs = Date.parse(retryAfter);
+  if (false === Number.isFinite(retryAfterTimestampMs)) {
+    return undefined;
+  }
+
+  return Math.max(1_000, retryAfterTimestampMs - nowMs);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
+}

--- a/modules/timers.test.ts
+++ b/modules/timers.test.ts
@@ -318,7 +318,7 @@ describe("timers: NYSE and MNC", () => {
     }));
   });
 
-  test("startMncTimers includes a Gemini summary when available", async () => {
+  test("startMncTimers includes an AI summary when available", async () => {
     const {client, send} = createClientWithChannel();
     getMncSummaryMock.mockResolvedValueOnce("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
 


### PR DESCRIPTION
## Summary
- add provider-neutral AI facade with Gemini as the default and a dormant OpenAI Responses backend
- default OpenAI local caps to 20 calls per minute and 200 calls per day
- route earnings, MNC summaries, and market-close recaps through the provider boundary
- remember no-metrics earnings result filings for the watcher lifetime to stop repeated warning spam
- replace the local AI preflight HTML-stripping regex that matched the open CodeQL alert

## Validation
- npm run typecheck
- npx vitest run modules/openai.test.ts modules/ai-provider.test.ts
- npx vitest run modules/earnings-results.test.ts modules/earnings-results-format.test.ts
- npm run test:coverage