### PR TITLE
[codex] Fix MNC summary rendering

### DIFF
--- a/modules/mnc-summary.test.ts
+++ b/modules/mnc-summary.test.ts
@@ -41,7 +41,7 @@ describe("MNC AI summary", () => {
       readSecretFn,
     });
 
-    expect(summary).toBe("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
+    expect(summary).toBe("- Futures firm ahead of payrolls.");
     expect(postWithRetryFn).toHaveBeenCalledWith(
       expect.stringContaining("gemini-2.5-flash-lite:generateContent"),
       expect.objectContaining({
@@ -61,6 +61,20 @@ describe("MNC AI summary", () => {
           "x-goog-api-key": "gemini-key",
         }),
       }),
+      expect.any(Object),
+    );
+    expect(postWithRetryFn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        contents: [expect.objectContaining({
+          parts: expect.arrayContaining([
+            expect.objectContaining({
+              text: expect.stringContaining("Do not include a Morning News Call heading"),
+            }),
+          ]),
+        })],
+      }),
+      expect.any(Object),
       expect.any(Object),
     );
   });
@@ -126,7 +140,7 @@ describe("MNC AI summary", () => {
 
     expect(summary).toBeDefined();
     expect(summary).not.toContain("```");
-    expect(summary).toContain("**Morning News Call - TL;DR**");
+    expect(summary).not.toContain("**Morning News Call - TL;DR**");
     expect(summary).not.toContain("📰 **Morning News Call - TL;DR**");
     expect(summary!.length).toBeLessThanOrEqual(1_930);
     expect(summary).toContain("\n...");
@@ -168,13 +182,14 @@ describe("MNC AI summary", () => {
 
     expect(summary).toBeDefined();
     expect(summary!.length).toBeLessThanOrEqual(1_930);
+    expect(summary).not.toContain("Morning News Call - TL;DR");
     expect(summary).toContain("**Stocks in focus**");
     expect(summary).toContain("**Watchlist**");
     expect(summary).toContain("Watch Treasury supply");
     expect(summary).not.toContain("\n...");
   });
 
-  test("removes legacy newspaper emoji from the summary heading", async () => {
+  test("removes generated Morning News Call headings", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {
         candidates: [{
@@ -195,7 +210,54 @@ describe("MNC AI summary", () => {
       readSecretFn,
     });
 
-    expect(summary).toBe("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
+    expect(summary).toBe("- Futures firm ahead of payrolls.");
+  });
+
+  test("normalizes common AI Markdown rendering glitches", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                summaryMarkdown: [
+                  "**Morning News Call - TL;DR**",
+                  "- U.S. futures opened firmer while easing geopolitical तनाव and AI optimism lifted risk appetite.",
+                  "- Gold jumped more than `3%`.",
+                  "",
+                  "**Stocks in focus**",
+                  "- Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$$1.57` / `$$25.2B`, with ~`12%` FY26 EPS growth.",
+                  "- Super Micro Computer `SMCI` forecast Q4 revenue of `$$11B`-`$$12.5B` and adjusted EPS of `65c`-`79c`.",
+                  "- PayPal `PYPL` reported Q1 revenue of `$$8.35B`, targeting `$$1.5B` of savings over `2`-`3` years.",
+                  "",
+                  "**Watchlist**",
+                  "- All eyes on `ADP` April payrolls (`99K` expected).",
+                ].join("\n"),
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBe([
+      "- U.S. futures opened firmer while easing geopolitical and AI optimism lifted risk appetite.",
+      "- Gold jumped more than `3%`.",
+      "",
+      "**Stocks in focus**",
+      "- Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$1.57` / `$25.2B`, with ~`12%` FY26 EPS growth.",
+      "- Super Micro Computer `SMCI` forecast Q4 revenue of `$11B-$12.5B` and adjusted EPS of `65c-79c`.",
+      "- PayPal `PYPL` reported Q1 revenue of `$8.35B`, targeting `$1.5B` of savings over `2-3` years.",
+      "",
+      "**Watchlist**",
+      "- All eyes on `ADP` April payrolls (`99K` expected).",
+    ].join("\n"));
   });
 
   test("hard-truncates summaries that cannot be compacted or split by line", async () => {

--- a/modules/mnc-summary.ts
+++ b/modules/mnc-summary.ts
@@ -73,7 +73,13 @@ export async function getMncSummary(
   }
 
   const normalizedSummary = normalizeMarkdownSummary(summaryMarkdown);
-  return "" === normalizedSummary ? undefined : truncateMarkdownSummary(normalizedSummary);
+  if ("" === normalizedSummary) {
+    return undefined;
+  }
+
+  const truncatedSummary = truncateMarkdownSummary(normalizedSummary);
+  const finalSummary = removeMncTldrHeading(truncatedSummary).trim();
+  return "" === finalSummary ? undefined : finalSummary;
 }
 
 function getMncSummaryPrompt(): string {
@@ -82,7 +88,6 @@ function getMncSummaryPrompt(): string {
     "Return only JSON matching the schema. Do not include markdown outside the JSON string.",
     "Write summaryMarkdown as a one-minute read in concise Discord Markdown.",
     "Required shape:",
-    "**Morning News Call - TL;DR**",
     "- Exactly 2 bullets with the market setup and most important macro drivers.",
     "",
     "**Stocks in focus**",
@@ -94,6 +99,8 @@ function getMncSummaryPrompt(): string {
     "- Keep the full summary under 1,750 characters.",
     "- Use exactly 7 bullets total; each bullet should fit one Discord line.",
     "- Prioritize concrete, market-moving information from the PDF.",
+    "- Do not include a Morning News Call heading; the Discord message title already provides it.",
+    "- Write in English only.",
     "- Format ticker symbols and quantitative metrics as inline code, e.g. `AAPL`, `$2.14`, `3.1%`, `10Y`, `250K`.",
     "- In stock-specific bullets, start with Company Name `TICKER` when the PDF explicitly provides a ticker; common short company names are fine, e.g. Apple `AAPL`.",
     "- If the PDF does not explicitly provide a ticker, start with the company name without inventing a ticker.",
@@ -110,12 +117,52 @@ function normalizeMarkdownSummary(value: string): string {
     .filter(line => false === /^```/.test(line.trim()))
     .join("\n")
     .replace(/\\([$€£¥])/g, "$1")
+    .replace(/\${2,}/g, "$")
     .trim();
-  if (summary.startsWith("📰 **Morning News Call - TL;DR**")) {
-    return summary.slice("📰 ".length);
-  }
 
-  return summary;
+  return normalizeInlineCodeRanges(removeUnexpectedScriptTokens(removeMncTldrHeading(summary))).trim();
+}
+
+function removeMncTldrHeading(value: string): string {
+  return value
+    .split("\n")
+    .filter(line => false === isMncTldrHeading(line))
+    .join("\n")
+    .trim();
+}
+
+function isMncTldrHeading(line: string): boolean {
+  return /^\s*(?:📰\s*)?\*\*Morning News Call\s*-\s*TL;?DR\*\*\s*$/i.test(line);
+}
+
+function removeUnexpectedScriptTokens(value: string): string {
+  return value
+    .split("\n")
+    .map(line => line
+      .replace(/\S*[\p{Script=Arabic}\p{Script=Devanagari}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]\S*/gu, "")
+      .replace(/\s+([,.;:])/g, "$1")
+      .replace(/[ \t]{2,}/g, " ")
+      .trimEnd())
+    .join("\n");
+}
+
+function normalizeInlineCodeRanges(value: string): string {
+  return value.replace(
+    /`([^`\n]+)`\s*([-–—])\s*`([^`\n]+)`/g,
+    (match, firstValue: string, separator: string, secondValue: string) => {
+      const firstToken = firstValue.trim();
+      const secondToken = secondValue.trim();
+      if (false === isRangeInlineCodeToken(firstToken) || false === isRangeInlineCodeToken(secondToken)) {
+        return match;
+      }
+
+      return `\`${firstToken}${separator}${secondToken}\``;
+    },
+  );
+}
+
+function isRangeInlineCodeToken(value: string): boolean {
+  return /[$€£¥]|\d/.test(value);
 }
 
 function truncateMarkdownSummary(value: string): string {
@@ -179,11 +226,12 @@ function buildCompactedSectionSummary(
   const tldrHeadingIndex = lines.findIndex(line => line.includes("Morning News Call - TL;DR"));
   const stocksHeadingIndex = lines.findIndex(line => line.trim() === "**Stocks in focus**");
   const watchlistHeadingIndex = lines.findIndex(line => line.trim() === "**Watchlist**");
-  if (-1 === tldrHeadingIndex || -1 === stocksHeadingIndex || -1 === watchlistHeadingIndex) {
+  if (-1 === stocksHeadingIndex || -1 === watchlistHeadingIndex) {
     return undefined;
   }
 
-  const tldrBullets = getBulletLines(lines.slice(tldrHeadingIndex + 1, stocksHeadingIndex)).slice(0, 2);
+  const tldrStartIndex = -1 === tldrHeadingIndex ? 0 : tldrHeadingIndex + 1;
+  const tldrBullets = getBulletLines(lines.slice(tldrStartIndex, stocksHeadingIndex)).slice(0, 2);
   const stockBullets = getBulletLines(lines.slice(stocksHeadingIndex + 1, watchlistHeadingIndex)).slice(0, stockBulletLimit);
   const watchlistBullets = getBulletLines(lines.slice(watchlistHeadingIndex + 1)).slice(0, watchlistBulletLimit);
   if (0 === tldrBullets.length || 0 === stockBullets.length || 0 === watchlistBullets.length) {
@@ -191,7 +239,6 @@ function buildCompactedSectionSummary(
   }
 
   return [
-    lines[tldrHeadingIndex],
     ...tldrBullets,
     "",
     "**Stocks in focus**",

--- a/modules/timers.test.ts
+++ b/modules/timers.test.ts
@@ -359,7 +359,7 @@ describe("timers: NYSE and MNC", () => {
 
   test("startMncTimers includes an AI summary when available", async () => {
     const {client, send} = createClientWithChannel();
-    getMncSummaryMock.mockResolvedValueOnce("**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.");
+    getMncSummaryMock.mockResolvedValueOnce("- Futures firm ahead of payrolls.");
 
     startMncTimers(client, "channel-id");
     const mncJob = getScheduledJobByTime(9, 0, "US/Eastern");
@@ -373,11 +373,11 @@ describe("timers: NYSE and MNC", () => {
       files: expect.any(Array),
     }));
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining("**Morning News Call - TL;DR**"),
+      content: expect.stringContaining("- Futures firm ahead of payrolls."),
       files: expect.any(Array),
     }));
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.not.stringContaining("📰 **Morning News Call - TL;DR**"),
+      content: expect.not.stringContaining("**Morning News Call - TL;DR**"),
       files: expect.any(Array),
     }));
   });


### PR DESCRIPTION
Summary
- Remove the generated Morning News Call TL;DR heading because the Discord announcement title already provides it.
- Normalize common AI Markdown rendering glitches: doubled dollar signs, split inline-code ranges, and unexpected non-English script tokens.
- Add regression coverage for screenshot-like output and timer summary expectations.

Validation
- npx vitest run modules/mnc-summary.test.ts modules/timers.test.ts
- npm run typecheck
- npm test
- npm run test:coverage