### PR TITLE
[codex] Fix outlook money range parsing

### DIFF
--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -131,6 +131,20 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  test("does not treat margin percentage ranges as revenue guidance", () => {
+    expect(extractOutlookMetrics([
+      "Outlook",
+      "The Company is updating its estimates for the year ending December 31, 2026, which reflects the addition of PayneCrest. Net income is expected to be between $223.0 million and $234.0 million. Earnings per Share (EPS) is expected to be between $4.05 and $4.25 per fully diluted share. Adjusted EPS is estimated in the range of $4.80 to $5.00, and Adjusted EBITDA for the full year 2026 is expected to range from $480.0 to $500.0 million.",
+      "The Company is targeting SG&A expenses as a percentage of revenue in the mid-to-high 5% range for full year 2026. The Company's targeted gross margins by segment are as follows: Utilities in the range of 10 to 12%; Energy in the range of 9 to 11%.",
+    ])).toEqual([
+      {
+        key: "eps",
+        label: "EPS",
+        value: "$4.05 to $4.25",
+      },
+    ]);
+  });
+
   test("extracts single-value outlook metrics across supported value types", () => {
     const metrics = extractOutlookMetrics([
       "Guidance",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -237,7 +237,7 @@ function getOutlookRangeValue(value: string, valueType: OutlookValueType): strin
       : null;
   }
 
-  const moneyRangeMatch = value.match(/(\(?\$?\s*-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:trillion|billion|million|t|b|m)?\)?)(?:\s*(?:to|through|-|–|and)\s*)(\(?\$?\s*-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:trillion|billion|million|t|b|m)?\)?)/i);
+  const moneyRangeMatch = value.match(/(\(?\$?\s*-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:(?:trillion|billion|million|tn|bn|mm|[tbm])\b)?\)?)(?:\s*(?:to|through|-|–|and)\s*)(\(?\$?\s*-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:(?:trillion|billion|million|tn|bn|mm|[tbm])\b)?\)?)/i);
   if (!moneyRangeMatch) {
     return null;
   }
@@ -254,6 +254,10 @@ function getOutlookRangeValue(value: string, valueType: OutlookValueType): strin
     return null === firstValue || null === secondValue
       ? null
       : `${formatEps(firstValue)} to ${formatEps(secondValue)}`;
+  }
+
+  if (false === hasMoneyValueCue(firstRangeValue) && false === hasMoneyValueCue(secondRangeValue)) {
+    return null;
   }
 
   const inferredUnit = getMoneyUnit(secondRangeValue) ?? getMoneyUnit(firstRangeValue);
@@ -276,7 +280,7 @@ function getSingleOutlookValue(value: string, valueType: OutlookValueType): stri
   }
 
   if ("money" === valueType) {
-    const moneyMatch = value.match(/\$?\s*-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:trillion|billion|million|t|b|m)/i);
+    const moneyMatch = value.match(/\$?\s*-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:trillion|billion|million|tn|bn|mm|[tbm])\b/i);
     const moneyValue = moneyMatch ? parseMoneyWithOptionalUnit(moneyMatch[0]) : null;
     return null === moneyValue ? null : formatUsdCompact(moneyValue);
   }
@@ -347,19 +351,23 @@ function parseMoneyWithOptionalUnit(value: string, inferredUnit?: string): numbe
     return parsedValue;
   }
 
-  if ("trillion" === unit || "t" === unit) {
+  if ("trillion" === unit || "tn" === unit || "t" === unit) {
     return parsedValue * 1_000_000_000_000;
   }
 
-  if ("billion" === unit || "b" === unit) {
+  if ("billion" === unit || "bn" === unit || "b" === unit) {
     return parsedValue * 1_000_000_000;
   }
 
   return parsedValue * 1_000_000;
 }
 
+function hasMoneyValueCue(value: string): boolean {
+  return value.includes("$") || undefined !== getMoneyUnit(value);
+}
+
 function getMoneyUnit(value: string): string | undefined {
-  return value.match(/(trillion|billion|million|[tbm])\b/i)?.[1]?.toLowerCase();
+  return value.match(/(trillion|billion|million|tn|bn|mm|[tbm])\b/i)?.[1]?.toLowerCase();
 }
 
 function formatEps(value: number): string {


### PR DESCRIPTION
## Summary
- Require non-EPS outlook money ranges to include a money cue before formatting them as dollars.
- Preserve short money unit parsing for tn/bn/mm/t/b/m with proper word boundaries.
- Add a PRIM regression case covering margin percentage ranges after revenue mentions.

## Root Cause
PRIM guidance mentioned SG&A as a percentage of revenue and later listed segment gross margin ranges of 10 to 12% and 9 to 11%. The revenue outlook extractor accepted bare numeric ranges as money ranges, so it rendered 10 to 12 as a revenue range.

## Validation
- npm test -- modules/earnings-results-format.test.ts modules/earnings-results-outlook.test.ts
- npm run typecheck
- npm test
- npm run lint