### PR TITLE
[codex] Fix Shell earnings extraction retries

### DIFF
--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -292,6 +292,63 @@ describe("AI earnings helpers", () => {
     expect(result?.metrics).toEqual([]);
   });
 
+  test("drops AI revenue metrics contradicted by evidence or extraction issues", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: "Q1 2026",
+                metrics: [{
+                  key: "revenue",
+                  numericValue: 17_741_000_000,
+                  currencyCode: "USD",
+                  sourceSnippet: "17,741 | 12,799 | 15,250 | Adjusted EBITDA",
+                }, {
+                  key: "revenue",
+                  numericValue: 0,
+                  currencyCode: "USD",
+                  sourceSnippet: "No explicit consolidated revenue figure was provided in the supplied filing text.",
+                }, {
+                  key: "net_income",
+                  numericValue: 5_694_000_000,
+                  currencyCode: "USD",
+                  sourceSnippet: "5,694 | 4,134 | 4,780 | Income attributable to Shell plc shareholders",
+                }],
+                issues: [
+                  "No explicit consolidated revenue figure was provided in the supplied filing text; the available summary shows income, adjusted earnings, EBITDA, cash flow, and EPS, but not revenue.",
+                ],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await extractEarningsWithAi({
+      companyName: "Shell",
+      filingForm: "6-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: `
+        <p>17,741 | 12,799 | 15,250 | Adjusted EBITDA</p>
+        <p>No explicit consolidated revenue figure was provided in the supplied filing text.</p>
+        <p>5,694 | 4,134 | 4,780 | Income attributable to Shell plc shareholders</p>
+      `,
+      ticker: "SHEL",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result?.metrics).toEqual([expect.objectContaining({
+      key: "net_income",
+      value: "$5.69B",
+    })]);
+  });
+
   test("caps AI calls with the local per-minute limiter", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -410,6 +410,8 @@ function getExtractionPrompt(input: EarningsAiExtractionInput, sourceText: strin
     "Rules:",
     "- Extract only values for the reported quarter, not year-to-date totals, prior-year periods, dates, footnotes, page numbers, share counts, percentages, or outlook.",
     "- Revenue and net income numericValue must be full currency units after applying table scale such as thousands, millions, or billions.",
+    "- Omit revenue when the filing excerpt does not explicitly report revenue, revenues, net sales, or third-party revenue.",
+    "- Do not use Adjusted EBITDA, sales volumes, production, cash flow, or a zero placeholder as revenue.",
     "- EPS numericValue must be currency units per share. Convert cents to dollars, e.g. 77 cents becomes 0.77.",
     "- Include adjusted EPS only when explicitly non-GAAP/adjusted. Include GAAP EPS only when explicitly GAAP/diluted/basic EPS.",
     "- Every metric must include a short exact sourceSnippet from the filing text that proves the metric and scale.",
@@ -459,13 +461,13 @@ function parseAiExtraction(value: unknown, sourceText: string): EarningsAiExtrac
     return null;
   }
 
-  const metrics = getArray(value["metrics"]).flatMap(metricValue => {
-    const metric = parseAiMetric(metricValue, sourceText);
-    return null === metric ? [] : [metric];
-  });
   const issues = getArray(value["issues"]).flatMap(issue =>
     "string" === typeof issue && "" !== issue.trim() ? [issue.trim()] : [],
   );
+  const metrics = getArray(value["metrics"]).flatMap(metricValue => {
+    const metric = parseAiMetric(metricValue, sourceText);
+    return null === metric || true === isContradictedByExtractionIssues(metric, issues) ? [] : [metric];
+  });
   const quarterLabel = parseQuarterLabel(value["quarterLabel"]);
   const result: EarningsAiExtraction = {
     issues,
@@ -506,6 +508,10 @@ function parseAiMetric(value: unknown, sourceText: string): EarningsResultMetric
     return null;
   }
 
+  if ("revenue" === key && (0 === numericValue || false === isRevenueEvidenceSnippet(sourceSnippet))) {
+    return null;
+  }
+
   if ("money" === definition.valueType && Math.abs(numericValue) > 20_000_000_000_000) {
     return null;
   }
@@ -520,6 +526,25 @@ function parseAiMetric(value: unknown, sourceText: string): EarningsResultMetric
       ? formatEps(numericValue, currencyCode)
       : formatMoneyCompact(numericValue, currencyCode),
   };
+}
+
+function isRevenueEvidenceSnippet(sourceSnippet: string): boolean {
+  if (/\b(?:adjusted\s+ebitda|sales\s+volumes?|production|cash\s+flow)\b/i.test(sourceSnippet)) {
+    return false;
+  }
+
+  return /\b(?:revenues?|net\s+sales|third-party\s+revenue|total\s+revenue)\b/i.test(sourceSnippet);
+}
+
+function isContradictedByExtractionIssues(metric: EarningsResultMetric, issues: string[]): boolean {
+  if ("revenue" !== metric.key) {
+    return false;
+  }
+
+  return issues.some(issue =>
+    /\b(?:no|not|without|missing|unable|could\s+not|does\s+not)\b.{0,120}\b(?:revenues?|sales)\b/i.test(issue) ||
+    /\b(?:revenues?|sales)\b.{0,120}\b(?:no|not|missing|unable|could\s+not|incorrect|not\s+directly|not\s+explicitly)\b/i.test(issue),
+  );
 }
 
 function parseQualityGate(value: unknown, sourceText: string): EarningsAiQualityGateResult | null {

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -125,6 +125,45 @@ describe("earnings result formatting", () => {
     ]));
   });
 
+  test("parses Shell-style revenue rows without treating sales volumes as revenue", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>1 st QUARTER 2026 UNAUDITED RESULTS</h1>
+          <p>$ million</p>
+          <p>527 | | (98) | | (247) | | Income/(loss) for the period | | | |</p>
+          <p>72 | 72 | 76 | External power sales (terawatt hours)</p>
+          <p>197 | 160 | 184 | Sales of pipeline gas to end-use customers (terawatt hours)</p>
+          <p>69,691 | | 64,093 | | 69,234 | | Revenue 1</p>
+          <p>1.01 | 0.72 | 0.79 | Basic earnings per share ($)</p>
+          <p>1.22 | 0.57 | 0.92 | Adjusted Earnings per share ($)</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q1 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        value: "$69.69B",
+      }),
+      expect.objectContaining({
+        key: "adjusted_eps",
+        value: "$1.22",
+      }),
+      expect.objectContaining({
+        key: "gaap_eps",
+        value: "$1.01",
+      }),
+    ]));
+    expect(parsedDocument.metrics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        value: "$527M",
+      }),
+    ]));
+  });
+
   test("renders result and outlook metrics before optional earnings summaries", () => {
     const parsedDocument = {
       metrics: [],

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -87,7 +87,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\brevenues?\b/i,
       /\bsales\b/i,
     ],
-    skipPattern: /\bcost\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b/i,
+    skipPattern: /\bcost\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b|\bsales\s+volumes?\b|\b(?:external\s+power|pipeline\s+gas|hydrocarbon)\s+sales\b|\bsales\s+of\s+pipeline\s+gas\b/i,
     valueType: "money",
   },
   {
@@ -408,6 +408,11 @@ function getQuarterLabel(text: string): string | undefined {
     return `${fiscalQuarterMatch[1].toUpperCase()} ${normalizeFiscalYear(fiscalQuarterMatch[2])}`;
   }
 
+  const ordinalQuarterMatch = text.match(/\b([1-4])\s*(?:st|nd|rd|th)\s+quarter\s+(20\d{2})\b/i);
+  if (undefined !== ordinalQuarterMatch?.[1] && undefined !== ordinalQuarterMatch[2]) {
+    return `Q${ordinalQuarterMatch[1]} ${ordinalQuarterMatch[2]}`;
+  }
+
   const writtenFiscalQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter(?:\s+and\s+full)?\s+(?:fiscal\s+year|FY)\s*(20\d{2}|\d{2})\b/i);
   if (undefined !== writtenFiscalQuarterMatch?.[1] && undefined !== writtenFiscalQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenFiscalQuarterMatch[1]);
@@ -605,9 +610,13 @@ function extractMetricValue(
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
   const searchText = patternMatch ? line.slice(patternMatch.index + patternMatch[0].length) : line;
+  const fallbackSearchText = patternMatch ? line.slice(0, patternMatch.index) : "";
 
   if ("eps" === valueType) {
     const value = findNumericValue(searchText, {
+      maxAbsValue: 100,
+      parseCents: true,
+    }) ?? findNumericValue(fallbackSearchText, {
       maxAbsValue: 100,
       parseCents: true,
     });
@@ -615,17 +624,26 @@ function extractMetricValue(
   }
 
   if ("money" === valueType) {
-    const parsedValue = findNumericValue(searchText, {
+    const searchValue = findNumericValue(searchText, {
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
       skipPercentages: true,
     });
+    const fallbackValue = findNumericValue(fallbackSearchText, {
+      requireMoneyCue: 1 === contextMoney.scale,
+      skipTableNoteRefs,
+      skipPercentages: true,
+    });
+    const useFallbackValue = null !== fallbackValue &&
+      (null === searchValue || true === isMetricLabelSuffixTableNote(searchText));
+    const parsedValue = true === useFallbackValue ? fallbackValue : searchValue ?? fallbackValue;
     if (null === parsedValue) {
       return null;
     }
 
-    const explicitScale = getExplicitMoneyScale(searchText);
-    const currencyCode = getCurrencyCodeFromText(searchText) ?? contextMoney.currencyCode;
+    const metricText = true === useFallbackValue ? fallbackSearchText : searchText;
+    const explicitScale = getExplicitMoneyScale(metricText);
+    const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
     const amount = parsedValue * (explicitScale ?? contextMoney.scale);
     return {
       currencyCode,
@@ -634,7 +652,8 @@ function extractMetricValue(
     };
   }
 
-  const value = findNumericValue(searchText, {skipPercentages: true});
+  const value = findNumericValue(searchText, {skipPercentages: true}) ??
+    findNumericValue(fallbackSearchText, {skipPercentages: true});
   if (null === value) {
     return null;
   }
@@ -674,6 +693,10 @@ function getContextMoney(lines: string[], lineIndex: number): MoneyContext {
   };
 }
 
+function isMetricLabelSuffixTableNote(text: string): boolean {
+  return /^\s*\d{1,2}\s*$/.test(text);
+}
+
 function isNearTableNoteColumn(lines: string[], lineIndex: number): boolean {
   for (let index = lineIndex; index >= 0 && index >= lineIndex - 5; index--) {
     const line = lines[index];
@@ -686,15 +709,15 @@ function isNearTableNoteColumn(lines: string[], lineIndex: number): boolean {
 }
 
 function getMoneyScaleFromContextText(text: string): number | null {
-  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?thousands(?:\s+of\s+dollars)?\b/i.test(text)) {
+  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?thousands?(?:\s+of\s+dollars)?\b/i.test(text)) {
     return 1_000;
   }
 
-  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?millions(?:\s+of\s+dollars)?\b/i.test(text)) {
+  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?millions?(?:\s+of\s+dollars)?\b/i.test(text)) {
     return 1_000_000;
   }
 
-  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?billions(?:\s+of\s+dollars)?\b/i.test(text)) {
+  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?billions?(?:\s+of\s+dollars)?\b/i.test(text)) {
     return 1_000_000_000;
   }
 

--- a/modules/earnings-results.test.ts
+++ b/modules/earnings-results.test.ts
@@ -13,6 +13,12 @@ type NoMetricsSkipStateForTest = {
   retryAfterMs: number;
 };
 
+type QualityGateSkipStateForTest = {
+  attempts: number;
+  gaveUp: boolean;
+  retryAfterMs: number;
+};
+
 describe("earnings result announcements", () => {
   const logger = {
     log: vi.fn(),
@@ -370,7 +376,7 @@ describe("earnings result announcements", () => {
     expect(postWithRetryFn).toHaveBeenCalledTimes(1);
   });
 
-  test("suppresses hard revenue contradictions after AI extraction without a quality gate override", async () => {
+  test("suppresses hard revenue contradictions and stops retrying after repeated AI checks", async () => {
     getWithRetryFn.mockImplementation(async (url: string) => {
       if (url.includes("company_tickers.json")) {
         return {
@@ -474,38 +480,76 @@ describe("earnings result announcements", () => {
         }],
       },
     });
-    const skippedQualityGateAccessions = new Map<string, number>();
+    const skippedQualityGateAccessions = new Map<string, QualityGateSkipStateForTest>();
+    const getDependenciesForTime = (time: string) => ({
+      getEarningsResultFn,
+      getWithRetryFn,
+      logger,
+      now: () => moment.tz(time, "YYYY-MM-DD HH:mm", "US/Eastern"),
+      postWithRetryFn,
+      readSecretFn: vi.fn((secretName: string) => {
+        if ("gemini_api_key" === secretName) {
+          return "gemini-key";
+        }
+
+        if ("gemini_calls_per_minute" === secretName) {
+          return "14";
+        }
+
+        throw new Error(`missing ${secretName}`);
+      }),
+    });
 
     const result = await getEarningsResultAnnouncements({
-      dependencies: {
-        getEarningsResultFn,
-        getWithRetryFn,
-        logger,
-        now: () => moment.tz("2026-05-01 08:05", "YYYY-MM-DD HH:mm", "US/Eastern"),
-        postWithRetryFn,
-        readSecretFn: vi.fn((secretName: string) => {
-          if ("gemini_api_key" === secretName) {
-            return "gemini-key";
-          }
-
-          if ("gemini_calls_per_minute" === secretName) {
-            return "14";
-          }
-
-          throw new Error(`missing ${secretName}`);
-        }),
-      },
+      dependencies: getDependenciesForTime("2026-05-01 08:05"),
       skippedQualityGateAccessions,
     });
 
     expect(result.announcements).toEqual([]);
     expect(postWithRetryFn).toHaveBeenCalledTimes(1);
-    expect(skippedQualityGateAccessions.get("0000034088-26-000042")).toBe(
-      moment.tz("2026-05-01 08:10", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
-    );
+    expect(skippedQualityGateAccessions.get("0000034088-26-000042")).toEqual({
+      attempts: 1,
+      gaveUp: false,
+      retryAfterMs: moment.tz("2026-05-01 08:10", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
+    });
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
       "Skipping earnings result announcement for XOM: suspicious metrics were not verified.",
+    );
+
+    postWithRetryFn.mockClear();
+    logger.log.mockClear();
+
+    const retryResult = await getEarningsResultAnnouncements({
+      dependencies: getDependenciesForTime("2026-05-01 08:11"),
+      skippedQualityGateAccessions,
+    });
+
+    expect(retryResult.announcements).toEqual([]);
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(skippedQualityGateAccessions.get("0000034088-26-000042")).toEqual({
+      attempts: 2,
+      gaveUp: true,
+      retryAfterMs: Number.POSITIVE_INFINITY,
+    });
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "Giving up earnings result announcement for XOM: suspicious metrics were not verified after 2 attempts.",
+    );
+
+    postWithRetryFn.mockClear();
+    logger.log.mockClear();
+
+    const gaveUpResult = await getEarningsResultAnnouncements({
+      dependencies: getDependenciesForTime("2026-05-01 08:16"),
+      skippedQualityGateAccessions,
+    });
+
+    expect(gaveUpResult.announcements).toEqual([]);
+    expect(postWithRetryFn).not.toHaveBeenCalled();
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("suspicious metrics were not verified"),
     );
   });
 
@@ -1519,7 +1563,7 @@ describe("earnings result announcements", () => {
         },
       });
 
-    const skippedQualityGateAccessions = new Map<string, number>();
+    const skippedQualityGateAccessions = new Map<string, QualityGateSkipStateForTest>();
     const result = await getEarningsResultAnnouncements({
       dependencies: {
         getEarningsResultFn,
@@ -1544,9 +1588,11 @@ describe("earnings result announcements", () => {
 
     expect(result.announcements).toEqual([]);
     expect(postWithRetryFn).toHaveBeenCalledTimes(2);
-    expect(skippedQualityGateAccessions.get("0001193125-26-123456")).toBe(
-      moment.tz("2026-05-01 08:10", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
-    );
+    expect(skippedQualityGateAccessions.get("0001193125-26-123456")).toEqual({
+      attempts: 1,
+      gaveUp: false,
+      retryAfterMs: moment.tz("2026-05-01 08:10", "YYYY-MM-DD HH:mm", "US/Eastern").valueOf(),
+    });
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
       "Skipping earnings result announcement for BUD: suspicious metrics were not verified.",

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -135,6 +135,12 @@ type NoMetricsSkipState = {
   retryAfterMs: number;
 };
 
+type QualityGateSkipState = {
+  attempts: number;
+  gaveUp: boolean;
+  retryAfterMs: number;
+};
+
 type SecFilingDetails = {
   documentUrl: string;
   html: string;
@@ -162,6 +168,7 @@ const earningsResultMinMarketCap = 100_000_000_000;
 const earningsWatchTtlMs = 15 * 60_000;
 const noMetricsRetryDelayMs = 5 * 60_000;
 const noMetricsGiveUpDelayMs = 15 * 60_000;
+const qualityGateMaxAttempts = 2;
 const qualityGateRetryDelayMs = 5 * 60_000;
 const nasdaqEarningsSurpriseEndpoint = "https://api.nasdaq.com/api/company";
 const noMentions = {
@@ -196,7 +203,7 @@ export function startEarningsResultWatcher(
   const seenAccessions = new Set<string>();
   const seenResultKeys = new Set<string>();
   const skippedNoMetricsAccessions = new Map<string, NoMetricsSkipState>();
-  const skippedQualityGateAccessions = new Map<string, number>();
+  const skippedQualityGateAccessions = new Map<string, QualityGateSkipState>();
   const dependencies = getDependencies(options);
   let seenAccessionsSeeded = false;
   let stopped = false;
@@ -231,7 +238,7 @@ export function startEarningsResultWatcher(
       seenAccessions: Set<string>;
       seenResultKeys: Set<string>;
       skippedNoMetricsAccessions: Map<string, NoMetricsSkipState>;
-      skippedQualityGateAccessions: Map<string, number>;
+      skippedQualityGateAccessions: Map<string, QualityGateSkipState>;
     } = {
       dependencies,
       seenAccessions,
@@ -311,7 +318,7 @@ export async function getEarningsResultAnnouncements({
   seenAccessions = new Set<string>(),
   seenResultKeys = new Set<string>(),
   skippedNoMetricsAccessions = new Map<string, NoMetricsSkipState>(),
-  skippedQualityGateAccessions = new Map<string, number>(),
+  skippedQualityGateAccessions = new Map<string, QualityGateSkipState>(),
 }: {
   dependencies?: EarningsResultDependencies;
   maxAnnouncementsPerScan?: number;
@@ -319,7 +326,7 @@ export async function getEarningsResultAnnouncements({
   seenAccessions?: Set<string>;
   seenResultKeys?: Set<string>;
   skippedNoMetricsAccessions?: Map<string, NoMetricsSkipState>;
-  skippedQualityGateAccessions?: Map<string, number>;
+  skippedQualityGateAccessions?: Map<string, QualityGateSkipState>;
 } = {}): Promise<EarningsResultScanResult> {
   const now = dependencies.now().clone().tz(usEasternTimezone);
   const watches = await getTodaysEarningsWatches(dependencies, now);
@@ -346,13 +353,11 @@ export async function getEarningsResultAnnouncements({
       continue;
     }
 
-    const qualityGateRetryAfterMs = skippedQualityGateAccessions.get(filing.accessionNumber);
-    if (undefined !== qualityGateRetryAfterMs) {
-      if (now.valueOf() < qualityGateRetryAfterMs) {
+    const qualityGateSkipState = skippedQualityGateAccessions.get(filing.accessionNumber);
+    if (undefined !== qualityGateSkipState) {
+      if (true === qualityGateSkipState.gaveUp || now.valueOf() < qualityGateSkipState.retryAfterMs) {
         continue;
       }
-
-      skippedQualityGateAccessions.delete(filing.accessionNumber);
     }
 
     const noMetricsSkipState = skippedNoMetricsAccessions.get(filing.accessionNumber);
@@ -651,7 +656,7 @@ async function buildEarningsResultAnnouncement(
   dependencies: EarningsResultDependencies,
   now: moment.Moment,
   skippedNoMetricsAccessions: Map<string, NoMetricsSkipState>,
-  skippedQualityGateAccessions: Map<string, number>,
+  skippedQualityGateAccessions: Map<string, QualityGateSkipState>,
 ): Promise<EarningsResultAnnouncement | null> {
   const [filingDetails, xbrlMetrics] = await Promise.all([
     loadSecFilingDetails(filing, dependencies, {
@@ -727,11 +732,7 @@ async function buildEarningsResultAnnouncement(
     ticker: watch.event.ticker,
   });
   if (true === hasHardMetricContradiction(suspiciousReasons)) {
-    skippedQualityGateAccessions.set(filing.accessionNumber, now.valueOf() + qualityGateRetryDelayMs);
-    dependencies.logger.log(
-      "warn",
-      `Skipping earnings result announcement for ${watch.event.ticker}: suspicious metrics were not verified.`,
-    );
+    updateQualityGateSkipState(filing, watch, dependencies, now, skippedQualityGateAccessions);
     return null;
   }
 
@@ -748,13 +749,11 @@ async function buildEarningsResultAnnouncement(
     ticker: watch.event.ticker,
   }, dependencies);
   if (true === shouldSuppressAnnouncement(qualityGate, suspiciousReasons)) {
-    skippedQualityGateAccessions.set(filing.accessionNumber, now.valueOf() + qualityGateRetryDelayMs);
-    dependencies.logger.log(
-      "warn",
-      `Skipping earnings result announcement for ${watch.event.ticker}: suspicious metrics were not verified.`,
-    );
+    updateQualityGateSkipState(filing, watch, dependencies, now, skippedQualityGateAccessions);
     return null;
   }
+
+  skippedQualityGateAccessions.delete(filing.accessionNumber);
 
   const summary = await summarizeEarningsWithAi({
     companyName: watch.companyName,
@@ -789,6 +788,29 @@ async function buildEarningsResultAnnouncement(
 
 function hasParsedEarningsDocumentContent(parsedDocument: ParsedEarningsDocument): boolean {
   return 0 < parsedDocument.metrics.length || 0 < parsedDocument.outlook.length;
+}
+
+function updateQualityGateSkipState(
+  filing: SecCurrentFiling,
+  watch: EarningsWatchEntry,
+  dependencies: EarningsResultDependencies,
+  now: moment.Moment,
+  skippedQualityGateAccessions: Map<string, QualityGateSkipState>,
+) {
+  const existingState = skippedQualityGateAccessions.get(filing.accessionNumber);
+  const attempts = (existingState?.attempts ?? 0) + 1;
+  const gaveUp = attempts >= qualityGateMaxAttempts;
+  skippedQualityGateAccessions.set(filing.accessionNumber, {
+    attempts,
+    gaveUp,
+    retryAfterMs: gaveUp ? Number.POSITIVE_INFINITY : now.valueOf() + qualityGateRetryDelayMs,
+  });
+  dependencies.logger.log(
+    "warn",
+    true === gaveUp
+      ? `Giving up earnings result announcement for ${watch.event.ticker}: suspicious metrics were not verified after ${attempts} attempts.`
+      : `Skipping earnings result announcement for ${watch.event.ticker}: suspicious metrics were not verified.`,
+  );
 }
 
 function updateNoMetricsSkipState(


### PR DESCRIPTION
## Summary
- parse Shell-style revenue rows where values appear before labels such as Revenue 1 under a $ million table header
- reject AI revenue extractions backed by EBITDA, sales-volume, zero, or self-contradictory no-revenue evidence
- cap repeated quality-gate retries after two suspicious attempts per accession

## Root Cause
Shell's Q1 filing puts top-line revenue in the EX-99.2 quarterly report, below the summary table. The parser could miss that row and the AI fallback could keep trying to force revenue from the summary table, including Adjusted EBITDA or zero placeholders.

## Validation
- npm test -- modules/earnings-results-format.test.ts modules/earnings-results-ai.test.ts modules/earnings-results.test.ts
- npm run typecheck
- npm run lint
- npm run test:coverage