### PR TITLE
[codex] Render final earnings result spacer

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -129,6 +129,7 @@ describe("earnings result formatting", () => {
       "",
       "📝 ExampleCo beat expectations. Revenue improved. Management raised guidance.",
       "",
+      "\u200B",
     ].join("\n"));
   });
 
@@ -713,6 +714,8 @@ describe("earnings result formatting", () => {
       "**Example (`EX`)** - [10-Q](https://www.sec.gov/example)",
       "📊 **Results**",
       "- **Production:** `1,200 boepd`",
+      "",
+      "\u200B",
     ].join("\n"));
   });
 

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -53,6 +53,8 @@ type MetricDefinition = {
   valueType: MetricValueType;
 };
 
+const discordBlankLineSpacer = "\u200B";
+
 const earningsMetricDefinitions: MetricDefinition[] = [
   {
     key: "adjusted_eps",
@@ -290,8 +292,9 @@ export function getEarningsResultMessage({
       lines.push("");
     }
     lines.push(`📝 ${summary.trim()}`);
-    lines.push("");
   }
+
+  lines.push("", discordBlankLineSpacer);
 
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary

- Append a Discord-rendered blank spacer to every earnings result announcement, regardless of whether it ends with Results, Outlook, or an AI summary.
- Use a zero-width spacer line so Discord does not trim the final blank line at the message boundary.
- Cover summary and no-summary announcements with exact-output tests.

## Validation

- `npx vitest run modules/earnings-results-format.test.ts modules/earnings-results.test.ts`
- `npm run typecheck`
- `npm test`
