### PR TITLE
[codex] Fix tastytrade crypto moves

### DIFF
--- a/modules/market-data-tastytrade.test.ts
+++ b/modules/market-data-tastytrade.test.ts
@@ -179,6 +179,72 @@ describe("tastytrade crypto market data stream", () => {
     );
   });
 
+  test("derives crypto move from summary previous close", async () => {
+    const stream = createStreamer();
+    const options = createOptions({
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    stream.emit([{
+      eventSymbol: "BTC/USD",
+      eventType: "Summary",
+      dayClosePrice: 105,
+      prevDayClosePrice: 100,
+    }]);
+
+    expect(options.onMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({botClientId: "btc-client"}),
+      105,
+      5,
+      5,
+    );
+
+    stream.emit([{
+      eventSymbol: "BTC/USD",
+      eventType: "Quote",
+      bidPrice: 105.9,
+      askPrice: 106.1,
+    }]);
+
+    expect(options.onMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({botClientId: "btc-client"}),
+      106,
+      6,
+      6,
+    );
+  });
+
+  test("derives crypto percentage move from trade change", async () => {
+    const stream = createStreamer();
+    const options = createOptions({
+      clientFactory: vi.fn(() => ({
+        quoteStreamer: stream.streamer,
+      })),
+    });
+
+    startTastytradeCryptoStream(options);
+    await flushAsyncWork();
+
+    stream.emit([{
+      eventSymbol: "BTC/USD",
+      eventType: "Trade",
+      price: 103,
+      change: 3,
+    }]);
+
+    expect(options.onMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({botClientId: "btc-client"}),
+      103,
+      3,
+      3,
+    );
+  });
+
   test("resubscribes once when no initial quote arrives", async () => {
     const stream = createStreamer();
     const options = createOptions({
@@ -329,6 +395,11 @@ describe("tastytrade crypto market data stream", () => {
     expect(dxLinkFeed.configure).toHaveBeenCalledWith({
       acceptAggregationPeriod: 10,
       acceptDataFormat: "COMPACT",
+      acceptEventFields: {
+        Quote: ["eventSymbol", "bidPrice", "askPrice"],
+        Summary: ["eventSymbol", "dayClosePrice", "prevDayClosePrice"],
+        Trade: ["eventSymbol", "price", "change"],
+      },
     });
     expect(dxLinkFeed.addEventListener).toHaveBeenCalledWith(feedListener);
     expect(dxLinkFeed.addSubscriptions).toHaveBeenCalledWith({

--- a/modules/market-data-tastytrade.ts
+++ b/modules/market-data-tastytrade.ts
@@ -66,6 +66,7 @@ type DxLinkFeedLike = {
   configure: (acceptConfig: {
     acceptAggregationPeriod: number;
     acceptDataFormat: FeedDataFormat;
+    acceptEventFields?: Record<string, string[]>;
   }) => void;
   removeEventListener: (listener: TastytradeEventListener) => void;
   removeSubscriptions: (...subscriptions: {symbol: string; type: string}[]) => void;
@@ -104,6 +105,11 @@ const quoteSubscriptionTypes = [
   MarketDataSubscriptionType.Quote,
   MarketDataSubscriptionType.Summary,
 ];
+const tastytradeCryptoEventFields = {
+  [MarketDataSubscriptionType.Trade]: ["eventSymbol", "price", "change"],
+  [MarketDataSubscriptionType.Quote]: ["eventSymbol", "bidPrice", "askPrice"],
+  [MarketDataSubscriptionType.Summary]: ["eventSymbol", "dayClosePrice", "prevDayClosePrice"],
+} satisfies Record<string, string[]>;
 
 const webSocketGlobal = globalThis as typeof globalThis & {
   WebSocket?: unknown;
@@ -146,6 +152,7 @@ export function startTastytradeCryptoStream({
   let removeQuoteStreamerErrorListener: (() => void) | undefined;
   let stopped = false;
   const previousPrices = new Map<string, number>();
+  const referencePrices = new Map<string, number>();
 
   const clearTimer = (timer: TimerHandle | undefined) => {
     if (undefined !== timer) {
@@ -249,17 +256,29 @@ export function startTastytradeCryptoStream({
         continue;
       }
 
-      const previousPrice = previousPrices.get(getAssetKey(streamEvent.asset)) ?? null;
-      const priceChange = streamEvent.priceChange ?? (
-        null === previousPrice ? 0 : streamEvent.lastNumeric - previousPrice
+      const assetKey = getAssetKey(streamEvent.asset);
+      const previousPrice = previousPrices.get(assetKey) ?? null;
+      const eventReferencePrice = normalizeReferencePrice(streamEvent.referencePrice);
+      const referencePrice = eventReferencePrice ?? referencePrices.get(assetKey) ?? null;
+      if (null !== eventReferencePrice) {
+        referencePrices.set(assetKey, eventReferencePrice);
+      }
+
+      const priceChange = getTastytradePriceChange(
+        streamEvent.lastNumeric,
+        streamEvent.priceChange,
+        referencePrice,
+        previousPrice,
       );
-      const percentageChange = streamEvent.percentageChange ?? (
-        null === previousPrice || 0 === previousPrice
-          ? 0
-          : ((streamEvent.lastNumeric - previousPrice) / previousPrice) * 100
+      const percentageChange = getTastytradePercentageChange(
+        streamEvent.lastNumeric,
+        priceChange,
+        streamEvent.percentageChange,
+        referencePrice,
+        previousPrice,
       );
 
-      previousPrices.set(getAssetKey(streamEvent.asset), streamEvent.lastNumeric);
+      previousPrices.set(assetKey, streamEvent.lastNumeric);
       const eventTimeMs = now();
       lastValidEventAtMs = eventTimeMs;
       clearTimer(initialResubscribeTimer);
@@ -442,6 +461,7 @@ class HandledDxLinkQuoteStreamer implements TastytradeQuoteStreamer {
     this.dxLinkFeed.configure({
       acceptAggregationPeriod: 10,
       acceptDataFormat: FeedDataFormat.COMPACT,
+      acceptEventFields: tastytradeCryptoEventFields,
     });
     for (const listener of this.eventListeners) {
       this.dxLinkFeed.addEventListener(listener);
@@ -617,6 +637,7 @@ function parseTastytradeCryptoEvent(
   lastNumeric: number;
   percentageChange: number | null;
   priceChange: number | null;
+  referencePrice: number | null;
   streamerSymbol: string;
 } | null {
   const eventSymbol = getStringField(event, ["eventSymbol", "event-symbol", "symbol"]);
@@ -658,6 +679,12 @@ function parseTastytradeCryptoEvent(
       "dayChange",
       "day-change",
       "change",
+    ]),
+    referencePrice: getNumericField(event, [
+      "prevDayClosePrice",
+      "prev-day-close-price",
+      "previousDayClosePrice",
+      "previous-day-close-price",
     ]),
     streamerSymbol: eventSymbol,
   };
@@ -715,4 +742,52 @@ function parseNumericValue(value: unknown): number | null {
   }
 
   return null;
+}
+
+function normalizeReferencePrice(referencePrice: number | null): number | null {
+  return null !== referencePrice && 0 < referencePrice ? referencePrice : null;
+}
+
+function getTastytradePriceChange(
+  lastNumeric: number,
+  eventPriceChange: number | null,
+  referencePrice: number | null,
+  previousPrice: number | null,
+): number {
+  if (null !== eventPriceChange) {
+    return eventPriceChange;
+  }
+
+  if (null !== referencePrice) {
+    return lastNumeric - referencePrice;
+  }
+
+  return null === previousPrice ? 0 : lastNumeric - previousPrice;
+}
+
+function getTastytradePercentageChange(
+  lastNumeric: number,
+  priceChange: number,
+  eventPercentageChange: number | null,
+  referencePrice: number | null,
+  previousPrice: number | null,
+): number {
+  if (null !== eventPercentageChange) {
+    return eventPercentageChange;
+  }
+
+  if (null !== referencePrice) {
+    return (priceChange / referencePrice) * 100;
+  }
+
+  const impliedReferencePrice = lastNumeric - priceChange;
+  if (0 < impliedReferencePrice) {
+    return (priceChange / impliedReferencePrice) * 100;
+  }
+
+  if (null !== previousPrice && 0 !== previousPrice) {
+    return ((lastNumeric - previousPrice) / previousPrice) * 100;
+  }
+
+  return 0;
 }


### PR DESCRIPTION
## Summary
- Request dxFeed crypto summary fields from the tastytrade stream, including previous day close.
- Prefer explicit stream move values, then previous-close based move values, before falling back to tick-to-tick math.
- Add regressions for summary previous-close moves and trade change-derived percentages.

## Root Cause
BTC and ETH sometimes arrived through tastytrade events without explicit daily percentage fields, so the bot used the previous stream tick as the movement reference. That rendered near-zero values such as +0.00 or -0.01 instead of the daily move.

## Validation
- npm test -- modules/market-data-tastytrade.test.ts
- npm run typecheck
- npm run test:coverage