### PR TITLE
[codex] Adjust MNC title and remove XMR bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ The health-check server port can be overridden via the `HEALTHCHECK_PORT` enviro
   "discord_ethusd_client_ID": "",
   "discord_solusd_token": "",
   "discord_solusd_client_ID": "",
-  "discord_oneusd_token": "",
-  "discord_oneusd_client_ID": "",
   "discord_es_token": "",
   "discord_es_client_ID": "",
   "discord_nq_token": "",

--- a/assets/marketdata.yaml
+++ b/assets/marketdata.yaml
@@ -114,21 +114,6 @@
   decimals: 2
   lastUpdate: 0
   order: 2
-- name: oneusd
-  trigger: forexpros_ws
-  botTokenReference: discord_oneusd_token
-  botToken: ""
-  botClientIdReference: discord_oneusd_client_ID
-  botClientId: ""
-  botName: "Monero/USD"
-  id: 1176959
-  suffix: "$"
-  unit: "PCT"
-  marketHours: "crypto"
-  # XMR/USD and ONE/USD are not tastytrade cryptocurrency instruments; this bot uses Investing.com only.
-  decimals: 2
-  lastUpdate: 0
-  order: 3
 - name: cl
   trigger: forexpros_ws
   botTokenReference: discord_cl_token

--- a/modules/mnc-summary.test.ts
+++ b/modules/mnc-summary.test.ts
@@ -41,7 +41,7 @@ describe("MNC AI summary", () => {
       readSecretFn,
     });
 
-    expect(summary).toBe("📰 **Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
+    expect(summary).toBe("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
     expect(postWithRetryFn).toHaveBeenCalledWith(
       expect.stringContaining("gemini-2.5-flash-lite:generateContent"),
       expect.objectContaining({
@@ -126,7 +126,8 @@ describe("MNC AI summary", () => {
 
     expect(summary).toBeDefined();
     expect(summary).not.toContain("```");
-    expect(summary).toContain("📰 **Morning News Call - TL;DR**");
+    expect(summary).toContain("**Morning News Call - TL;DR**");
+    expect(summary).not.toContain("📰 **Morning News Call - TL;DR**");
     expect(summary!.length).toBeLessThanOrEqual(1_930);
     expect(summary).toContain("\n...");
     expect(summary).not.toContain("\n- ...");
@@ -171,6 +172,30 @@ describe("MNC AI summary", () => {
     expect(summary).toContain("**Watchlist**");
     expect(summary).toContain("Watch Treasury supply");
     expect(summary).not.toContain("\n...");
+  });
+
+  test("removes legacy newspaper emoji from the summary heading", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summaryMarkdown: "📰 **Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBe("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
   });
 
   test("hard-truncates summaries that cannot be compacted or split by line", async () => {

--- a/modules/mnc-summary.ts
+++ b/modules/mnc-summary.ts
@@ -112,11 +112,7 @@ function normalizeMarkdownSummary(value: string): string {
     .replace(/\\([$€£¥])/g, "$1")
     .trim();
   if (summary.startsWith("📰 **Morning News Call - TL;DR**")) {
-    return summary;
-  }
-
-  if (summary.startsWith("**Morning News Call - TL;DR**")) {
-    return `📰 ${summary}`;
+    return summary.slice("📰 ".length);
   }
 
   return summary;

--- a/modules/timers.test.ts
+++ b/modules/timers.test.ts
@@ -313,7 +313,7 @@ describe("timers: NYSE and MNC", () => {
       name: expect.stringMatching(/^MNC-\d{4}-\d{2}-\d{2}\.pdf$/),
     }));
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining("Morning News Call"),
+      content: expect.stringContaining("📰 Morning News Call"),
       files: expect.any(Array),
     }));
   });
@@ -330,7 +330,15 @@ describe("timers: NYSE and MNC", () => {
     await Promise.resolve();
 
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining("📰 Morning News Call"),
+      files: expect.any(Array),
+    }));
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringContaining("**Morning News Call - TL;DR**"),
+      files: expect.any(Array),
+    }));
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.not.stringContaining("📰 **Morning News Call - TL;DR**"),
       files: expect.any(Array),
     }));
   });

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -683,7 +683,7 @@ export function startMncTimers(client: TimerClient, channelID: string) {
 }
 
 function getMncAnnouncementContent(date: string, summary: string | undefined): string {
-  const title = `Morning News Call (${date})`;
+  const title = `📰 Morning News Call (${date})`;
   return undefined === summary
     ? title
     : `${title}\n\n${summary}`;

--- a/tools/docker-compose-production.yml
+++ b/tools/docker-compose-production.yml
@@ -27,8 +27,6 @@ services:
       - production_discord_btcusd_client_ID
       - production_discord_ethusd_token
       - production_discord_ethusd_client_ID
-      - production_discord_oneusd_token
-      - production_discord_oneusd_client_ID
       - production_discord_solusd_token
       - production_discord_solusd_client_ID
       - production_discord_es_token
@@ -105,10 +103,6 @@ secrets:
   production_discord_ethusd_token:
     external: true
   production_discord_ethusd_client_ID:
-    external: true
-  production_discord_oneusd_token:
-    external: true
-  production_discord_oneusd_client_ID:
     external: true
   production_discord_solusd_token:
     external: true


### PR DESCRIPTION
## Summary
- Move the newspaper emoji from the MNC summary heading to the announcement title.
- Strip legacy summary-heading newspaper emoji if an AI provider still returns it.
- Remove the Monero/XMR market-data bot and its oneusd secret references.

## Validation
- npm run typecheck
- npx vitest run modules/mnc-summary.test.ts modules/timers.test.ts modules/assets.test.ts
- npm run test:coverage