### PR TITLE
[codex] merge earnings dates into headlines

### DIFF
--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -383,6 +383,12 @@ describe("timers: other announcements", () => {
   test("startOtherTimers sends earnings on Sunday evening for Monday trading day", async () => {
     const {client, send} = createClientWithChannel();
     vi.setSystemTime(new Date("2025-02-23T19:30:00+01:00"));
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nearnings-text"],
+      truncated: false,
+      totalEvents: 1,
+      includedEvents: 1,
+    });
 
     startOtherTimers(client, "channel-id", [], []);
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
@@ -401,7 +407,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "earnings-text",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-text",
       allowedMentions: {
         parse: [],
       },
@@ -431,6 +437,12 @@ describe("timers: other announcements", () => {
       status: "ok",
     });
     addExpectedMovesToEarningsEventsMock.mockResolvedValue(enrichedEvents);
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nearnings-text"],
+      truncated: false,
+      totalEvents: 1,
+      includedEvents: 1,
+    });
 
     startOtherTimers(client, "channel-id", [], []);
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
@@ -446,7 +458,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "earnings-text",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-text",
     }));
   });
 
@@ -489,13 +501,13 @@ describe("timers: other announcements", () => {
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD", "AEHR"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
-        messages: ["anticipated-earnings"],
+        messages: ["**Montag, 24. Februar 2025**\nanticipated-earnings"],
         truncated: false,
         totalEvents: 2,
         includedEvents: 2,
       })
       .mockReturnValueOnce({
-        messages: ["regular-earnings"],
+        messages: ["**Montag, 24. Februar 2025**\nregular-earnings"],
         truncated: false,
         totalEvents: 1,
         includedEvents: 1,
@@ -527,13 +539,13 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings**\nanticipated-earnings",
+      content: "🔥 **Most Anticipated Earnings** (Montag, 24. Februar 2025)\nanticipated-earnings",
       allowedMentions: {
         parse: [],
       },
     });
     expect(send).toHaveBeenNthCalledWith(2, {
-      content: "regular-earnings",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nregular-earnings",
       allowedMentions: {
         parse: [],
       },
@@ -559,7 +571,7 @@ describe("timers: other announcements", () => {
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
-        messages: ["anticipated-only"],
+        messages: ["**Montag, 24. Februar 2025**\nanticipated-only"],
         truncated: false,
         totalEvents: 1,
         includedEvents: 1,
@@ -577,7 +589,7 @@ describe("timers: other announcements", () => {
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
-      content: "🔥 **Most Anticipated Earnings**\nanticipated-only",
+      content: "🔥 **Most Anticipated Earnings** (Montag, 24. Februar 2025)\nanticipated-only",
       allowedMentions: {
         parse: [],
       },
@@ -587,7 +599,7 @@ describe("timers: other announcements", () => {
   test("startOtherTimers sends chunked earnings messages in order with mention restrictions", async () => {
     const {client, send} = createClientWithChannel();
     getEarningsMessagesMock.mockReturnValue({
-      messages: ["earnings-1", "earnings-2", "earnings-3"],
+      messages: ["**Montag, 24. Februar 2025**\nearnings-1", "earnings-2", "earnings-3"],
       truncated: false,
       totalEvents: 9,
       includedEvents: 9,
@@ -601,7 +613,7 @@ describe("timers: other announcements", () => {
       source: "timer-earnings",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "earnings-1",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-1",
       allowedMentions: {
         parse: [],
       },
@@ -640,13 +652,19 @@ describe("timers: other announcements", () => {
         },
       },
     };
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nearnings-text"],
+      truncated: false,
+      totalEvents: 1,
+      includedEvents: 1,
+    });
 
     startOtherTimers(client, "channel-id", [], [], [], [], "earnings-expectations-thread");
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
     await dailyEarningsJob.callback();
 
     expect(threadSend).toHaveBeenCalledWith({
-      content: "earnings-text",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nearnings-text",
       allowedMentions: {
         parse: [],
       },
@@ -731,7 +749,7 @@ describe("timers: other announcements", () => {
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["MSFT", "AAPL"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
-        messages: ["weekly-anticipated"],
+        messages: ["**Montag, 24. Februar 2025**\nweekly-anticipated"],
         truncated: false,
         totalEvents: 2,
         includedEvents: 2,
@@ -767,7 +785,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings der nächsten Handelswoche**\nweekly-anticipated",
+      content: "🔥 **Most Anticipated Earnings der nächsten Handelswoche** (Montag, 24. Februar 2025)\nweekly-anticipated",
       allowedMentions: {
         parse: [],
       },

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -53,6 +53,7 @@ const calendarReminderAnnouncementSource = "calendar-reminder";
 const earningsReminderSource = "earnings-reminder";
 const calendarMessageDelayMs = 500;
 const usEasternTimezone = "US/Eastern";
+const dailyEarningsHeadline = "**Earnings**";
 const weeklyEarningsHeadline = "📅 **Earnings der nächsten Handelswoche**";
 const anticipatedEarningsHeadline = "🔥 **Most Anticipated Earnings**";
 const anticipatedWeeklyEarningsHeadline = "🔥 **Most Anticipated Earnings der nächsten Handelswoche**";
@@ -443,9 +444,8 @@ async function runEarningsAnnouncement(
       "earnings",
     );
   }
-  const messages = config.headline
-    ? prependHeadlineToFirstMessage(earningsBatch.messages, config.headline, EARNINGS_MAX_MESSAGE_LENGTH)
-    : earningsBatch.messages;
+  const earningsHeadline = config.headline ?? dailyEarningsHeadline;
+  const messages = prependHeadlineToFirstMessage(earningsBatch.messages, earningsHeadline, EARNINGS_MAX_MESSAGE_LENGTH);
   if (0 < messages.length) {
     await sendChunkedMessages(channel, messages, "earnings");
   }
@@ -1098,19 +1098,27 @@ function prependHeadlineToFirstMessage(
 
 function getFirstMessageWithHeadline(headline: string, firstMessage: string): string {
   const periodMatch = /^\*\*Zeitraum:\*\* ([^\n]+)\n?/.exec(firstMessage);
-  if (null === periodMatch) {
-    return `${headline}\n${firstMessage}`;
+  if (null !== periodMatch) {
+    return getFirstMessageWithMergedHeadline(headline, firstMessage, periodMatch[1] ?? "", periodMatch[0].length);
   }
 
-  const periodText = periodMatch[1] ?? "";
-  const restMessage = firstMessage.slice(periodMatch[0].length);
+  const dateHeadingMatch = /^\*\*((?:Montag|Dienstag|Mittwoch|Donnerstag|Freitag|Samstag|Sonntag), [^\n*]+)\*\*\n*/.exec(firstMessage);
+  if (null !== dateHeadingMatch) {
+    return getFirstMessageWithMergedHeadline(headline, firstMessage, dateHeadingMatch[1] ?? "", dateHeadingMatch[0].length);
+  }
+
+  return `${headline}\n${firstMessage}`;
+}
+
+function getFirstMessageWithMergedHeadline(headline: string, firstMessage: string, detailText: string, detailLength: number): string {
+  const restMessage = firstMessage.slice(detailLength);
   const normalizedHeadline = headline.replace(/:\*\*$/, "**");
-  const mergedHeadline = `${normalizedHeadline} (${periodText})`;
+  const mergedHeadline = `${normalizedHeadline} (${detailText})`;
   if ("" === restMessage.trim()) {
     return mergedHeadline;
   }
 
-  return `${mergedHeadline}\n${restMessage}`;
+  return `${mergedHeadline}\n${restMessage.trimStart()}`;
 }
 
 async function sendChunkedMessages(channel: SendableChannel | null, messages: string[], source: "calendar" | "earnings") {


### PR DESCRIPTION
## Summary
- merge single-day earnings date headings into normal daily earnings headlines
- apply the same date-merge behavior to daily and weekly Most Anticipated earnings posts
- keep weekly regular earnings range merging intact

## Validation
- npm test -- modules/timers-other.test.ts modules/timers.test.ts modules/earnings.test.ts modules/calendar.test.ts
- npm run typecheck