### PR TITLE
[codex] Harden EOG earnings revenue validation

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -85,23 +85,22 @@ describe("earnings result formatting", () => {
     })).toContain("**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/example/ex-991.htm)");
   });
 
-  test("renders optional earnings summaries before result metrics", () => {
-    const parsedDocument = parseEarningsDocument(`
-      <html>
-        <body>
-          <h1>ExampleCo reports first quarter 2026 results</h1>
-          <table>
-            <tr><td>Adjusted EPS</td><td>$1.16</td></tr>
-          </table>
-        </body>
-      </html>
-    `);
-    const metrics = getMessageMetrics(parsedDocument.metrics, null, {
-      ticker: "EXM",
-      when: "before_open",
-      date: "2026-05-01",
-      importance: 1,
-    });
+  test("renders result and outlook metrics before optional earnings summaries", () => {
+    const parsedDocument = {
+      metrics: [],
+      outlook: [{
+        key: "revenue",
+        label: "Revenue",
+        value: "$89B to $91B",
+      }],
+      quarterLabel: "Q1 2026",
+    } satisfies ReturnType<typeof parseEarningsDocument>;
+    const metrics = [{
+      key: "adjusted_eps",
+      label: "Adj EPS",
+      numericValue: 1.16,
+      value: "$1.16",
+    }] satisfies ReturnType<typeof getMessageMetrics>;
 
     expect(getEarningsResultMessage({
       companyName: "ExampleCo",
@@ -116,10 +115,13 @@ describe("earnings result formatting", () => {
       ticker: "EXM",
     })).toBe([
       "**ExampleCo (`EXM`)** - Q1 2026 - [8-K](https://www.sec.gov/example)",
-      "📝 ExampleCo beat expectations. Revenue improved. Management raised guidance.",
-      "",
       "📊 **Results**",
       "- **Adj EPS:** `$1.16`",
+      "",
+      "🔮 **Outlook**",
+      "- **Revenue:** `$89B` to `$91B`",
+      "",
+      "📝 ExampleCo beat expectations. Revenue improved. Management raised guidance.",
     ].join("\n"));
   });
 

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -264,9 +264,6 @@ export function getEarningsResultMessage({
   titleParts.push(` - ${getFilingFormText(filing, filingUrl)}`);
 
   const lines = [titleParts.join("")];
-  if (undefined !== summary && "" !== summary.trim()) {
-    lines.push(`📝 ${summary.trim()}`);
-  }
 
   if (0 < metrics.length) {
     if (1 < lines.length) {
@@ -286,6 +283,13 @@ export function getEarningsResultMessage({
     for (const metric of parsedDocument.outlook) {
       lines.push(`- **${metric.label}:** ${formatOutlookValue(metric.value)}`);
     }
+  }
+
+  if (undefined !== summary && "" !== summary.trim()) {
+    if (1 < lines.length) {
+      lines.push("");
+    }
+    lines.push(`📝 ${summary.trim()}`);
   }
 
   return lines.join("\n");

--- a/modules/earnings-results-summary.test.ts
+++ b/modules/earnings-results-summary.test.ts
@@ -1,4 +1,5 @@
 import {beforeEach, describe, expect, test, vi} from "vitest";
+import {clearAiProviderState} from "./ai-provider.ts";
 import {summarizeEarningsWithAi} from "./earnings-results-summary.ts";
 
 describe("AI earnings summaries", () => {
@@ -15,6 +16,7 @@ describe("AI earnings summaries", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearAiProviderState();
   });
 
   test("summarizes a bounded opening excerpt plus later guidance context", async () => {
@@ -142,6 +144,48 @@ describe("AI earnings summaries", () => {
         value: "-$9M",
       }],
       ticker: "OXY",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects summaries with bare money values that conflict with displayed result metrics", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summary: "For Q1 2026, revenue rose to 1.980 billion of net income on 6.921 billion of total operating revenues. Results were driven by stronger realized oil prices. No quantified outlook is provided.",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await summarizeEarningsWithAi({
+      companyName: "EOG Resources, Inc.",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: "<html><body><h1>EOG reports first quarter 2026 results</h1></body></html>",
+      metrics: [{
+        key: "revenue",
+        label: "Revenue",
+        numericValue: 3.58,
+        value: "$3.58",
+      }, {
+        key: "net_income",
+        label: "Net income",
+        numericValue: 1_460_000_000,
+        value: "$1.46B",
+      }],
+      ticker: "EOG",
     }, {
       logger,
       nowMs: () => 1_000,

--- a/modules/earnings-results-summary.test.ts
+++ b/modules/earnings-results-summary.test.ts
@@ -74,6 +74,7 @@ describe("AI earnings summaries", () => {
     const prompt = requestBody.contents?.[0]?.parts?.find(part => "string" === typeof part.text)?.text ?? "";
     const filingText = prompt.split("Filing text:\n")[1] ?? "";
     expect(prompt).toContain("Write exactly three concise plain-text sentences.");
+    expect(prompt).toContain("Return plain text only; do not include markdown, backticks, bullets, headings, or labels.");
     expect(prompt).toContain("Do not mention the company name in the summary");
     expect(prompt).toContain("Displayed result metrics:\n- Revenue: $10.2B");
     expect(filingText.length).toBeLessThanOrEqual(20_100);
@@ -256,6 +257,37 @@ describe("AI earnings summaries", () => {
       filingUrl: "https://www.sec.gov/example",
       html: "<html><body><h1>Example Corp reports first quarter 2026 results</h1></body></html>",
       ticker: "EXM",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects summaries with markdown or correction artifacts", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summary: "Revenue was >$411 million and net income was $165 million. Free cash flow reached a record -? no, We reiterate: record free cash flow was $144 million. `The company reiterated production and cost guidance.`",
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await summarizeEarningsWithAi({
+      companyName: "Hecla Mining Company",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: "<html><body><h1>Hecla reports first quarter 2026 results</h1></body></html>",
+      ticker: "HL",
     }, {
       logger,
       nowMs: () => 1_000,

--- a/modules/earnings-results-summary.ts
+++ b/modules/earnings-results-summary.ts
@@ -84,7 +84,8 @@ function getSummaryPrompt(input: EarningsAiSummaryInput, filingText: string): st
     "- Sentence 1 covers the reported period and headline performance.",
     "- Sentence 2 covers the most important business drivers, segment notes, or margin/profit details.",
     "- Sentence 3 covers outlook, guidance, or management expectations when present; otherwise state that no quantified outlook is provided.",
-    "- Format ticker symbols and concrete metrics as inline code, e.g. `AAPL`, `$2.14`, `3.1%`, `180 bps`, `$42 billion`.",
+    "- Return plain text only; do not include markdown, backticks, bullets, headings, or labels.",
+    "- The Discord bot formats ticker symbols and concrete metrics after validation.",
     "- Do not mention the company name in the summary; the Discord alert title already identifies the company.",
     "- If you mention any displayed result metric, use exactly the displayed value and do not mention a different value for the same metric.",
     "- Use only the provided filing text and do not mention the SEC filing, source text, or any AI provider.",
@@ -202,6 +203,8 @@ function parseSummary(value: unknown, input: EarningsAiSummaryInput): string | n
     .trim();
   if ("" === normalizedSummary ||
       normalizedSummary.length > maxSummaryLength ||
+      true === hasUnexpectedMarkdown(normalizedSummary) ||
+      true === hasCorrectionArtifact(normalizedSummary) ||
       true === hasUnexpectedCjkCharacters(normalizedSummary)) {
     return null;
   }
@@ -269,6 +272,15 @@ function isForwardLookingMetricSentence(sentence: string): boolean {
 
 function hasUnexpectedCjkCharacters(value: string): boolean {
   return /\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}/u.test(value);
+}
+
+function hasUnexpectedMarkdown(value: string): boolean {
+  return /[`*_#]|\n\s*[-*]\s+/.test(value);
+}
+
+function hasCorrectionArtifact(value: string): boolean {
+  return /\b(?:no|yes),\s+(?:we|i)\s+(?:reiterate|should|will|can|need|must|mean)\b/i.test(value) ||
+    /-\?\s*(?:no|yes)?\s*,/i.test(value);
 }
 
 function hasConflictingMoneyValue(sentence: string, expectedValue: number): boolean {

--- a/modules/earnings-results-summary.ts
+++ b/modules/earnings-results-summary.ts
@@ -278,7 +278,7 @@ function hasConflictingMoneyValue(sentence: string, expectedValue: number): bool
 
 function extractMoneyValues(sentence: string): number[] {
   const values: number[] = [];
-  const matches = sentence.matchAll(/\(?-?[$€£¥]\s*\d[\d,]*(?:\.\d+)?\)?(?:\s*(?:trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands|[tbmk]))?/gi);
+  const matches = sentence.matchAll(/\(?-?(?:(?:[$€£¥]\s*)?\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands|[tbmk]))|[$€£¥]\s*\d[\d,]*(?:\.\d+)?)\)?/gi);
   for (const match of matches) {
     const parsedValue = parseMoneyValue(match[0]);
     if (null !== parsedValue) {
@@ -291,7 +291,7 @@ function extractMoneyValues(sentence: string): number[] {
 
 function parseMoneyValue(value: string): number | null {
   const normalizedValue = value.trim();
-  const numberMatch = normalizedValue.match(/\(?-?[$€£¥]\s*([\d,]+(?:\.\d+)?)\)?/);
+  const numberMatch = normalizedValue.match(/\(?-?(?:[$€£¥]\s*)?([\d,]+(?:\.\d+)?)\)?/);
   if (undefined === numberMatch?.[1]) {
     return null;
   }

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -330,8 +330,147 @@ describe("earnings result announcements", () => {
     const message = result.announcements[0]!.message;
     expect(message).toContain(`📝 ${formattedSummary}`);
     expect(message).not.toContain("📝 **Summary**");
-    expect(message.indexOf(`📝 ${formattedSummary}`)).toBeLessThan(message.indexOf("📊 **Results**"));
+    expect(message.indexOf("📊 **Results**")).toBeLessThan(message.indexOf(`📝 ${formattedSummary}`));
     expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("suppresses hard revenue contradictions after AI extraction without a quality gate override", async () => {
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.includes("company_tickers.json")) {
+        return {
+          data: {
+            0: {
+              cik_str: 34088,
+              ticker: "XOM",
+              title: "EXXON MOBIL CORP",
+            },
+          },
+        };
+      }
+
+      if (url.includes("type=8-K")) {
+        return {
+          data: `
+            <feed>
+              <entry>
+                <title>8-K - EXXON MOBIL CORP</title>
+                <id>urn:tag:sec.gov,2026:accession-number=0000034088-26-000042</id>
+                <updated>2026-05-01T08:01:00-04:00</updated>
+                <category term="8-K" />
+                <link href="https://www.sec.gov/Archives/edgar/data/34088/000003408826000042/0000034088-26-000042-index.htm" />
+                <summary>
+                  &lt;b&gt;CIK:&lt;/b&gt; 0000034088&lt;br/&gt;
+                  &lt;b&gt;Items:&lt;/b&gt; 2.02, 9.01
+                </summary>
+              </entry>
+            </feed>
+          `,
+        };
+      }
+
+      if (url.includes("type=6-K")) {
+        return {
+          data: "<feed></feed>",
+        };
+      }
+
+      if (url.includes("companyfacts/CIK0000034088.json")) {
+        return {
+          data: {
+            facts: {},
+          },
+        };
+      }
+
+      if (url.endsWith("/index.json")) {
+        return {
+          data: {
+            directory: {
+              item: [{
+                name: "xom-ex991.htm",
+                type: "EX-99.1",
+              }],
+            },
+          },
+        };
+      }
+
+      if (url.endsWith("/xom-ex991.htm")) {
+        return {
+          data: `
+            <html>
+              <body>
+                <h1>Exxon Mobil reports first quarter 2026 results</h1>
+                <p>Revenue was $3.58.</p>
+                <p>Net income was $1.46 billion.</p>
+              </body>
+            </html>
+          `,
+        };
+      }
+
+      if (url.includes("/XOM/earnings-surprise")) {
+        return {
+          data: {
+            data: {
+              earningsSurpriseTable: {
+                rows: [],
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    postWithRetryFn.mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: null,
+                metrics: [],
+                issues: ["Revenue scale could not be verified."],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+    const skippedQualityGateAccessions = new Map<string, number>();
+
+    const result = await getEarningsResultAnnouncements({
+      dependencies: {
+        getEarningsResultFn,
+        getWithRetryFn,
+        logger,
+        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
+        postWithRetryFn,
+        readSecretFn: vi.fn((secretName: string) => {
+          if ("gemini_api_key" === secretName) {
+            return "gemini-key";
+          }
+
+          if ("gemini_calls_per_minute" === secretName) {
+            return "14";
+          }
+
+          throw new Error(`missing ${secretName}`);
+        }),
+      },
+      skippedQualityGateAccessions,
+    });
+
+    expect(result.announcements).toEqual([]);
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(skippedQualityGateAccessions.get("0000034088-26-000042")).toBe(
+      moment.tz("2026-05-01 08:10", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Skipping earnings result announcement for XOM: suspicious metrics were not verified.",
+    );
   });
 
   test("skips accessions that were already announced", async () => {

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -689,6 +689,15 @@ async function buildEarningsResultAnnouncement(
     parsedDocument,
     ticker: watch.event.ticker,
   });
+  if (true === hasHardMetricContradiction(suspiciousReasons)) {
+    skippedQualityGateAccessions.set(filing.accessionNumber, now.valueOf() + qualityGateRetryDelayMs);
+    dependencies.logger.log(
+      "warn",
+      `Skipping earnings result announcement for ${watch.event.ticker}: suspicious metrics were not verified.`,
+    );
+    return null;
+  }
+
   const qualityGate = await checkEarningsQualityWithAi({
     companyName: watch.companyName,
     event: watch.event,
@@ -831,11 +840,22 @@ function shouldSuppressAnnouncement(
   qualityGate: {confidence: number; decision: "allow" | "suppress";} | null,
   suspiciousReasons: SuspiciousEarningsReason[],
 ): boolean {
+  if (true === hasHardMetricContradiction(suspiciousReasons)) {
+    return true;
+  }
+
   if (null !== qualityGate) {
     return "suppress" === qualityGate.decision && qualityGate.confidence >= 0.75;
   }
 
   return hasHighSeveritySuspicion(suspiciousReasons);
+}
+
+function hasHardMetricContradiction(suspiciousReasons: SuspiciousEarningsReason[]): boolean {
+  return suspiciousReasons.some(reason =>
+    "high" === reason.severity &&
+    "revenue" === reason.metricKey &&
+    /\b(?:lower\s+than\s+net\s+income|not\s+positive\s+while\s+net\s+income)\b/i.test(reason.message));
 }
 
 function getSuspiciousQuarterReasons(


### PR DESCRIPTION
Summary
- Render earnings result posts with Results and Outlook before the AI summary.
- Reject AI summaries whose bare money values conflict with displayed metrics, covering EOG-style `1.980 billion` output.
- Suppress hard revenue/net-income contradictions before the AI quality gate can allow them.

Validation
- npx vitest run modules/earnings-results-format.test.ts modules/earnings-results-summary.test.ts modules/earnings-results.test.ts
- npm run typecheck
- npm run test:coverage
- npm run lint