### PR TITLE
[codex] add calendar alert follow-ups and fix crypto baseline

### DIFF
--- a/modules/calendar-economic-summary.test.ts
+++ b/modules/calendar-economic-summary.test.ts
@@ -1,0 +1,173 @@
+import {describe, expect, test, vi} from "vitest";
+import {CalendarEvent} from "./calendar.ts";
+import {getCalendarOfficialSummary} from "./calendar-economic-summary.ts";
+
+function createCalendarEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  const event = new CalendarEvent();
+  event.date = "2026-05-06";
+  event.time = "20:00";
+  event.country = "🇺🇸";
+  event.name = "FOMC Statement";
+  Object.assign(event, overrides);
+  return event;
+}
+
+describe("calendar-economic-summary", () => {
+  test("summarizes FOMC statement text from the dated Federal Reserve source", async () => {
+    const logger = {
+      log: vi.fn(),
+    };
+    const getWithRetryFn = vi.fn().mockResolvedValue({
+      data: "<html><body><main><h1>FOMC Statement</h1><p>Inflation remains elevated and the Committee is attentive to labor market risks.</p></main></body></html>",
+    });
+    const callAiProviderJsonFn = vi.fn().mockResolvedValue(JSON.stringify({
+      summaryMarkdown: "The Fed emphasized elevated inflation and labor-market risks. Policy remains data dependent.",
+    }));
+
+    const summary = await getCalendarOfficialSummary([createCalendarEvent()], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+
+    expect(getWithRetryFn).toHaveBeenCalledWith(
+      "https://www.federalreserve.gov/newsevents/pressreleases/monetary20260506a.htm",
+      expect.objectContaining({
+        responseType: "text",
+      }),
+      expect.objectContaining({
+        maxAttempts: 2,
+      }),
+    );
+    expect(callAiProviderJsonFn.mock.calls[0]?.[0]).toContain("Inflation remains elevated");
+    expect(summary).toEqual({
+      name: "Federal Reserve",
+      summaryMarkdown: "The Fed emphasized elevated inflation and labor-market risks. Policy remains data dependent.",
+      url: "https://www.federalreserve.gov/newsevents/pressreleases/monetary20260506a.htm",
+    });
+  });
+
+  test("uses authoritative release pages for macro events with no metric fields", async () => {
+    const logger = {
+      log: vi.fn(),
+    };
+    const getWithRetryFn = vi.fn().mockResolvedValue({
+      data: "Total nonfarm payroll employment increased.",
+    });
+    const callAiProviderJsonFn = vi.fn().mockResolvedValue(JSON.stringify({
+      summaryMarkdown: "Payroll growth was the main topic.",
+    }));
+
+    const summary = await getCalendarOfficialSummary([createCalendarEvent({
+      name: "Nonfarm Payrolls",
+      time: "14:30",
+    })], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+
+    expect(getWithRetryFn.mock.calls[0]?.[0]).toBe("https://www.bls.gov/news.release/empsit.nr0.htm");
+    expect(summary?.name).toBe("U.S. Bureau of Labor Statistics");
+    expect(summary?.summaryMarkdown).toBe("Payroll growth was the main topic.");
+  });
+
+  test("maps configured alert events to official release sources", async () => {
+    const logger = {
+      log: vi.fn(),
+    };
+    const getWithRetryFn = vi.fn().mockResolvedValue({
+      data: "Official source text.",
+    });
+    const callAiProviderJsonFn = vi.fn().mockResolvedValue(JSON.stringify({
+      summaryMarkdown: "Official release summary.",
+    }));
+
+    await getCalendarOfficialSummary([createCalendarEvent({name: "Consumer Price Index (CPI)"})], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+    await getCalendarOfficialSummary([createCalendarEvent({name: "Producer Price Index (PPI)"})], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+    await getCalendarOfficialSummary([createCalendarEvent({name: "GDP q/q"})], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+
+    expect(getWithRetryFn.mock.calls.map(call => call[0])).toEqual([
+      "https://www.bls.gov/news.release/cpi.nr0.htm",
+      "https://www.bls.gov/news.release/ppi.nr0.htm",
+      "https://www.bea.gov/data/gdp/gross-domestic-product",
+    ]);
+  });
+
+  test("returns undefined when official source loading fails", async () => {
+    const logger = {
+      log: vi.fn(),
+    };
+    const getWithRetryFn = vi.fn().mockRejectedValue(new Error("network"));
+    const callAiProviderJsonFn = vi.fn();
+
+    const summary = await getCalendarOfficialSummary([createCalendarEvent({
+      name: "Consumer Price Index (CPI)",
+    })], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+
+    expect(summary).toBeUndefined();
+    expect(callAiProviderJsonFn).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith("warn", expect.stringContaining("Loading official calendar source failed"));
+  });
+
+  test("returns undefined for invalid AI summary responses", async () => {
+    const logger = {
+      log: vi.fn(),
+    };
+    const getWithRetryFn = vi.fn().mockResolvedValue({
+      data: "Official source text.",
+    });
+    const callAiProviderJsonFn = vi.fn()
+      .mockResolvedValueOnce("not-json")
+      .mockResolvedValueOnce(JSON.stringify({summaryMarkdown: ""}));
+
+    await expect(getCalendarOfficialSummary([createCalendarEvent()], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    })).resolves.toBeUndefined();
+    await expect(getCalendarOfficialSummary([createCalendarEvent()], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    })).resolves.toBeUndefined();
+
+    expect(logger.log).toHaveBeenCalledWith("warn", "AI calendar official source summary returned invalid JSON.");
+  });
+
+  test("returns undefined when there is no official source match", async () => {
+    const logger = {
+      log: vi.fn(),
+    };
+    const getWithRetryFn = vi.fn();
+    const callAiProviderJsonFn = vi.fn();
+
+    const summary = await getCalendarOfficialSummary([createCalendarEvent({
+      name: "Existing Home Sales",
+    })], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+
+    expect(summary).toBeUndefined();
+    expect(getWithRetryFn).not.toHaveBeenCalled();
+    expect(callAiProviderJsonFn).not.toHaveBeenCalled();
+  });
+});

--- a/modules/calendar-economic-summary.test.ts
+++ b/modules/calendar-economic-summary.test.ts
@@ -53,8 +53,8 @@ describe("calendar-economic-summary", () => {
     };
     const getWithRetryFn = vi.fn().mockResolvedValue({
       data: [
-        "<script>remove me</script >",
-        "<style>remove styles</style >",
+        "<script>remove me</script\t\n bar>",
+        "<style>remove styles</style malformed>",
         "<noscript>remove fallback</noscript >",
         "<p>A&nbsp;&amp;&quot;&apos;&rsquo;&lsquo;&rdquo;&ldquo;&ndash;&mdash;&#65;&#x42;&#9999999999;</p>",
       ].join(""),

--- a/modules/calendar-economic-summary.test.ts
+++ b/modules/calendar-economic-summary.test.ts
@@ -47,6 +47,35 @@ describe("calendar-economic-summary", () => {
     });
   });
 
+  test("strips script-like blocks and decodes official source entities once", async () => {
+    const logger = {
+      log: vi.fn(),
+    };
+    const getWithRetryFn = vi.fn().mockResolvedValue({
+      data: [
+        "<script>remove me</script >",
+        "<style>remove styles</style >",
+        "<noscript>remove fallback</noscript >",
+        "<p>A&nbsp;&amp;&quot;&apos;&rsquo;&lsquo;&rdquo;&ldquo;&ndash;&mdash;&#65;&#x42;&#9999999999;</p>",
+      ].join(""),
+    });
+    const callAiProviderJsonFn = vi.fn().mockResolvedValue(JSON.stringify({
+      summaryMarkdown: "Decoded source summary.",
+    }));
+
+    await getCalendarOfficialSummary([createCalendarEvent()], {
+      callAiProviderJsonFn,
+      getWithRetryFn,
+      logger,
+    });
+
+    const prompt = callAiProviderJsonFn.mock.calls[0]?.[0] ?? "";
+    expect(prompt).not.toContain("remove me");
+    expect(prompt).not.toContain("remove styles");
+    expect(prompt).not.toContain("remove fallback");
+    expect(prompt).toContain("A &\"'''\"\"--AB&#9999999999;");
+  });
+
   test("uses authoritative release pages for macro events with no metric fields", async () => {
     const logger = {
       log: vi.fn(),

--- a/modules/calendar-economic-summary.ts
+++ b/modules/calendar-economic-summary.ts
@@ -195,9 +195,9 @@ async function getOfficialSourceText(
 function normalizeOfficialSourceText(value: string): string {
   return decodeHtmlEntities(
     value
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
-      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ")
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
+      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript\s*>/gi, " ")
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/(?:p|div|h[1-6]|li|tr)>/gi, "\n")
       .replace(/<[^>]+>/g, " "),
@@ -208,20 +208,44 @@ function normalizeOfficialSourceText(value: string): string {
 }
 
 function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&#(\d+);/g, (_match, code: string) => String.fromCodePoint(Number(code)))
-    .replace(/&#x([0-9a-f]+);/gi, (_match, code: string) => String.fromCodePoint(Number.parseInt(code, 16)))
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&quot;/g, "\"")
-    .replace(/&apos;/g, "'")
-    .replace(/&#39;/g, "'")
-    .replace(/&rsquo;/g, "'")
-    .replace(/&lsquo;/g, "'")
-    .replace(/&rdquo;/g, "\"")
-    .replace(/&ldquo;/g, "\"")
-    .replace(/&ndash;/g, "-")
-    .replace(/&mdash;/g, "-");
+  return value.replace(/&(#(\d+)|#x([0-9a-f]+)|nbsp|amp|quot|apos|rsquo|lsquo|rdquo|ldquo|ndash|mdash);/gi, (match, entity: string, decimalCode: string | undefined, hexCode: string | undefined) => {
+    if (undefined !== decimalCode) {
+      return decodeHtmlCodePoint(Number(decimalCode), match);
+    }
+
+    if (undefined !== hexCode) {
+      return decodeHtmlCodePoint(Number.parseInt(hexCode, 16), match);
+    }
+
+    switch (entity.toLowerCase()) {
+      case "nbsp":
+        return " ";
+      case "amp":
+        return "&";
+      case "quot":
+        return "\"";
+      case "apos":
+      case "rsquo":
+      case "lsquo":
+        return "'";
+      case "rdquo":
+      case "ldquo":
+        return "\"";
+      case "ndash":
+      case "mdash":
+        return "-";
+      default:
+        return match;
+    }
+  });
+}
+
+function decodeHtmlCodePoint(codePoint: number, fallback: string): string {
+  if (false === Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return fallback;
+  }
+
+  return String.fromCodePoint(codePoint);
 }
 
 function getCalendarOfficialSummaryPrompt(

--- a/modules/calendar-economic-summary.ts
+++ b/modules/calendar-economic-summary.ts
@@ -1,0 +1,281 @@
+import moment from "moment-timezone";
+import {callAiProviderJson, type AiProviderDependencies} from "./ai-provider.ts";
+import {type CalendarEvent} from "./calendar.ts";
+import {getWithRetry} from "./http-retry.ts";
+
+type CalendarOfficialSource = {
+  name: string;
+  url: string;
+};
+
+export type CalendarOfficialSummary = CalendarOfficialSource & {
+  summaryMarkdown: string;
+};
+
+export type CalendarOfficialSummaryDependencies = AiProviderDependencies & {
+  callAiProviderJsonFn?: typeof callAiProviderJson;
+  getWithRetryFn?: typeof getWithRetry;
+};
+
+const maxOfficialSourceTextLength = 12_000;
+const maxSummaryLength = 900;
+const calendarOfficialSummarySchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    summaryMarkdown: {
+      type: "string",
+      description: "A concise Discord Markdown summary of the main topics from the official source text.",
+    },
+  },
+  required: ["summaryMarkdown"],
+} satisfies Record<string, unknown>;
+
+export async function getCalendarOfficialSummary(
+  calendarEvents: CalendarEvent[],
+  dependencies: CalendarOfficialSummaryDependencies,
+): Promise<CalendarOfficialSummary | undefined> {
+  const source = getOfficialSource(calendarEvents);
+  if (undefined === source) {
+    return undefined;
+  }
+
+  const sourceText = await getOfficialSourceText(source, dependencies);
+  if (undefined === sourceText) {
+    return undefined;
+  }
+
+  const callAiProviderJsonFn = dependencies.callAiProviderJsonFn ?? callAiProviderJson;
+  const jsonText = await callAiProviderJsonFn(
+    getCalendarOfficialSummaryPrompt(calendarEvents, source, sourceText),
+    calendarOfficialSummarySchema,
+    dependencies,
+    "calendar official source summary",
+    undefined,
+    {
+      timeoutMs: 30_000,
+    },
+  ).catch(error => {
+    dependencies.logger.log(
+      "warn",
+      `AI calendar official source summary failed: ${error}`,
+    );
+    return null;
+  });
+
+  if (null === jsonText) {
+    return undefined;
+  }
+
+  const parsedJson = parseJson(jsonText);
+  if (false === isRecord(parsedJson)) {
+    dependencies.logger.log(
+      "warn",
+      "AI calendar official source summary returned invalid JSON.",
+    );
+    return undefined;
+  }
+
+  const summaryMarkdown = parsedJson["summaryMarkdown"];
+  if ("string" !== typeof summaryMarkdown) {
+    dependencies.logger.log(
+      "warn",
+      "AI calendar official source summary response did not contain summaryMarkdown.",
+    );
+    return undefined;
+  }
+
+  const normalizedSummary = normalizeSummaryMarkdown(summaryMarkdown);
+  if ("" === normalizedSummary) {
+    return undefined;
+  }
+
+  return {
+    ...source,
+    summaryMarkdown: truncateSummary(normalizedSummary),
+  };
+}
+
+function getOfficialSource(calendarEvents: CalendarEvent[]): CalendarOfficialSource | undefined {
+  const eventNames = calendarEvents
+    .map(calendarEvent => calendarEvent.name)
+    .join(" ")
+    .toLowerCase();
+  const primaryEvent = calendarEvents[0];
+
+  if (/\b(?:fomc statement|federal open market committee \(fomc\) statement|fed interest rate decision|federal reserve system \(fed\) interest rate decision)\b/i.test(eventNames)) {
+    return {
+      name: "Federal Reserve",
+      url: getFederalReserveStatementUrl(primaryEvent),
+    };
+  }
+
+  if (/\b(?:consumer price index|cpi)\b/i.test(eventNames)) {
+    return {
+      name: "U.S. Bureau of Labor Statistics",
+      url: "https://www.bls.gov/news.release/cpi.nr0.htm",
+    };
+  }
+
+  if (/\b(?:producer price index|ppi)\b/i.test(eventNames)) {
+    return {
+      name: "U.S. Bureau of Labor Statistics",
+      url: "https://www.bls.gov/news.release/ppi.nr0.htm",
+    };
+  }
+
+  if (/\bnonfarm payrolls\b/i.test(eventNames)) {
+    return {
+      name: "U.S. Bureau of Labor Statistics",
+      url: "https://www.bls.gov/news.release/empsit.nr0.htm",
+    };
+  }
+
+  if (/\b(?:gross domestic product|gdp q\/q)\b/i.test(eventNames)) {
+    return {
+      name: "U.S. Bureau of Economic Analysis",
+      url: "https://www.bea.gov/data/gdp/gross-domestic-product",
+    };
+  }
+
+  return undefined;
+}
+
+function getFederalReserveStatementUrl(calendarEvent: CalendarEvent | undefined): string {
+  const eventDate = calendarEvent?.date ?? "";
+  const parsedDate = moment(eventDate, "YYYY-MM-DD", true);
+  const dateStamp = true === parsedDate.isValid()
+    ? parsedDate.format("YYYYMMDD")
+    : moment().format("YYYYMMDD");
+
+  return `https://www.federalreserve.gov/newsevents/pressreleases/monetary${dateStamp}a.htm`;
+}
+
+async function getOfficialSourceText(
+  source: CalendarOfficialSource,
+  dependencies: CalendarOfficialSummaryDependencies,
+): Promise<string | undefined> {
+  const getWithRetryFn = dependencies.getWithRetryFn ?? getWithRetry;
+  const response = await getWithRetryFn<string>(
+    source.url,
+    {
+      responseType: "text",
+      headers: {
+        "User-Agent": "Mozilla/5.0",
+      },
+    },
+    {
+      maxAttempts: 2,
+      timeoutMs: 10_000,
+    },
+  ).catch(error => {
+    dependencies.logger.log(
+      "warn",
+      `Loading official calendar source failed (${source.name}): ${error}`,
+    );
+    return null;
+  });
+
+  if (null === response) {
+    return undefined;
+  }
+
+  const sourceText = normalizeOfficialSourceText(response.data);
+  if ("" === sourceText) {
+    dependencies.logger.log(
+      "warn",
+      `Official calendar source did not contain usable text (${source.name}).`,
+    );
+    return undefined;
+  }
+
+  return sourceText.slice(0, maxOfficialSourceTextLength);
+}
+
+function normalizeOfficialSourceText(value: string): string {
+  return decodeHtmlEntities(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/(?:p|div|h[1-6]|li|tr)>/gi, "\n")
+      .replace(/<[^>]+>/g, " "),
+  )
+    .replace(/\u00a0/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&#(\d+);/g, (_match, code: string) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_match, code: string) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, "\"")
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&rsquo;/g, "'")
+    .replace(/&lsquo;/g, "'")
+    .replace(/&rdquo;/g, "\"")
+    .replace(/&ldquo;/g, "\"")
+    .replace(/&ndash;/g, "-")
+    .replace(/&mdash;/g, "-");
+}
+
+function getCalendarOfficialSummaryPrompt(
+  calendarEvents: CalendarEvent[],
+  source: CalendarOfficialSource,
+  sourceText: string,
+): string {
+  const eventNames = calendarEvents
+    .map(calendarEvent => calendarEvent.name)
+    .filter(eventName => "" !== eventName.trim())
+    .join(", ");
+
+  return [
+    "Summarize this official economic release for a Discord trading alert.",
+    "Return only JSON matching the schema. Do not include markdown outside the JSON string.",
+    `Event(s): ${eventNames}`,
+    `Official source: ${source.name}`,
+    "Write summaryMarkdown as 2 short sentences maximum.",
+    "Focus on the main policy or macro topics that are likely market-relevant.",
+    "Use only the official source text below. Do not infer, forecast, or invent numbers.",
+    "Do not include links, code blocks, tables, emojis, or disclaimers.",
+    "",
+    "Official source text:",
+    sourceText,
+  ].join("\n");
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
+}
+
+function normalizeSummaryMarkdown(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => "" !== line && false === /^```/.test(line))
+    .join("\n")
+    .replace(/\s+\n/g, "\n")
+    .trim();
+}
+
+function truncateSummary(summaryMarkdown: string): string {
+  if (summaryMarkdown.length <= maxSummaryLength) {
+    return summaryMarkdown;
+  }
+
+  return `${summaryMarkdown.slice(0, maxSummaryLength - 3).trimEnd()}...`;
+}

--- a/modules/calendar-economic-summary.ts
+++ b/modules/calendar-economic-summary.ts
@@ -195,9 +195,9 @@ async function getOfficialSourceText(
 function normalizeOfficialSourceText(value: string): string {
   return decodeHtmlEntities(
     value
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
-      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript\s*>/gi, " ")
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
+      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript\b[^>]*>/gi, " ")
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/(?:p|div|h[1-6]|li|tr)>/gi, "\n")
       .replace(/<[^>]+>/g, " "),

--- a/modules/calendar.test.ts
+++ b/modules/calendar.test.ts
@@ -83,9 +83,16 @@ describe("getCalendarMessages", () => {
     mockPostWithRetry.mockResolvedValueOnce({
       data: [
         {
+          ActualValue: "178\u00a0K",
           Country: 840,
+          CurrencyCode: "USD",
           EventName: "US Payrolls",
+          ForecastValue: "140\u00a0K",
           FullDate: "2026-05-04T12:30:00Z",
+          Id: 123,
+          OldPreviousValue: "135\u00a0K",
+          PreviousValue: "138\u00a0K",
+          Url: "/en/economic-calendar/united-states/nonfarm-payrolls",
         },
         {
           Country: 999,
@@ -116,6 +123,15 @@ describe("getCalendarMessages", () => {
       "14:30 🇺🇸 US Payrolls",
       "10:00 🇪🇺 Eurozone CPI",
     ]);
+    expect(result.events[0]).toEqual(expect.objectContaining({
+      actualValue: "178 K",
+      currencyCode: "USD",
+      forecastValue: "140 K",
+      oldPreviousValue: "135 K",
+      previousValue: "138 K",
+      sourceEventId: "123",
+      sourceUrl: "https://www.mql5.com/en/economic-calendar/united-states/nonfarm-payrolls",
+    }));
   });
 
   test("handles empty, short and failed calendar loader responses", async () => {

--- a/modules/calendar.ts
+++ b/modules/calendar.ts
@@ -58,9 +58,16 @@ type CalendarMessageChunk = {
 };
 
 type CalendarApiEvent = {
+  ActualValue?: string | null;
   Country: number;
+  CurrencyCode?: string | null;
   EventName: string;
+  ForecastValue?: string | null;
   FullDate: string;
+  Id?: number | string | null;
+  OldPreviousValue?: string | null;
+  PreviousValue?: string | null;
+  Url?: string | null;
 };
 
 function getCalendarRangeInBerlin(startDay: string, range: number): {startDate: moment.Moment; endDate: moment.Moment} {
@@ -136,6 +143,13 @@ export async function getCalendarEventsResult(startDay: string, range: number): 
           calendarEvent.time = eventDeTime;
           calendarEvent.country = country;
           calendarEvent.name = element.EventName;
+          calendarEvent.actualValue = normalizeCalendarValue(element.ActualValue);
+          calendarEvent.forecastValue = normalizeCalendarValue(element.ForecastValue);
+          calendarEvent.previousValue = normalizeCalendarValue(element.PreviousValue);
+          calendarEvent.oldPreviousValue = normalizeCalendarValue(element.OldPreviousValue);
+          calendarEvent.currencyCode = normalizeCalendarValue(element.CurrencyCode);
+          calendarEvent.sourceEventId = normalizeCalendarValue(element.Id);
+          calendarEvent.sourceUrl = getCalendarEventSourceUrl(element.Url);
           calendarEvents.push(calendarEvent);
         }
       }
@@ -152,6 +166,31 @@ export async function getCalendarEventsResult(startDay: string, range: number): 
     events: calendarEvents,
     status,
   };
+}
+
+function normalizeCalendarValue(value: unknown): string {
+  if ("string" === typeof value || "number" === typeof value) {
+    return String(value)
+      .replace(/\u00a0/g, " ")
+      .replace(/\u200b/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  return "";
+}
+
+function getCalendarEventSourceUrl(url: string | null | undefined): string {
+  const normalizedUrl = normalizeCalendarValue(url);
+  if ("" === normalizedUrl) {
+    return "";
+  }
+
+  if (/^https?:\/\//i.test(normalizedUrl)) {
+    return normalizedUrl;
+  }
+
+  return `https://www.mql5.com${normalizedUrl.startsWith("/") ? "" : "/"}${normalizedUrl}`;
 }
 
 export function getCalendarMessages(
@@ -315,10 +354,25 @@ export function getCalendarText(calendarEvents: CalendarEvent[]): string {
 }
 
 export class CalendarEvent {
+  private _actualValue = "";
   private _date = "";
   private _time = "";
   private _country = "";
+  private _currencyCode = "";
+  private _forecastValue = "";
   private _name = "";
+  private _oldPreviousValue = "";
+  private _previousValue = "";
+  private _sourceEventId = "";
+  private _sourceUrl = "";
+
+  public get actualValue() {
+    return this._actualValue;
+  }
+
+  public set actualValue(actualValue: string) {
+    this._actualValue = actualValue;
+  }
 
   public get date() {
     return this._date;
@@ -344,12 +398,60 @@ export class CalendarEvent {
     this._country = country;
   }
 
+  public get currencyCode() {
+    return this._currencyCode;
+  }
+
+  public set currencyCode(currencyCode: string) {
+    this._currencyCode = currencyCode;
+  }
+
+  public get forecastValue() {
+    return this._forecastValue;
+  }
+
+  public set forecastValue(forecastValue: string) {
+    this._forecastValue = forecastValue;
+  }
+
   public get name() {
     return this._name;
   }
 
   public set name(name: string) {
     this._name = name;
+  }
+
+  public get oldPreviousValue() {
+    return this._oldPreviousValue;
+  }
+
+  public set oldPreviousValue(oldPreviousValue: string) {
+    this._oldPreviousValue = oldPreviousValue;
+  }
+
+  public get previousValue() {
+    return this._previousValue;
+  }
+
+  public set previousValue(previousValue: string) {
+    this._previousValue = previousValue;
+  }
+
+  public get sourceEventId() {
+    return this._sourceEventId;
+  }
+
+  public set sourceEventId(sourceEventId: string) {
+    this._sourceEventId = sourceEventId;
+  }
+
+  public get sourceUrl() {
+    return this._sourceUrl;
+  }
+
+  public set sourceUrl(sourceUrl: string) {
+    this._sourceUrl = sourceUrl;
   }
 }
 

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -85,6 +85,46 @@ describe("earnings result formatting", () => {
     })).toContain("**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/example/ex-991.htm)");
   });
 
+  test("prefers ARM-style Q4 FYE section metrics over full-year figures", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <p>Arm delivered record-breaking results this quarter and in fiscal 2026.</p>
+          <p>For the full year, revenue reached a record $4.92 billion. Non-GAAP EPS was also a record at $1.77.</p>
+          <h2>Q4 FYE26 Financial Overview</h2>
+          <p>Total revenue increased 20% year-over-year to $1,490 million.</p>
+          <p>GAAP net income was $313 million.</p>
+          <p>Non-GAAP fully diluted EPS was $0.60 compared with $0.55 in the same period a year ago.</p>
+          <h2>Fiscal year 2026 financial overview</h2>
+          <p>Total revenue increased 23% year-over-year to a record $4,920 million.</p>
+          <p>Non-GAAP fully diluted EPS was $1.77 compared with $1.63 in the same period a year ago.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q4 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "adjusted_eps",
+        value: "$0.60",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        value: "$1.49B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        value: "$313M",
+      }),
+    ]));
+    expect(parsedDocument.metrics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        value: "$4.92B",
+      }),
+    ]));
+  });
+
   test("renders result and outlook metrics before optional earnings summaries", () => {
     const parsedDocument = {
       metrics: [],

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -61,6 +61,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
     label: "Adj EPS",
     patterns: [
       /\badjusted\s+(?:diluted\s+)?(?:earnings\s+per\s+(?:common\s+)?share|eps)\b/i,
+      /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?eps\b/i,
       /\bnon-gaap\s+(?:diluted\s+)?(?:earnings\s+per\s+share|eps)\b/i,
     ],
     valueType: "eps",
@@ -402,7 +403,7 @@ function getDocumentHeadline(lines: string[]): string | undefined {
 }
 
 function getQuarterLabel(text: string): string | undefined {
-  const fiscalQuarterMatch = text.match(/\b(Q[1-4])\s+(?:fiscal\s+year|FY)\s*(20\d{2}|\d{2})\b/i);
+  const fiscalQuarterMatch = text.match(/\b(Q[1-4])\s+(?:fiscal\s+year|FY|FYE)\s*(20\d{2}|\d{2})\b/i);
   if (undefined !== fiscalQuarterMatch?.[1] && undefined !== fiscalQuarterMatch[2]) {
     return `${fiscalQuarterMatch[1].toUpperCase()} ${normalizeFiscalYear(fiscalQuarterMatch[2])}`;
   }
@@ -515,12 +516,17 @@ function getQuarterSpecificMetricLines(lines: string[]): string[] {
 }
 
 function isQuarterSpecificSectionLine(line: string): boolean {
-  return /^\s*(?:for\s+)?Q[1-4]\s+(?:fiscal\s+year|FY)\s*(?:20\d{2}|\d{2})\s*:?$/i.test(line) ||
+  if (/\b(?:guidance|outlook|forecast)\b/i.test(line)) {
+    return false;
+  }
+
+  return /^\s*(?:for\s+)?Q[1-4]\s+(?:fiscal\s+year|FY|FYE)\s*(?:20\d{2}|\d{2})(?:\s+(?:financial\s+overview|results?|earnings))?\s*:?$/i.test(line) ||
     /^\s*(?:for\s+)?(?:the\s+)?(?:first|second|third|fourth)\s+quarter(?:\s+(?:of\s+)?(?:fiscal\s+year|FY)\s*(?:20\d{2}|\d{2}))?\s*:?$/i.test(line);
 }
 
 function isQuarterSpecificSectionBoundary(line: string): boolean {
   return /^\s*(?:outlook|guidance|financial\s+outlook|business\s+outlook|use\s+of\s+non-gaap|forward-looking|supplemental\s+financial\s+information)\b/i.test(line) ||
+    /^\s*(?:fiscal\s+year|FY|FYE)\s*(?:20\d{2}|\d{2})\b/i.test(line) ||
     /^\s*for\s+fiscal\s+year\s+(?:20\d{2}|\d{2})\s*:?$/i.test(line);
 }
 

--- a/modules/earnings-results-sec.test.ts
+++ b/modules/earnings-results-sec.test.ts
@@ -306,6 +306,74 @@ describe("SEC earnings result source", () => {
     });
   });
 
+  test("falls back from an empty 99.1 stub to a usable shareholder letter exhibit", async () => {
+    const filing = createFiling({
+      accessionNumber: "0001973239-26-000062",
+      cik: "0001973239",
+      form: "6-K",
+      items: [],
+    });
+    getWithRetryFn.mockImplementation(async (url: string) => {
+      if (url.endsWith("/index.json")) {
+        return {
+          data: {
+            directory: {
+              item: [
+                {
+                  name: "arm-20260506.htm",
+                  type: "text.gif",
+                },
+                {
+                  name: "exhibit991fye26q431-marx26.htm",
+                  type: "text.gif",
+                },
+                {
+                  name: "exhibit992fye26q431-marx26.htm",
+                  type: "text.gif",
+                },
+              ],
+            },
+          },
+        };
+      }
+
+      if (url.endsWith("/exhibit991fye26q431-marx26.htm")) {
+        return {
+          data: "<html><body><h1>Arm Holdings plc Reports Results</h1></body></html>",
+        };
+      }
+
+      if (url.endsWith("/exhibit992fye26q431-marx26.htm")) {
+        return {
+          data: "<html><body><h1>Q4 FYE26 Financial Overview</h1><p>Total revenue increased to $1,490 million.</p></body></html>",
+        };
+      }
+
+      return {
+        data: "<html><body>Form 6-K wrapper</body></html>",
+      };
+    });
+    const dependencies = {
+      getWithRetryFn,
+      logger,
+    } as Parameters<typeof loadSecFilingDetails>[1];
+
+    const details = await loadSecFilingDetails(filing, dependencies, {
+      isUsableDocument: html => html.includes("Total revenue"),
+    });
+
+    expect(details).toEqual({
+      documentUrl: "https://www.sec.gov/Archives/edgar/data/1973239/000197323926000062/exhibit992fye26q431-marx26.htm",
+      html: "<html><body><h1>Q4 FYE26 Financial Overview</h1><p>Total revenue increased to $1,490 million.</p></body></html>",
+    });
+    expect(getWithRetryFn).toHaveBeenCalledWith(
+      "https://www.sec.gov/Archives/edgar/data/1973239/000197323926000062/exhibit991fye26q431-marx26.htm",
+      expect.objectContaining({
+        responseType: "text",
+      }),
+    );
+  });
+
   test("selects underscore exhibit 99.1 filenames before primary 8-K HTML", async () => {
     const filing = createFiling({
       accessionNumber: "0001104659-26-052145",

--- a/modules/earnings-results-sec.ts
+++ b/modules/earnings-results-sec.ts
@@ -51,6 +51,10 @@ type SecArchiveIndexResponse = {
   };
 };
 
+type SecFilingDetailsOptions = {
+  isUsableDocument?: (html: string, documentUrl: string) => boolean;
+};
+
 type SecTickerMapCache = {
   loadedAtMs: number;
   tickerToCompany: Map<string, SecCompany>;
@@ -200,6 +204,7 @@ export function isLikelyEarningsFiling(filing: SecCurrentFiling): boolean {
 export async function loadSecFilingDetails(
   filing: SecCurrentFiling,
   dependencies: SecRequestDependencies,
+  options: SecFilingDetailsOptions = {},
 ): Promise<{documentUrl: string; html: string;}> {
   const archiveBaseUrl = getSecArchiveBaseUrl(filing);
   const indexUrl = `${archiveBaseUrl}/index.json`;
@@ -210,25 +215,31 @@ export async function loadSecFilingDetails(
     },
   );
   const documents = normalizeSecArchiveDocuments(indexResponse.data?.directory?.item);
-  const selectedDocument = selectEarningsReleaseDocument(documents);
-  if (!selectedDocument?.name) {
+  const rankedDocuments = getRankedEarningsReleaseDocuments(documents);
+  if (0 === rankedDocuments.length) {
     return {
       documentUrl: filing.filingUrl,
       html: "",
     };
   }
 
-  const documentUrl = `${archiveBaseUrl}/${selectedDocument.name}`;
-  const documentResponse = await dependencies.getWithRetryFn<string>(
-    documentUrl,
-    {
-      headers: secRequestHeaders,
-      responseType: "text",
-    },
-  );
-  return {
-    documentUrl,
-    html: String(documentResponse.data),
+  let fallbackDetails: {documentUrl: string; html: string;} | undefined;
+  for (const selectedDocument of rankedDocuments) {
+    if (!selectedDocument.name) {
+      continue;
+    }
+
+    const details = await loadSecArchiveHtmlDocument(archiveBaseUrl, selectedDocument.name, dependencies);
+    fallbackDetails ??= details;
+    if (undefined === options.isUsableDocument ||
+        true === options.isUsableDocument(details.html, details.documentUrl)) {
+      return details;
+    }
+  }
+
+  return fallbackDetails ?? {
+    documentUrl: filing.filingUrl,
+    html: "",
   };
 }
 
@@ -260,8 +271,8 @@ function normalizeSecArchiveDocuments(value: SecArchiveDocument[] | SecArchiveDo
   return [];
 }
 
-function selectEarningsReleaseDocument(documents: SecArchiveDocument[]): SecArchiveDocument | undefined {
-  const rankedDocuments = documents
+function getRankedEarningsReleaseDocuments(documents: SecArchiveDocument[]): SecArchiveDocument[] {
+  return documents
     .filter(isPotentialSecFilingDocument)
     .map((document, index) => ({
       document,
@@ -274,9 +285,27 @@ function selectEarningsReleaseDocument(documents: SecArchiveDocument[]): SecArch
       }
 
       return first.index - second.index;
-    });
+    })
+    .map(rankedDocument => rankedDocument.document);
+}
 
-  return rankedDocuments[0]?.document;
+async function loadSecArchiveHtmlDocument(
+  archiveBaseUrl: string,
+  documentName: string,
+  dependencies: SecRequestDependencies,
+): Promise<{documentUrl: string; html: string;}> {
+  const documentUrl = `${archiveBaseUrl}/${documentName}`;
+  const documentResponse = await dependencies.getWithRetryFn<string>(
+    documentUrl,
+    {
+      headers: secRequestHeaders,
+      responseType: "text",
+    },
+  );
+  return {
+    documentUrl,
+    html: String(documentResponse.data),
+  };
 }
 
 function isPotentialSecFilingDocument(document: SecArchiveDocument): boolean {

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -654,7 +654,9 @@ async function buildEarningsResultAnnouncement(
   skippedQualityGateAccessions: Map<string, number>,
 ): Promise<EarningsResultAnnouncement | null> {
   const [filingDetails, xbrlMetrics] = await Promise.all([
-    loadSecFilingDetails(filing, dependencies).catch(error => {
+    loadSecFilingDetails(filing, dependencies, {
+      isUsableDocument: html => hasParsedEarningsDocumentContent(parseEarningsDocument(html)),
+    }).catch(error => {
       dependencies.logger.log(
         "warn",
         `Skipping earnings result announcement for ${watch.event.ticker}: SEC filing details could not be loaded: ${error}`,
@@ -783,6 +785,10 @@ async function buildEarningsResultAnnouncement(
     message,
     ticker: watch.event.ticker,
   };
+}
+
+function hasParsedEarningsDocumentContent(parsedDocument: ParsedEarningsDocument): boolean {
+  return 0 < parsedDocument.metrics.length || 0 < parsedDocument.outlook.length;
 }
 
 function updateNoMetricsSkipState(

--- a/modules/market-close-recap.test.ts
+++ b/modules/market-close-recap.test.ts
@@ -192,6 +192,57 @@ describe("market close recap", () => {
     });
   });
 
+  test("matches hydrated Discord poll answer media and camelCase answer ids", async () => {
+    const mediaVotersFetch = vi.fn().mockResolvedValue(new Map([
+      ["789", {id: "789"}],
+    ]));
+
+    const mediaRecap = await getMarketCloseRecap({
+      poll: {
+        answers: [{
+          answerId: 1,
+          pollMedia: {
+            text: "🟢 Risk-on",
+          },
+          voters: {
+            fetch: mediaVotersFetch,
+          },
+        }],
+      },
+    }, {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    const idVotersFetch = vi.fn().mockResolvedValue(new Map([
+      ["987", {id: "987"}],
+    ]));
+    const idRecap = await getMarketCloseRecap({
+      poll: {
+        answers: [{
+          answerId: 1,
+          emoji: {name: "🟢"},
+          text: null,
+          voters: {
+            fetch: idVotersFetch,
+          },
+        }],
+      },
+    }, {
+      logger,
+      postWithRetryFn: createPostWithRecap(),
+      readSecretFn,
+    });
+
+    expect(mediaRecap?.allowedUserIds).toEqual(["789"]);
+    expect(idRecap?.allowedUserIds).toEqual(["987"]);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      "Skipping market close recap voter mentions: poll answer Risk-on was not found.",
+    );
+  });
+
   test("falls back to stable poll answer IDs when answer text is partial", async () => {
     const votersFetch = vi.fn().mockResolvedValue(new Map([
       ["456", {id: "456"}],
@@ -370,7 +421,7 @@ describe("market close recap", () => {
     );
   });
 
-  test("rejects output that mentions the provider or omits VIX", async () => {
+  test("rejects output that mentions provider, ETF proxies, sentiment labels or omits VIX", async () => {
     const providerMentionRecap = await getMarketCloseRecap(undefined, {
       logger,
       postWithRetryFn: createPostWithRecap({
@@ -385,16 +436,32 @@ describe("market close recap", () => {
       }),
       readSecretFn,
     });
+    const forbiddenEtfRecap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        summaryMarkdown: "`SPX` und `QQQ` waren fest, der `VIX` fiel um `1 Punkt`.",
+      }),
+      readSecretFn,
+    });
+    const sentimentInSummaryRecap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        summaryMarkdown: "Risk-on dominierte den Handel, der `VIX` fiel um `1 Punkt`.",
+      }),
+      readSecretFn,
+    });
     const missingVixRecap = await getMarketCloseRecap(undefined, {
       logger,
       postWithRetryFn: createPostWithRecap({
-        summaryMarkdown: "`SPX` war fest und `QQQ` erholte sich.",
+        summaryMarkdown: "`SPX` und `NQ` erholten sich.",
       }),
       readSecretFn,
     });
 
     expect(providerMentionRecap).toBeUndefined();
     expect(gptMentionRecap).toBeUndefined();
+    expect(forbiddenEtfRecap).toBeUndefined();
+    expect(sentimentInSummaryRecap).toBeUndefined();
     expect(missingVixRecap).toBeUndefined();
     expect(logger.log).toHaveBeenCalledWith(
       "warn",

--- a/modules/market-close-recap.ts
+++ b/modules/market-close-recap.ts
@@ -27,8 +27,15 @@ type PollAnswerVoters = {
 
 type PollAnswerLike = {
   answer_id?: number | undefined;
+  answerId?: number | undefined;
   id?: number | undefined;
+  media?: {
+    text?: string | null | undefined;
+  } | undefined;
   poll_media?: {
+    text?: string | null | undefined;
+  } | undefined;
+  pollMedia?: {
     text?: string | null | undefined;
   } | undefined;
   text?: string | null | undefined;
@@ -190,7 +197,8 @@ function getMarketCloseRecapPrompt(date: Date): string {
     `Heute ist nach US-Börsenschluss am ${usEasternDate} (US/Eastern).`,
     "Nutze Websuche, um den US-Cash-Handelstag realitätsnah einzuordnen.",
     "Bewerte den Handelstag vom regulären US-Open bis zum regulären US-Close.",
-    "Berücksichtige `SPX` oder `SPY`, `NQ` oder `QQQ`, `RTY` oder `IWM` sowie zwingend den `VIX`.",
+    "Berücksichtige ausschließlich `SPX`, `NQ`, `RTY` sowie zwingend den `VIX`.",
+    "Erwähne nicht die ETF-Pendants `SPY`, `QQQ` oder `IWM`.",
     "Der `VIX` darf niemals als Prozentwert beschrieben werden. Beschreibe ihn nur als Stand, Veränderung in Punkten oder Richtung, z.B. `18,4` auf `20,1` oder `+1,7 Punkte`.",
     "Wähle genau eine passende Antwort aus dem Opening-Sentiment-Poll:",
     "- Risk-on: breite Stärke, fallender oder ruhiger `VIX`, Risikoappetit.",
@@ -201,7 +209,8 @@ function getMarketCloseRecapPrompt(date: Date): string {
     "Schreibe `summaryMarkdown` auf Deutsch für einen Discord-Trading-Channel.",
     "Halte `summaryMarkdown` unter 1.000 Zeichen.",
     "Nutze 2-4 kurze Absätze oder Bulletpoints.",
-    "Formatiere Ticker und konkrete Kennzahlen als Inline-Code, z.B. `SPX`, `QQQ`, `+0,4%`, `1,7 Punkte`.",
+    "Nenne die Poll-Sentiment-Labels `Risk-on`, `Risk-off`, `Cash` und `Chaos` nicht in `summaryMarkdown`; das gewählte Sentiment steht nur in der separaten Sentiment-Zeile.",
+    "Formatiere Ticker und konkrete Kennzahlen als Inline-Code, z.B. `SPX`, `NQ`, `RTY`, `+0,4%`, `1,7 Punkte`.",
     "Erwähne weder KI-Anbieter, KI, Modell, Websuche, Quellen, Grounding noch Rechercheprozess.",
     "Keine Disclaimer, keine Links, keine Tabellen, keine Codeblöcke.",
   ].join("\n");
@@ -238,7 +247,9 @@ function parseAiMarketCloseRecap(
   const combinedText = `${normalizedSummary}\n${normalizedTitle}`;
   if ("" === normalizedSummary ||
       false === /\bVIX\b/i.test(combinedText) ||
+      true === hasPollSentimentLabel(normalizedSummary) ||
       true === hasForbiddenProviderMention(combinedText) ||
+      true === hasForbiddenMarketProxyMention(combinedText) ||
       true === hasVixPercent(combinedText)) {
     dependencies.logger.log(
       "warn",
@@ -512,6 +523,14 @@ function hasForbiddenProviderMention(value: string): boolean {
   return /\b(Gemini|OpenAI|GPT|ChatGPT|KI|Künstliche Intelligenz|Modell|Google Search|Websuche|Grounding)\b/iu.test(value);
 }
 
+function hasPollSentimentLabel(value: string): boolean {
+  return /\b(?:Risk-on|Risk-off|Cash|Chaos)\b/iu.test(value);
+}
+
+function hasForbiddenMarketProxyMention(value: string): boolean {
+  return /\b(?:SPY|QQQ|IWM)\b/iu.test(value);
+}
+
 function hasVixPercent(value: string): boolean {
   return /\bVIX\b[^\n.?!;:]*[+-]?\d+(?:[,.]\d+)?\s*%/iu.test(value);
 }
@@ -536,18 +555,18 @@ function getPollAnswerText(answer: unknown): string | undefined {
     return undefined;
   }
 
-  const directText = answer["text"];
-  if ("string" === typeof directText) {
-    return directText;
+  for (const textContainer of [answer, answer["poll_media"], answer["pollMedia"], answer["media"]]) {
+    if (false === isRecord(textContainer)) {
+      continue;
+    }
+
+    const text = textContainer["text"];
+    if ("string" === typeof text) {
+      return text;
+    }
   }
 
-  const pollMedia = answer["poll_media"];
-  if (false === isRecord(pollMedia)) {
-    return undefined;
-  }
-
-  const pollMediaText = pollMedia["text"];
-  return "string" === typeof pollMediaText ? pollMediaText : undefined;
+  return undefined;
 }
 
 function getPollAnswerId(answer: unknown): number | undefined {
@@ -565,12 +584,17 @@ function getPollAnswerId(answer: unknown): number | undefined {
     return answerId;
   }
 
+  const camelCaseAnswerId = answer["answerId"];
+  if ("number" === typeof camelCaseAnswerId && Number.isFinite(camelCaseAnswerId)) {
+    return camelCaseAnswerId;
+  }
+
   return undefined;
 }
 
 function normalizePollAnswerText(value: string | undefined): string {
   return value
-    ?.replace(/^[\p{Emoji_Presentation}\p{Emoji}\uFE0F\s]+/u, "")
+    ?.replace(/[\p{Emoji_Presentation}\p{Emoji}\uFE0F]/gu, "")
     .replace(/[‐‑‒–—―]/gu, "-")
     .replace(/\s+/g, " ")
     .trim()

--- a/modules/market-data-tastytrade.test.ts
+++ b/modules/market-data-tastytrade.test.ts
@@ -217,6 +217,21 @@ describe("tastytrade crypto market data stream", () => {
       6,
       6,
     );
+
+    stream.emit([{
+      change: 0.1,
+      eventSymbol: "BTC/USD",
+      eventType: "Trade",
+      percentageChange: 0.09,
+      price: 107,
+    }]);
+
+    expect(options.onMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({botClientId: "btc-client"}),
+      107,
+      7,
+      7.000000000000001,
+    );
   });
 
   test("derives crypto percentage move from trade change", async () => {

--- a/modules/market-data-tastytrade.ts
+++ b/modules/market-data-tastytrade.ts
@@ -754,12 +754,12 @@ function getTastytradePriceChange(
   referencePrice: number | null,
   previousPrice: number | null,
 ): number {
-  if (null !== eventPriceChange) {
-    return eventPriceChange;
-  }
-
   if (null !== referencePrice) {
     return lastNumeric - referencePrice;
+  }
+
+  if (null !== eventPriceChange) {
+    return eventPriceChange;
   }
 
   return null === previousPrice ? 0 : lastNumeric - previousPrice;
@@ -772,12 +772,12 @@ function getTastytradePercentageChange(
   referencePrice: number | null,
   previousPrice: number | null,
 ): number {
-  if (null !== eventPercentageChange) {
-    return eventPercentageChange;
-  }
-
   if (null !== referencePrice) {
     return (priceChange / referencePrice) * 100;
+  }
+
+  if (null !== eventPercentageChange) {
+    return eventPercentageChange;
   }
 
   const impliedReferencePrice = lastNumeric - priceChange;

--- a/modules/test-utils/timers.ts
+++ b/modules/test-utils/timers.ts
@@ -33,6 +33,7 @@ const getAssetByNameMock = vi.fn();
 const getCalendarEventsMock = vi.fn();
 const getCalendarEventsResultMock = vi.fn();
 const getCalendarMessagesMock = vi.fn();
+const getCalendarOfficialSummaryMock = vi.fn();
 const addExpectedMovesToEarningsEventsMock = vi.fn();
 const warmExpectedMoveCacheForEarningsEventsMock = vi.fn();
 const getEarningsResultMock = vi.fn();
@@ -81,6 +82,10 @@ vi.mock("../calendar.ts", () => ({
   getCalendarEvents: (...args: unknown[]) => getCalendarEventsMock(...args),
   getCalendarEventsResult: (...args: unknown[]) => getCalendarEventsResultMock(...args),
   getCalendarMessages: (...args: unknown[]) => getCalendarMessagesMock(...args),
+}));
+
+vi.mock("../calendar-economic-summary.ts", () => ({
+  getCalendarOfficialSummary: (...args: unknown[]) => getCalendarOfficialSummaryMock(...args),
 }));
 
 vi.mock("../earnings.ts", () => ({
@@ -254,6 +259,7 @@ export function resetTimerMocks() {
     events: [],
     status: "ok",
   });
+  getCalendarOfficialSummaryMock.mockResolvedValue(undefined);
   getCalendarMessagesMock.mockReturnValue({
     messages: ["calendar-text"],
     truncated: false,
@@ -278,6 +284,7 @@ export {
   getCalendarEventsMock,
   getCalendarEventsResultMock,
   getCalendarMessagesMock,
+  getCalendarOfficialSummaryMock,
   getEarningsMessagesMock,
   getEarningsReminderJob,
   getEarningsResultMock,

--- a/modules/timer-reminders.test.ts
+++ b/modules/timer-reminders.test.ts
@@ -5,10 +5,14 @@ import type {EarningsEvent} from "./earnings-types.ts";
 import {
   getAllowedRoleMentions,
   getCalendarReminderMessage,
+  getCalendarReminderSummaryMessage,
+  getCalendarReminderUpdateMessage,
   getEarningsReminderMessage,
   getMatchedCalendarReminderEventGroups,
   getMatchedEarningsReminderEvents,
   getNormalizedRoleId,
+  hasCalendarReminderActualValues,
+  hasCalendarReminderClearMetrics,
 } from "./timer-reminders.ts";
 
 function createCalendarEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
@@ -87,6 +91,36 @@ describe("timer-reminders", () => {
       "<@&role-1> Heute wichtig: `14:30` 🇺🇸 ISM Manufacturing PMI, ISM Manufacturing PMI Final",
     );
     expect(getCalendarReminderMessage("role-1", [])).toBe("<@&role-1> Heute wichtig:");
+  });
+
+  test("formats calendar reminders with expected actual and previous values", () => {
+    const event = createCalendarEvent({
+      actualValue: "3.4%",
+      forecastValue: "3.2%",
+      previousValue: "3.1%",
+      name: "Consumer Price Index (CPI) y/y",
+    });
+
+    expect(hasCalendarReminderActualValues([event])).toBe(true);
+    expect(hasCalendarReminderClearMetrics([event])).toBe(true);
+    expect(getCalendarReminderMessage("role-1", [event])).toBe(
+      "<@&role-1> Heute wichtig: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: actual `3.4%`, exp. `3.2%`, prev. `3.1%`",
+    );
+    expect(getCalendarReminderUpdateMessage("role-1", [event])).toBe(
+      "<@&role-1> Update: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: actual `3.4%`, exp. `3.2%`, prev. `3.1%`",
+    );
+  });
+
+  test("formats calendar reminder summaries for events without clear metrics", () => {
+    const event = createCalendarEvent({
+      name: "FOMC Statement",
+    });
+
+    expect(hasCalendarReminderActualValues([event])).toBe(false);
+    expect(hasCalendarReminderClearMetrics([event])).toBe(false);
+    expect(getCalendarReminderSummaryMessage("role-1", [event], "Federal Reserve", "Policy remains data dependent.")).toBe(
+      "<@&role-1> Update: `14:30` 🇺🇸 FOMC Statement\nSource: Federal Reserve\nPolicy remains data dependent.",
+    );
   });
 
   test("matches earnings reminder tickers, removes duplicates and formats by time bucket", () => {

--- a/modules/timer-reminders.ts
+++ b/modules/timer-reminders.ts
@@ -123,13 +123,99 @@ function getCalendarReminderEventSummary(calendarEvents: CalendarEvent[]): strin
   return uniqueEventNames.join(", ");
 }
 
+function getCalendarEventDisplayValue(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function getCalendarEventMetricSegments(calendarEvent: CalendarEvent): string[] {
+  const segments: string[] = [];
+  const actualValue = getCalendarEventDisplayValue(calendarEvent.actualValue);
+  const forecastValue = getCalendarEventDisplayValue(calendarEvent.forecastValue);
+  const previousValue = getCalendarEventDisplayValue(calendarEvent.previousValue);
+
+  if ("" !== actualValue) {
+    segments.push(`actual ${getDiscordMonospaceText(actualValue)}`);
+  }
+
+  if ("" !== forecastValue) {
+    segments.push(`exp. ${getDiscordMonospaceText(forecastValue)}`);
+  }
+
+  if ("" !== previousValue) {
+    segments.push(`prev. ${getDiscordMonospaceText(previousValue)}`);
+  }
+
+  return segments;
+}
+
+function getCalendarReminderEventDetail(calendarEvent: CalendarEvent): string {
+  const metricSegments = getCalendarEventMetricSegments(calendarEvent);
+  if (0 === metricSegments.length) {
+    return calendarEvent.name;
+  }
+
+  return `${calendarEvent.name}: ${metricSegments.join(", ")}`;
+}
+
+function getCalendarReminderEventDetails(calendarEvents: CalendarEvent[]): string {
+  if (false === hasCalendarReminderClearMetrics(calendarEvents)) {
+    return getCalendarReminderEventSummary(calendarEvents);
+  }
+
+  const eventDetails: string[] = [];
+  const seenEventDetails = new Set<string>();
+
+  for (const calendarEvent of calendarEvents) {
+    const eventDetail = getCalendarReminderEventDetail(calendarEvent).trim();
+    if (!eventDetail || true === seenEventDetails.has(eventDetail)) {
+      continue;
+    }
+
+    eventDetails.push(eventDetail);
+    seenEventDetails.add(eventDetail);
+  }
+
+  return eventDetails.join("; ");
+}
+
+export function hasCalendarReminderActualValues(calendarEvents: CalendarEvent[]): boolean {
+  return calendarEvents.some(calendarEvent => "" !== getCalendarEventDisplayValue(calendarEvent.actualValue));
+}
+
+export function hasCalendarReminderClearMetrics(calendarEvents: CalendarEvent[]): boolean {
+  return calendarEvents.some(calendarEvent => 0 < getCalendarEventMetricSegments(calendarEvent).length);
+}
+
 export function getCalendarReminderMessage(roleId: string, calendarEvents: CalendarEvent[]): string {
   const primaryEvent = calendarEvents[0];
   if (undefined === primaryEvent) {
     return `${getRoleMention(roleId)} Heute wichtig:`;
   }
 
-  return `${getRoleMention(roleId)} Heute wichtig: \`${primaryEvent.time}\` ${primaryEvent.country} ${getCalendarReminderEventSummary(calendarEvents)}`;
+  return `${getRoleMention(roleId)} Heute wichtig: \`${primaryEvent.time}\` ${primaryEvent.country} ${getCalendarReminderEventDetails(calendarEvents)}`;
+}
+
+export function getCalendarReminderUpdateMessage(roleId: string, calendarEvents: CalendarEvent[]): string {
+  const primaryEvent = calendarEvents[0];
+  if (undefined === primaryEvent) {
+    return `${getRoleMention(roleId)} Update:`;
+  }
+
+  return `${getRoleMention(roleId)} Update: \`${primaryEvent.time}\` ${primaryEvent.country} ${getCalendarReminderEventDetails(calendarEvents)}`;
+}
+
+export function getCalendarReminderSummaryMessage(
+  roleId: string,
+  calendarEvents: CalendarEvent[],
+  sourceName: string,
+  summaryMarkdown: string,
+): string {
+  const primaryEvent = calendarEvents[0];
+  if (undefined === primaryEvent) {
+    return `${getRoleMention(roleId)} Update:\nSource: ${sourceName}\n${summaryMarkdown}`;
+  }
+
+  return `${getRoleMention(roleId)} Update: \`${primaryEvent.time}\` ${primaryEvent.country} ${getCalendarReminderEventSummary(calendarEvents)}\nSource: ${sourceName}\n${summaryMarkdown}`;
 }
 
 export function getMatchedCalendarReminderEventGroups(

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -8,10 +8,12 @@ import {
   createClientWithChannel,
   getAssetByNameMock,
   getCalendarEventsMock,
+  getCalendarOfficialSummaryMock,
   getCalendarMessagesMock,
   getEarningsMessagesMock,
   getEarningsReminderJob,
   getEarningsResultMock,
+  getScheduledDateJobs,
   getScheduledJobByTime,
   isHolidayMock,
   loggerMock,
@@ -195,6 +197,117 @@ describe("timers: other announcements", () => {
 
     expect(send).toHaveBeenNthCalledWith(2, {
       content: "<@&role-123> Heute wichtig: `14:30` 🇺🇸 CPI y/y, Core CPI y/y, CPI m/m",
+      allowedMentions: {
+        parse: [],
+        roles: ["role-123"],
+      },
+    });
+  });
+
+  test("startOtherTimers posts calendar actuals after the release when they become available", async () => {
+    const {client, send} = createClientWithChannel();
+    getCalendarEventsMock
+      .mockResolvedValueOnce([
+        {
+          date: "2025-02-19",
+          time: "14:30",
+          country: "🇺🇸",
+          forecastValue: "3.2%",
+          name: "Consumer Price Index (CPI) y/y",
+          previousValue: "3.1%",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          actualValue: "3.4%",
+          date: "2025-02-19",
+          time: "14:30",
+          country: "🇺🇸",
+          forecastValue: "3.2%",
+          name: "Consumer Price Index (CPI) y/y",
+          previousValue: "3.1%",
+        },
+      ]);
+
+    startOtherTimers(client, "channel-id", [], [], [createCalendarReminderAsset({
+      name: "us-cpi-1h",
+      eventNameSubstrings: ["cpi"],
+      countryFlags: ["🇺🇸"],
+      roleId: "role-123",
+    })], []);
+    const dailyCalendarJob = getScheduledJobByTime(8, 30, "Europe/Berlin");
+    await dailyCalendarJob.callback();
+
+    const followUpJobs = getScheduledDateJobs();
+    expect(followUpJobs).toHaveLength(10);
+    expect(followUpJobs.map(job => job.rule.toISOString())).toEqual([
+      "2025-02-19T13:30:05.000Z",
+      "2025-02-19T13:30:10.000Z",
+      "2025-02-19T13:30:20.000Z",
+      "2025-02-19T13:30:30.000Z",
+      "2025-02-19T13:31:00.000Z",
+      "2025-02-19T13:32:00.000Z",
+      "2025-02-19T13:33:00.000Z",
+      "2025-02-19T13:35:00.000Z",
+      "2025-02-19T13:40:00.000Z",
+      "2025-02-19T13:45:00.000Z",
+    ]);
+    await followUpJobs[0]!.callback();
+
+    expect(send).toHaveBeenNthCalledWith(2, {
+      content: "<@&role-123> Heute wichtig: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: exp. `3.2%`, prev. `3.1%`",
+      allowedMentions: {
+        parse: [],
+        roles: ["role-123"],
+      },
+    });
+    expect(send).toHaveBeenNthCalledWith(3, {
+      content: "<@&role-123> Update: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: actual `3.4%`, exp. `3.2%`, prev. `3.1%`",
+      allowedMentions: {
+        parse: [],
+        roles: ["role-123"],
+      },
+    });
+  });
+
+  test("startOtherTimers posts official AI summary after no-metric calendar releases", async () => {
+    const {client, send} = createClientWithChannel();
+    getCalendarEventsMock.mockResolvedValueOnce([
+      {
+        date: "2025-02-19",
+        time: "20:00",
+        country: "🇺🇸",
+        name: "FOMC Statement",
+      },
+    ]);
+    getCalendarOfficialSummaryMock.mockResolvedValueOnce({
+      name: "Federal Reserve",
+      summaryMarkdown: "The Fed emphasized inflation and labor-market risks.",
+      url: "https://www.federalreserve.gov/newsevents/pressreleases/monetary20250219a.htm",
+    });
+
+    startOtherTimers(client, "channel-id", [], [], [createCalendarReminderAsset({
+      name: "us-fomc-statement-1h",
+      eventNameSubstrings: ["fomc statement"],
+      countryFlags: ["🇺🇸"],
+      roleId: "role-123",
+    })], []);
+    const dailyCalendarJob = getScheduledJobByTime(8, 30, "Europe/Berlin");
+    await dailyCalendarJob.callback();
+
+    await getScheduledDateJobs()[0]!.callback();
+
+    expect(getCalendarOfficialSummaryMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: "FOMC Statement",
+      }),
+    ], expect.objectContaining({
+      logger: expect.objectContaining({
+        log: expect.any(Function),
+      }),
+    }));
+    expect(send).toHaveBeenNthCalledWith(3, {
+      content: "<@&role-123> Update: `20:00` 🇺🇸 FOMC Statement\nSource: Federal Reserve\nThe Fed emphasized inflation and labor-market risks.",
       allowedMentions: {
         parse: [],
         roles: ["role-123"],

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -10,11 +10,13 @@ import {
 import {
   CALENDAR_MAX_MESSAGE_LENGTH,
   CALENDAR_MAX_MESSAGES_TIMER,
+  getCalendarEventDateTime,
   getCalendarEvents,
   getCalendarMessages,
   type CalendarEvent,
   type CalendarMessageBatch,
 } from "./calendar.ts";
+import {getCalendarOfficialSummary} from "./calendar-economic-summary.ts";
 import {
   EARNINGS_MAX_MESSAGE_LENGTH,
   EARNINGS_MAX_MESSAGES_TIMER,
@@ -34,10 +36,14 @@ import {type Ticker} from "./tickers.ts";
 import {
   getAllowedRoleMentions,
   getCalendarReminderMessage,
+  getCalendarReminderSummaryMessage,
+  getCalendarReminderUpdateMessage,
   getEarningsReminderMessage,
   getMatchedCalendarReminderEventGroups,
   getMatchedEarningsReminderEvents,
   getNormalizedRoleId,
+  hasCalendarReminderActualValues,
+  hasCalendarReminderClearMetrics,
 } from "./timer-reminders.ts";
 
 const logger = getLogger();
@@ -52,6 +58,7 @@ type FileAnnouncementAsset = {
 const calendarReminderAnnouncementSource = "calendar-reminder";
 const earningsReminderSource = "earnings-reminder";
 const calendarMessageDelayMs = 500;
+const calendarReminderFollowUpDelaySeconds = [5, 10, 20, 30, 60, 120, 180, 300, 600, 900];
 const usEasternTimezone = "US/Eastern";
 const dailyEarningsHeadline = "**Earnings**";
 const weeklyEarningsHeadline = "📅 **Earnings der nächsten Handelswoche**";
@@ -106,6 +113,10 @@ type EarningsAnnouncementConfig = {
   headline?: string;
   source: string;
   when: "all" | "before_open" | "during_session" | "after_close" | string;
+};
+type CalendarReminderGroup = {
+  asset: CalendarReminderAsset;
+  events: CalendarEvent[];
 };
 const nyseSentimentPollAnswers = [
   {emoji: "🟢", text: "Risk-on"},
@@ -1040,6 +1051,7 @@ export function startOtherTimers(
         calendarReminderAnnouncementSource,
       );
     }
+    scheduleCalendarReminderFollowUpJobs(client, channelID, matchedReminderGroups);
   });
 
   const ruleEventsWeekly = createRecurrenceRule({
@@ -1088,6 +1100,125 @@ function dedupeCalendarEvents(calendarEvents: CalendarEvent[]): CalendarEvent[] 
   }
 
   return dedupedEvents;
+}
+
+function scheduleCalendarReminderFollowUpJobs(
+  client: TimerClient,
+  channelID: string,
+  matchedReminderGroups: CalendarReminderGroup[],
+) {
+  const sentFollowUpKeys = new Set<string>();
+
+  for (const matchedReminderGroup of matchedReminderGroups) {
+    if (false === shouldScheduleCalendarReminderFollowUp(matchedReminderGroup)) {
+      continue;
+    }
+
+    const primaryEvent = matchedReminderGroup.events[0];
+    if (undefined === primaryEvent) {
+      continue;
+    }
+
+    const eventDateTime = getCalendarEventDateTime(primaryEvent);
+    if (false === eventDateTime.isValid()) {
+      continue;
+    }
+
+    const followUpKey = getCalendarReminderFollowUpKey(matchedReminderGroup);
+    for (const delaySeconds of calendarReminderFollowUpDelaySeconds) {
+      const scheduledDateTime = eventDateTime.clone().add(delaySeconds, "seconds");
+      if (true === scheduledDateTime.isSameOrBefore(moment())) {
+        continue;
+      }
+
+      Schedule.scheduleJob(scheduledDateTime.toDate(), async () => {
+        if (true === sentFollowUpKeys.has(followUpKey)) {
+          return;
+        }
+
+        const sent = await sendCalendarReminderFollowUp(client, channelID, matchedReminderGroup);
+        if (true === sent) {
+          sentFollowUpKeys.add(followUpKey);
+        }
+      });
+    }
+  }
+}
+
+function shouldScheduleCalendarReminderFollowUp(matchedReminderGroup: CalendarReminderGroup): boolean {
+  return false === hasCalendarReminderActualValues(matchedReminderGroup.events);
+}
+
+function getCalendarReminderFollowUpKey(matchedReminderGroup: CalendarReminderGroup): string {
+  const primaryEvent = matchedReminderGroup.events[0];
+  const roleId = getNormalizedRoleId(matchedReminderGroup.asset.roleId) ?? "missing-role";
+  const assetName = matchedReminderGroup.asset.name?.trim() || "calendar-reminder";
+  if (undefined === primaryEvent) {
+    return `${assetName}|${roleId}|missing-event`;
+  }
+
+  return `${assetName}|${roleId}|${primaryEvent.date}|${primaryEvent.time}|${primaryEvent.country}`;
+}
+
+async function sendCalendarReminderFollowUp(
+  client: TimerClient,
+  channelID: string,
+  matchedReminderGroup: CalendarReminderGroup,
+): Promise<boolean> {
+  const roleId = getNormalizedRoleId(matchedReminderGroup.asset.roleId);
+  const primaryEvent = matchedReminderGroup.events[0];
+  if (!roleId || undefined === primaryEvent) {
+    return false;
+  }
+
+  const refreshedEvents = await getCalendarEvents(primaryEvent.date, 0);
+  const refreshedReminderGroup = findMatchingCalendarReminderGroup(matchedReminderGroup, refreshedEvents);
+  const calendarEvents = refreshedReminderGroup?.events ?? matchedReminderGroup.events;
+
+  if (true === hasCalendarReminderActualValues(calendarEvents)) {
+    await sendAnnouncement(
+      client,
+      channelID,
+      {
+        content: getCalendarReminderUpdateMessage(roleId, calendarEvents),
+        allowedMentions: getAllowedRoleMentions(roleId),
+      },
+      calendarReminderAnnouncementSource,
+    );
+    return true;
+  }
+
+  if (false === hasCalendarReminderClearMetrics(calendarEvents)) {
+    const officialSummary = await getCalendarOfficialSummary(calendarEvents, {logger});
+    if (undefined !== officialSummary) {
+      await sendAnnouncement(
+        client,
+        channelID,
+        {
+          content: getCalendarReminderSummaryMessage(
+            roleId,
+            calendarEvents,
+            officialSummary.name,
+            officialSummary.summaryMarkdown,
+          ),
+          allowedMentions: getAllowedRoleMentions(roleId),
+        },
+        calendarReminderAnnouncementSource,
+      );
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function findMatchingCalendarReminderGroup(
+  matchedReminderGroup: CalendarReminderGroup,
+  calendarEvents: CalendarEvent[],
+): CalendarReminderGroup | undefined {
+  const followUpKey = getCalendarReminderFollowUpKey(matchedReminderGroup);
+  return getMatchedCalendarReminderEventGroups([matchedReminderGroup.asset], calendarEvents)
+    .find(candidate => getCalendarReminderFollowUpKey(candidate) === followUpKey);
 }
 
 function prependHeadlineToFirstMessage(


### PR DESCRIPTION
## Summary

- Adds economic calendar alert values for forecast, previous, and actual fields from the calendar payload.
- Adds post-release calendar alert follow-up polling at 5s, 10s, 20s, 30s, then 1m, 2m, 3m, 5m, 10m, and 15m after the release time.
- Adds official-source AI summaries for no-metric alert events such as FOMC statements, using Federal Reserve, BLS, or BEA source pages.
- Fixes tastytrade crypto change calculation so a known day reference price wins over tiny trade-level change fields.

## Impact

- Morning calendar reminders can show expected and previous values when present.
- Post-release updates can send actual-vs-expected/previous values once the provider publishes actuals.
- Text-only official releases get concise source-grounded summaries instead of empty metric output.
- Crypto status moves stay anchored to the day baseline once `prevDayClosePrice` has arrived.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`
