### PR TITLE
[codex] Fix earnings result summary spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,13 @@ Example Discord output:
 @alerts Heute Earnings: `AAPL` (nach Handelsschluss)
 @alerts Heute Earnings: `NVDA`, `MSFT` (nach Handelsschluss)
 **Apple Inc. (`AAPL`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm)
-📝 Apple reported Q1 2026 results ahead of expectations, with EPS of `$2.84` and revenue of `$143.8B` both beating consensus. Revenue strength supported net income of `$42.1B` for the quarter. The company did not provide a quantified outlook.
-
 📊 **Results**
 - **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)
 - **Revenue:** `$143.8B` vs est. `$138.25B` (🟢 beat)
+- **Net income:** `$42.1B`
+
+📝 Apple reported Q1 2026 results ahead of expectations, with EPS of `$2.84` and revenue of `$143.8B` both beating consensus. Revenue strength supported net income of `$42.1B` for the quarter. The company did not provide a quantified outlook.
+
 ```
 
 ## Market data

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -100,6 +100,11 @@ describe("earnings result formatting", () => {
       label: "Adj EPS",
       numericValue: 1.16,
       value: "$1.16",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 10_500_000_000,
+      value: "$10.5B",
     }] satisfies ReturnType<typeof getMessageMetrics>;
 
     expect(getEarningsResultMessage({
@@ -117,11 +122,13 @@ describe("earnings result formatting", () => {
       "**ExampleCo (`EXM`)** - Q1 2026 - [8-K](https://www.sec.gov/example)",
       "📊 **Results**",
       "- **Adj EPS:** `$1.16`",
+      "- **Revenue:** `$10.5B`",
       "",
       "🔮 **Outlook**",
       "- **Revenue:** `$89B` to `$91B`",
       "",
       "📝 ExampleCo beat expectations. Revenue improved. Management raised guidance.",
+      "",
     ].join("\n"));
   });
 

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -290,6 +290,7 @@ export function getEarningsResultMessage({
       lines.push("");
     }
     lines.push(`📝 ${summary.trim()}`);
+    lines.push("");
   }
 
   return lines.join("\n");

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -191,6 +191,25 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  test("keeps EPS percentage outlook as percentages instead of dollar EPS values", () => {
+    expect(extractOutlookMetrics([
+      "Guidance and Outlook",
+      "Full year adjusted EPS growth of approximately 12%.",
+      "Revenue expected to increase high single-digit.",
+    ])).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        value: "high single-digit growth",
+      },
+      {
+        key: "eps",
+        label: "EPS",
+        value: "12% growth",
+      },
+    ]);
+  });
+
   test("limits outlook scanning and ignores unusable fallback values", () => {
     const lines = [
       "Business Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -198,6 +198,7 @@ function extractOutlookValue(
 
   return getGrowthOutlookValue(valueText) ??
     getOutlookRangeValue(valueText, valueType) ??
+    ("eps" === valueType ? getEpsPercentOutlookValue(valueText) : null) ??
     ("text" === valueType ? getSingleOutlookValue(valueText, "money") : null) ??
     getSingleOutlookValue(valueText, valueType);
 }
@@ -230,6 +231,13 @@ function getGrowthDirection(value: string): "growth" | "decline" {
 }
 
 function getOutlookRangeValue(value: string, valueType: OutlookValueType): string | null {
+  if ("eps" === valueType) {
+    const percentRangeValue = getPercentRangeOutlookValue(value);
+    if (null !== percentRangeValue) {
+      return withPercentGrowthDirection(percentRangeValue, value);
+    }
+  }
+
   if ("percent" === valueType) {
     const percentRangeMatch = value.match(/(-?\d+(?:\.\d+)?)\s*%\s*(?:to|through|-|–|and)\s*(-?\d+(?:\.\d+)?)\s*%/i);
     return undefined !== percentRangeMatch?.[1] && undefined !== percentRangeMatch[2]
@@ -275,7 +283,7 @@ function getSingleOutlookValue(value: string, valueType: OutlookValueType): stri
   }
 
   if ("eps" === valueType) {
-    const epsValue = findNumericValue(value, {maxAbsValue: 100});
+    const epsValue = findNumericValue(value, {maxAbsValue: 100, skipPercentages: true});
     return null === epsValue ? null : formatEps(epsValue);
   }
 
@@ -286,6 +294,34 @@ function getSingleOutlookValue(value: string, valueType: OutlookValueType): stri
   }
 
   return null;
+}
+
+function getEpsPercentOutlookValue(value: string): string | null {
+  const percentMatch = value.match(/(-?\d+(?:\.\d+)?)\s*%/);
+  if (undefined === percentMatch?.[1]) {
+    return null;
+  }
+
+  return withPercentGrowthDirection(formatPercent(Number.parseFloat(percentMatch[1])), value);
+}
+
+function getPercentRangeOutlookValue(value: string): string | null {
+  const percentRangeMatch = value.match(/(-?\d+(?:\.\d+)?)\s*%\s*(?:to|through|-|–|and)\s*(-?\d+(?:\.\d+)?)\s*%/i);
+  return undefined !== percentRangeMatch?.[1] && undefined !== percentRangeMatch[2]
+    ? `${formatPercent(Number.parseFloat(percentRangeMatch[1]))} to ${formatPercent(Number.parseFloat(percentRangeMatch[2]))}`
+    : null;
+}
+
+function withPercentGrowthDirection(value: string, source: string): string {
+  if (/\b(?:decline|decrease|down|lower)\b/i.test(source)) {
+    return `${value} decline`;
+  }
+
+  if (/\b(?:growth|grow|increase|up|higher)\b/i.test(source)) {
+    return `${value} growth`;
+  }
+
+  return value;
 }
 
 function findNumericValue(

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -1022,13 +1022,36 @@ function parseNasdaqMoney(value: unknown): number | null {
 }
 
 export function getExampleEarningsResultOutput(): string {
-  return [
-    "**Apple Inc. (`AAPL`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm)",
-    "📝 Apple reported Q1 2026 results ahead of expectations, with EPS of `$2.84` and revenue of `$143.8B` both beating consensus. Revenue strength supported net income of `$42.1B` for the quarter. The company did not provide a quantified outlook.",
-    "",
-    "📊 **Results**",
-    "- **EPS:** `$2.84` vs est. `$2.67` (🟢 beat)",
-    `- **Revenue:** \`${formatUsdCompact(143_800_000_000)}\` vs est. \`${formatUsdCompact(138_250_000_000)}\` (🟢 beat)`,
-    `- **Net income:** \`${formatUsdCompact(42_097_000_000)}\``,
-  ].join("\n");
+  return getEarningsResultMessage({
+    companyName: "Apple Inc.",
+    filing: {
+      form: "8-K",
+      items: ["2.02", "9.01"],
+    },
+    filingUrl: "https://www.sec.gov/Archives/edgar/data/320193/000032019326000005/a8-kex991q1202612272025.htm",
+    metrics: [{
+      key: "gaap_eps",
+      label: "EPS",
+      value: "$2.84",
+      estimate: "$2.67",
+      outcome: "beat",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      value: formatUsdCompact(143_800_000_000),
+      estimate: formatUsdCompact(138_250_000_000),
+      outcome: "beat",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      value: formatUsdCompact(42_097_000_000),
+    }],
+    parsedDocument: {
+      metrics: [],
+      outlook: [],
+      quarterLabel: "Q1 2026",
+    },
+    summary: "Apple reported Q1 2026 results ahead of expectations, with EPS of `$2.84` and revenue of `$143.8B` both beating consensus. Revenue strength supported net income of `$42.1B` for the quarter. The company did not provide a quantified outlook.",
+    ticker: "AAPL",
+  });
 }


### PR DESCRIPTION
## Summary

- Add a trailing blank line after optional earnings AI summaries while keeping result metric bullets stacked.
- Keep EPS percentage outlook values as percentages, so guidance like 12% growth is not rendered as $12.
- Update the earnings result sample output helper and README example to match the formatter.

## Validation

- `npx vitest run modules/earnings-results-format.test.ts modules/earnings-results-outlook.test.ts modules/earnings-results.test.ts`
- `npm run typecheck`
- `npm test`
