### PR TITLE
[codex] Fix websocket error event logging

### DIFF
--- a/modules/market-data.test.ts
+++ b/modules/market-data.test.ts
@@ -146,6 +146,104 @@ describe("updateMarketData", () => {
     expect(wsClient.send).toHaveBeenCalledWith(expect.stringContaining("pid-123:%%"));
   });
 
+  test("logs circular websocket error events without throwing", async () => {
+    queuedClientIds.push("client-1");
+    mockGetAssets.mockResolvedValue([
+      {
+        botToken: "token-1",
+        botName: "bot-one",
+        botClientId: "client-1",
+        id: 123,
+        decimals: 2,
+        order: 1,
+        suffix: "",
+        unit: "",
+        lastUpdate: 0,
+      },
+    ]);
+
+    await updateMarketData();
+    clientInstances[0]!.handlers.get("clientReady")();
+
+    const wsClient = websocketInstances[0]!;
+    const errorHandler = wsClient.handlers.get("error");
+    const circularEvent: Record<string, unknown> = {
+      error: new Error("socket timeout"),
+      message: "timeout",
+      type: "error",
+    };
+    circularEvent["request"] = circularEvent;
+
+    expect(() => errorHandler(circularEvent)).not.toThrow();
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("message=timeout"),
+    );
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("error=Error: socket timeout"),
+    );
+  });
+
+  test("logs websocket error event variants without serializing full objects", async () => {
+    queuedClientIds.push("client-1");
+    mockGetAssets.mockResolvedValue([
+      {
+        botToken: "token-1",
+        botName: "bot-one",
+        botClientId: "client-1",
+        id: 123,
+        decimals: 2,
+        order: 1,
+        suffix: "",
+        unit: "",
+        lastUpdate: 0,
+      },
+    ]);
+
+    await updateMarketData();
+    clientInstances[0]!.handlers.get("clientReady")();
+
+    const wsClient = websocketInstances[0]!;
+    const errorHandler = wsClient.handlers.get("error");
+    errorHandler("plain timeout");
+    errorHandler(1000);
+    errorHandler({
+      code: 1000,
+      reason: "timeout",
+    });
+    errorHandler({
+      error: {
+        code: 1001,
+        message: "nested timeout",
+        name: "TimeoutError",
+        reason: "stale",
+      },
+    });
+    errorHandler({});
+
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("plain timeout"),
+    );
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("1000"),
+    );
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("code=1000, reason=timeout"),
+    );
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("error=name=TimeoutError, message=nested timeout, code=1001, reason=stale"),
+    );
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("[object Object]"),
+    );
+  });
+
   test("updates nickname and presence from market stream payload", async () => {
     queuedClientIds.push("client-1");
     mockGetAssets.mockResolvedValue([

--- a/modules/market-data.ts
+++ b/modules/market-data.ts
@@ -43,7 +43,10 @@ type ReconnectingWebSocketInstance = {
   addEventListener: (type: "open" | "close" | "error" | "message", listener: (event: {
     code?: number;
     data?: unknown;
+    error?: unknown;
+    message?: string;
     reason?: string;
+    type?: string;
   }) => void) => void;
   readyState: number;
   reconnect: () => void;
@@ -352,7 +355,7 @@ function initInvestingCom(clientsById: Map<string, Client<true>>, marketDataAsse
   wsClient.addEventListener("error", event => {
     logger.log(
       "error",
-      `Error at websocket connection ${wsClient.url}: ${JSON.stringify(event)}`,
+      `Error at websocket connection ${wsClient.url}: ${formatWebSocketErrorEvent(event)}`,
     );
   });
 
@@ -737,6 +740,68 @@ function getInitialMarketDataPresence(marketDataAsset: MarketDataAsset): string 
   return "crypto" === marketDataAsset.marketHours
     ? marketOpenPresence
     : marketClosedPresence;
+}
+
+function formatWebSocketErrorEvent(event: unknown): string {
+  if (false === isRecord(event)) {
+    return formatWebSocketErrorValue(event);
+  }
+
+  const parts: string[] = [];
+  appendStringField(parts, "type", event["type"]);
+  appendStringField(parts, "message", event["message"]);
+  appendNumberField(parts, "code", event["code"]);
+  appendStringField(parts, "reason", event["reason"]);
+
+  if (undefined !== event["error"]) {
+    parts.push(`error=${formatWebSocketErrorValue(event["error"])}`);
+  }
+
+  return 0 < parts.length ? parts.join(", ") : formatWebSocketErrorValue(event);
+}
+
+function appendStringField(parts: string[], label: string, value: unknown) {
+  if ("string" === typeof value && "" !== value.trim()) {
+    parts.push(`${label}=${value.trim()}`);
+  }
+}
+
+function appendNumberField(parts: string[], label: string, value: unknown) {
+  if ("number" === typeof value && Number.isFinite(value)) {
+    parts.push(`${label}=${value}`);
+  }
+}
+
+function formatWebSocketErrorValue(value: unknown): string {
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}`;
+  }
+
+  if ("string" === typeof value) {
+    return value;
+  }
+
+  if ("number" === typeof value || "boolean" === typeof value || null === value) {
+    return String(value);
+  }
+
+  if (true === isRecord(value)) {
+    const parts: string[] = [];
+    appendStringField(parts, "name", value["name"]);
+    appendStringField(parts, "message", value["message"]);
+    appendNumberField(parts, "code", value["code"]);
+    appendStringField(parts, "reason", value["reason"]);
+
+    if (0 < parts.length) {
+      return parts.join(", ");
+    }
+  }
+
+  return Object.prototype.toString.call(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return null !== value && "object" === typeof value;
 }
 
 function logAppliedMarketDataUpdate(logData: AppliedMarketDataUpdateLog) {


### PR DESCRIPTION
## Summary

- Stop serializing full websocket error events, which can contain circular request/socket internals.
- Log selected safe fields from websocket errors: type, message, code, reason, and nested error details.
- Add a regression for circular websocket error events so timeout errors log without throwing.

## Validation

- `npx vitest run modules/market-data.test.ts`
- `npm run typecheck`
- `npm test`
