### PR TITLE
[codex] enrich anticipated earnings expected moves

### DIFF
--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -497,7 +497,7 @@ describe("timers: other announcements", () => {
       events: earningsEvents,
       status: "ok",
     });
-    addExpectedMovesToEarningsEventsMock.mockResolvedValue(earningsEvents);
+    addExpectedMovesToEarningsEventsMock.mockImplementation(async events => events);
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD", "AEHR"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
@@ -519,6 +519,14 @@ describe("timers: other announcements", () => {
 
     expect(loadEarningsWhispersWeeklyTickersMock).toHaveBeenCalledTimes(1);
     expect(loadEarningsWhispersWeeklyTickersMock.mock.calls[0]?.[0].now.format("YYYY-MM-DD")).toBe("2025-02-24");
+    expect(addExpectedMovesToEarningsEventsMock).toHaveBeenNthCalledWith(1, [earningsEvents[0], earningsEvents[2]], {
+      marketCapFilter: "all",
+      when: "all",
+    });
+    expect(addExpectedMovesToEarningsEventsMock).toHaveBeenNthCalledWith(2, [earningsEvents[1]], {
+      marketCapFilter: "bluechips",
+      when: "all",
+    });
     expect(getEarningsMessagesMock).toHaveBeenNthCalledWith(
       1,
       [earningsEvents[0], earningsEvents[2]],
@@ -567,7 +575,7 @@ describe("timers: other announcements", () => {
       events: earningsEvents,
       status: "ok",
     });
-    addExpectedMovesToEarningsEventsMock.mockResolvedValue(earningsEvents);
+    addExpectedMovesToEarningsEventsMock.mockImplementation(async events => events);
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
@@ -587,6 +595,14 @@ describe("timers: other announcements", () => {
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
     await dailyEarningsJob.callback();
 
+    expect(addExpectedMovesToEarningsEventsMock).toHaveBeenNthCalledWith(1, [earningsEvents[0]], {
+      marketCapFilter: "all",
+      when: "all",
+    });
+    expect(addExpectedMovesToEarningsEventsMock).toHaveBeenNthCalledWith(2, [], {
+      marketCapFilter: "bluechips",
+      when: "all",
+    });
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
       content: "🔥 **Most Anticipated Earnings** (Montag, 24. Februar 2025)\nanticipated-only",
@@ -745,7 +761,7 @@ describe("timers: other announcements", () => {
       events: earningsEvents,
       status: "ok",
     });
-    addExpectedMovesToEarningsEventsMock.mockResolvedValue(earningsEvents);
+    addExpectedMovesToEarningsEventsMock.mockImplementation(async events => events);
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["MSFT", "AAPL"]));
     getEarningsMessagesMock
       .mockReturnValueOnce({
@@ -765,6 +781,14 @@ describe("timers: other announcements", () => {
     const weeklyEarningsJob = getScheduledJobByTime(23, 30, "Europe/Berlin");
     await weeklyEarningsJob.callback();
 
+    expect(addExpectedMovesToEarningsEventsMock).toHaveBeenNthCalledWith(1, [earningsEvents[0], earningsEvents[2]], {
+      marketCapFilter: "all",
+      when: "all",
+    });
+    expect(addExpectedMovesToEarningsEventsMock).toHaveBeenNthCalledWith(2, [earningsEvents[1]], {
+      marketCapFilter: "bluechips",
+      when: "all",
+    });
     expect(getEarningsMessagesMock).toHaveBeenNthCalledWith(
       1,
       [earningsEvents[0], earningsEvents[2]],

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -396,13 +396,19 @@ async function runEarningsAnnouncement(
   const earningsResult = await getEarningsResult(config.days, config.date, {
     source: config.source,
   });
-  const earningsEvents = await addExpectedMovesToEarningsEvents(earningsResult.events, {
+  const anticipatedTickerSymbols = await getAnticipatedEarningsTickerSymbols(earningsResult.events);
+  const anticipatedEarningsCandidates = getEarningsEventsByTickerSymbols(earningsResult.events, anticipatedTickerSymbols);
+  const regularEarningsCandidates = getEarningsEventsWithoutTickerSymbols(earningsResult.events, anticipatedTickerSymbols);
+  const anticipatedEarningsEvents = 0 < anticipatedEarningsCandidates.length
+    ? await addExpectedMovesToEarningsEvents(anticipatedEarningsCandidates, {
+      marketCapFilter: "all",
+      when: config.when,
+    })
+    : [];
+  const regularEarningsEvents = await addExpectedMovesToEarningsEvents(regularEarningsCandidates, {
     marketCapFilter: config.filter,
     when: config.when,
   });
-  const anticipatedTickerSymbols = await getAnticipatedEarningsTickerSymbols(earningsEvents);
-  const anticipatedEarningsEvents = getEarningsEventsByTickerSymbols(earningsEvents, anticipatedTickerSymbols);
-  const regularEarningsEvents = getEarningsEventsWithoutTickerSymbols(earningsEvents, anticipatedTickerSymbols);
   const anticipatedEarningsBatch = 0 < anticipatedEarningsEvents.length
     ? getEarningsMessages(anticipatedEarningsEvents, config.when, getHighlightedAnticipatedTickers(tickers, anticipatedEarningsEvents), {
       maxMessageLength: EARNINGS_MAX_MESSAGE_LENGTH,
@@ -565,7 +571,17 @@ async function warmExpectedMovesForAnnouncement(config: EarningsAnnouncementConf
     return;
   }
 
-  await warmExpectedMoveCacheForEarningsEvents(earningsResult.events, {
+  const anticipatedTickerSymbols = await getAnticipatedEarningsTickerSymbols(earningsResult.events);
+  const anticipatedEarningsEvents = getEarningsEventsByTickerSymbols(earningsResult.events, anticipatedTickerSymbols);
+  const regularEarningsEvents = getEarningsEventsWithoutTickerSymbols(earningsResult.events, anticipatedTickerSymbols);
+  if (0 < anticipatedEarningsEvents.length) {
+    await warmExpectedMoveCacheForEarningsEvents(anticipatedEarningsEvents, {
+      marketCapFilter: "all",
+      when: config.when,
+    });
+  }
+
+  await warmExpectedMoveCacheForEarningsEvents(regularEarningsEvents, {
     marketCapFilter: config.filter,
     when: config.when,
   });


### PR DESCRIPTION
## Summary
- split anticipated Earnings Whispers tickers before expected-move enrichment
- enrich anticipated earnings with marketCapFilter=all so lower market-cap anticipated names can show expected moves
- keep regular earnings enrichment on the configured bluechip filter
- warm expected-move cache for anticipated and regular earnings with their respective filters

## Validation
- npm test -- modules/timers-other.test.ts modules/timers.test.ts modules/earnings.test.ts modules/calendar.test.ts
- npm run typecheck