### PR TITLE
[codex] Flag revenue below net income

### DIFF
--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -640,8 +640,32 @@ describe("AI earnings helpers", () => {
       "gaap_eps",
       "revenue",
       "revenue",
+      "revenue",
       "net_income",
     ]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(true);
+  });
+
+  test("identifies revenue that is implausibly lower than net income", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 2_000_000,
+      value: "$2M",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: 274_100_000,
+      value: "$274.1M",
+    }], null, getEvent({
+      marketCap: 9_000_000_000,
+    }));
+
+    expect(reasons).toEqual([{
+      message: "Revenue $2M is lower than net income $274.1M.",
+      metricKey: "revenue",
+      severity: "high",
+    }]);
     expect(hasHighSeveritySuspicion(reasons)).toBe(true);
   });
 

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -365,6 +365,20 @@ export function getSuspiciousEarningsReasons(
   }
 
   const netIncomeMetric = metrics.find(metric => "net_income" === metric.key);
+  if (undefined !== revenueMetric &&
+      undefined !== netIncomeMetric &&
+      "number" === typeof revenueMetric.numericValue &&
+      "number" === typeof netIncomeMetric.numericValue &&
+      revenueMetric.numericValue > 0 &&
+      netIncomeMetric.numericValue > 0 &&
+      revenueMetric.numericValue < netIncomeMetric.numericValue) {
+    reasons.push({
+      message: `Revenue ${revenueMetric.value} is lower than net income ${netIncomeMetric.value}.`,
+      metricKey: "revenue",
+      severity: revenueMetric.numericValue <= netIncomeMetric.numericValue * 0.5 ? "high" : "medium",
+    });
+  }
+
   if (undefined !== netIncomeMetric &&
       "number" === typeof netIncomeMetric.numericValue &&
       "number" === typeof event.marketCap &&


### PR DESCRIPTION
## Summary

- Add a deterministic suspicious-earnings check for positive revenue that is lower than positive net income.
- Mark severe cases, such as `$2M` revenue against `$274.1M` net income, as high severity so unverified posts are suppressed.
- Cover the AIZ-shaped regression in earnings AI helper tests.

## Root Cause

The AI quality gate only runs when deterministic suspicious checks produce a reason. The existing revenue checks depended on Nasdaq consensus or a large-cap floor below `$1M`, so `Revenue: $2M` did not trigger review even though it was implausible next to `$274.1M` net income.

## Validation

- `npx vitest run modules/earnings-results-ai.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`