### PR TITLE
[codex] Ground close recaps with ticker facts

### DIFF
--- a/modules/market-close-recap.test.ts
+++ b/modules/market-close-recap.test.ts
@@ -4,6 +4,7 @@ import {
   findMarketOpenSentimentPollMessage,
   getMarketCloseRecap,
 } from "./market-close-recap.ts";
+import {type MarketCloseTickerFact} from "./market-close-ticker-facts.ts";
 
 describe("market close recap", () => {
   const logger = {
@@ -21,6 +22,112 @@ describe("market close recap", () => {
     summaryMarkdown: "`SPX` schloss über dem Open. Der `VIX` fiel um `1,1 Punkte`.",
     winningPollAnswer: "Risk-on",
   };
+  const riskOnTickerFacts = [{
+    close: 5225,
+    closeChange: 25,
+    closeChangePercent: 0.48,
+    date: "2026-05-07",
+    high: 5230,
+    low: 5175,
+    open: 5190,
+    openToCloseChange: 35,
+    openToCloseChangePercent: 0.67,
+    previousClose: 5200,
+    sourceSymbol: "^GSPC",
+    symbol: "SPX",
+  }, {
+    close: 18750,
+    closeChange: 90,
+    closeChangePercent: 0.48,
+    date: "2026-05-07",
+    high: 18780,
+    low: 18550,
+    open: 18610,
+    openToCloseChange: 140,
+    openToCloseChangePercent: 0.75,
+    previousClose: 18660,
+    sourceSymbol: "^NDX",
+    symbol: "NQ",
+  }, {
+    close: 2095,
+    closeChange: 15,
+    closeChangePercent: 0.72,
+    date: "2026-05-07",
+    high: 2100,
+    low: 2070,
+    open: 2080,
+    openToCloseChange: 15,
+    openToCloseChangePercent: 0.72,
+    previousClose: 2080,
+    sourceSymbol: "^RUT",
+    symbol: "RTY",
+  }, {
+    close: 17.1,
+    closeChange: -0.4,
+    closeChangePercent: -2.29,
+    date: "2026-05-07",
+    high: 17.7,
+    low: 16.9,
+    open: 17.4,
+    openToCloseChange: -0.3,
+    openToCloseChangePercent: -1.72,
+    previousClose: 17.5,
+    sourceSymbol: "^VIX",
+    symbol: "VIX",
+  }] satisfies MarketCloseTickerFact[];
+  const weakTickerFacts = [{
+    close: 5110,
+    closeChange: -80,
+    closeChangePercent: -1.54,
+    date: "2026-05-07",
+    high: 5220,
+    low: 5100,
+    open: 5200,
+    openToCloseChange: -90,
+    openToCloseChangePercent: -1.73,
+    previousClose: 5190,
+    sourceSymbol: "^GSPC",
+    symbol: "SPX",
+  }, {
+    close: 18280,
+    closeChange: -180,
+    closeChangePercent: -0.98,
+    date: "2026-05-07",
+    high: 18620,
+    low: 18230,
+    open: 18570,
+    openToCloseChange: -290,
+    openToCloseChangePercent: -1.56,
+    previousClose: 18460,
+    sourceSymbol: "^NDX",
+    symbol: "NQ",
+  }, {
+    close: 2035,
+    closeChange: -40,
+    closeChangePercent: -1.93,
+    date: "2026-05-07",
+    high: 2088,
+    low: 2025,
+    open: 2070,
+    openToCloseChange: -35,
+    openToCloseChangePercent: -1.69,
+    previousClose: 2075,
+    sourceSymbol: "^RUT",
+    symbol: "RTY",
+  }, {
+    close: 17.39,
+    closeChange: 0.01,
+    closeChangePercent: 0.06,
+    date: "2026-05-07",
+    high: 18.2,
+    low: 17.1,
+    open: 17.38,
+    openToCloseChange: 0.01,
+    openToCloseChangePercent: 0.06,
+    previousClose: 17.38,
+    sourceSymbol: "^VIX",
+    symbol: "VIX",
+  }] satisfies MarketCloseTickerFact[];
 
   function createPostWithRecap(overrides: Record<string, unknown> = {}) {
     return vi.fn().mockResolvedValue({
@@ -37,6 +144,34 @@ describe("market close recap", () => {
         }],
       },
     });
+  }
+
+  function createYahooChartResponse(
+    previousTimestamp: number,
+    targetTimestamp: number,
+    previousClose: number,
+    open: number,
+    high: number,
+    low: number,
+    close: number,
+  ) {
+    return {
+      data: {
+        chart: {
+          result: [{
+            indicators: {
+              quote: [{
+                close: [previousClose, close],
+                high: [previousClose, high],
+                low: [previousClose, low],
+                open: [previousClose, open],
+              }],
+            },
+            timestamp: [previousTimestamp, targetTimestamp],
+          }],
+        },
+      },
+    };
   }
 
   function createPollMessage(answerText: string, fetch: ReturnType<typeof vi.fn>) {
@@ -133,6 +268,84 @@ describe("market close recap", () => {
     );
     const requestBody = postWithRetryFn.mock.calls[0]?.[1] as {contents?: {parts?: {text?: string}[]}[]};
     expect(requestBody.contents?.[0]?.parts?.[0]?.text).toContain("Der `VIX` darf niemals als Prozentwert beschrieben werden.");
+    expect(requestBody.contents?.[0]?.parts?.[0]?.text).toContain("Reuters, Bloomberg, CNBC, MarketWatch, WSJ, Nasdaq, NYSE, Cboe und S&P Dow Jones Indices");
+  });
+
+  test("grounds the close recap prompt with ticker facts when available", async () => {
+    const postWithRetryFn = createPostWithRecap();
+
+    const recap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    }, {
+      date: new Date("2026-05-07T20:15:00Z"),
+      tickerFacts: riskOnTickerFacts,
+    });
+
+    expect(recap?.content).toContain("Das heutige Sentiment war: **🟢 Risk-on**");
+    const requestBody = postWithRetryFn.mock.calls[0]?.[1] as {contents?: {parts?: {text?: string}[]}[]};
+    const prompt = requestBody.contents?.[0]?.parts?.[0]?.text ?? "";
+    expect(prompt).toContain("Verifizierte Ticker-Daten aus Daily-Bars fuer den Zieltag:");
+    expect(prompt).toContain("`SPX` (^GSPC); Open `5.190,00`; High `5.230,00`; Low `5.175,00`; Close `5.225,00`");
+    expect(prompt).toContain("Diese Ticker-Daten haben Vorrang vor News-Texten");
+    expect(prompt).toContain("Behaupte keine Schlusskurs-Rekorde");
+  });
+
+  test("loads daily ticker bars before asking the AI provider", async () => {
+    const postWithRetryFn = createPostWithRecap();
+    const previousTimestamp = Date.parse("2026-05-06T13:30:00Z") / 1000;
+    const targetTimestamp = Date.parse("2026-05-07T13:30:00Z") / 1000;
+    const getWithRetryFn = vi.fn()
+      .mockResolvedValueOnce(createYahooChartResponse(previousTimestamp, targetTimestamp, 5200, 5190, 5230, 5175, 5225))
+      .mockResolvedValueOnce(createYahooChartResponse(previousTimestamp, targetTimestamp, 18660, 18610, 18780, 18550, 18750))
+      .mockResolvedValueOnce(createYahooChartResponse(previousTimestamp, targetTimestamp, 2080, 2080, 2100, 2070, 2095))
+      .mockResolvedValueOnce(createYahooChartResponse(previousTimestamp, targetTimestamp, 17.5, 17.4, 17.7, 16.9, 17.1));
+
+    await getMarketCloseRecap(undefined, {
+      getWithRetryFn,
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    }, {
+      date: new Date("2026-05-07T20:15:00Z"),
+    });
+
+    expect(getWithRetryFn).toHaveBeenCalledTimes(4);
+    expect(getWithRetryFn).toHaveBeenCalledWith(
+      expect.stringContaining("/%5EGSPC?"),
+      undefined,
+      expect.objectContaining({
+        maxAttempts: 2,
+        timeoutMs: 8_000,
+      }),
+    );
+    const requestBody = postWithRetryFn.mock.calls[0]?.[1] as {contents?: {parts?: {text?: string}[]}[]};
+    expect(requestBody.contents?.[0]?.parts?.[0]?.text).toContain("Close-to-close `+0,48%`");
+  });
+
+  test("rejects stale bullish close-high claims that contradict ticker facts", async () => {
+    const recap = await getMarketCloseRecap(undefined, {
+      logger,
+      postWithRetryFn: createPostWithRecap({
+        sentimentTitle: "breiter Risikoappetit bis zum Schluss",
+        summaryMarkdown: [
+          "`SPX` und `NQ` zogen bis zum regulären Close auf neue Hochs, `RTY` lief mit.",
+          "Der `VIX` stand praktisch seitwärts bei `17,39` und änderte sich um `+0,01 Punkte`.",
+        ].join("\n"),
+        winningPollAnswer: "Risk-on",
+      }),
+      readSecretFn,
+    }, {
+      date: new Date("2026-05-07T20:15:00Z"),
+      tickerFacts: weakTickerFacts,
+    });
+
+    expect(recap).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      "AI market close recap contradicted ticker facts: output claimed closing highs not supported by ticker facts.",
+    );
   });
 
   test("stays disabled when the active provider API key is missing", async () => {

--- a/modules/market-close-recap.ts
+++ b/modules/market-close-recap.ts
@@ -1,5 +1,12 @@
 import moment from "moment-timezone";
 import {callAiProviderJson, type AiProviderDependencies} from "./ai-provider.ts";
+import {type getWithRetry} from "./http-retry.ts";
+import {
+  formatMarketCloseTickerFactsForPrompt,
+  getTickerFactValidationIssue,
+  loadMarketCloseTickerFacts,
+  type MarketCloseTickerFact,
+} from "./market-close-ticker-facts.ts";
 
 export type MarketCloseSentimentAnswer = "Risk-on" | "Risk-off" | "Cash" | "Chaos";
 
@@ -8,12 +15,15 @@ export type MarketCloseRecapPayload = {
   content: string;
 };
 
-export type MarketCloseRecapDependencies = AiProviderDependencies;
+export type MarketCloseRecapDependencies = AiProviderDependencies & {
+  getWithRetryFn?: typeof getWithRetry | undefined;
+};
 
 export type MarketCloseRecapOptions = {
   date?: Date | undefined;
   maxFetchedWinners?: number | undefined;
   maxMentionedWinners?: number | undefined;
+  tickerFacts?: MarketCloseTickerFact[] | null | undefined;
 };
 
 type PollAnswerFetchOptions = {
@@ -108,8 +118,10 @@ export async function getMarketCloseRecap(
   dependencies: MarketCloseRecapDependencies,
   options: MarketCloseRecapOptions = {},
 ): Promise<MarketCloseRecapPayload | undefined> {
+  const date = options.date ?? new Date();
+  const tickerFacts = await getTickerFacts(date, dependencies, options);
   const jsonText = await callAiProviderJson(
-    getMarketCloseRecapPrompt(options.date ?? new Date()),
+    getMarketCloseRecapPrompt(date, tickerFacts),
     marketCloseRecapSchema,
     dependencies,
     "market close recap",
@@ -129,7 +141,7 @@ export async function getMarketCloseRecap(
     return undefined;
   }
 
-  const recap = parseAiMarketCloseRecap(jsonText, dependencies);
+  const recap = parseAiMarketCloseRecap(jsonText, dependencies, tickerFacts);
   if (undefined === recap) {
     return undefined;
   }
@@ -191,12 +203,36 @@ function getMessageManager(channel: unknown): {fetch?: (options?: {limit?: numbe
   };
 }
 
-function getMarketCloseRecapPrompt(date: Date): string {
+async function getTickerFacts(
+  date: Date,
+  dependencies: MarketCloseRecapDependencies,
+  options: MarketCloseRecapOptions,
+): Promise<MarketCloseTickerFact[]> {
+  if (Array.isArray(options.tickerFacts)) {
+    return options.tickerFacts;
+  }
+
+  if (null === options.tickerFacts || undefined === dependencies.getWithRetryFn) {
+    return [];
+  }
+
+  return loadMarketCloseTickerFacts(date, {
+    getWithRetryFn: dependencies.getWithRetryFn,
+    logger: dependencies.logger,
+  });
+}
+
+function getMarketCloseRecapPrompt(date: Date, tickerFacts: MarketCloseTickerFact[]): string {
   const usEasternDate = moment(date).tz(usEasternTimezone).format("YYYY-MM-DD");
+  const tickerFactsPrompt = formatMarketCloseTickerFactsForPrompt(tickerFacts);
   return [
     `Heute ist nach US-Börsenschluss am ${usEasternDate} (US/Eastern).`,
     "Nutze Websuche, um den US-Cash-Handelstag realitätsnah einzuordnen.",
+    "Priorisiere bei schnellen Markt-Wrapups offizielle Börsen-/Indexanbieter und etablierte Finanznachrichten wie Reuters, Bloomberg, CNBC, MarketWatch, WSJ, Nasdaq, NYSE, Cboe und S&P Dow Jones Indices.",
+    "Ignoriere Blogs, Social Posts, SEO-Seiten und fachfremde Nachrichtenportale, wenn sie den Ticker-Daten oder autoritativen Finanzquellen widersprechen.",
+    tickerFactsPrompt,
     "Bewerte den Handelstag vom regulären US-Open bis zum regulären US-Close.",
+    "Für die Poll-Sentiment-Auswahl ist Open-to-close maßgeblich; Close-to-close darf nur als Tagesveränderung genannt werden.",
     "Berücksichtige ausschließlich `SPX`, `NQ`, `RTY` sowie zwingend den `VIX`.",
     "Erwähne nicht die ETF-Pendants `SPY`, `QQQ` oder `IWM`.",
     "Der `VIX` darf niemals als Prozentwert beschrieben werden. Beschreibe ihn nur als Stand, Veränderung in Punkten oder Richtung, z.B. `18,4` auf `20,1` oder `+1,7 Punkte`.",
@@ -213,12 +249,13 @@ function getMarketCloseRecapPrompt(date: Date): string {
     "Formatiere Ticker und konkrete Kennzahlen als Inline-Code, z.B. `SPX`, `NQ`, `RTY`, `+0,4%`, `1,7 Punkte`.",
     "Erwähne weder KI-Anbieter, KI, Modell, Websuche, Quellen, Grounding noch Rechercheprozess.",
     "Keine Disclaimer, keine Links, keine Tabellen, keine Codeblöcke.",
-  ].join("\n");
+  ].filter(line => "" !== line).join("\n");
 }
 
 function parseAiMarketCloseRecap(
   jsonText: string,
   dependencies: MarketCloseRecapDependencies,
+  tickerFacts: MarketCloseTickerFact[],
 ): AiMarketCloseRecap | undefined {
   const parsedJson = parseJson(jsonText);
   if (false === isRecord(parsedJson)) {
@@ -254,6 +291,15 @@ function parseAiMarketCloseRecap(
     dependencies.logger.log(
       "warn",
       "AI market close recap failed output validation.",
+    );
+    return undefined;
+  }
+
+  const tickerValidationIssue = getTickerFactValidationIssue(combinedText, winningPollAnswer, tickerFacts);
+  if (undefined !== tickerValidationIssue) {
+    dependencies.logger.log(
+      "warn",
+      `AI market close recap contradicted ticker facts: ${tickerValidationIssue}.`,
     );
     return undefined;
   }

--- a/modules/market-close-ticker-facts.ts
+++ b/modules/market-close-ticker-facts.ts
@@ -1,0 +1,331 @@
+import moment from "moment-timezone";
+import {type getWithRetry} from "./http-retry.ts";
+
+export type MarketCloseTickerSymbol = "SPX" | "NQ" | "RTY" | "VIX";
+
+export type MarketCloseTickerFact = {
+  close: number;
+  closeChange: number;
+  closeChangePercent: number;
+  date: string;
+  high: number;
+  low: number;
+  open: number;
+  openToCloseChange: number;
+  openToCloseChangePercent: number;
+  previousClose: number;
+  sourceSymbol: string;
+  symbol: MarketCloseTickerSymbol;
+};
+
+type Logger = {
+  log: (level: string, message: string) => void;
+};
+
+type MarketCloseTickerFactsDependencies = {
+  getWithRetryFn: typeof getWithRetry;
+  logger: Logger;
+};
+
+type YahooChartResponse = {
+  chart?: {
+    error?: unknown;
+    result?: unknown;
+  };
+};
+
+type YahooDailyBar = {
+  close: number;
+  date: string;
+  high: number;
+  low: number;
+  open: number;
+};
+
+const usEasternTimezone = "US/Eastern";
+const yahooChartBaseUrl = "https://query1.finance.yahoo.com/v8/finance/chart";
+const yahooTickers = [
+  {symbol: "SPX", sourceSymbol: "^GSPC"},
+  {symbol: "NQ", sourceSymbol: "^NDX"},
+  {symbol: "RTY", sourceSymbol: "^RUT"},
+  {symbol: "VIX", sourceSymbol: "^VIX"},
+] satisfies {sourceSymbol: string; symbol: MarketCloseTickerSymbol}[];
+
+export async function loadMarketCloseTickerFacts(
+  date: Date,
+  dependencies: MarketCloseTickerFactsDependencies,
+): Promise<MarketCloseTickerFact[]> {
+  const facts = await Promise.all(yahooTickers.map(ticker => loadTickerFact(date, ticker, dependencies)));
+  return facts.filter(isDefined);
+}
+
+export function formatMarketCloseTickerFactsForPrompt(facts: MarketCloseTickerFact[]): string {
+  if (0 === facts.length) {
+    return "";
+  }
+
+  return [
+    "Verifizierte Ticker-Daten aus Daily-Bars fuer den Zieltag:",
+    ...facts.map(fact => [
+      `- \`${fact.symbol}\` (${fact.sourceSymbol})`,
+      `Open \`${formatValue(fact.open)}\``,
+      `High \`${formatValue(fact.high)}\``,
+      `Low \`${formatValue(fact.low)}\``,
+      `Close \`${formatValue(fact.close)}\``,
+      `Vortag \`${formatValue(fact.previousClose)}\``,
+      `Close-to-close \`${formatSignedPercent(fact.closeChangePercent)}\``,
+      `Open-to-close \`${formatSignedPercent(fact.openToCloseChangePercent)}\``,
+    ].join("; ")),
+    "Diese Ticker-Daten haben Vorrang vor News-Texten: Nutze Websuche nur fuer Ursachen/Einordnung, nicht fuer Richtung, Schlusskurs oder Sentiment.",
+    "Behaupte keine Schlusskurs-Rekorde, neuen Hochs zum Close oder breite Staerke, wenn diese Daily-Bars das nicht stuetzen.",
+  ].join("\n");
+}
+
+export function getTickerFactValidationIssue(
+  combinedText: string,
+  winningPollAnswer: string,
+  facts: MarketCloseTickerFact[],
+): string | undefined {
+  if (0 === facts.length) {
+    return undefined;
+  }
+
+  if (true === hasUnsupportedClosingHighClaim(combinedText, facts)) {
+    return "output claimed closing highs not supported by ticker facts";
+  }
+
+  const contradictedSymbol = facts.find(fact => hasSymbolDirectionContradiction(combinedText, fact))?.symbol;
+  if (undefined !== contradictedSymbol) {
+    return `output direction contradicted ticker facts for ${contradictedSymbol}`;
+  }
+
+  if (true === hasUnsupportedSentimentAnswer(winningPollAnswer, facts)) {
+    return `poll answer ${winningPollAnswer} contradicted ticker facts`;
+  }
+
+  return undefined;
+}
+
+async function loadTickerFact(
+  date: Date,
+  ticker: {sourceSymbol: string; symbol: MarketCloseTickerSymbol},
+  dependencies: MarketCloseTickerFactsDependencies,
+): Promise<MarketCloseTickerFact | undefined> {
+  const targetDate = moment(date).tz(usEasternTimezone).format("YYYY-MM-DD");
+  const requestStart = moment.tz(`${targetDate} 00:00`, "YYYY-MM-DD HH:mm", usEasternTimezone).subtract(10, "days");
+  const requestEnd = moment.tz(`${targetDate} 00:00`, "YYYY-MM-DD HH:mm", usEasternTimezone).add(2, "days");
+  const url = `${yahooChartBaseUrl}/${encodeURIComponent(ticker.sourceSymbol)}` +
+    `?period1=${requestStart.unix()}` +
+    `&period2=${requestEnd.unix()}` +
+    "&interval=1d" +
+    "&includePrePost=false";
+
+  const response = await dependencies.getWithRetryFn<YahooChartResponse>(url, undefined, {
+    maxAttempts: 2,
+    timeoutMs: 8_000,
+  }).catch(error => {
+    dependencies.logger.log(
+      "warn",
+      `Could not load market close ticker facts for ${ticker.symbol}: ${error}`,
+    );
+    return undefined;
+  });
+  if (undefined === response) {
+    return undefined;
+  }
+
+  const bars = parseYahooDailyBars(response.data);
+  const targetIndex = bars.findIndex(bar => bar.date === targetDate);
+  if (targetIndex <= 0) {
+    dependencies.logger.log(
+      "warn",
+      `Market close ticker facts for ${ticker.symbol} did not include ${targetDate} with a prior close.`,
+    );
+    return undefined;
+  }
+
+  const targetBar = bars[targetIndex];
+  const previousBar = bars[targetIndex - 1];
+  if (undefined === targetBar || undefined === previousBar) {
+    return undefined;
+  }
+
+  const closeChange = targetBar.close - previousBar.close;
+  const openToCloseChange = targetBar.close - targetBar.open;
+  return {
+    close: targetBar.close,
+    closeChange,
+    closeChangePercent: getPercentChange(closeChange, previousBar.close),
+    date: targetBar.date,
+    high: targetBar.high,
+    low: targetBar.low,
+    open: targetBar.open,
+    openToCloseChange,
+    openToCloseChangePercent: getPercentChange(openToCloseChange, targetBar.open),
+    previousClose: previousBar.close,
+    sourceSymbol: ticker.sourceSymbol,
+    symbol: ticker.symbol,
+  };
+}
+
+function parseYahooDailyBars(data: YahooChartResponse): YahooDailyBar[] {
+  const result = getFirstResult(data);
+  if (undefined === result) {
+    return [];
+  }
+
+  const timestamps = getNumberArray(result["timestamp"]);
+  const quote = getFirstQuote(result);
+  if (undefined === quote) {
+    return [];
+  }
+
+  const opens = getNumberArray(quote["open"]);
+  const highs = getNumberArray(quote["high"]);
+  const lows = getNumberArray(quote["low"]);
+  const closes = getNumberArray(quote["close"]);
+  const bars: YahooDailyBar[] = [];
+  for (let index = 0; index < timestamps.length; index++) {
+    const timestamp = timestamps[index];
+    const open = opens[index];
+    const high = highs[index];
+    const low = lows[index];
+    const close = closes[index];
+    if (undefined === timestamp ||
+        undefined === open ||
+        undefined === high ||
+        undefined === low ||
+        undefined === close) {
+      continue;
+    }
+
+    bars.push({
+      close,
+      date: moment.unix(timestamp).tz(usEasternTimezone).format("YYYY-MM-DD"),
+      high,
+      low,
+      open,
+    });
+  }
+
+  return bars;
+}
+
+function getFirstResult(data: YahooChartResponse): Record<string, unknown> | undefined {
+  const result = data.chart?.result;
+  if (false === Array.isArray(result)) {
+    return undefined;
+  }
+
+  const firstResult: unknown = result[0];
+  return isRecord(firstResult) ? firstResult : undefined;
+}
+
+function getFirstQuote(result: Record<string, unknown>): Record<string, unknown> | undefined {
+  const indicators = result["indicators"];
+  if (false === isRecord(indicators)) {
+    return undefined;
+  }
+
+  const quote = indicators["quote"];
+  if (false === Array.isArray(quote)) {
+    return undefined;
+  }
+
+  const firstQuote: unknown = quote[0];
+  return isRecord(firstQuote) ? firstQuote : undefined;
+}
+
+function getNumberArray(value: unknown): (number | undefined)[] {
+  if (false === Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map(item => "number" === typeof item && Number.isFinite(item) ? item : undefined);
+}
+
+function hasUnsupportedClosingHighClaim(value: string, facts: MarketCloseTickerFact[]): boolean {
+  if (false === /(?:schluss|schloss|close|closing|bis zum (?:regulaeren |regulären )?(?:close|schluss)|bis zum schluss|zum (?:close|schluss))[^\n.?!;:]{0,120}(?:neue?n? hochs?|rekordhoch|rekord|record high|new highs?)|(?:neue?n? hochs?|rekordhoch|rekord|record high|new highs?)[^\n.?!;:]{0,120}(?:schluss|schloss|close|closing|bis zum (?:regulaeren |regulären )?(?:close|schluss)|bis zum schluss|zum (?:close|schluss))/iu.test(value)) {
+    return false;
+  }
+
+  const relevantFacts = getReferencedEquityFacts(value, facts);
+  return relevantFacts.some(fact => false === isCloseNearDailyHigh(fact) || fact.closeChange < 0);
+}
+
+function hasSymbolDirectionContradiction(value: string, fact: MarketCloseTickerFact): boolean {
+  if (fact.closeChangePercent > -0.1 || fact.openToCloseChangePercent > -0.1) {
+    return false;
+  }
+
+  const symbolPattern = `\\b${fact.symbol}\\b`;
+  const bullishAfterSymbol = new RegExp(`${symbolPattern}[^\\n.?!;:]{0,100}\\b(?:stieg|zogen|zog|legte(?:n)? zu|gewann(?:en)?|schloss(?:en)? (?:hoeher|höher|fester|im plus)|neue?n? hochs?|record high|new highs?|higher|up)\\b`, "iu");
+  const bullishBeforeSymbol = new RegExp(`\\b(?:stieg|zogen|zog|legte(?:n)? zu|gewann(?:en)?|schloss(?:en)? (?:hoeher|höher|fester|im plus)|higher|up)\\b[^\\n.?!;:]{0,100}${symbolPattern}`, "iu");
+  return bullishAfterSymbol.test(value) || bullishBeforeSymbol.test(value);
+}
+
+function hasUnsupportedSentimentAnswer(winningPollAnswer: string, facts: MarketCloseTickerFact[]): boolean {
+  const equityFacts = facts.filter(fact => "VIX" !== fact.symbol);
+  if (equityFacts.length < 2) {
+    return false;
+  }
+
+  const weakEquityCount = equityFacts.filter(fact => fact.openToCloseChangePercent <= -0.1).length;
+  const strongEquityCount = equityFacts.filter(fact => fact.openToCloseChangePercent >= 0.1).length;
+  const vixFact = facts.find(fact => "VIX" === fact.symbol);
+  if ("Risk-on" === winningPollAnswer &&
+      weakEquityCount >= 2 &&
+      (undefined === vixFact || vixFact.openToCloseChange >= -0.05)) {
+    return true;
+  }
+
+  if ("Risk-off" === winningPollAnswer &&
+      strongEquityCount >= 2 &&
+      (undefined === vixFact || vixFact.openToCloseChange <= 0.05)) {
+    return true;
+  }
+
+  return false;
+}
+
+function getReferencedEquityFacts(value: string, facts: MarketCloseTickerFact[]): MarketCloseTickerFact[] {
+  const equityFacts = facts.filter(fact => "VIX" !== fact.symbol);
+  const referencedFacts = equityFacts.filter(fact => new RegExp(`\\b${fact.symbol}\\b`, "iu").test(value));
+  return 0 < referencedFacts.length ? referencedFacts : equityFacts;
+}
+
+function isCloseNearDailyHigh(fact: MarketCloseTickerFact): boolean {
+  if (0 === fact.high) {
+    return false;
+  }
+
+  return ((fact.high - fact.close) / fact.high) <= 0.001;
+}
+
+function getPercentChange(change: number, base: number): number {
+  if (0 === base) {
+    return 0;
+  }
+
+  return (change / base) * 100;
+}
+
+function formatValue(value: number): string {
+  const [integer = "0", decimal = "00"] = Math.abs(value).toFixed(2).split(".");
+  const formattedInteger = integer.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  const sign = value < 0 ? "-" : "";
+  return `${sign}${formattedInteger},${decimal}`;
+}
+
+function formatSignedPercent(value: number): string {
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}${value.toFixed(2).replace(".", ",")}%`;
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return undefined !== value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value && false === Array.isArray(value);
+}

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -380,6 +380,7 @@ async function runNyseMarketCloseRecap(
   });
   const pollMessage = recoveredPollMessage ?? sentimentPollState.message;
   const recap = await getMarketCloseRecap(pollMessage, {
+    getWithRetryFn: getWithRetry,
     logger,
   }, {
     date,


### PR DESCRIPTION
## Summary
- fetch SPX, NQ, RTY, and VIX daily bars before generating the market close recap
- include open/high/low/close, prior close, close-to-close, and open-to-close facts in the recap prompt
- instruct web search to prioritize official index/exchange sources and established financial wires, while ignoring blogs and non-finance sites when they conflict
- reject AI recaps that claim unsupported closing highs, contradict ticker direction, or pick an obviously unsupported poll sentiment

## Root Cause
The close recap relied on web-search prose alone, so intraday or stale market-wrap headlines could be treated as the final close and produce stale risk-on wording.

## Validation
- npm test -- modules/market-close-recap.test.ts modules/timers.test.ts
- npm run lint
- npm run typecheck
- npm run test:coverage