### PR TITLE
[codex] Fix earnings guidance range formatting

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -92,6 +92,10 @@ describe("earnings result formatting", () => {
         key: "revenue",
         label: "Revenue",
         value: "$89B to $91B",
+      }, {
+        key: "capex",
+        label: "Capex",
+        value: "$190M-$210M",
       }],
       quarterLabel: "Q1 2026",
     } satisfies ReturnType<typeof parseEarningsDocument>;
@@ -126,6 +130,7 @@ describe("earnings result formatting", () => {
       "",
       "🔮 **Outlook**",
       "- **Revenue:** `$89B` to `$91B`",
+      "- **Capex:** `$190M-$210M`",
       "",
       "📝 ExampleCo beat expectations. Revenue improved. Management raised guidance.",
       "",

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -323,10 +323,13 @@ function isQuantitativeText(value: string): boolean {
 
 function formatQuantitativeTokens(value: string): string {
   return value.replace(
-    /-?(?:[$€£¥]\s*)?\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|billions?|millions?|thousands?|tn|bn|mm|[tbmk]|kbd|koebd|boepd|bpd|mmboe|bcfe|mmcf|mw|gw)\b|\s*%)?/gi,
+    quantitativeTokenPattern,
     token => formatInlineCode(token.trim()),
   );
 }
+
+const quantitativeValuePattern = String.raw`-?(?:[$€£¥]\s*)?\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|billions?|millions?|thousands?|tn|bn|mm|[tbmk]|kbd|koebd|boepd|bpd|mmboe|bcfe|mmcf|mw|gw)\b|\s*%)?`;
+const quantitativeTokenPattern = new RegExp(`${quantitativeValuePattern}(?:\\s*(?:-|–|—)\\s*${quantitativeValuePattern})?`, "gi");
 
 function formatInlineCode(value: string): string {
   return `\`${value.replaceAll("`", "'")}\``;

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -210,6 +210,29 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  test("keeps same-sentence outlook values scoped to their metric labels", () => {
+    expect(extractOutlookMetrics([
+      "Fiscal 2026 Outlook",
+      "Management expects approximately 14% total revenue growth and guided to net sales of $690-$710M, adjusted EPS of $3.65-$3.85, and adjusted tax rate of 21%-22%.",
+    ])).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        value: "$690M to $710M",
+      },
+      {
+        key: "eps",
+        label: "EPS",
+        value: "$3.65 to $3.85",
+      },
+      {
+        key: "tax_rate",
+        label: "Tax rate",
+        value: "21% to 22%",
+      },
+    ]);
+  });
+
   test("limits outlook scanning and ignores unusable fallback values", () => {
     const lines = [
       "Business Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -158,21 +158,22 @@ function extractOutlookMetric(
       continue;
     }
 
-    const pattern = definition.patterns.find(candidatePattern => candidatePattern.test(line));
-    if (!pattern) {
-      continue;
-    }
+    for (const pattern of definition.patterns) {
+      if (false === pattern.test(line)) {
+        continue;
+      }
 
-    const value = extractOutlookValue(line, pattern, definition.valueType);
-    if (null === value) {
-      continue;
-    }
+      const value = extractOutlookValue(line, pattern, definition.valueType);
+      if (null === value) {
+        continue;
+      }
 
-    return {
-      key: definition.key,
-      label: definition.label,
-      value,
-    };
+      return {
+        key: definition.key,
+        label: definition.label,
+        value,
+      };
+    }
   }
 
   return null;
@@ -190,7 +191,7 @@ function extractOutlookValue(
 ): string | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
-  const rawValueText = patternMatch ? line.slice(patternMatch.index + patternMatch[0].length) : line;
+  const rawValueText = getOutlookValueSegment(line, patternMatch);
   const valueText = normalizeOutlookValueText(rawValueText);
   if ("" === valueText) {
     return null;
@@ -201,6 +202,17 @@ function extractOutlookValue(
     ("eps" === valueType ? getEpsPercentOutlookValue(valueText) : null) ??
     ("text" === valueType ? getSingleOutlookValue(valueText, "money") : null) ??
     getSingleOutlookValue(valueText, valueType);
+}
+
+function getOutlookValueSegment(line: string, patternMatch: RegExpExecArray | null): string {
+  if (null === patternMatch) {
+    return line;
+  }
+
+  const rawValueText = line.slice(patternMatch.index + patternMatch[0].length);
+  const nextMetricMatch = /\b(?:adjusted\s+eps|diluted\s+eps|eps|earnings\s+per\s+(?:common\s+)?share|revenues?|net\s+sales|sales|gross\s+margin|operating\s+margin|operating\s+income|operating\s+expenses?|opex|tax\s+rate|capex|capital\s+expenditures?|free\s+cash\s+flow|adjusted\s+ebitda|ebitda)\b/i.exec(rawValueText);
+  const endIndex = nextMetricMatch?.index ?? rawValueText.length;
+  return rawValueText.slice(0, endIndex);
 }
 
 function normalizeOutlookValueText(value: string): string {

--- a/modules/earnings-results-summary.test.ts
+++ b/modules/earnings-results-summary.test.ts
@@ -92,7 +92,7 @@ describe("AI earnings summaries", () => {
           content: {
             parts: [{
               text: JSON.stringify({
-                summary: "EXM revenue rose 12% to $10.2 billion while operating margin expanded 180 basis points to 24.3%. EXM guided adjusted EPS to $5.80 to $6.10. Revenue momentum remained broad.",
+                summary: "EXM revenue rose 12% to $10.2 billion while operating margin expanded 180 basis points to 24.3%. EXM guided net sales to $690-$710M, adjusted EPS to $3.65-$3.85, and adjusted tax rate to 21%-22%. Revenue momentum remained broad.",
               }),
             }],
           },
@@ -114,7 +114,7 @@ describe("AI earnings summaries", () => {
     });
 
     expect(result).toBe(
-      "`EXM` revenue rose `12%` to `$10.2 billion` while operating margin expanded `180 basis points` to `24.3%`. `EXM` guided adjusted EPS to `$5.80` to `$6.10`. Revenue momentum remained broad.",
+      "`EXM` revenue rose `12%` to `$10.2 billion` while operating margin expanded `180 basis points` to `24.3%`. `EXM` guided net sales to `$690-$710M`, adjusted EPS to `$3.65-$3.85`, and adjusted tax rate to `21%-22%`. Revenue momentum remained broad.",
     );
   });
 

--- a/modules/earnings-results-summary.ts
+++ b/modules/earnings-results-summary.ts
@@ -410,10 +410,13 @@ function formatTickerInlineCode(value: string, ticker: string): string {
 
 function formatMetricInlineCode(value: string): string {
   return value.replace(
-    /-?(?:(?:[$€£¥]\s*)\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b)?|\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|billions?|millions?|thousands?|tn|bn|mm|bps?|basis points?|points?|[tbmk])\b|\s*%))/gi,
+    summaryMetricTokenPattern,
     token => `\`${token.trim()}\``,
   );
 }
+
+const summaryMetricValuePattern = String.raw`-?(?:(?:[$€£¥]\s*)\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b)?|\d[\d,]*(?:\.\d+)?(?:\s*(?:trillion|billions?|millions?|thousands?|tn|bn|mm|bps?|basis points?|points?|[tbmk])\b|\s*%))`;
+const summaryMetricTokenPattern = new RegExp(`${summaryMetricValuePattern}(?:\\s*(?:-|–|—)\\s*${summaryMetricValuePattern})?`, "gi");
 
 function mapTextOutsideInlineCode(value: string, mapper: (text: string) => string): string {
   return value


### PR DESCRIPTION
## Summary

- Treat hyphenated guidance ranges such as `$690-$710M`, `$3.65-$3.85`, and `21%-22%` as one inline-code token in earnings summaries and outlook text.
- Keep same-sentence outlook values scoped to their own metric labels so revenue does not inherit an EPS range.
- Add regressions for GPN-style outlook guidance and hyphenated AI summary ranges.

## Validation

- `npx vitest run modules/earnings-results-summary.test.ts modules/earnings-results-outlook.test.ts modules/earnings-results-format.test.ts`
- `npm run typecheck`
- `npm test`
