### PR TITLE
[codex] merge earnings dates into headlines

### DIFF
--- a/modules/calendar.test.ts
+++ b/modules/calendar.test.ts
@@ -73,8 +73,8 @@ describe("getCalendarMessages", () => {
     expect(batch.truncated).toBe(false);
     expect(batch.totalEvents).toBe(2);
     expect(batch.includedEvents).toBe(2);
-    expect(batch.messages[0]!).toContain("Wichtige Termine:");
-    expect(batch.messages[0]!).toContain("Wichtige Termine:\n\n**Montag, 3. März 2025**");
+    expect(batch.messages[0]!).toContain("**Wichtige Termine** (Montag, 3. März 2025)");
+    expect(batch.messages[0]!).not.toContain("Wichtige Termine:\n\n**Montag, 3. März 2025**");
     expect(batch.messages[0]!).toContain("Event A");
     expect(batch.messages[0]!).toContain("Event B");
   });
@@ -155,8 +155,8 @@ describe("getCalendarMessages", () => {
       keepDayTogether: true,
     });
 
-    expect(batch.messages[0]!).toContain("📅 **Wichtige Termine der nächsten Handelswoche:**");
-    expect(batch.messages[0]!).not.toContain("Wichtige Termine:\n");
+    expect(batch.messages[0]!).toContain("📅 **Wichtige Termine der nächsten Handelswoche** (Montag, 3. März 2025)");
+    expect(batch.messages[0]!).not.toContain("Wichtige Termine der nächsten Handelswoche:**\n");
   });
 
   test("chunks by day boundaries across multiple days", () => {

--- a/modules/calendar.ts
+++ b/modules/calendar.ts
@@ -177,24 +177,27 @@ export function getCalendarMessages(
 
   const dayBlocks = getCalendarDayBlocks(calendarEvents);
   const chunks: CalendarMessageChunk[] = [];
-  let currentChunk = getEmptyCalendarMessageChunk(0, title);
+  let currentChunk = getEmptyCalendarMessageChunk();
+  let pendingTitle = title.trim();
   let contentTruncated = false;
 
   for (const dayBlock of dayBlocks) {
-    const fullDayBlockText = getDayBlockText(dayBlock, false, continuationLabel);
+    const fullDayBlockText = getDayBlockText(dayBlock, false, continuationLabel, pendingTitle);
 
     if (true === canAppendToChunk(currentChunk, fullDayBlockText, maxMessageLength)) {
       appendToChunk(currentChunk, fullDayBlockText, dayBlock.lines.length, dayBlock.date);
+      pendingTitle = "";
       continue;
     }
 
     if (0 < currentChunk.eventCount) {
       chunks.push(cloneChunk(currentChunk));
-      currentChunk = getEmptyCalendarMessageChunk(chunks.length, title);
+      currentChunk = getEmptyCalendarMessageChunk();
     }
 
     if (true === canAppendToChunk(currentChunk, fullDayBlockText, maxMessageLength)) {
       appendToChunk(currentChunk, fullDayBlockText, dayBlock.lines.length, dayBlock.date);
+      pendingTitle = "";
       continue;
     }
 
@@ -202,7 +205,7 @@ export function getCalendarMessages(
     let lineIndex = 0;
     let continuation = false;
     while (lineIndex < dayBlock.lines.length) {
-      const header = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation);
+      const header = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation, pendingTitle);
       const lines: string[] = [];
 
       while (lineIndex < dayBlock.lines.length) {
@@ -226,7 +229,7 @@ export function getCalendarMessages(
         const availableLineLength = maxMessageLength - getAppendedChunkText(currentChunk, headerText).length - 1;
         if (availableLineLength <= 0 && 0 < currentChunk.eventCount) {
           chunks.push(cloneChunk(currentChunk));
-          currentChunk = getEmptyCalendarMessageChunk(chunks.length, title);
+          currentChunk = getEmptyCalendarMessageChunk();
           continue;
         }
 
@@ -245,10 +248,11 @@ export function getCalendarMessages(
 
       const partText = getDayText(header, lines);
       appendToChunk(currentChunk, partText, lines.length, dayBlock.date);
+      pendingTitle = "";
 
       if (lineIndex < dayBlock.lines.length) {
         chunks.push(cloneChunk(currentChunk));
-        currentChunk = getEmptyCalendarMessageChunk(chunks.length, title);
+        currentChunk = getEmptyCalendarMessageChunk();
         continuation = true;
       }
     }
@@ -385,23 +389,38 @@ function getDayText(dayHeader: string, lines: string[]): string {
   return `\n${dayHeader}\n${lines.join("\n")}\n`;
 }
 
-function getDayHeader(friendlyDate: string, continuationLabel: string, continuation: boolean): string {
+function getDayHeader(friendlyDate: string, continuationLabel: string, continuation: boolean, title = ""): string {
   if (false === continuation) {
+    if ("" !== title) {
+      return getTitledDayHeader(title, friendlyDate);
+    }
+
     return `**${friendlyDate}**`;
   }
 
   return `**${friendlyDate} ${continuationLabel}**`;
 }
 
-function getDayBlockText(dayBlock: CalendarDayBlock, continuation: boolean, continuationLabel: string): string {
-  const dayHeader = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation);
+function getDayBlockText(dayBlock: CalendarDayBlock, continuation: boolean, continuationLabel: string, title = ""): string {
+  const dayHeader = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation, title);
   return getDayText(dayHeader, dayBlock.lines);
 }
 
-function getEmptyCalendarMessageChunk(messageIndex: number, title: string): CalendarMessageChunk {
-  const prefix = 0 === messageIndex && 0 < title.length ? `${title}\n` : "";
+function getTitledDayHeader(title: string, friendlyDate: string): string {
+  const trimmedTitle = title.trim();
+  const boldTitleMatch = /^(.*\*\*)([^*]*):?\*\*$/.exec(trimmedTitle);
+  if (null !== boldTitleMatch) {
+    const boldPrefix = boldTitleMatch[1] ?? "";
+    const boldTitle = boldTitleMatch[2] ?? "";
+    return `${boldPrefix}${boldTitle.trim().replace(/:+$/, "")}** (${friendlyDate})`;
+  }
+
+  return `**${trimmedTitle.replace(/:+$/, "")}** (${friendlyDate})`;
+}
+
+function getEmptyCalendarMessageChunk(): CalendarMessageChunk {
   return {
-    content: prefix,
+    content: "",
     eventCount: 0,
     dayKeys: new Set<string>(),
   };
@@ -409,7 +428,7 @@ function getEmptyCalendarMessageChunk(messageIndex: number, title: string): Cale
 
 function getAppendedChunkText(chunk: CalendarMessageChunk, text: string): string {
   if ("" === chunk.content) {
-    return text;
+    return text.trimStart();
   }
 
   if (chunk.content.endsWith("\n")) {

--- a/modules/earnings-format-render.ts
+++ b/modules/earnings-format-render.ts
@@ -65,10 +65,10 @@ function getEarningsSectionHeading(
   continuationLabel: string
 ): string {
   if (false === continuation) {
-    return `**${label}:**`;
+    return `**${label}**`;
   }
 
-  return `**${label} ${continuationLabel}:**`;
+  return `**${label} ${continuationLabel}**`;
 }
 
 function getEarningsSectionText(
@@ -321,5 +321,5 @@ function getEarningsWhenLabel(earningsWhen: EarningsWhen): string {
 }
 
 function getEarningsWhenSubheading(earningsWhen: EarningsWhen): string {
-  return `**${getEarningsWhenLabel(earningsWhen)}:**`;
+  return `**${getEarningsWhenLabel(earningsWhen)}**`;
 }

--- a/modules/earnings.test.ts
+++ b/modules/earnings.test.ts
@@ -413,7 +413,7 @@ describe("getEarningsText", () => {
     ], "all", []);
 
     expect(text).not.toContain("Earnings am");
-    expect(text).toContain("**Mittwoch, 3. Januar 2024:**");
+    expect(text).toContain("**Mittwoch, 3. Januar 2024**");
   });
 
   test("returns grouped ticker-first one-line output", () => {
@@ -448,11 +448,11 @@ describe("getEarningsText", () => {
     const text = getEarningsText(earningEvents, "all", [getTicker("BIG")]);
 
     expect(text).toContain("**Zeitraum:** Mittwoch, 3. Januar 2024 bis Donnerstag, 4. Januar 2024");
-    expect(text).toContain("**Mittwoch, 3. Januar 2024:**");
-    expect(text).toContain("**Donnerstag, 4. Januar 2024:**");
-    expect(text).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt:**");
-    expect(text).toContain("**Nach Handelsschluss:**");
-    expect(text).toContain("**Vor Handelsbeginn:**");
+    expect(text).toContain("**Mittwoch, 3. Januar 2024**");
+    expect(text).toContain("**Donnerstag, 4. Januar 2024**");
+    expect(text).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
+    expect(text).toContain("**Nach Handelsschluss**");
+    expect(text).toContain("**Vor Handelsbeginn**");
 
     const lines = text.split("\n").filter(line => line.includes(" MCap: "));
     const parsedLines = lines.map(parseEarningsLine);
@@ -511,9 +511,9 @@ describe("getEarningsMessages", () => {
     expect(batch.truncated).toBe(false);
     expect(batch.totalEvents).toBe(3);
     expect(batch.includedEvents).toBe(3);
-    expect(batch.messages[0]!).toContain("**Vor Handelsbeginn:**");
-    expect(batch.messages[0]!).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt:**");
-    expect(batch.messages[0]!).toContain("**Nach Handelsschluss:**");
+    expect(batch.messages[0]!).toContain("**Vor Handelsbeginn**");
+    expect(batch.messages[0]!).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
+    expect(batch.messages[0]!).toContain("**Nach Handelsschluss**");
     expect(batch.messages[0]!).not.toContain("Earnings am");
 
     const lines = batch.messages[0]!.split("\n").filter(line => line.includes(" MCap: "));
@@ -619,8 +619,8 @@ describe("getEarningsMessages", () => {
     expect(parsedLines[1]!.ticker.trim()).toBe("DURING");
     expect(parsedLines[2]!.ticker.trim()).toBe("AFTER");
     const text = batch.messages[0]!;
-    expect(text.indexOf("**Vor Handelsbeginn:**")).toBeLessThan(text.indexOf("**Während der Handelszeiten oder unbekannter Zeitpunkt:**"));
-    expect(text.indexOf("**Während der Handelszeiten oder unbekannter Zeitpunkt:**")).toBeLessThan(text.indexOf("**Nach Handelsschluss:**"));
+    expect(text.indexOf("**Vor Handelsbeginn**")).toBeLessThan(text.indexOf("**Während der Handelszeiten oder unbekannter Zeitpunkt**"));
+    expect(text.indexOf("**Während der Handelszeiten oder unbekannter Zeitpunkt**")).toBeLessThan(text.indexOf("**Nach Handelsschluss**"));
   });
 
   test("filters by when and keeps ticker-first format", () => {
@@ -634,7 +634,7 @@ describe("getEarningsMessages", () => {
     expect(lines).toHaveLength(1);
     const parsedLine = parseEarningsLine(lines[0]!);
     expect(parsedLine.ticker.trim()).toBe("SMALL");
-    expect(batch.messages[0]!).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt:**");
+    expect(batch.messages[0]!).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
   });
 
   test("filters by bluechip market cap threshold when marketCapFilter is bluechips", () => {
@@ -749,8 +749,8 @@ describe("getEarningsMessages", () => {
     expect(batch.totalEvents).toBe(4);
     expect(batch.includedEvents).toBeLessThan(4);
     expect(batch.messages).toHaveLength(2);
-    expect(combinedText).toContain("**Mittwoch, 3. Januar 2024:**");
-    expect(combinedText).toContain("**Donnerstag, 4. Januar 2024:**");
+    expect(combinedText).toContain("**Mittwoch, 3. Januar 2024**");
+    expect(combinedText).toContain("**Donnerstag, 4. Januar 2024**");
     expect(combinedText).toContain("`D1TOP`");
     expect(combinedText).toContain("`D2TOP`");
     expect(combinedText).not.toContain("`D1LOW`");

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -383,6 +383,12 @@ describe("timers: other announcements", () => {
   test("startOtherTimers sends earnings on Sunday evening for Monday trading day", async () => {
     const {client, send} = createClientWithChannel();
     vi.setSystemTime(new Date("2025-02-23T19:30:00+01:00"));
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nearnings-text"],
+      truncated: false,
+      totalEvents: 1,
+      includedEvents: 1,
+    });
 
     startOtherTimers(client, "channel-id", [], []);
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
@@ -401,7 +407,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "earnings-text",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-text",
       allowedMentions: {
         parse: [],
       },
@@ -431,6 +437,12 @@ describe("timers: other announcements", () => {
       status: "ok",
     });
     addExpectedMovesToEarningsEventsMock.mockResolvedValue(enrichedEvents);
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nearnings-text"],
+      truncated: false,
+      totalEvents: 1,
+      includedEvents: 1,
+    });
 
     startOtherTimers(client, "channel-id", [], []);
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
@@ -446,7 +458,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "earnings-text",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-text",
     }));
   });
 
@@ -489,13 +501,13 @@ describe("timers: other announcements", () => {
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD", "AEHR"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
-        messages: ["anticipated-earnings"],
+        messages: ["**Montag, 24. Februar 2025**\nanticipated-earnings"],
         truncated: false,
         totalEvents: 2,
         includedEvents: 2,
       })
       .mockReturnValueOnce({
-        messages: ["regular-earnings"],
+        messages: ["**Montag, 24. Februar 2025**\nregular-earnings"],
         truncated: false,
         totalEvents: 1,
         includedEvents: 1,
@@ -527,13 +539,13 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings**\nanticipated-earnings",
+      content: "🔥 **Most Anticipated Earnings** (Montag, 24. Februar 2025)\nanticipated-earnings",
       allowedMentions: {
         parse: [],
       },
     });
     expect(send).toHaveBeenNthCalledWith(2, {
-      content: "regular-earnings",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nregular-earnings",
       allowedMentions: {
         parse: [],
       },
@@ -559,7 +571,7 @@ describe("timers: other announcements", () => {
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
-        messages: ["anticipated-only"],
+        messages: ["**Montag, 24. Februar 2025**\nanticipated-only"],
         truncated: false,
         totalEvents: 1,
         includedEvents: 1,
@@ -577,7 +589,7 @@ describe("timers: other announcements", () => {
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
-      content: "🔥 **Most Anticipated Earnings**\nanticipated-only",
+      content: "🔥 **Most Anticipated Earnings** (Montag, 24. Februar 2025)\nanticipated-only",
       allowedMentions: {
         parse: [],
       },
@@ -587,7 +599,7 @@ describe("timers: other announcements", () => {
   test("startOtherTimers sends chunked earnings messages in order with mention restrictions", async () => {
     const {client, send} = createClientWithChannel();
     getEarningsMessagesMock.mockReturnValue({
-      messages: ["earnings-1", "earnings-2", "earnings-3"],
+      messages: ["**Montag, 24. Februar 2025**\nearnings-1", "earnings-2", "earnings-3"],
       truncated: false,
       totalEvents: 9,
       includedEvents: 9,
@@ -601,7 +613,7 @@ describe("timers: other announcements", () => {
       source: "timer-earnings",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "earnings-1",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-1",
       allowedMentions: {
         parse: [],
       },
@@ -640,13 +652,19 @@ describe("timers: other announcements", () => {
         },
       },
     };
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nearnings-text"],
+      truncated: false,
+      totalEvents: 1,
+      includedEvents: 1,
+    });
 
     startOtherTimers(client, "channel-id", [], [], [], [], "earnings-expectations-thread");
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
     await dailyEarningsJob.callback();
 
     expect(threadSend).toHaveBeenCalledWith({
-      content: "earnings-text",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-text",
       allowedMentions: {
         parse: [],
       },
@@ -731,7 +749,7 @@ describe("timers: other announcements", () => {
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["MSFT", "AAPL"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
-        messages: ["weekly-anticipated"],
+        messages: ["**Montag, 24. Februar 2025**\nweekly-anticipated"],
         truncated: false,
         totalEvents: 2,
         includedEvents: 2,
@@ -767,7 +785,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings der nächsten Handelswoche**\nweekly-anticipated",
+      content: "🔥 **Most Anticipated Earnings der nächsten Handelswoche** (Montag, 24. Februar 2025)\nweekly-anticipated",
       allowedMentions: {
         parse: [],
       },

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -527,7 +527,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings (Earnings Whispers):**\n\nanticipated-earnings",
+      content: "🔥 **Most Anticipated Earnings**\nanticipated-earnings",
       allowedMentions: {
         parse: [],
       },
@@ -577,7 +577,7 @@ describe("timers: other announcements", () => {
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
-      content: "🔥 **Most Anticipated Earnings (Earnings Whispers):**\n\nanticipated-only",
+      content: "🔥 **Most Anticipated Earnings**\nanticipated-only",
       allowedMentions: {
         parse: [],
       },
@@ -657,7 +657,10 @@ describe("timers: other announcements", () => {
   test("startOtherTimers sends weekly earnings with dedicated headline on Friday evening", async () => {
     const {client, send} = createClientWithChannel();
     getEarningsMessagesMock.mockReturnValue({
-      messages: ["weekly-earnings-1", "weekly-earnings-2"],
+      messages: [
+        "**Zeitraum:** Mittwoch, 6. Mai 2026 bis Donnerstag, 7. Mai 2026\n**Mittwoch, 6. Mai 2026**\nweekly-earnings-1",
+        "weekly-earnings-2",
+      ],
       truncated: false,
       totalEvents: 10,
       includedEvents: 10,
@@ -676,7 +679,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "📅 **Earnings der nächsten Handelswoche:**\n\nweekly-earnings-1",
+      content: "📅 **Earnings der nächsten Handelswoche** (Mittwoch, 6. Mai 2026 bis Donnerstag, 7. Mai 2026)\n**Mittwoch, 6. Mai 2026**\nweekly-earnings-1",
       allowedMentions: {
         parse: [],
       },
@@ -764,13 +767,13 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings der nächsten Handelswoche (Earnings Whispers):**\n\nweekly-anticipated",
+      content: "🔥 **Most Anticipated Earnings der nächsten Handelswoche**\nweekly-anticipated",
       allowedMentions: {
         parse: [],
       },
     });
     expect(send).toHaveBeenNthCalledWith(2, {
-      content: "📅 **Earnings der nächsten Handelswoche:**\n\nweekly-regular",
+      content: "📅 **Earnings der nächsten Handelswoche**\nweekly-regular",
       allowedMentions: {
         parse: [],
       },

--- a/modules/timers.test.ts
+++ b/modules/timers.test.ts
@@ -352,7 +352,7 @@ describe("timers: NYSE and MNC", () => {
       name: expect.stringMatching(/^MNC-\d{4}-\d{2}-\d{2}\.pdf$/),
     }));
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining("📰 Morning News Call"),
+      content: expect.stringContaining("📰 **Morning News Call"),
       files: expect.any(Array),
     }));
   });
@@ -369,7 +369,11 @@ describe("timers: NYSE and MNC", () => {
     await Promise.resolve();
 
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining("📰 Morning News Call"),
+      content: expect.stringContaining("📰 **Morning News Call"),
+      files: expect.any(Array),
+    }));
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.not.stringContaining("\n\n- Futures firm ahead of payrolls."),
       files: expect.any(Array),
     }));
     expect(send).toHaveBeenCalledWith(expect.objectContaining({

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -53,6 +53,7 @@ const calendarReminderAnnouncementSource = "calendar-reminder";
 const earningsReminderSource = "earnings-reminder";
 const calendarMessageDelayMs = 500;
 const usEasternTimezone = "US/Eastern";
+const dailyEarningsHeadline = "**Earnings**";
 const weeklyEarningsHeadline = "📅 **Earnings der nächsten Handelswoche**";
 const anticipatedEarningsHeadline = "🔥 **Most Anticipated Earnings**";
 const anticipatedWeeklyEarningsHeadline = "🔥 **Most Anticipated Earnings der nächsten Handelswoche**";
@@ -443,9 +444,8 @@ async function runEarningsAnnouncement(
       "earnings",
     );
   }
-  const messages = config.headline
-    ? prependHeadlineToFirstMessage(earningsBatch.messages, config.headline, EARNINGS_MAX_MESSAGE_LENGTH)
-    : earningsBatch.messages;
+  const earningsHeadline = config.headline ?? dailyEarningsHeadline;
+  const messages = prependHeadlineToFirstMessage(earningsBatch.messages, earningsHeadline, EARNINGS_MAX_MESSAGE_LENGTH);
   if (0 < messages.length) {
     await sendChunkedMessages(channel, messages, "earnings");
   }
@@ -1098,19 +1098,27 @@ function prependHeadlineToFirstMessage(
 
 function getFirstMessageWithHeadline(headline: string, firstMessage: string): string {
   const periodMatch = /^\*\*Zeitraum:\*\* ([^\n]+)\n?/.exec(firstMessage);
-  if (null === periodMatch) {
-    return `${headline}\n${firstMessage}`;
+  if (null !== periodMatch) {
+    return getFirstMessageWithMergedHeadline(headline, firstMessage, periodMatch[1] ?? "", periodMatch[0].length);
   }
 
-  const periodText = periodMatch[1] ?? "";
-  const restMessage = firstMessage.slice(periodMatch[0].length);
+  const dateHeadingMatch = /^\*\*((?:Montag|Dienstag|Mittwoch|Donnerstag|Freitag|Samstag|Sonntag), [^\n*]+)\*\*\n*/.exec(firstMessage);
+  if (null !== dateHeadingMatch) {
+    return getFirstMessageWithMergedHeadline(headline, firstMessage, dateHeadingMatch[1] ?? "", dateHeadingMatch[0].length);
+  }
+
+  return `${headline}\n${firstMessage}`;
+}
+
+function getFirstMessageWithMergedHeadline(headline: string, firstMessage: string, detailText: string, detailLength: number): string {
+  const restMessage = firstMessage.slice(detailLength);
   const normalizedHeadline = headline.replace(/:\*\*$/, "**");
-  const mergedHeadline = `${normalizedHeadline} (${periodText})`;
+  const mergedHeadline = `${normalizedHeadline} (${detailText})`;
   if ("" === restMessage.trim()) {
     return mergedHeadline;
   }
 
-  return `${mergedHeadline}\n${restMessage}`;
+  return `${mergedHeadline}\n${restMessage.trimStart()}`;
 }
 
 async function sendChunkedMessages(channel: SendableChannel | null, messages: string[], source: "calendar" | "earnings") {

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -53,9 +53,9 @@ const calendarReminderAnnouncementSource = "calendar-reminder";
 const earningsReminderSource = "earnings-reminder";
 const calendarMessageDelayMs = 500;
 const usEasternTimezone = "US/Eastern";
-const weeklyEarningsHeadline = "📅 **Earnings der nächsten Handelswoche:**";
-const anticipatedEarningsHeadline = "🔥 **Most Anticipated Earnings (Earnings Whispers):**";
-const anticipatedWeeklyEarningsHeadline = "🔥 **Most Anticipated Earnings der nächsten Handelswoche (Earnings Whispers):**";
+const weeklyEarningsHeadline = "📅 **Earnings der nächsten Handelswoche**";
+const anticipatedEarningsHeadline = "🔥 **Most Anticipated Earnings**";
+const anticipatedWeeklyEarningsHeadline = "🔥 **Most Anticipated Earnings der nächsten Handelswoche**";
 const weeklyCalendarHeadline = "📅 **Wichtige Termine der nächsten Handelswoche:**";
 const europeBerlinTimezone = "Europe/Berlin";
 const usEasternWeekdays = [new Schedule.Range(1, 5)];
@@ -810,10 +810,10 @@ export function startMncTimers(client: TimerClient, channelID: string) {
 }
 
 function getMncAnnouncementContent(date: string, summary: string | undefined): string {
-  const title = `📰 Morning News Call (${date})`;
+  const title = `📰 **Morning News Call** (${date})`;
   return undefined === summary
     ? title
-    : `${title}\n\n${summary}`;
+    : `${title}\n${summary}`;
 }
 
 export function startOtherTimers(
@@ -1088,12 +1088,29 @@ function prependHeadlineToFirstMessage(
     return [headline];
   }
 
-  const firstMessageWithHeadline = `${headline}\n\n${firstMessage}`;
+  const firstMessageWithHeadline = getFirstMessageWithHeadline(headline, firstMessage);
   if (firstMessageWithHeadline.length <= maxMessageLength) {
     return [firstMessageWithHeadline, ...messages.slice(1)];
   }
 
   return [headline, ...messages];
+}
+
+function getFirstMessageWithHeadline(headline: string, firstMessage: string): string {
+  const periodMatch = /^\*\*Zeitraum:\*\* ([^\n]+)\n?/.exec(firstMessage);
+  if (null === periodMatch) {
+    return `${headline}\n${firstMessage}`;
+  }
+
+  const periodText = periodMatch[1] ?? "";
+  const restMessage = firstMessage.slice(periodMatch[0].length);
+  const normalizedHeadline = headline.replace(/:\*\*$/, "**");
+  const mergedHeadline = `${normalizedHeadline} (${periodText})`;
+  if ("" === restMessage.trim()) {
+    return mergedHeadline;
+  }
+
+  return `${mergedHeadline}\n${restMessage}`;
 }
 
 async function sendChunkedMessages(channel: SendableChannel | null, messages: string[], source: "calendar" | "earnings") {


### PR DESCRIPTION
## Summary
- merge single-day earnings date headings into normal daily earnings headlines
- apply the same date-merge behavior to daily and weekly Most Anticipated earnings posts
- keep weekly regular earnings range merging intact

## Validation
- npm test -- modules/timers-other.test.ts modules/timers.test.ts modules/earnings.test.ts modules/calendar.test.ts
- npm run typecheck