### PR TITLE
[codex] Handle dxLink fallback and trim earnings summaries

### DIFF
--- a/modules/earnings-results-summary.test.ts
+++ b/modules/earnings-results-summary.test.ts
@@ -60,12 +60,13 @@ describe("AI earnings summaries", () => {
     });
 
     expect(result).toBe(
-      "Example Corp reported first-quarter revenue of `$10.2 billion` and adjusted EPS of `$1.42`. Segment demand remained resilient during the period. Management guided fiscal 2026 revenue to `$42 billion` to `$44 billion` and adjusted EPS to `$5.80` to `$6.10`.",
+      "Reported first-quarter revenue of `$10.2 billion` and adjusted EPS of `$1.42`. Segment demand remained resilient during the period. Management guided fiscal 2026 revenue to `$42 billion` to `$44 billion` and adjusted EPS to `$5.80` to `$6.10`.",
     );
     const requestBody = postWithRetryFn.mock.calls[0]?.[1] as {contents?: {parts?: {text?: string}[]}[]};
     const prompt = requestBody.contents?.[0]?.parts?.find(part => "string" === typeof part.text)?.text ?? "";
     const filingText = prompt.split("Filing text:\n")[1] ?? "";
     expect(prompt).toContain("Write exactly three concise plain-text sentences.");
+    expect(prompt).toContain("Do not mention the company name in the summary");
     expect(filingText.length).toBeLessThanOrEqual(20_100);
     expect(filingText).toContain("Opening excerpt:");
     expect(filingText).toContain("Example Corp reports first quarter 2026 results");
@@ -135,7 +136,69 @@ describe("AI earnings summaries", () => {
       readSecretFn,
     });
 
-    expect(result).toBe("Example Corp grew revenue. Margins improved. Guidance increased.");
+    expect(result).toBe("Grew revenue. Margins improved. Guidance increased.");
+  });
+
+  test("keeps summary content when company and ticker metadata are blank", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summary: "Revenue rose 12%. Margins improved. Guidance increased.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await summarizeEarningsWithAi({
+      companyName: " ",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: "<html><body><h1>Revenue rose 12%</h1></body></html>",
+      ticker: " ",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBe("Revenue rose `12%`. Margins improved. Guidance increased.");
+  });
+
+  test("strips leading company names that contain periods or suffixes", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summary: "L.B. Foster Company reported revenue of $10 million. L.B. Foster's margins improved. Guidance increased.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await summarizeEarningsWithAi({
+      companyName: "L.B. Foster Company",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: "<html><body><h1>L.B. Foster Company reports results</h1></body></html>",
+      ticker: "FSTR",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBe("Reported revenue of `$10 million`. Margins improved. Guidance increased.");
   });
 
   test("returns null when the provider is unavailable", async () => {

--- a/modules/earnings-results-summary.ts
+++ b/modules/earnings-results-summary.ts
@@ -70,7 +70,7 @@ export async function summarizeEarningsWithAi(
     return null;
   }
 
-  return parseSummary(parsedJson, input.ticker);
+  return parseSummary(parsedJson, input.ticker, input.companyName);
 }
 
 function getSummaryPrompt(input: EarningsAiSummaryInput, filingText: string): string {
@@ -83,6 +83,7 @@ function getSummaryPrompt(input: EarningsAiSummaryInput, filingText: string): st
     "- Sentence 2 covers the most important business drivers, segment notes, or margin/profit details.",
     "- Sentence 3 covers outlook, guidance, or management expectations when present; otherwise state that no quantified outlook is provided.",
     "- Format ticker symbols and concrete metrics as inline code, e.g. `AAPL`, `$2.14`, `3.1%`, `180 bps`, `$42 billion`.",
+    "- Do not mention the company name in the summary; the Discord alert title already identifies the company.",
     "- Use only the provided filing text and do not mention the SEC filing, source text, or any AI provider.",
     `Company: ${input.companyName}`,
     `Ticker: ${input.ticker}`,
@@ -172,7 +173,7 @@ function parseJson(value: string): unknown | null {
   }
 }
 
-function parseSummary(value: unknown, ticker: string): string | null {
+function parseSummary(value: unknown, ticker: string, companyName: string): string | null {
   if (false === isRecord(value)) {
     return null;
   }
@@ -190,7 +191,56 @@ function parseSummary(value: unknown, ticker: string): string | null {
     return null;
   }
 
-  return formatSummaryInlineCode(normalizedSummary, ticker);
+  return formatSummaryInlineCode(removeRedundantCompanyNameMentions(normalizedSummary, companyName), ticker);
+}
+
+function removeRedundantCompanyNameMentions(value: string, companyName: string): string {
+  const companyNamePatterns = getCompanyNamePatterns(companyName);
+  if (0 === companyNamePatterns.length) {
+    return value;
+  }
+
+  let result = value;
+  for (const companyNamePattern of companyNamePatterns) {
+    result = result.replace(
+      companyNamePattern,
+      (_match, sentencePrefix: string, nextCharacter: string) => `${sentencePrefix}${capitalizeFirstLetter(nextCharacter)}`,
+    );
+  }
+
+  return result;
+}
+
+function getCompanyNamePatterns(companyName: string): RegExp[] {
+  const normalizedCompanyName = companyName.replace(/\s+/g, " ").trim();
+  if ("" === normalizedCompanyName) {
+    return [];
+  }
+
+  const aliases = new Set<string>([normalizedCompanyName]);
+  const suffixlessCompanyName = normalizedCompanyName
+    .replace(/,?\s+(?:incorporated|inc\.?|corporation|corp\.?|company|co\.?|limited|ltd\.?|plc|group|holdings?)\.?$/i, "")
+    .trim();
+  if ("" !== suffixlessCompanyName) {
+    aliases.add(suffixlessCompanyName);
+  }
+
+  for (const alias of [...aliases]) {
+    aliases.add(alias.replace(/^the\s+/i, "").trim());
+  }
+
+  return [...aliases]
+    .filter(alias => "" !== alias)
+    .sort((first, second) => second.length - first.length)
+    .map(alias => new RegExp(`(^|[.!?]\\s+)${escapeRegExp(alias)}(?:\\s*\\([A-Z0-9.:-]+\\))?(?:\\s*'s)?(?:\\s+|\\s*[,;:.-]\\s*)(\\S)`, "gi"));
+}
+
+function capitalizeFirstLetter(value: string): string {
+  return value.replace(/[A-Za-z]/, letter => letter.toUpperCase());
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function formatSummaryInlineCode(value: string, ticker: string): string {

--- a/modules/market-data-tastytrade.test.ts
+++ b/modules/market-data-tastytrade.test.ts
@@ -1,12 +1,14 @@
 import {beforeEach, describe, expect, test, vi} from "vitest";
 import {MarketDataSubscriptionType} from "@tastytrade/api";
 import {
+  createHandledDxLinkQuoteStreamer,
   startTastytradeCryptoStream,
   type TastytradeCryptoStreamOptions,
 } from "./market-data-tastytrade.ts";
 import {type MarketDataAsset} from "./market-data-types.ts";
 
 type StreamerListener = (events: Record<string, unknown>[]) => void;
+type StreamerErrorListener = (error: {message: string; type?: string | undefined}) => void;
 
 function createCryptoAsset(overrides: Partial<MarketDataAsset> = {}): MarketDataAsset {
   return {
@@ -27,8 +29,15 @@ function createCryptoAsset(overrides: Partial<MarketDataAsset> = {}): MarketData
 
 function createStreamer() {
   let listener: StreamerListener | undefined;
+  let errorListener: StreamerErrorListener | undefined;
   return {
     streamer: {
+      addErrorListener: vi.fn((newListener: StreamerErrorListener) => {
+        errorListener = newListener;
+        return vi.fn(() => {
+          errorListener = undefined;
+        });
+      }),
       addEventListener: vi.fn((newListener: StreamerListener) => {
         listener = newListener;
         return vi.fn(() => {
@@ -38,9 +47,13 @@ function createStreamer() {
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn(),
       subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
     },
     emit: (events: Record<string, unknown>[]) => {
       listener?.(events);
+    },
+    emitError: (error: {message: string; type?: string | undefined}) => {
+      errorListener?.(error);
     },
   };
 }
@@ -243,6 +256,96 @@ describe("tastytrade crypto market data stream", () => {
     await vi.advanceTimersByTimeAsync(1);
     await flushAsyncWork();
     expect(connect).toHaveBeenCalledTimes(3);
+  });
+
+  test("handles dxLink streamer errors through fallback and retry", async () => {
+    const stream = createStreamer();
+    const options = createOptions({
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    stream.emitError({type: "UNKNOWN", message: "Unable to connect"});
+
+    expect(options.onFallback).toHaveBeenCalledWith("dxLink UNKNOWN: Unable to connect");
+    expect(stream.streamer.disconnect).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flushAsyncWork();
+
+    expect(stream.streamer.connect).toHaveBeenCalledTimes(2);
+
+    stream.emitError({message: "   "});
+
+    expect(options.onFallback).toHaveBeenLastCalledWith("dxLink: unknown error");
+  });
+
+  test("creates a handled dxLink quote streamer with subscriptions and error listeners", async () => {
+    const dxLinkErrorListener = vi.fn();
+    const feedListener = vi.fn();
+    const dxLinkClient = {
+      addErrorListener: vi.fn((listener: StreamerErrorListener) => {
+        dxLinkErrorListener.mockImplementation(listener);
+      }),
+      close: vi.fn(),
+      connect: vi.fn(),
+      removeErrorListener: vi.fn(),
+      setAuthToken: vi.fn(),
+    };
+    const dxLinkFeed = {
+      addEventListener: vi.fn(),
+      addSubscriptions: vi.fn(),
+      close: vi.fn(),
+      configure: vi.fn(),
+      removeEventListener: vi.fn(),
+      removeSubscriptions: vi.fn(),
+    };
+    const quoteStreamer = createHandledDxLinkQuoteStreamer({
+      getApiQuoteToken: vi.fn().mockResolvedValue({
+        "dxlink-url": "wss://quote.example",
+        token: "quote-token",
+      }),
+    }, {
+      createClient: () => dxLinkClient,
+      createFeed: () => dxLinkFeed,
+    });
+    const quoteErrorListener = vi.fn();
+    const removeErrorListener = quoteStreamer.addErrorListener?.(quoteErrorListener);
+
+    quoteStreamer.addEventListener(feedListener);
+    await quoteStreamer.connect();
+    quoteStreamer.subscribe(["BTC/USD:CXTALP"], [MarketDataSubscriptionType.Trade]);
+    quoteStreamer.unsubscribe(["BTC/USD:CXTALP"]);
+    dxLinkErrorListener({type: "UNKNOWN", message: "Unable to connect"});
+    removeErrorListener?.();
+    quoteStreamer.disconnect();
+
+    expect(dxLinkClient.connect).toHaveBeenCalledWith("wss://quote.example");
+    expect(dxLinkClient.setAuthToken).toHaveBeenCalledWith("quote-token");
+    expect(dxLinkFeed.configure).toHaveBeenCalledWith({
+      acceptAggregationPeriod: 10,
+      acceptDataFormat: "COMPACT",
+    });
+    expect(dxLinkFeed.addEventListener).toHaveBeenCalledWith(feedListener);
+    expect(dxLinkFeed.addSubscriptions).toHaveBeenCalledWith({
+      symbol: "BTC/USD:CXTALP",
+      type: MarketDataSubscriptionType.Trade,
+    });
+    expect(dxLinkFeed.removeSubscriptions).toHaveBeenCalledWith({
+      symbol: "BTC/USD:CXTALP",
+      type: MarketDataSubscriptionType.Trade,
+    });
+    expect(quoteErrorListener).toHaveBeenCalledWith({
+      message: "Unable to connect",
+      type: "UNKNOWN",
+    });
+    expect(dxLinkClient.removeErrorListener).toHaveBeenCalledTimes(1);
+    expect(dxLinkFeed.close).toHaveBeenCalledTimes(1);
+    expect(dxLinkClient.close).toHaveBeenCalledTimes(1);
   });
 
   test("falls back when a connected stream stays stale and recovers on the next valid event", async () => {

--- a/modules/market-data-tastytrade.ts
+++ b/modules/market-data-tastytrade.ts
@@ -395,12 +395,12 @@ export function createHandledDxLinkQuoteStreamer(
 ): TastytradeQuoteStreamer {
   const createClient = dependencies.createClient ?? (() => new DXLinkWebSocketClient({
     logLevel: DXLinkLogLevel.ERROR,
-  }) as unknown as DxLinkClientLike);
+  }));
   const createFeed = dependencies.createFeed ?? ((dxLinkClient: DxLinkClientLike) => new DXLinkFeed(
     dxLinkClient as unknown as DXLinkClient,
     FeedContract.AUTO,
     {logLevel: DXLinkLogLevel.ERROR},
-  ) as unknown as DxLinkFeedLike);
+  ));
 
   return new HandledDxLinkQuoteStreamer(accountsAndCustomersService, {
     createClient,

--- a/modules/market-data-tastytrade.ts
+++ b/modules/market-data-tastytrade.ts
@@ -1,3 +1,11 @@
+import {
+  DXLinkFeed,
+  DXLinkLogLevel,
+  DXLinkWebSocketClient,
+  FeedContract,
+  FeedDataFormat,
+  type DXLinkClient,
+} from "@dxfeed/dxlink-api";
 import TastytradeClient, {MarketDataSubscriptionType} from "@tastytrade/api";
 import WS from "ws";
 import {type MarketDataAsset} from "./market-data-types.ts";
@@ -10,16 +18,27 @@ type Logger = {
 type TimerHandle = ReturnType<typeof setTimeout>;
 type TastytradeEvent = Record<string, unknown>;
 type TastytradeEventListener = (events: TastytradeEvent[]) => void;
+type TastytradeQuoteStreamerError = {
+  message: string;
+  type?: string | undefined;
+};
+type TastytradeQuoteStreamerErrorListener = (error: TastytradeQuoteStreamerError) => void;
 type TastytradeQuoteStreamer = {
+  addErrorListener?: (listener: TastytradeQuoteStreamerErrorListener) => () => void;
   addEventListener: (listener: TastytradeEventListener) => () => void;
   connect: () => Promise<void>;
   disconnect: () => void;
   subscribe: (streamerSymbols: string[], types?: MarketDataSubscriptionType[] | null) => void;
+  unsubscribe: (streamerSymbols: string[]) => void;
+};
+export type TastytradeAccountsAndCustomersService = {
+  getApiQuoteToken: () => Promise<Record<string, unknown>>;
 };
 type TastytradeInstrumentsService = {
   getCryptocurrencies: (symbols: string[]) => Promise<Record<string, unknown>[]>;
 };
 type TastytradeMarketDataClient = {
+  accountsAndCustomersService?: TastytradeAccountsAndCustomersService;
   instrumentsService?: TastytradeInstrumentsService;
   quoteStreamer: TastytradeQuoteStreamer;
 };
@@ -32,6 +51,28 @@ type CryptoStreamAsset = {
   asset: MarketDataAsset;
   configuredSymbol: string;
   streamerSymbol: string;
+};
+type DxLinkClientLike = {
+  addErrorListener: (listener: TastytradeQuoteStreamerErrorListener) => unknown;
+  close: () => void;
+  connect: (url: string) => void;
+  removeErrorListener: (listener: TastytradeQuoteStreamerErrorListener) => unknown;
+  setAuthToken: (token: string) => void;
+};
+type DxLinkFeedLike = {
+  addEventListener: (listener: TastytradeEventListener) => void;
+  addSubscriptions: (...subscriptions: {symbol: string; type: string}[]) => void;
+  close: () => void;
+  configure: (acceptConfig: {
+    acceptAggregationPeriod: number;
+    acceptDataFormat: FeedDataFormat;
+  }) => void;
+  removeEventListener: (listener: TastytradeEventListener) => void;
+  removeSubscriptions: (...subscriptions: {symbol: string; type: string}[]) => void;
+};
+export type HandledDxLinkQuoteStreamerDependencies = {
+  createClient?: () => DxLinkClientLike;
+  createFeed?: (client: DxLinkClientLike) => DxLinkFeedLike;
 };
 
 export type TastytradeCryptoStreamOptions = {
@@ -102,6 +143,7 @@ export function startTastytradeCryptoStream({
   let retryTimer: TimerHandle | undefined;
   let staleTimer: TimerHandle | undefined;
   let removeListener: (() => void) | undefined;
+  let removeQuoteStreamerErrorListener: (() => void) | undefined;
   let stopped = false;
   const previousPrices = new Map<string, number>();
 
@@ -118,6 +160,11 @@ export function startTastytradeCryptoStream({
     if (undefined !== removeListener) {
       removeListener();
       removeListener = undefined;
+    }
+
+    if (undefined !== removeQuoteStreamerErrorListener) {
+      removeQuoteStreamerErrorListener();
+      removeQuoteStreamerErrorListener = undefined;
     }
 
     if (undefined !== client) {
@@ -149,6 +196,10 @@ export function startTastytradeCryptoStream({
   };
 
   const fail = (reason: string) => {
+    if (true === stopped) {
+      return;
+    }
+
     clearTimer(initialResubscribeTimer);
     clearTimer(staleTimer);
     disconnect();
@@ -277,10 +328,17 @@ export function startTastytradeCryptoStream({
 
       disconnect();
       client = clientFactory({clientSecret, refreshToken});
+      removeQuoteStreamerErrorListener = client.quoteStreamer.addErrorListener?.(error => {
+        fail(formatQuoteStreamerError(error));
+      });
       streamAssets = await resolveCryptoStreamAssets(configuredStreamAssets, client, logger);
       assetByStreamerSymbol = getAssetByStreamerSymbol(streamAssets);
       removeListener = client.quoteStreamer.addEventListener(handleEvents);
       await client.quoteStreamer.connect();
+      if (undefined === client) {
+        return;
+      }
+
       connectedAtMs = now();
       lastValidEventAtMs = 0;
       lastValidEventAtBySymbol.clear();
@@ -316,13 +374,153 @@ function createTastytradeMarketDataClient(credentials: {
   clientSecret: string;
   refreshToken: string;
 }): TastytradeMarketDataClient {
-  return new TastytradeClient({
+  const client = new TastytradeClient({
     baseUrl: "https://api.tastyworks.com",
     accountStreamerUrl: "wss://streamer.tastyworks.com",
     clientSecret: credentials.clientSecret,
     refreshToken: credentials.refreshToken,
     oauthScopes: ["read"],
   });
+
+  return {
+    accountsAndCustomersService: client.accountsAndCustomersService,
+    instrumentsService: client.instrumentsService,
+    quoteStreamer: createHandledDxLinkQuoteStreamer(client.accountsAndCustomersService),
+  };
+}
+
+export function createHandledDxLinkQuoteStreamer(
+  accountsAndCustomersService: TastytradeAccountsAndCustomersService,
+  dependencies: HandledDxLinkQuoteStreamerDependencies = {},
+): TastytradeQuoteStreamer {
+  const createClient = dependencies.createClient ?? (() => new DXLinkWebSocketClient({
+    logLevel: DXLinkLogLevel.ERROR,
+  }) as unknown as DxLinkClientLike);
+  const createFeed = dependencies.createFeed ?? ((dxLinkClient: DxLinkClientLike) => new DXLinkFeed(
+    dxLinkClient as unknown as DXLinkClient,
+    FeedContract.AUTO,
+    {logLevel: DXLinkLogLevel.ERROR},
+  ) as unknown as DxLinkFeedLike);
+
+  return new HandledDxLinkQuoteStreamer(accountsAndCustomersService, {
+    createClient,
+    createFeed,
+  });
+}
+
+class HandledDxLinkQuoteStreamer implements TastytradeQuoteStreamer {
+  private readonly accountsAndCustomersService: TastytradeAccountsAndCustomersService;
+  private readonly dependencies: Required<HandledDxLinkQuoteStreamerDependencies>;
+  private dxLinkClient: DxLinkClientLike | null = null;
+  private dxLinkFeed: DxLinkFeedLike | null = null;
+  private readonly errorListeners = new Set<TastytradeQuoteStreamerErrorListener>();
+  private readonly eventListeners = new Set<TastytradeEventListener>();
+
+  constructor(
+    accountsAndCustomersService: TastytradeAccountsAndCustomersService,
+    dependencies: Required<HandledDxLinkQuoteStreamerDependencies>,
+  ) {
+    this.accountsAndCustomersService = accountsAndCustomersService;
+    this.dependencies = dependencies;
+  }
+
+  async connect(): Promise<void> {
+    const tokenResponse = await this.accountsAndCustomersService.getApiQuoteToken();
+    const dxLinkUrl = getStringField(tokenResponse, ["dxlink-url", "dxLinkUrl", "dxlinkUrl"]);
+    const dxLinkAuthToken = getStringField(tokenResponse, ["token"]);
+    if (null === dxLinkUrl || null === dxLinkAuthToken) {
+      throw new Error("tastytrade dxLink quote token response is missing connection details");
+    }
+
+    this.disconnect();
+    this.dxLinkClient = this.dependencies.createClient();
+    this.dxLinkClient.addErrorListener(this.handleDxLinkError);
+    this.dxLinkClient.connect(dxLinkUrl);
+    this.dxLinkClient.setAuthToken(dxLinkAuthToken);
+
+    this.dxLinkFeed = this.dependencies.createFeed(this.dxLinkClient);
+    this.dxLinkFeed.configure({
+      acceptAggregationPeriod: 10,
+      acceptDataFormat: FeedDataFormat.COMPACT,
+    });
+    for (const listener of this.eventListeners) {
+      this.dxLinkFeed.addEventListener(listener);
+    }
+  }
+
+  disconnect(): void {
+    const dxLinkFeed = this.dxLinkFeed;
+    const dxLinkClient = this.dxLinkClient;
+    this.dxLinkFeed = null;
+    this.dxLinkClient = null;
+
+    dxLinkClient?.removeErrorListener(this.handleDxLinkError);
+    dxLinkFeed?.close();
+    dxLinkClient?.close();
+  }
+
+  addEventListener(listener: TastytradeEventListener): () => void {
+    this.eventListeners.add(listener);
+    this.dxLinkFeed?.addEventListener(listener);
+
+    return () => {
+      this.removeEventListener(listener);
+    };
+  }
+
+  removeEventListener(listener: TastytradeEventListener): void {
+    this.eventListeners.delete(listener);
+    this.dxLinkFeed?.removeEventListener(listener);
+  }
+
+  addErrorListener(listener: TastytradeQuoteStreamerErrorListener): () => void {
+    this.errorListeners.add(listener);
+
+    return () => {
+      this.errorListeners.delete(listener);
+    };
+  }
+
+  subscribe(streamerSymbols: string[], types: MarketDataSubscriptionType[] | null = null): void {
+    if (null === this.dxLinkFeed) {
+      throw new Error("DxLink feed is not connected");
+    }
+
+    const subscriptionTypes = types ?? quoteSubscriptionTypes;
+    for (const streamerSymbol of streamerSymbols) {
+      for (const type of subscriptionTypes) {
+        this.dxLinkFeed.addSubscriptions({type, symbol: streamerSymbol});
+      }
+    }
+  }
+
+  unsubscribe(streamerSymbols: string[]): void {
+    if (null === this.dxLinkFeed) {
+      throw new Error("DxLink feed is not connected");
+    }
+
+    for (const streamerSymbol of streamerSymbols) {
+      for (const type of quoteSubscriptionTypes) {
+        this.dxLinkFeed.removeSubscriptions({type, symbol: streamerSymbol});
+      }
+    }
+  }
+
+  private readonly handleDxLinkError = (error: TastytradeQuoteStreamerError): void => {
+    for (const listener of this.errorListeners) {
+      listener(error);
+    }
+  };
+}
+
+function formatQuoteStreamerError(error: TastytradeQuoteStreamerError): string {
+  const message = "" === error.message.trim() ? "unknown error" : error.message.trim();
+  const type = error.type?.trim();
+  if (undefined === type || "" === type) {
+    return `dxLink: ${message}`;
+  }
+
+  return `dxLink ${type}: ${message}`;
 }
 
 function ensureWebSocketGlobal() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@dxfeed/dxlink-api": "^0.3.0",
         "@tastytrade/api": "^7.0.1",
         "axios": "^1.15.2",
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "@dxfeed/dxlink-api": "^0.3.0",
     "@tastytrade/api": "^7.0.1",
     "axios": "^1.15.2",
     "class-transformer": "^0.5.1",


### PR DESCRIPTION
## Summary

- Route tastytrade crypto quotes through a handled dxLink adapter so dxLink connection errors enter the existing Investing.com fallback and retry flow.
- Add a direct `@dxfeed/dxlink-api` dependency because the app now imports dxLink directly.
- Keep earnings summary copy from repeating the company name already shown in the alert title.

## Root Cause

`@tastytrade/api` creates a `DXLinkWebSocketClient` without an error listener, so dxLink writes connection failures such as `Unable to connect` directly to the console as unhandled errors. Earnings summaries also lacked prompt and output cleanup to avoid restating the company name from the alert context.

## Validation

- `npx vitest run modules/market-data-tastytrade.test.ts modules/earnings-results-summary.test.ts`
- `npm run typecheck`
- `npm run test:coverage`