### PR TITLE
[codex] fix CodeQL double escaping

### DIFF
--- a/modules/earnings-whispers.test.ts
+++ b/modules/earnings-whispers.test.ts
@@ -63,6 +63,13 @@ describe("Earnings Whispers weekly tickers", () => {
     }
   });
 
+  test("does not treat escaped html entities as source markup", () => {
+    expect(extractEarningsWhispersWeeklyTickers(
+      "#earnings for the week of May 4, 2026 &amp;lt;$PLTR&amp;gt; $AMD",
+      moment.tz("2026-05-06 12:00", "YYYY-MM-DD HH:mm", "US/Eastern"),
+    )).toEqual(new Set(["PLTR", "AMD"]));
+  });
+
   test("ignores adjacent weekly posts and non-weekly earnings posts", () => {
     const sourceText = `
       Earnings Whispers @eWhispers

--- a/modules/earnings-whispers.ts
+++ b/modules/earnings-whispers.ts
@@ -225,11 +225,11 @@ function normalizeEarningsWhispersSourceText(value: string): string {
 
 function decodeHtmlEntities(value: string): string {
   return value
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, "\"")
-    .replace(/&#39;/g, "'");
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
 }
 
 function normalizeEarningsWhispersTicker(value: string): string {


### PR DESCRIPTION
## Summary
- Decode HTML ampersands last in the Earnings Whispers source normalizer.
- Add a regression test for escaped entity text that must remain plain source text.

## Root Cause
The local HTML entity decoder handled &amp; before other entities, so input such as &amp;lt; could become a real < token during the same normalization pass.

## Impact
This addresses the open CodeQL js/double-escaping alert without changing the public ticker extraction API.

## Verification
- npm test -- modules/earnings-whispers.test.ts
- npm run typecheck
- npm run test:coverage