### PR TITLE
[codex] Harden earnings summary and parser validation

### DIFF
--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -669,6 +669,29 @@ describe("AI earnings helpers", () => {
     expect(hasHighSeveritySuspicion(reasons)).toBe(true);
   });
 
+  test("identifies negative revenue when net income is positive", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "revenue",
+      label: "Revenue",
+      numericValue: -3_000_000,
+      value: "-$3M",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: 13_000_000,
+      value: "$13M",
+    }], null, getEvent({
+      marketCap: 9_000_000_000,
+    }));
+
+    expect(reasons).toEqual([{
+      message: "Revenue -$3M is not positive while net income $13M is positive.",
+      metricKey: "revenue",
+      severity: "high",
+    }]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(true);
+  });
+
   test("identifies medium EPS and revenue suspicion without high severity", () => {
     const reasons = getSuspiciousEarningsReasons([{
       key: "gaap_eps",

--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -692,6 +692,29 @@ describe("AI earnings helpers", () => {
     expect(hasHighSeveritySuspicion(reasons)).toBe(true);
   });
 
+  test("identifies zero revenue when net income is positive", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 0,
+      value: "$0",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: 193_480_000,
+      value: "$193.48M",
+    }], null, getEvent({
+      marketCap: 9_000_000_000,
+    }));
+
+    expect(reasons).toEqual([{
+      message: "Revenue $0 is not positive while net income $193.48M is positive.",
+      metricKey: "revenue",
+      severity: "high",
+    }]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(true);
+  });
+
   test("identifies medium EPS and revenue suspicion without high severity", () => {
     const reasons = getSuspiciousEarningsReasons([{
       key: "gaap_eps",

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -369,14 +369,20 @@ export function getSuspiciousEarningsReasons(
       undefined !== netIncomeMetric &&
       "number" === typeof revenueMetric.numericValue &&
       "number" === typeof netIncomeMetric.numericValue &&
-      revenueMetric.numericValue > 0 &&
-      netIncomeMetric.numericValue > 0 &&
-      revenueMetric.numericValue < netIncomeMetric.numericValue) {
-    reasons.push({
-      message: `Revenue ${revenueMetric.value} is lower than net income ${netIncomeMetric.value}.`,
-      metricKey: "revenue",
-      severity: revenueMetric.numericValue <= netIncomeMetric.numericValue * 0.5 ? "high" : "medium",
-    });
+      netIncomeMetric.numericValue > 0) {
+    if (revenueMetric.numericValue <= 0) {
+      reasons.push({
+        message: `Revenue ${revenueMetric.value} is not positive while net income ${netIncomeMetric.value} is positive.`,
+        metricKey: "revenue",
+        severity: "high",
+      });
+    } else if (revenueMetric.numericValue < netIncomeMetric.numericValue) {
+      reasons.push({
+        message: `Revenue ${revenueMetric.value} is lower than net income ${netIncomeMetric.value}.`,
+        metricKey: "revenue",
+        severity: revenueMetric.numericValue <= netIncomeMetric.numericValue * 0.5 ? "high" : "medium",
+      });
+    }
   }
 
   if (undefined !== netIncomeMetric &&

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -428,6 +428,60 @@ describe("earnings result formatting", () => {
     ]);
   });
 
+  test("prefers quarter metrics when a Q4 release lists full-year results first", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Logitech Announces Q4 and Full Fiscal Year 2026 Results</h1>
+          <p>For Fiscal Year 2026:</p>
+          <p>Sales were $4.84 billion, up 6 percent compared to the prior year.</p>
+          <p>GAAP earnings per share was $4.80. Non-GAAP EPS was $5.78.</p>
+          <p>For Q4 Fiscal Year 2026:</p>
+          <p>Sales were $1.09 billion, up 7 percent compared to Q4 of the prior year.</p>
+          <p>GAAP EPS was $0.98. Non-GAAP EPS was $1.13.</p>
+          <table>
+            <tr><td>(In thousands, except per share amounts) - unaudited</td></tr>
+            <tr><td>Three Months Ended</td></tr>
+            <tr><td>March 31,</td></tr>
+            <tr><td>Fiscal Years Ended</td></tr>
+            <tr><td>March 31,</td></tr>
+            <tr><td>GAAP CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS</td><td>2026</td><td>2025</td><td>2026</td><td>2025</td></tr>
+            <tr><td>Net income</td><td>$</td><td>143,463</td><td>$</td><td>144,066</td><td>$</td><td>711,187</td><td>$</td><td>631,529</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q4 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "adjusted_eps",
+        numericValue: 1.13,
+        value: "$1.13",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 1_090_000_000,
+        value: "$1.09B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 143_463_000,
+        value: "$143.46M",
+      }),
+    ]));
+    expect(parsedDocument.metrics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "adjusted_eps",
+        value: "$5.78",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        value: "$4.84B",
+      }),
+    ]));
+  });
+
   test("skips generic production mentions without operational units", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -391,6 +391,19 @@ function getDocumentHeadline(lines: string[]): string | undefined {
 }
 
 function getQuarterLabel(text: string): string | undefined {
+  const fiscalQuarterMatch = text.match(/\b(Q[1-4])\s+(?:fiscal\s+year|FY)\s*(20\d{2}|\d{2})\b/i);
+  if (undefined !== fiscalQuarterMatch?.[1] && undefined !== fiscalQuarterMatch[2]) {
+    return `${fiscalQuarterMatch[1].toUpperCase()} ${normalizeFiscalYear(fiscalQuarterMatch[2])}`;
+  }
+
+  const writtenFiscalQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter(?:\s+and\s+full)?\s+(?:fiscal\s+year|FY)\s*(20\d{2}|\d{2})\b/i);
+  if (undefined !== writtenFiscalQuarterMatch?.[1] && undefined !== writtenFiscalQuarterMatch[2]) {
+    const quarter = getQuarterFromName(writtenFiscalQuarterMatch[1]);
+    if (quarter) {
+      return `${quarter} ${normalizeFiscalYear(writtenFiscalQuarterMatch[2])}`;
+    }
+  }
+
   const writtenQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter\s+(?:of\s+)?(20\d{2})\b/i);
   if (undefined !== writtenQuarterMatch?.[1] && undefined !== writtenQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenQuarterMatch[1]);
@@ -410,6 +423,10 @@ function getQuarterLabel(text: string): string | undefined {
   }
 
   return undefined;
+}
+
+function normalizeFiscalYear(value: string): string {
+  return 2 === value.length ? `20${value}` : value;
 }
 
 function getQuarterLabelFromPeriodEnded(text: string): string | undefined {
@@ -441,13 +458,14 @@ function getQuarterFromName(name: string): string | undefined {
 function extractEarningsMetrics(lines: string[]): EarningsResultMetric[] {
   const metrics: EarningsResultMetric[] = [];
   const seenKeys = new Set<string>();
+  const preferredLines = getQuarterSpecificMetricLines(lines);
 
   for (const definition of earningsMetricDefinitions) {
     if (true === seenKeys.has(definition.key)) {
       continue;
     }
 
-    const metric = extractMetric(lines, definition);
+    const metric = extractMetric(preferredLines, definition) ?? extractMetric(lines, definition);
     if (null === metric) {
       continue;
     }
@@ -457,6 +475,42 @@ function extractEarningsMetrics(lines: string[]): EarningsResultMetric[] {
   }
 
   return metrics;
+}
+
+function getQuarterSpecificMetricLines(lines: string[]): string[] {
+  const startIndex = lines.findIndex(isQuarterSpecificSectionLine);
+  if (-1 === startIndex) {
+    return [];
+  }
+
+  const selectedLines: string[] = [];
+  for (let index = startIndex; index < lines.length; index++) {
+    const line = lines[index];
+    if (undefined === line) {
+      continue;
+    }
+
+    if (index > startIndex && true === isQuarterSpecificSectionBoundary(line)) {
+      break;
+    }
+
+    selectedLines.push(line);
+    if (selectedLines.length >= 16) {
+      break;
+    }
+  }
+
+  return selectedLines;
+}
+
+function isQuarterSpecificSectionLine(line: string): boolean {
+  return /^\s*(?:for\s+)?Q[1-4]\s+(?:fiscal\s+year|FY)\s*(?:20\d{2}|\d{2})\s*:?$/i.test(line) ||
+    /^\s*(?:for\s+)?(?:the\s+)?(?:first|second|third|fourth)\s+quarter(?:\s+(?:of\s+)?(?:fiscal\s+year|FY)\s*(?:20\d{2}|\d{2}))?\s*:?$/i.test(line);
+}
+
+function isQuarterSpecificSectionBoundary(line: string): boolean {
+  return /^\s*(?:outlook|guidance|financial\s+outlook|business\s+outlook|use\s+of\s+non-gaap|forward-looking|supplemental\s+financial\s+information)\b/i.test(line) ||
+    /^\s*for\s+fiscal\s+year\s+(?:20\d{2}|\d{2})\s*:?$/i.test(line);
 }
 
 function extractMetric(

--- a/modules/earnings-results-summary.test.ts
+++ b/modules/earnings-results-summary.test.ts
@@ -51,6 +51,12 @@ describe("AI earnings summaries", () => {
       filingForm: "8-K",
       filingUrl: "https://www.sec.gov/example",
       html,
+      metrics: [{
+        key: "revenue",
+        label: "Revenue",
+        numericValue: 10_200_000_000,
+        value: "$10.2B",
+      }],
       ticker: "EXM",
     }, {
       logger,
@@ -67,6 +73,7 @@ describe("AI earnings summaries", () => {
     const filingText = prompt.split("Filing text:\n")[1] ?? "";
     expect(prompt).toContain("Write exactly three concise plain-text sentences.");
     expect(prompt).toContain("Do not mention the company name in the summary");
+    expect(prompt).toContain("Displayed result metrics:\n- Revenue: $10.2B");
     expect(filingText.length).toBeLessThanOrEqual(20_100);
     expect(filingText).toContain("Opening excerpt:");
     expect(filingText).toContain("Example Corp reports first quarter 2026 results");
@@ -106,6 +113,113 @@ describe("AI earnings summaries", () => {
     expect(result).toBe(
       "`EXM` revenue rose `12%` to `$10.2 billion` while operating margin expanded `180 basis points` to `24.3%`. `EXM` guided adjusted EPS to `$5.80` to `$6.10`. Revenue momentum remained broad.",
     );
+  });
+
+  test("rejects summaries that conflict with displayed result metrics", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summary: "OXY reported Q1 2026 net income of $3.2 billion and EPS of $3.13. Production improved. No quantified outlook was provided.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await summarizeEarningsWithAi({
+      companyName: "Occidental Petroleum",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: "<html><body><h1>Occidental reports first quarter 2026 results</h1></body></html>",
+      metrics: [{
+        key: "net_income",
+        label: "Net income",
+        numericValue: -9_000_000,
+        value: "-$9M",
+      }],
+      ticker: "OXY",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("allows other metrics in a sentence when the displayed metric matches", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summary: "DOC reported net income of $193.48 million and EPS of $0.34. Revenue grew year over year. Guidance increased.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await summarizeEarningsWithAi({
+      companyName: "Healthpeak Properties, Inc.",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: "<html><body><h1>Healthpeak reports first quarter 2026 results</h1></body></html>",
+      metrics: [{
+        key: "net_income",
+        label: "Net income",
+        numericValue: 193_480_000,
+        value: "$193.48M",
+      }],
+      ticker: "DOC",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBe(
+      "`DOC` reported net income of `$193.48 million` and EPS of `$0.34`. Revenue grew year over year. Guidance increased.",
+    );
+  });
+
+  test("rejects summaries with unexpected CJK characters", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summary: "Revenue rose on stronger sales. Margins improved. No quantified outlook is提供.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await summarizeEarningsWithAi({
+      companyName: "Example Corp",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: "<html><body><h1>Example Corp reports first quarter 2026 results</h1></body></html>",
+      ticker: "EXM",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBeNull();
   });
 
   test("normalizes summary whitespace", async () => {

--- a/modules/earnings-results-summary.ts
+++ b/modules/earnings-results-summary.ts
@@ -1,11 +1,12 @@
 import {callAiProviderJson, type AiProviderDependencies} from "./ai-provider.ts";
-import {htmlToText} from "./earnings-results-format.ts";
+import {htmlToText, type EarningsResultMetric} from "./earnings-results-format.ts";
 
 export type EarningsAiSummaryInput = {
   companyName: string;
   filingForm: string;
   filingUrl: string;
   html: string;
+  metrics?: EarningsResultMetric[] | undefined;
   ticker: string;
 };
 
@@ -70,10 +71,11 @@ export async function summarizeEarningsWithAi(
     return null;
   }
 
-  return parseSummary(parsedJson, input.ticker, input.companyName);
+  return parseSummary(parsedJson, input);
 }
 
 function getSummaryPrompt(input: EarningsAiSummaryInput, filingText: string): string {
+  const displayedMetricsText = getDisplayedMetricsText(input.metrics ?? []);
   return [
     "Summarize this public SEC earnings release for a Discord earnings alert.",
     "Return only JSON matching the schema. Do not include markdown.",
@@ -84,13 +86,24 @@ function getSummaryPrompt(input: EarningsAiSummaryInput, filingText: string): st
     "- Sentence 3 covers outlook, guidance, or management expectations when present; otherwise state that no quantified outlook is provided.",
     "- Format ticker symbols and concrete metrics as inline code, e.g. `AAPL`, `$2.14`, `3.1%`, `180 bps`, `$42 billion`.",
     "- Do not mention the company name in the summary; the Discord alert title already identifies the company.",
+    "- If you mention any displayed result metric, use exactly the displayed value and do not mention a different value for the same metric.",
     "- Use only the provided filing text and do not mention the SEC filing, source text, or any AI provider.",
     `Company: ${input.companyName}`,
     `Ticker: ${input.ticker}`,
     `Filing: ${input.filingForm} ${input.filingUrl}`,
+    ...(0 === displayedMetricsText.length ? [] : [
+      "Displayed result metrics:",
+      displayedMetricsText,
+    ]),
     "Filing text:",
     filingText,
   ].join("\n");
+}
+
+function getDisplayedMetricsText(metrics: EarningsResultMetric[]): string {
+  return metrics
+    .map(metric => `- ${metric.label}: ${metric.value}`)
+    .join("\n");
 }
 
 function getSummaryFilingText(html: string): string {
@@ -173,7 +186,7 @@ function parseJson(value: string): unknown | null {
   }
 }
 
-function parseSummary(value: unknown, ticker: string, companyName: string): string | null {
+function parseSummary(value: unknown, input: EarningsAiSummaryInput): string | null {
   if (false === isRecord(value)) {
     return null;
   }
@@ -187,11 +200,134 @@ function parseSummary(value: unknown, ticker: string, companyName: string): stri
     .replace(/\\[nr]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-  if ("" === normalizedSummary || normalizedSummary.length > maxSummaryLength) {
+  if ("" === normalizedSummary ||
+      normalizedSummary.length > maxSummaryLength ||
+      true === hasUnexpectedCjkCharacters(normalizedSummary)) {
     return null;
   }
 
-  return formatSummaryInlineCode(removeRedundantCompanyNameMentions(normalizedSummary, companyName), ticker);
+  if (true === hasDisplayedMetricConflict(normalizedSummary, input.metrics ?? [])) {
+    return null;
+  }
+
+  return formatSummaryInlineCode(removeRedundantCompanyNameMentions(normalizedSummary, input.companyName), input.ticker);
+}
+
+function hasDisplayedMetricConflict(summary: string, metrics: EarningsResultMetric[]): boolean {
+  return getSummarySentences(summary).some(sentence =>
+    metrics.some(metric => true === hasMetricConflict(sentence, metric)));
+}
+
+function getSummarySentences(summary: string): string[] {
+  return summary
+    .split(/(?<=[.!?])\s+/)
+    .map(sentence => sentence.trim())
+    .filter(sentence => "" !== sentence);
+}
+
+function hasMetricConflict(sentence: string, metric: EarningsResultMetric): boolean {
+  if ("number" !== typeof metric.numericValue) {
+    return false;
+  }
+
+  if (true === isForwardLookingMetricSentence(sentence)) {
+    return false;
+  }
+
+  if ("net_income" === metric.key) {
+    const metricLabelMatch = /\bnet\s+(?:income|earnings)\b/i.exec(sentence);
+    if (null === metricLabelMatch ||
+        true === /\bper\s+share\b/i.test(getMetricValueSegment(sentence, metricLabelMatch))) {
+      return false;
+    }
+
+    return hasConflictingMoneyValue(getMetricValueSegment(sentence, metricLabelMatch), metric.numericValue);
+  }
+
+  if ("revenue" === metric.key) {
+    const metricLabelMatch = /\b(?:revenue|sales)\b/i.exec(sentence);
+    if (null === metricLabelMatch) {
+      return false;
+    }
+
+    return hasConflictingMoneyValue(getMetricValueSegment(sentence, metricLabelMatch), metric.numericValue);
+  }
+
+  return false;
+}
+
+function getMetricValueSegment(sentence: string, metricLabelMatch: RegExpExecArray): string {
+  const afterMetricLabel = sentence.slice(metricLabelMatch.index + metricLabelMatch[0].length);
+  const nextMetricLabelMatch = /\b(?:adjusted\s+eps|eps|earnings\s+per\s+share|revenue|sales|net\s+(?:income|earnings)|ffo|ebitda|cash\s+flow|production|guidance|outlook)\b/i.exec(afterMetricLabel);
+  const endIndex = Math.min(nextMetricLabelMatch?.index ?? afterMetricLabel.length, 140);
+  return afterMetricLabel.slice(0, endIndex);
+}
+
+function isForwardLookingMetricSentence(sentence: string): boolean {
+  return /\b(?:guidance|guided|outlook|forecast|expects?|expectations?|target|range)\b/i.test(sentence);
+}
+
+function hasUnexpectedCjkCharacters(value: string): boolean {
+  return /\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}/u.test(value);
+}
+
+function hasConflictingMoneyValue(sentence: string, expectedValue: number): boolean {
+  const moneyValues = extractMoneyValues(sentence);
+  return moneyValues.some(value => false === isCloseMetricValue(value, expectedValue));
+}
+
+function extractMoneyValues(sentence: string): number[] {
+  const values: number[] = [];
+  const matches = sentence.matchAll(/\(?-?[$€£¥]\s*\d[\d,]*(?:\.\d+)?\)?(?:\s*(?:trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands|[tbmk]))?/gi);
+  for (const match of matches) {
+    const parsedValue = parseMoneyValue(match[0]);
+    if (null !== parsedValue) {
+      values.push(parsedValue);
+    }
+  }
+
+  return values;
+}
+
+function parseMoneyValue(value: string): number | null {
+  const normalizedValue = value.trim();
+  const numberMatch = normalizedValue.match(/\(?-?[$€£¥]\s*([\d,]+(?:\.\d+)?)\)?/);
+  if (undefined === numberMatch?.[1]) {
+    return null;
+  }
+
+  const parsedNumber = Number.parseFloat(numberMatch[1].replaceAll(",", ""));
+  if (false === Number.isFinite(parsedNumber)) {
+    return null;
+  }
+
+  const sign = /^\s*\(|^\s*-/.test(normalizedValue) ? -1 : 1;
+  return sign * parsedNumber * getMoneyUnitScale(normalizedValue);
+}
+
+function getMoneyUnitScale(value: string): number {
+  if (/\b(?:trillion|trillions|tn)\b|[\d)]\s*t\b/i.test(value)) {
+    return 1_000_000_000_000;
+  }
+
+  if (/\b(?:billion|billions|bn)\b|[\d)]\s*b\b/i.test(value)) {
+    return 1_000_000_000;
+  }
+
+  if (/\b(?:million|millions|mm)\b|[\d)]\s*m\b/i.test(value)) {
+    return 1_000_000;
+  }
+
+  if (/\b(?:thousand|thousands)\b|[\d)]\s*k\b/i.test(value)) {
+    return 1_000;
+  }
+
+  return 1;
+}
+
+function isCloseMetricValue(actualValue: number, expectedValue: number): boolean {
+  const tolerance = Math.max(1, Math.abs(expectedValue) * 0.01);
+  return Math.abs(actualValue - expectedValue) <= tolerance;
 }
 
 function removeRedundantCompanyNameMentions(value: string, companyName: string): string {

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -542,7 +542,7 @@ describe("earnings result announcements", () => {
     );
   });
 
-  test("skips SEC-only filings when no earnings metrics or outlook can be parsed", async () => {
+  test("backs off SEC-only filings when no earnings metrics or outlook can be parsed", async () => {
     getWithRetryFn.mockImplementation(async (url: string) => {
       if (url.includes("company_tickers.json")) {
         return {
@@ -616,7 +616,7 @@ describe("earnings result announcements", () => {
       throw new Error(`Unexpected URL ${url}`);
     });
 
-    const skippedNoMetricsAccessions = new Set<string>();
+    const skippedNoMetricsAccessions = new Map<string, number>();
     const result = await getEarningsResultAnnouncements({
       dependencies: {
         getEarningsResultFn,
@@ -628,7 +628,9 @@ describe("earnings result announcements", () => {
     });
 
     expect(result.announcements).toEqual([]);
-    expect(skippedNoMetricsAccessions.has("0000034088-26-000042")).toBe(true);
+    expect(skippedNoMetricsAccessions.get("0000034088-26-000042")).toBe(
+      moment.tz("2026-05-01 08:10", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
+    );
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
       "Skipping earnings result announcement for XOM: no earnings metrics or outlook could be parsed.",
@@ -656,6 +658,142 @@ describe("earnings result announcements", () => {
       expect.stringContaining("/index.json"),
       expect.anything(),
     );
+  });
+
+  test("retries SEC filings after a no-metrics backoff", async () => {
+    let indexRequests = 0;
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.includes("company_tickers.json")) {
+        return {
+          data: {
+            0: {
+              cik_str: 34088,
+              ticker: "XOM",
+              title: "EXXON MOBIL CORP",
+            },
+          },
+        };
+      }
+
+      if (url.includes("type=8-K")) {
+        return {
+          data: `
+            <feed>
+              <entry>
+                <title>8-K - EXXON MOBIL CORP</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0000034088-26-000042</id>
+                <updated>2026-05-01T08:01:00-04:00</updated>
+                <category term="8-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/0000034088-26-000042-index.htm" />
+                <summary>
+                  &lt;b&gt;CIK:&lt;/b&gt; 0000034088&lt;br/&gt;
+                  &lt;b&gt;Items:&lt;/b&gt; 2.02, 9.01
+                </summary>
+              </entry>
+            </feed>
+          `,
+        };
+      }
+
+      if (url.includes("type=6-K")) {
+        return {
+          data: "<feed></feed>",
+        };
+      }
+
+      if (url.includes("companyfacts/CIK0000034088.json")) {
+        return {
+          data: {
+            facts: {},
+          },
+        };
+      }
+
+      if (url.endsWith("/index.json")) {
+        indexRequests++;
+        return {
+          data: {
+            directory: {
+              item: 1 === indexRequests ? [{
+                name: "xom-20260331.htm",
+                type: "8-K",
+              }] : [{
+                name: "xom-ex991.htm",
+                type: "EX-99.1",
+              }],
+            },
+          },
+        };
+      }
+
+      if (url.endsWith("/xom-20260331.htm")) {
+        return {
+          data: `
+            <html>
+              <body>
+                <h1>Item 2.02 Results of Operations and Financial Condition</h1>
+                <p>A copy of the press release is furnished as Exhibit 99.1.</p>
+              </body>
+            </html>
+          `,
+        };
+      }
+
+      if (url.endsWith("/xom-ex991.htm")) {
+        return {
+          data: `
+            <html>
+              <body>
+                <h1>Exxon Mobil reports first quarter 2026 results</h1>
+                <p>Financial data in millions of dollars.</p>
+                <p>Total revenues were $100 million.</p>
+                <p>Net income was $10 million.</p>
+              </body>
+            </html>
+          `,
+        };
+      }
+
+      if (url.includes("/XOM/earnings-surprise")) {
+        return {
+          data: {
+            data: {
+              earningsSurpriseTable: {
+                rows: [],
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    const skippedNoMetricsAccessions = new Map<string, number>();
+    const firstResult = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      },
+      skippedNoMetricsAccessions,
+    });
+    expect(firstResult.announcements).toEqual([]);
+
+    const secondResult = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:11", "YYYY-MM-DD HH:mm", "US/Eastern"),
+      },
+      skippedNoMetricsAccessions,
+    });
+
+    expect(secondResult.announcements).toHaveLength(1);
+    expect(secondResult.announcements[0]?.message).toContain("**Revenue:** `$100M`");
+    expect(skippedNoMetricsAccessions.has("0000034088-26-000042")).toBe(false);
   });
 
   test("does not spend AI calls on primary 8-K shells with no parsed metrics", async () => {

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -1271,6 +1271,7 @@ describe("earnings result announcements", () => {
         },
       });
 
+    const skippedQualityGateAccessions = new Map<string, number>();
     const result = await getEarningsResultAnnouncements({
       dependencies: {
         getEarningsResultFn,
@@ -1290,14 +1291,115 @@ describe("earnings result announcements", () => {
           throw new Error(`missing ${secretName}`);
         }),
       },
+      skippedQualityGateAccessions,
     });
 
     expect(result.announcements).toEqual([]);
     expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(skippedQualityGateAccessions.get("0001193125-26-123456")).toBe(
+      moment.tz("2026-05-01 08:10", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
+    );
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
       "Skipping earnings result announcement for BUD: suspicious metrics were not verified.",
     );
+
+    postWithRetryFn.mockClear();
+    logger.log.mockClear();
+
+    const secondResult = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:06", "YYYY-MM-DD HH:mm", "US/Eastern"),
+        postWithRetryFn,
+        readSecretFn: vi.fn((secretName: string) => {
+          if ("gemini_api_key" === secretName) {
+            return "gemini-key";
+          }
+
+          if ("gemini_calls_per_minute" === secretName) {
+            return "14";
+          }
+
+          throw new Error(`missing ${secretName}`);
+        }),
+      },
+      skippedQualityGateAccessions,
+    });
+
+    expect(secondResult.announcements).toEqual([]);
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      "Skipping earnings result announcement for BUD: suspicious metrics were not verified.",
+    );
+
+    postWithRetryFn
+      .mockResolvedValueOnce({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: JSON.stringify({
+                  metrics: [{
+                    key: "revenue",
+                    label: "Revenue",
+                    value: "14.55",
+                    unit: "billion",
+                    currencyCode: "USD",
+                    sourceSnippet: "Revenue increased to 14.55 billion USD.",
+                  }],
+                  issues: [],
+                }),
+              }],
+            },
+          }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          candidates: [{
+            content: {
+              parts: [{
+                text: JSON.stringify({
+                  decision: "allow",
+                  confidence: 0.92,
+                  reason: "The filing text supports the metrics after retry.",
+                  issues: [],
+                }),
+              }],
+            },
+          }],
+        },
+      });
+
+    const retryResult = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:11", "YYYY-MM-DD HH:mm", "US/Eastern"),
+        postWithRetryFn,
+        readSecretFn: vi.fn((secretName: string) => {
+          if ("gemini_api_key" === secretName) {
+            return "gemini-key";
+          }
+
+          if ("gemini_calls_per_minute" === secretName) {
+            return "14";
+          }
+
+          throw new Error(`missing ${secretName}`);
+        }),
+      },
+      skippedQualityGateAccessions,
+    });
+
+    expect(retryResult.announcements).toHaveLength(1);
+    expect(postWithRetryFn).toHaveBeenCalledTimes(3);
+    expect(skippedQualityGateAccessions.has("0001193125-26-123456")).toBe(false);
   });
 
   test("watcher skips scans until channel history can be checked", async () => {

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -148,6 +148,7 @@ const defaultInactivePollIntervalMs = 15 * 60_000;
 const defaultSecCurrentFilingsLimit = 100;
 const defaultMaxAnnouncementsPerScan = 10;
 const earningsWatchTtlMs = 15 * 60_000;
+const noMetricsRetryDelayMs = 5 * 60_000;
 const nasdaqEarningsSurpriseEndpoint = "https://api.nasdaq.com/api/company";
 const noMentions = {
   parse: [],
@@ -179,7 +180,7 @@ export function startEarningsResultWatcher(
   const announcementThreadID = getOptionalChannelID(options.announcementThreadID);
   const seenAccessions = new Set<string>();
   const seenResultKeys = new Set<string>();
-  const skippedNoMetricsAccessions = new Set<string>();
+  const skippedNoMetricsAccessions = new Map<string, number>();
   const dependencies = getDependencies(options);
   let seenAccessionsSeeded = false;
   let stopped = false;
@@ -213,7 +214,7 @@ export function startEarningsResultWatcher(
       secCurrentFilingsLimit?: number;
       seenAccessions: Set<string>;
       seenResultKeys: Set<string>;
-      skippedNoMetricsAccessions: Set<string>;
+      skippedNoMetricsAccessions: Map<string, number>;
     } = {
       dependencies,
       seenAccessions,
@@ -291,14 +292,14 @@ export async function getEarningsResultAnnouncements({
   secCurrentFilingsLimit = defaultSecCurrentFilingsLimit,
   seenAccessions = new Set<string>(),
   seenResultKeys = new Set<string>(),
-  skippedNoMetricsAccessions = new Set<string>(),
+  skippedNoMetricsAccessions = new Map<string, number>(),
 }: {
   dependencies?: EarningsResultDependencies;
   maxAnnouncementsPerScan?: number;
   secCurrentFilingsLimit?: number;
   seenAccessions?: Set<string>;
   seenResultKeys?: Set<string>;
-  skippedNoMetricsAccessions?: Set<string>;
+  skippedNoMetricsAccessions?: Map<string, number>;
 } = {}): Promise<EarningsResultScanResult> {
   const now = dependencies.now().clone().tz(usEasternTimezone);
   const watches = await getTodaysEarningsWatches(dependencies, now);
@@ -325,8 +326,13 @@ export async function getEarningsResultAnnouncements({
       continue;
     }
 
-    if (true === skippedNoMetricsAccessions.has(filing.accessionNumber)) {
-      continue;
+    const noMetricsRetryAfterMs = skippedNoMetricsAccessions.get(filing.accessionNumber);
+    if (undefined !== noMetricsRetryAfterMs) {
+      if (now.valueOf() < noMetricsRetryAfterMs) {
+        continue;
+      }
+
+      skippedNoMetricsAccessions.delete(filing.accessionNumber);
     }
 
     if (false === isFilingUpdatedToday(filing, now)) {
@@ -591,7 +597,7 @@ async function buildEarningsResultAnnouncement(
   watch: EarningsWatchEntry,
   dependencies: EarningsResultDependencies,
   now: moment.Moment,
-  skippedNoMetricsAccessions: Set<string>,
+  skippedNoMetricsAccessions: Map<string, number>,
 ): Promise<EarningsResultAnnouncement | null> {
   const [filingDetails, xbrlMetrics] = await Promise.all([
     loadSecFilingDetails(filing, dependencies).catch(error => {
@@ -650,7 +656,7 @@ async function buildEarningsResultAnnouncement(
   const filingUrl = filingDetails?.documentUrl || filing.filingUrl;
 
   if (0 === metrics.length && 0 === parsedDocument.outlook.length) {
-    skippedNoMetricsAccessions.add(filing.accessionNumber);
+    skippedNoMetricsAccessions.set(filing.accessionNumber, now.valueOf() + noMetricsRetryDelayMs);
     dependencies.logger.log(
       "warn",
       `Skipping earnings result announcement for ${watch.event.ticker}: no earnings metrics or outlook could be parsed.`,

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -149,6 +149,7 @@ const defaultSecCurrentFilingsLimit = 100;
 const defaultMaxAnnouncementsPerScan = 10;
 const earningsWatchTtlMs = 15 * 60_000;
 const noMetricsRetryDelayMs = 5 * 60_000;
+const qualityGateRetryDelayMs = 5 * 60_000;
 const nasdaqEarningsSurpriseEndpoint = "https://api.nasdaq.com/api/company";
 const noMentions = {
   parse: [],
@@ -181,6 +182,7 @@ export function startEarningsResultWatcher(
   const seenAccessions = new Set<string>();
   const seenResultKeys = new Set<string>();
   const skippedNoMetricsAccessions = new Map<string, number>();
+  const skippedQualityGateAccessions = new Map<string, number>();
   const dependencies = getDependencies(options);
   let seenAccessionsSeeded = false;
   let stopped = false;
@@ -215,11 +217,13 @@ export function startEarningsResultWatcher(
       seenAccessions: Set<string>;
       seenResultKeys: Set<string>;
       skippedNoMetricsAccessions: Map<string, number>;
+      skippedQualityGateAccessions: Map<string, number>;
     } = {
       dependencies,
       seenAccessions,
       seenResultKeys,
       skippedNoMetricsAccessions,
+      skippedQualityGateAccessions,
     };
     if (undefined !== options.maxAnnouncementsPerScan) {
       announcementOptions.maxAnnouncementsPerScan = options.maxAnnouncementsPerScan;
@@ -293,6 +297,7 @@ export async function getEarningsResultAnnouncements({
   seenAccessions = new Set<string>(),
   seenResultKeys = new Set<string>(),
   skippedNoMetricsAccessions = new Map<string, number>(),
+  skippedQualityGateAccessions = new Map<string, number>(),
 }: {
   dependencies?: EarningsResultDependencies;
   maxAnnouncementsPerScan?: number;
@@ -300,6 +305,7 @@ export async function getEarningsResultAnnouncements({
   seenAccessions?: Set<string>;
   seenResultKeys?: Set<string>;
   skippedNoMetricsAccessions?: Map<string, number>;
+  skippedQualityGateAccessions?: Map<string, number>;
 } = {}): Promise<EarningsResultScanResult> {
   const now = dependencies.now().clone().tz(usEasternTimezone);
   const watches = await getTodaysEarningsWatches(dependencies, now);
@@ -324,6 +330,15 @@ export async function getEarningsResultAnnouncements({
 
     if (true === seenAccessions.has(filing.accessionNumber)) {
       continue;
+    }
+
+    const qualityGateRetryAfterMs = skippedQualityGateAccessions.get(filing.accessionNumber);
+    if (undefined !== qualityGateRetryAfterMs) {
+      if (now.valueOf() < qualityGateRetryAfterMs) {
+        continue;
+      }
+
+      skippedQualityGateAccessions.delete(filing.accessionNumber);
     }
 
     const noMetricsRetryAfterMs = skippedNoMetricsAccessions.get(filing.accessionNumber);
@@ -360,6 +375,7 @@ export async function getEarningsResultAnnouncements({
       dependencies,
       now,
       skippedNoMetricsAccessions,
+      skippedQualityGateAccessions,
     );
     if (null !== announcement) {
       announcements.push(announcement);
@@ -598,6 +614,7 @@ async function buildEarningsResultAnnouncement(
   dependencies: EarningsResultDependencies,
   now: moment.Moment,
   skippedNoMetricsAccessions: Map<string, number>,
+  skippedQualityGateAccessions: Map<string, number>,
 ): Promise<EarningsResultAnnouncement | null> {
   const [filingDetails, xbrlMetrics] = await Promise.all([
     loadSecFilingDetails(filing, dependencies).catch(error => {
@@ -685,6 +702,7 @@ async function buildEarningsResultAnnouncement(
     ticker: watch.event.ticker,
   }, dependencies);
   if (true === shouldSuppressAnnouncement(qualityGate, suspiciousReasons)) {
+    skippedQualityGateAccessions.set(filing.accessionNumber, now.valueOf() + qualityGateRetryDelayMs);
     dependencies.logger.log(
       "warn",
       `Skipping earnings result announcement for ${watch.event.ticker}: suspicious metrics were not verified.`,
@@ -697,6 +715,7 @@ async function buildEarningsResultAnnouncement(
     filingForm: filing.form,
     filingUrl,
     html: filingDetails?.html ?? "",
+    metrics,
     ticker: watch.event.ticker,
   }, dependencies);
   if (null !== summary) {

--- a/modules/market-close-recap.test.ts
+++ b/modules/market-close-recap.test.ts
@@ -106,6 +106,8 @@ describe("market close recap", () => {
       allowedUserIds: ["123", "456"],
       content: expect.stringContaining("**Börsenschluss - Kurzüberblick**"),
     });
+    expect(recap?.content).toContain("**Börsenschluss - Kurzüberblick**\n`SPX`");
+    expect(recap?.content).not.toContain("**Börsenschluss - Kurzüberblick**\n\n");
     expect(recap?.content).toContain("Das heutige Sentiment war: **🎢 Chaos**");
     expect(recap?.content).toContain("<@123> <@456>");
     expect(recap?.content).not.toContain("Gemini");
@@ -158,6 +160,66 @@ describe("market close recap", () => {
     expect(recap?.allowedUserIds).toEqual([]);
     expect(recap?.content).toContain("Das heutige Sentiment war: **🟢 Risk-on**");
     expect(recap?.content).not.toContain("Richtig gelegen");
+    expect(recap?.content).not.toContain("Punkte`.\n\nDas heutige");
+  });
+
+  test("matches Discord poll answer text variants when fetching voters", async () => {
+    const votersFetch = vi.fn().mockResolvedValue(new Map([
+      ["123", {id: "123"}],
+    ]));
+
+    const recap = await getMarketCloseRecap({
+      poll: {
+        answers: [{
+          answer_id: 1,
+          poll_media: {
+            text: "🟢 Risk‑on",
+          },
+          voters: {
+            fetch: votersFetch,
+          },
+        }],
+      },
+    }, {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    expect(recap?.allowedUserIds).toEqual(["123"]);
+    expect(votersFetch).toHaveBeenCalledWith({
+      limit: 100,
+    });
+  });
+
+  test("falls back to stable poll answer IDs when answer text is partial", async () => {
+    const votersFetch = vi.fn().mockResolvedValue(new Map([
+      ["456", {id: "456"}],
+    ]));
+
+    const recap = await getMarketCloseRecap({
+      poll: {
+        answers: new Map([
+          [1, {
+            id: 1,
+            text: null,
+            voters: {
+              fetch: votersFetch,
+            },
+          }],
+        ]),
+      },
+    }, {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    expect(recap?.allowedUserIds).toEqual(["456"]);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      "Skipping market close recap voter mentions: poll answer Risk-on was not found.",
+    );
   });
 
   test("handles an empty sentiment title and truncates long summaries", async () => {

--- a/modules/market-close-recap.ts
+++ b/modules/market-close-recap.ts
@@ -26,7 +26,11 @@ type PollAnswerVoters = {
 };
 
 type PollAnswerLike = {
+  answer_id?: number | undefined;
   id?: number | undefined;
+  poll_media?: {
+    text?: string | null | undefined;
+  } | undefined;
   text?: string | null | undefined;
   voters?: PollAnswerVoters | undefined;
 };
@@ -64,6 +68,12 @@ const sentimentLabels = {
   "Cash": "💵 Cash",
   "Chaos": "🎢 Chaos",
 } satisfies Record<MarketCloseSentimentAnswer, string>;
+const sentimentAnswerIds = {
+  "Risk-on": 1,
+  "Risk-off": 2,
+  "Cash": 3,
+  "Chaos": 4,
+} satisfies Record<MarketCloseSentimentAnswer, number>;
 
 const marketCloseRecapSchema = {
   type: "object",
@@ -256,7 +266,7 @@ function buildMarketCloseRecapContent(
     recap.summaryMarkdown,
     sentimentLine,
     voterSection,
-  ].filter(line => "" !== line).join("\n\n"));
+  ].filter(line => "" !== line).join("\n"));
 }
 
 function getSentimentLine(recap: AiMarketCloseRecap): string {
@@ -346,7 +356,15 @@ function getPollAnswerByText(
   pollMessage: unknown,
   answerText: MarketCloseSentimentAnswer,
 ): PollAnswerLike | undefined {
-  return getPollAnswers(pollMessage).find(answer => answer.text === answerText);
+  const answers = getPollAnswers(pollMessage);
+  const normalizedAnswerText = normalizePollAnswerText(answerText);
+  const textMatch = answers.find(answer => normalizePollAnswerText(getPollAnswerText(answer)) === normalizedAnswerText);
+  if (undefined !== textMatch) {
+    return textMatch;
+  }
+
+  const fallbackAnswerId = sentimentAnswerIds[answerText];
+  return answers.find(answer => getPollAnswerId(answer) === fallbackAnswerId);
 }
 
 function isSentimentPollMessage(message: PollMessageLike): boolean {
@@ -510,8 +528,53 @@ function isPollAnswerLike(value: unknown): value is PollAnswerLike {
     return false;
   }
 
-  const text = value["text"];
-  return "string" === typeof text && isMarketCloseSentimentAnswer(text);
+  return undefined !== getPollAnswerText(value) || undefined !== getPollAnswerId(value);
+}
+
+function getPollAnswerText(answer: unknown): string | undefined {
+  if (false === isRecord(answer)) {
+    return undefined;
+  }
+
+  const directText = answer["text"];
+  if ("string" === typeof directText) {
+    return directText;
+  }
+
+  const pollMedia = answer["poll_media"];
+  if (false === isRecord(pollMedia)) {
+    return undefined;
+  }
+
+  const pollMediaText = pollMedia["text"];
+  return "string" === typeof pollMediaText ? pollMediaText : undefined;
+}
+
+function getPollAnswerId(answer: unknown): number | undefined {
+  if (false === isRecord(answer)) {
+    return undefined;
+  }
+
+  const id = answer["id"];
+  if ("number" === typeof id && Number.isFinite(id)) {
+    return id;
+  }
+
+  const answerId = answer["answer_id"];
+  if ("number" === typeof answerId && Number.isFinite(answerId)) {
+    return answerId;
+  }
+
+  return undefined;
+}
+
+function normalizePollAnswerText(value: string | undefined): string {
+  return value
+    ?.replace(/^[\p{Emoji_Presentation}\p{Emoji}\uFE0F\s]+/u, "")
+    .replace(/[‐‑‒–—―]/gu, "-")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase() ?? "";
 }
 
 function isPollMessageLike(value: unknown): value is PollMessageLike {

--- a/modules/timers.test.ts
+++ b/modules/timers.test.ts
@@ -233,6 +233,45 @@ describe("timers: NYSE and MNC", () => {
     }));
   });
 
+  test("startNyseTimers prefers recovered closed poll for market close recap", async () => {
+    const {client, send} = createClientWithChannel();
+    const stalePollMessage = {
+      poll: {
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+    const recoveredPollMessage = {
+      poll: {
+        answers: new Map([
+          [1, {id: 1, text: "Risk-on"}],
+        ]),
+        question: {
+          text: "Opening Sentiment: Wie geht ihr in den Handel?",
+        },
+      },
+    };
+    send.mockResolvedValueOnce(stalePollMessage);
+    findMarketOpenSentimentPollMessageMock.mockResolvedValueOnce(recoveredPollMessage);
+    getMarketCloseRecapMock.mockResolvedValueOnce({
+      allowedUserIds: [],
+      content: "**Börsenschluss - Kurzüberblick**\n`VIX` fiel um `1,2 Punkte`.",
+    });
+
+    startNyseTimers(client, "channel-id");
+    const openJob = getScheduledJobByTime(9, 30, "US/Eastern");
+    openJob.callback();
+    await flushAsyncJobs();
+
+    const recapJob = getScheduledJobByTime(16, 10, "US/Eastern");
+    await recapJob.callback();
+    await flushAsyncJobs();
+
+    expect(getMarketCloseRecapMock).toHaveBeenCalledWith(recoveredPollMessage, expect.any(Object), expect.any(Object));
+    expect(getMarketCloseRecapMock).not.toHaveBeenCalledWith(stalePollMessage, expect.any(Object), expect.any(Object));
+  });
+
   test("startNyseTimers recovers the opening poll from history after a restart", async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const channel = {

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -356,11 +356,12 @@ async function runNyseMarketCloseRecap(
   }
 
   const date = getCurrentNyseDate();
-  const pollMessage = sentimentPollState.message ?? await findMarketOpenSentimentPollMessage(channel, {
+  const recoveredPollMessage = await findMarketOpenSentimentPollMessage(channel, {
     logger,
   }, {
     date,
   });
+  const pollMessage = recoveredPollMessage ?? sentimentPollState.message;
   const recap = await getMarketCloseRecap(pollMessage, {
     logger,
   }, {


### PR DESCRIPTION
Summary
- Validate AI earnings summaries against displayed result metrics and reject unexpected CJK leakage.
- Prefer Q4 metric sections when releases list full-year results before quarter results, covering LOGI.
- Add a timed quality-gate backoff so repeated suspicious-metric suppressions do not call AI every scan.

Validation
- npx vitest run modules/earnings-results-format.test.ts modules/earnings-results-summary.test.ts modules/earnings-results-ai.test.ts modules/earnings-results.test.ts
- npm run typecheck
- npm run test:coverage
- npm run lint