### PR TITLE
[codex] Format weekly calendar and earnings posts

### DIFF
--- a/modules/calendar.test.ts
+++ b/modules/calendar.test.ts
@@ -175,6 +175,28 @@ describe("getCalendarMessages", () => {
     expect(batch.messages[0]!).not.toContain("Wichtige Termine der nächsten Handelswoche:**\n");
   });
 
+  test("can keep a custom title separate from the first day heading", () => {
+    const calendarEvents: CalendarEvent[] = [
+      createCalendarEvent("2026-05-11", "16:00", "Existing Home Sales"),
+      createCalendarEvent("2026-05-12", "01:30", "Household Spending m/m", "🇯🇵"),
+    ];
+
+    const batch = getCalendarMessages(calendarEvents, {
+      title: "📅 **Wichtige Termine der nächsten Handelswoche (11. Mai 2026 - 15. Mai 2026)**",
+      titlePlacement: "standalone",
+      maxMessageLength: 1800,
+      maxMessages: 6,
+      keepDayTogether: true,
+    });
+
+    expect(batch.messages[0]!).toContain(
+      "📅 **Wichtige Termine der nächsten Handelswoche (11. Mai 2026 - 15. Mai 2026)**\n**Montag, 11. Mai 2026**\n`16:00` 🇺🇸 Existing Home Sales",
+    );
+    expect(batch.messages[0]!).not.toContain(")**\n\n**Montag");
+    expect(batch.messages[0]!).toContain("**Dienstag, 12. Mai 2026**\n`01:30` 🇯🇵 Household Spending m/m");
+    expect(batch.messages[0]!).not.toContain("**Wichtige Termine der nächsten Handelswoche (11. Mai 2026 - 15. Mai 2026)** (Montag");
+  });
+
   test("chunks by day boundaries across multiple days", () => {
     const dayOneEvents: CalendarEvent[] = [
       createCalendarEvent("2025-03-03", "09:00", "Day1-Event1"),

--- a/modules/calendar.ts
+++ b/modules/calendar.ts
@@ -43,6 +43,7 @@ export type CalendarMessageOptions = {
   keepDayTogether?: boolean;
   continuationLabel?: string;
   title?: string;
+  titlePlacement?: "merged" | "standalone";
 };
 
 type CalendarDayBlock = {
@@ -201,6 +202,7 @@ export function getCalendarMessages(
   const maxMessages = options.maxMessages ?? Number.POSITIVE_INFINITY;
   const continuationLabel = options.continuationLabel ?? CALENDAR_CONTINUATION_LABEL;
   const title = options.title ?? calendarTitle;
+  const titlePlacement = options.titlePlacement ?? "merged";
   const keepDayTogether = false !== options.keepDayTogether;
 
   if (0 === calendarEvents.length) {
@@ -221,7 +223,7 @@ export function getCalendarMessages(
   let contentTruncated = false;
 
   for (const dayBlock of dayBlocks) {
-    const fullDayBlockText = getDayBlockText(dayBlock, false, continuationLabel, pendingTitle);
+    const fullDayBlockText = getDayBlockText(dayBlock, false, continuationLabel, pendingTitle, titlePlacement);
 
     if (true === canAppendToChunk(currentChunk, fullDayBlockText, maxMessageLength)) {
       appendToChunk(currentChunk, fullDayBlockText, dayBlock.lines.length, dayBlock.date);
@@ -244,7 +246,7 @@ export function getCalendarMessages(
     let lineIndex = 0;
     let continuation = false;
     while (lineIndex < dayBlock.lines.length) {
-      const header = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation, pendingTitle);
+      const header = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation, pendingTitle, titlePlacement);
       const lines: string[] = [];
 
       while (lineIndex < dayBlock.lines.length) {
@@ -491,9 +493,19 @@ function getDayText(dayHeader: string, lines: string[]): string {
   return `\n${dayHeader}\n${lines.join("\n")}\n`;
 }
 
-function getDayHeader(friendlyDate: string, continuationLabel: string, continuation: boolean, title = ""): string {
+function getDayHeader(
+  friendlyDate: string,
+  continuationLabel: string,
+  continuation: boolean,
+  title = "",
+  titlePlacement: CalendarMessageOptions["titlePlacement"] = "merged",
+): string {
   if (false === continuation) {
     if ("" !== title) {
+      if ("standalone" === titlePlacement) {
+        return `${title.trim()}\n**${friendlyDate}**`;
+      }
+
       return getTitledDayHeader(title, friendlyDate);
     }
 
@@ -503,8 +515,14 @@ function getDayHeader(friendlyDate: string, continuationLabel: string, continuat
   return `**${friendlyDate} ${continuationLabel}**`;
 }
 
-function getDayBlockText(dayBlock: CalendarDayBlock, continuation: boolean, continuationLabel: string, title = ""): string {
-  const dayHeader = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation, title);
+function getDayBlockText(
+  dayBlock: CalendarDayBlock,
+  continuation: boolean,
+  continuationLabel: string,
+  title = "",
+  titlePlacement: CalendarMessageOptions["titlePlacement"] = "merged",
+): string {
+  const dayHeader = getDayHeader(dayBlock.friendlyDate, continuationLabel, continuation, title, titlePlacement);
   return getDayText(dayHeader, dayBlock.lines);
 }
 

--- a/modules/earnings-format-render.ts
+++ b/modules/earnings-format-render.ts
@@ -1,5 +1,4 @@
 import {
-  earningsWhenLabelByWhen,
   type EarningsEvent,
   type EarningsWhen,
   unknownValueLabel,
@@ -21,6 +20,12 @@ type EarningsLineWidths = {
   ticker: number;
   marketCap: number;
 };
+
+const earningsWhenEmojiByWhen = new Map<EarningsWhen, string>([
+  ["before_open", "☕"],
+  ["during_session", "🌞"],
+  ["after_close", "🌙"],
+]);
 
 export type EarningsMessageChunk = {
   eventCount: number;
@@ -77,25 +82,16 @@ function getEarningsSectionText(
   continuation: boolean,
   continuationLabel: string,
   highlightedTickerSymbols: Set<string>,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>,
   lineWidths: EarningsLineWidths
 ): string {
   const heading = getEarningsSectionHeading(label, continuation, continuationLabel);
-  const sectionLines: string[] = [];
-  let previousWhen: EarningsWhen | null = null;
-
-  for (const row of rows) {
-    if (row.when !== previousWhen) {
-      sectionLines.push("");
-      sectionLines.push(getEarningsWhenSubheading(row.when));
-      previousWhen = row.when;
-    }
-
-    sectionLines.push(row.lineOverride ?? getEarningsEventLine(
-      row.event,
-      highlightedTickerSymbols,
-      lineWidths
-    ));
-  }
+  const sectionLines = rows.map(row => row.lineOverride ?? getEarningsEventLine(
+    row.event,
+    highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
+    lineWidths
+  ));
 
   return `${heading}\n${sectionLines.join("\n")}\n\n`;
 }
@@ -124,6 +120,7 @@ export function canAppendToEarningsChunk(
   chunk: EarningsMessageChunk,
   section: EarningsMessageChunkSection,
   highlightedTickerSymbols: Set<string>,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>,
   maxMessageLength: number,
   title: string,
   continuationLabel: string
@@ -134,6 +131,7 @@ export function canAppendToEarningsChunk(
     candidateChunk,
     title,
     highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
     continuationLabel
   ).length <= maxMessageLength;
 }
@@ -168,6 +166,7 @@ export function getEarningsChunkText(
   chunk: EarningsMessageChunk,
   title: string,
   highlightedTickerSymbols: Set<string>,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>,
   continuationLabel: string
 ): string {
   const prefix = (0 === chunk.messageIndex && 0 < title.length) ? `${title}\n` : "";
@@ -178,6 +177,7 @@ export function getEarningsChunkText(
     section.continuation,
     continuationLabel,
     highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
     lineWidths
   )).join("");
 
@@ -190,6 +190,7 @@ export function getTruncatedEarningsSectionRow(
   continuation: boolean,
   chunk: EarningsMessageChunk,
   highlightedTickerSymbols: Set<string>,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>,
   maxMessageLength: number,
   title: string,
   continuationLabel: string
@@ -197,6 +198,7 @@ export function getTruncatedEarningsSectionRow(
   const fullLine = getEarningsEventLine(
     row.event,
     highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
     getEarningsLineWidths([row])
   );
   let bestLine = "";
@@ -216,7 +218,15 @@ export function getTruncatedEarningsSectionRow(
       continuation
     );
 
-    if (true === canAppendToEarningsChunk(chunk, candidateSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+    if (true === canAppendToEarningsChunk(
+      chunk,
+      candidateSection,
+      highlightedTickerSymbols,
+      mostAnticipatedTickerSymbols,
+      maxMessageLength,
+      title,
+      continuationLabel
+    )) {
       bestLine = candidateLine;
       low = midpoint + 1;
     } else {
@@ -245,8 +255,10 @@ function truncateEarningsLine(line: string, maxLength: number): string {
 function getEarningsEventLine(
   earningsEvent: EarningsEvent,
   highlightedTickerSymbols: Set<string>,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>,
   lineWidths: EarningsLineWidths
 ): string {
+  const prefix = getEarningsEventLinePrefix(earningsEvent, mostAnticipatedTickerSymbols);
   const ticker = getFormattedTicker(
     earningsEvent.ticker,
     highlightedTickerSymbols,
@@ -261,7 +273,19 @@ function getEarningsEventLine(
   const expectedMoveText = getFormattedExpectedMoveText(earningsEvent);
   const underlyingPriceText = getFormattedExpectedMoveUnderlyingPriceText(earningsEvent);
 
-  return `${ticker} 💰 MCap: \`${marketCapText}\`${marketCapPadding}${underlyingPriceText} 🔮 EPS: \`${epsConsensus}\`${expectedMoveText}`;
+  return `${prefix}${ticker} 💰 MCap: \`${marketCapText}\`${marketCapPadding}${underlyingPriceText} 🔮 EPS: \`${epsConsensus}\`${expectedMoveText}`;
+}
+
+function getEarningsEventLinePrefix(
+  earningsEvent: EarningsEvent,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>
+): string {
+  const whenEmoji = earningsWhenEmojiByWhen.get(earningsEvent.when) ?? "🌞";
+  const anticipatedEmoji = true === mostAnticipatedTickerSymbols.has(earningsEvent.ticker)
+    ? "🔥"
+    : "🏢";
+
+  return `${whenEmoji} ${anticipatedEmoji} `;
 }
 
 function getFormattedMarketCapText(
@@ -305,21 +329,8 @@ function getFormattedTicker(
 ): string {
   const tickerPadding = getEarningsColumnPadding(ticker, width);
   if (true === highlightedTickerSymbols.has(ticker)) {
-    return `**${ticker}**${tickerPadding}`;
+    return `**\`${ticker}\`**${tickerPadding}`;
   }
 
   return `\`${ticker}\`${tickerPadding}`;
-}
-
-function getEarningsWhenLabel(earningsWhen: EarningsWhen): string {
-  const label = earningsWhenLabelByWhen.get(earningsWhen);
-  if (undefined !== label) {
-    return label;
-  }
-
-  return "Während der Handelszeiten oder unbekannter Zeitpunkt";
-}
-
-function getEarningsWhenSubheading(earningsWhen: EarningsWhen): string {
-  return `**${getEarningsWhenLabel(earningsWhen)}**`;
 }

--- a/modules/earnings-format.ts
+++ b/modules/earnings-format.ts
@@ -65,10 +65,12 @@ export function getEarningsMessages(
   const highlightedTickerSymbols = new Set(
     tickers.map(ticker => ticker.symbol)
   );
+  const mostAnticipatedTickerSymbols = options.mostAnticipatedTickerSymbols ?? new Set<string>();
 
   const filteredAndSortedEvents = [...earningsEvents]
     .filter(event => selectedWhen.has(event.when))
-    .filter(event => isIncludedByMarketCapFilter(event, selectedMarketCapFilter))
+    .filter(event => true === mostAnticipatedTickerSymbols.has(event.ticker)
+      || isIncludedByMarketCapFilter(event, selectedMarketCapFilter))
     .sort(compareEarningsEventsForDisplay);
 
   const totalEvents = filteredAndSortedEvents.length;
@@ -84,6 +86,7 @@ export function getEarningsMessages(
   const initialBatch = buildEarningsMessageBatch(
     filteredAndSortedEvents,
     highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
     {
       maxMessageLength,
       maxMessages,
@@ -98,6 +101,7 @@ export function getEarningsMessages(
   const marketCapBalancedEvents = getMarketCapBalancedEventsForMultiDayFit(
     filteredAndSortedEvents,
     highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
     {
       maxMessageLength,
       maxMessages,
@@ -111,6 +115,7 @@ export function getEarningsMessages(
   const balancedBatch = buildEarningsMessageBatch(
     marketCapBalancedEvents,
     highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
     {
       maxMessageLength,
       maxMessages,
@@ -123,6 +128,7 @@ export function getEarningsMessages(
 function buildEarningsMessageBatch(
   filteredAndSortedEvents: EarningsEvent[],
   highlightedTickerSymbols: Set<string>,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>,
   options: {
     maxMessageLength: number;
     maxMessages: number;
@@ -154,7 +160,7 @@ function buildEarningsMessageBatch(
       section.rows,
       false
     );
-    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, title, continuationLabel)) {
       appendToEarningsChunk(currentChunk, fullSection);
       continue;
     }
@@ -164,7 +170,7 @@ function buildEarningsMessageBatch(
       currentChunk = getEmptyEarningsMessageChunk(chunks.length);
     }
 
-    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, title, continuationLabel)) {
       appendToEarningsChunk(currentChunk, fullSection);
       continue;
     }
@@ -186,7 +192,7 @@ function buildEarningsMessageBatch(
           continuation
         );
 
-        if (canAppendToEarningsChunk(currentChunk, candidateSection, highlightedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+        if (canAppendToEarningsChunk(currentChunk, candidateSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, title, continuationLabel)) {
           sectionRows.push(nextRow);
           rowIndex++;
         } else {
@@ -212,6 +218,7 @@ function buildEarningsMessageBatch(
           continuation,
           currentChunk,
           highlightedTickerSymbols,
+          mostAnticipatedTickerSymbols,
           maxMessageLength,
           title,
           continuationLabel
@@ -253,6 +260,7 @@ function buildEarningsMessageBatch(
     chunk,
     title,
     highlightedTickerSymbols,
+    mostAnticipatedTickerSymbols,
     continuationLabel
   ).trimEnd());
   const includedEvents = visibleChunks.reduce(
@@ -281,6 +289,7 @@ function buildEarningsMessageBatch(
 function getMarketCapBalancedEventsForMultiDayFit(
   filteredAndSortedEvents: EarningsEvent[],
   highlightedTickerSymbols: Set<string>,
+  mostAnticipatedTickerSymbols: ReadonlySet<string>,
   options: {
     maxMessageLength: number;
     maxMessages: number;
@@ -304,6 +313,7 @@ function getMarketCapBalancedEventsForMultiDayFit(
     const candidateBatch = buildEarningsMessageBatch(
       selectedEvents,
       highlightedTickerSymbols,
+      mostAnticipatedTickerSymbols,
       options
     );
     if (candidateBatch.includedEvents === selectedEvents.length) {

--- a/modules/earnings-types.ts
+++ b/modules/earnings-types.ts
@@ -40,6 +40,7 @@ export type EarningsMessageOptions = {
   maxMessages?: number;
   continuationLabel?: string;
   marketCapFilter?: "all" | "bluechips" | string;
+  mostAnticipatedTickerSymbols?: ReadonlySet<string>;
 };
 
 export const earningsTruncationNote = "... weitere Earnings konnten wegen Discord-Limits nicht angezeigt werden.";

--- a/modules/earnings.test.ts
+++ b/modules/earnings.test.ts
@@ -53,16 +53,17 @@ function getEarningsEvent(overrides: Partial<EarningsEvent> = {}): EarningsEvent
 
 function parseEarningsLine(
   line: string
-): {ticker: string; marketCap: string; eps: string} {
-  const match = line.match(/^(?:(?:\*\*)?`([^`]+)`(?:\*\*)?|\*\*([^*]+)\*\*)( *) 💰 MCap: `([^`]+)`( *)(?: 📈 Last: `\$[^`]+`)? 🔮 EPS: `([^`]+)`(?: .*)?$/);
+): {prefix: string; ticker: string; marketCap: string; eps: string} {
+  const match = line.match(/^((?:☕|🌞|🌙) (?:🔥|🏢) )(?:(?:\*\*)?`([^`]+)`(?:\*\*)?|\*\*([^*]+)\*\*)( *) 💰 MCap: `([^`]+)`( *)(?: 📈 Last: `\$[^`]+`)? 🔮 EPS: `([^`]+)`(?: .*)?$/u);
   if (null === match) {
     throw new Error(`Unexpected earnings line format: ${line}`);
   }
 
   return {
-    ticker: `${match[1] ?? match[2]}${match[3]}`,
-    marketCap: `${match[4]}${match[5]}`,
-    eps: match[6]!,
+    prefix: match[1]!.trimEnd(),
+    ticker: `${match[2] ?? match[3]}${match[4]}`,
+    marketCap: `${match[5]}${match[6]}`,
+    eps: match[7]!,
   };
 }
 
@@ -416,7 +417,7 @@ describe("getEarningsText", () => {
     expect(text).toContain("**Mittwoch, 3. Januar 2024**");
   });
 
-  test("returns grouped ticker-first one-line output", () => {
+  test("returns grouped emoji-prefixed one-line output", () => {
     const earningEvents: EarningsEvent[] = [
       getEarningsEvent({
         ticker: "SMALL",
@@ -450,22 +451,24 @@ describe("getEarningsText", () => {
     expect(text).toContain("**Zeitraum:** Mittwoch, 3. Januar 2024 bis Donnerstag, 4. Januar 2024");
     expect(text).toContain("**Mittwoch, 3. Januar 2024**");
     expect(text).toContain("**Donnerstag, 4. Januar 2024**");
-    expect(text).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
-    expect(text).toContain("**Nach Handelsschluss**");
-    expect(text).toContain("**Vor Handelsbeginn**");
+    expect(text).not.toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
+    expect(text).not.toContain("**Nach Handelsschluss**");
+    expect(text).not.toContain("**Vor Handelsbeginn**");
 
     const lines = text.split("\n").filter(line => line.includes(" MCap: "));
     const parsedLines = lines.map(parseEarningsLine);
-    expect(lines[0]!.startsWith("**BIG**")).toBe(true);
+    expect(lines[0]!.startsWith("🌞 🏢 **`BIG`**")).toBe(true);
     expect(lines[0]!).not.toContain("`BIG ");
     expect(lines[0]!).not.toContain("$1B ");
     expect(parsedLines[0]!).toEqual(expect.objectContaining({
+      prefix: "🌞 🏢",
       ticker: "BIG  ",
       marketCap: expect.stringMatching(/^\$1B +$/),
       eps: "1.20",
     }));
     expect(parsedLines[1]!.ticker.trim()).toBe("SMALL");
     expect(parsedLines[2]!.ticker.trim()).toBe("NEXT");
+    expect(parsedLines.map(entry => entry.prefix)).toEqual(["🌞 🏢", "🌙 🏢", "☕ 🏢"]);
     expect(new Set(parsedLines.map(entry => entry.ticker.length)).size).toBe(1);
     expect(new Set(parsedLines.map(entry => entry.marketCap.length)).size).toBe(1);
     expect(parsedLines.map(entry => entry.eps)).toEqual(["1.20", "0.50", "0.75"]);
@@ -501,7 +504,7 @@ describe("getEarningsMessages", () => {
     }),
   ];
 
-  test("returns one message with one line per earning and ticker first", () => {
+  test("returns one message with one emoji-prefixed line per earning", () => {
     const batch = getEarningsMessages(earningEvents, "all", [getTicker("BIG")], {
       maxMessageLength: 1800,
       maxMessages: 6,
@@ -511,23 +514,41 @@ describe("getEarningsMessages", () => {
     expect(batch.truncated).toBe(false);
     expect(batch.totalEvents).toBe(3);
     expect(batch.includedEvents).toBe(3);
-    expect(batch.messages[0]!).toContain("**Vor Handelsbeginn**");
-    expect(batch.messages[0]!).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
-    expect(batch.messages[0]!).toContain("**Nach Handelsschluss**");
+    expect(batch.messages[0]!).not.toContain("**Vor Handelsbeginn**");
+    expect(batch.messages[0]!).not.toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
+    expect(batch.messages[0]!).not.toContain("**Nach Handelsschluss**");
     expect(batch.messages[0]!).not.toContain("Earnings am");
 
     const lines = batch.messages[0]!.split("\n").filter(line => line.includes(" MCap: "));
     const parsedLines = lines.map(parseEarningsLine);
-    expect(lines[0]!.startsWith("**BIG**")).toBe(true);
+    expect(lines[0]!.startsWith("☕ 🏢 **`BIG`**")).toBe(true);
     expect(lines[0]!).not.toContain("`BIG ");
     expect(lines[0]!).not.toContain("$1.5B ");
     expect(parsedLines[0]!.ticker.trim()).toBe("BIG");
     expect(parsedLines[1]!.ticker.trim()).toBe("SMALL");
     expect(parsedLines[2]!.ticker.trim()).toBe("MID");
+    expect(parsedLines.map(entry => entry.prefix)).toEqual(["☕ 🏢", "🌞 🏢", "🌙 🏢"]);
     expect(parsedLines[0]!.eps.trim()).toBe("2.20");
     expect(new Set(parsedLines.map(entry => entry.ticker.length)).size).toBe(1);
     expect(new Set(parsedLines.map(entry => entry.marketCap.length)).size).toBe(1);
     expect(parsedLines.map(entry => entry.eps)).toEqual(["2.20", "0.10", "0.80"]);
+  });
+
+  test("adds fire to most anticipated earnings without marking other highlighted tickers", () => {
+    const batch = getEarningsMessages(earningEvents, "all", [getTicker("BIG")], {
+      maxMessageLength: 1800,
+      maxMessages: 6,
+      mostAnticipatedTickerSymbols: new Set(["MID"]),
+    });
+
+    const lines = batch.messages[0]!.split("\n").filter(line => line.includes(" MCap: "));
+    const parsedLines = lines.map(parseEarningsLine);
+    expect(parsedLines[0]!.ticker.trim()).toBe("BIG");
+    expect(parsedLines[0]!.prefix).toBe("☕ 🏢");
+    expect(parsedLines[2]!.ticker.trim()).toBe("MID");
+    expect(parsedLines[2]!.prefix).toBe("🌙 🔥");
+    expect(lines[2]!).toContain("`MID`");
+    expect(lines[2]!).not.toContain("**MID**");
   });
 
   test("includes expected move details when earnings events are enriched", () => {
@@ -568,7 +589,7 @@ describe("getEarningsMessages", () => {
         epsConsensus: "0.10",
       }),
     ], "all", [], {
-      maxMessageLength: 150,
+      maxMessageLength: 130,
       maxMessages: 3,
     });
 
@@ -618,12 +639,10 @@ describe("getEarningsMessages", () => {
     expect(parsedLines[0]!.ticker.trim()).toBe("BEFORE");
     expect(parsedLines[1]!.ticker.trim()).toBe("DURING");
     expect(parsedLines[2]!.ticker.trim()).toBe("AFTER");
-    const text = batch.messages[0]!;
-    expect(text.indexOf("**Vor Handelsbeginn**")).toBeLessThan(text.indexOf("**Während der Handelszeiten oder unbekannter Zeitpunkt**"));
-    expect(text.indexOf("**Während der Handelszeiten oder unbekannter Zeitpunkt**")).toBeLessThan(text.indexOf("**Nach Handelsschluss**"));
+    expect(parsedLines.map(entry => entry.prefix)).toEqual(["☕ 🏢", "🌞 🏢", "🌙 🏢"]);
   });
 
-  test("filters by when and keeps ticker-first format", () => {
+  test("filters by when and keeps emoji-prefixed format", () => {
     const batch = getEarningsMessages(earningEvents, "during_session", [], {
       maxMessageLength: 1800,
       maxMessages: 6,
@@ -634,7 +653,8 @@ describe("getEarningsMessages", () => {
     expect(lines).toHaveLength(1);
     const parsedLine = parseEarningsLine(lines[0]!);
     expect(parsedLine.ticker.trim()).toBe("SMALL");
-    expect(batch.messages[0]!).toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
+    expect(parsedLine.prefix).toBe("🌞 🏢");
+    expect(batch.messages[0]!).not.toContain("**Während der Handelszeiten oder unbekannter Zeitpunkt**");
   });
 
   test("filters by bluechip market cap threshold when marketCapFilter is bluechips", () => {
@@ -686,6 +706,46 @@ describe("getEarningsMessages", () => {
     expect(batch.messages[0]!).not.toContain("`UNKNOWN`");
     expect(batch.messages[0]!).not.toContain("Bluechip Fifty");
     expect(batch.messages[0]!).not.toContain("Bluechip Seventy Five");
+  });
+
+  test("keeps most anticipated tickers when bluechip market cap filtering is enabled", () => {
+    const batch = getEarningsMessages([
+      getEarningsEvent({
+        ticker: "BLUE50",
+        when: "before_open",
+        companyName: "Bluechip Fifty",
+        marketCap: 50_000_000_000,
+        marketCapText: "$50B",
+        epsConsensus: "5.00",
+      }),
+      getEarningsEvent({
+        ticker: "MID49",
+        when: "after_close",
+        companyName: "Mid Forty Nine",
+        marketCap: 49_000_000_000,
+        marketCapText: "$49B",
+        epsConsensus: "4.90",
+      }),
+      getEarningsEvent({
+        ticker: "SMALL",
+        when: "during_session",
+        companyName: "Small Cap",
+        marketCap: 1_000_000_000,
+        marketCapText: "$1B",
+        epsConsensus: "1.00",
+      }),
+    ], "all", [], {
+      maxMessageLength: 1800,
+      maxMessages: 6,
+      marketCapFilter: "bluechips",
+      mostAnticipatedTickerSymbols: new Set(["MID49"]),
+    });
+
+    expect(batch.totalEvents).toBe(2);
+    expect(batch.includedEvents).toBe(2);
+    expect(batch.messages[0]!).toContain("`BLUE50`");
+    expect(batch.messages[0]!).toContain("🌙 🔥 `MID49`");
+    expect(batch.messages[0]!).not.toContain("`SMALL`");
   });
 
   test("falls back to all market caps for unknown marketCapFilter values", () => {

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -575,7 +575,7 @@ describe("timers: other announcements", () => {
     }));
   });
 
-  test("startOtherTimers sends most anticipated daily earnings separately and removes them from the regular post", async () => {
+  test("startOtherTimers folds most anticipated daily earnings into the regular post", async () => {
     const {client, send} = createClientWithChannel();
     const earningsEvents = [
       {
@@ -612,19 +612,12 @@ describe("timers: other announcements", () => {
     });
     addExpectedMovesToEarningsEventsMock.mockImplementation(async events => events);
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD", "AEHR"]));
-    getEarningsMessagesMock
-      .mockReturnValueOnce({
-        messages: ["**Montag, 24. Februar 2025**\nanticipated-earnings"],
-        truncated: false,
-        totalEvents: 2,
-        includedEvents: 2,
-      })
-      .mockReturnValueOnce({
-        messages: ["**Montag, 24. Februar 2025**\nregular-earnings"],
-        truncated: false,
-        totalEvents: 1,
-        includedEvents: 1,
-      });
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nfolded-earnings"],
+      truncated: false,
+      totalEvents: 3,
+      includedEvents: 3,
+    });
 
     startOtherTimers(client, "channel-id", [], []);
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
@@ -640,33 +633,21 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
       when: "all",
     });
-    expect(getEarningsMessagesMock).toHaveBeenNthCalledWith(
-      1,
-      [earningsEvents[0], earningsEvents[2]],
+    expect(getEarningsMessagesMock).toHaveBeenCalledTimes(1);
+    expect(getEarningsMessagesMock).toHaveBeenCalledWith(
+      [earningsEvents[0], earningsEvents[2], earningsEvents[1]],
       "all",
-      expect.arrayContaining([
-        expect.objectContaining({symbol: "AMD", exchange: "earnings-whispers"}),
-        expect.objectContaining({symbol: "AEHR", exchange: "earnings-whispers"}),
-      ]),
+      [],
       {
         maxMessageLength: 1800,
         maxMessages: 8,
-        marketCapFilter: "all",
+        marketCapFilter: "bluechips",
+        mostAnticipatedTickerSymbols: new Set(["AMD", "AEHR"]),
       },
     );
-    expect(getEarningsMessagesMock).toHaveBeenNthCalledWith(2, [earningsEvents[1]], "all", [], {
-      maxMessageLength: 1800,
-      maxMessages: 8,
-      marketCapFilter: "bluechips",
-    });
-    expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings** (Montag, 24. Februar 2025)\nanticipated-earnings",
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    expect(send).toHaveBeenNthCalledWith(2, {
-      content: "**Earnings** (Montag, 24. Februar 2025)\nregular-earnings",
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({
+      content: "**Earnings** (Montag, 24. Februar 2025)\nfolded-earnings",
       allowedMentions: {
         parse: [],
       },
@@ -690,19 +671,12 @@ describe("timers: other announcements", () => {
     });
     addExpectedMovesToEarningsEventsMock.mockImplementation(async events => events);
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["AMD"]));
-    getEarningsMessagesMock
-      .mockReturnValueOnce({
-        messages: ["**Montag, 24. Februar 2025**\nanticipated-only"],
-        truncated: false,
-        totalEvents: 1,
-        includedEvents: 1,
-      })
-      .mockReturnValueOnce({
-        messages: [],
-        truncated: false,
-        totalEvents: 0,
-        includedEvents: 0,
-      });
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Montag, 24. Februar 2025**\nanticipated-only"],
+      truncated: false,
+      totalEvents: 1,
+      includedEvents: 1,
+    });
 
     startOtherTimers(client, "channel-id", [], []);
     const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
@@ -716,9 +690,20 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
       when: "all",
     });
+    expect(getEarningsMessagesMock).toHaveBeenCalledWith(
+      [earningsEvents[0]],
+      "all",
+      [],
+      {
+        maxMessageLength: 1800,
+        maxMessages: 8,
+        marketCapFilter: "bluechips",
+        mostAnticipatedTickerSymbols: new Set(["AMD"]),
+      },
+    );
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
-      content: "🔥 **Most Anticipated Earnings** (Montag, 24. Februar 2025)\nanticipated-only",
+      content: "**Earnings** (Montag, 24. Februar 2025)\nanticipated-only",
       allowedMentions: {
         parse: [],
       },
@@ -759,6 +744,42 @@ describe("timers: other announcements", () => {
         parse: [],
       },
     });
+  });
+
+  test("startOtherTimers logs truncated earnings and merges multi-day period fallback", async () => {
+    const {client, send} = createClientWithChannel();
+    getEarningsResultMock.mockResolvedValue({
+      events: [],
+      status: "error",
+    });
+    getEarningsMessagesMock.mockReturnValue({
+      messages: ["**Zeitraum:** Montag, 24. Februar 2025 bis Dienstag, 25. Februar 2025\n**Montag, 24. Februar 2025**\nearnings-truncated"],
+      truncated: true,
+      totalEvents: 40,
+      includedEvents: 20,
+    });
+
+    startOtherTimers(client, "channel-id", [], []);
+    const dailyEarningsJob = getScheduledJobByTime(19, 30, "Europe/Berlin");
+    await dailyEarningsJob.callback();
+
+    expect(send).toHaveBeenCalledWith({
+      content: "**Earnings** (Montag, 24. Februar 2025 bis Dienstag, 25. Februar 2025)\n**Montag, 24. Februar 2025**\nearnings-truncated",
+      allowedMentions: {
+        parse: [],
+      },
+    });
+    expect(loggerMock.log).toHaveBeenCalledWith("warn", expect.objectContaining({
+      source: "timer-earnings",
+      status: "error",
+      message: "Earnings konnten nicht geladen werden.",
+    }));
+    expect(loggerMock.log).toHaveBeenCalledWith("warn", expect.objectContaining({
+      source: "timer-earnings",
+      includedEvents: 20,
+      totalEvents: 40,
+      message: "Earnings output truncated because message limits were reached.",
+    }));
   });
 
   test("startOtherTimers sends upcoming earnings to the optional expectations thread", async () => {
@@ -805,7 +826,7 @@ describe("timers: other announcements", () => {
     const {client, send} = createClientWithChannel();
     getEarningsMessagesMock.mockReturnValue({
       messages: [
-        "**Zeitraum:** Mittwoch, 6. Mai 2026 bis Donnerstag, 7. Mai 2026\n**Mittwoch, 6. Mai 2026**\nweekly-earnings-1",
+        "**Zeitraum:** Montag, 24. Februar 2025 bis Donnerstag, 27. Februar 2025\n**Montag, 24. Februar 2025**\nweekly-earnings-1",
         "weekly-earnings-2",
       ],
       truncated: false,
@@ -826,7 +847,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "📅 **Earnings der nächsten Handelswoche** (Mittwoch, 6. Mai 2026 bis Donnerstag, 7. Mai 2026)\n**Mittwoch, 6. Mai 2026**\nweekly-earnings-1",
+      content: "💸 **Earnings der nächsten Handelswoche (24. Februar 2025 - 27. Februar 2025)**\n**Montag, 24. Februar 2025**\nweekly-earnings-1",
       allowedMentions: {
         parse: [],
       },
@@ -839,7 +860,7 @@ describe("timers: other announcements", () => {
     });
   });
 
-  test("startOtherTimers sends most anticipated weekly earnings separately and excludes them from weekly earnings", async () => {
+  test("startOtherTimers folds most anticipated weekly earnings into the regular post", async () => {
     const {client, send} = createClientWithChannel();
     const earningsEvents = [
       {
@@ -876,19 +897,14 @@ describe("timers: other announcements", () => {
     });
     addExpectedMovesToEarningsEventsMock.mockImplementation(async events => events);
     loadEarningsWhispersWeeklyTickersMock.mockResolvedValue(new Set(["MSFT", "AAPL"]));
-    getEarningsMessagesMock
-      .mockReturnValueOnce({
-        messages: ["**Montag, 24. Februar 2025**\nweekly-anticipated"],
-        truncated: false,
-        totalEvents: 2,
-        includedEvents: 2,
-      })
-      .mockReturnValueOnce({
-        messages: ["weekly-regular"],
-        truncated: false,
-        totalEvents: 1,
-        includedEvents: 1,
-      });
+    getEarningsMessagesMock.mockReturnValue({
+      messages: [
+        "**Zeitraum:** Montag, 24. Februar 2025 bis Freitag, 28. Februar 2025\n**Montag, 24. Februar 2025**\nweekly-folded",
+      ],
+      truncated: false,
+      totalEvents: 3,
+      includedEvents: 3,
+    });
 
     startOtherTimers(client, "channel-id", [], []);
     const weeklyEarningsJob = getScheduledJobByTime(23, 30, "Europe/Berlin");
@@ -902,33 +918,21 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
       when: "all",
     });
-    expect(getEarningsMessagesMock).toHaveBeenNthCalledWith(
-      1,
-      [earningsEvents[0], earningsEvents[2]],
+    expect(getEarningsMessagesMock).toHaveBeenCalledTimes(1);
+    expect(getEarningsMessagesMock).toHaveBeenCalledWith(
+      [earningsEvents[0], earningsEvents[2], earningsEvents[1]],
       "all",
-      expect.arrayContaining([
-        expect.objectContaining({symbol: "MSFT", exchange: "earnings-whispers"}),
-        expect.objectContaining({symbol: "AAPL", exchange: "earnings-whispers"}),
-      ]),
+      [],
       {
         maxMessageLength: 1800,
         maxMessages: 8,
-        marketCapFilter: "all",
+        marketCapFilter: "bluechips",
+        mostAnticipatedTickerSymbols: new Set(["MSFT", "AAPL"]),
       },
     );
-    expect(getEarningsMessagesMock).toHaveBeenNthCalledWith(2, [earningsEvents[1]], "all", [], {
-      maxMessageLength: 1800,
-      maxMessages: 8,
-      marketCapFilter: "bluechips",
-    });
-    expect(send).toHaveBeenNthCalledWith(1, {
-      content: "🔥 **Most Anticipated Earnings der nächsten Handelswoche** (Montag, 24. Februar 2025)\nweekly-anticipated",
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    expect(send).toHaveBeenNthCalledWith(2, {
-      content: "📅 **Earnings der nächsten Handelswoche**\nweekly-regular",
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({
+      content: "💸 **Earnings der nächsten Handelswoche (24. Februar 2025 - 28. Februar 2025)**\n**Montag, 24. Februar 2025**\nweekly-folded",
       allowedMentions: {
         parse: [],
       },

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -24,6 +24,7 @@ import {
   getEarningsMessages,
   type EarningsEvent,
   type EarningsMessageBatch,
+  type EarningsMessageOptions,
 } from "./earnings.ts";
 import {addExpectedMovesToEarningsEvents, warmExpectedMoveCacheForEarningsEvents} from "./earnings-expected-move.ts";
 import {loadEarningsWhispersWeeklyTickers} from "./earnings-whispers.ts";
@@ -61,9 +62,7 @@ const calendarMessageDelayMs = 500;
 const calendarReminderFollowUpDelaySeconds = [5, 10, 20, 30, 60, 120, 180, 300, 600, 900];
 const usEasternTimezone = "US/Eastern";
 const dailyEarningsHeadline = "**Earnings**";
-const weeklyEarningsHeadline = "📅 **Earnings der nächsten Handelswoche**";
-const anticipatedEarningsHeadline = "🔥 **Most Anticipated Earnings**";
-const anticipatedWeeklyEarningsHeadline = "🔥 **Most Anticipated Earnings der nächsten Handelswoche**";
+const weeklyEarningsHeadline = "💸 **Earnings der nächsten Handelswoche**";
 const weeklyCalendarHeadline = "📅 **Wichtige Termine der nächsten Handelswoche:**";
 const europeBerlinTimezone = "Europe/Berlin";
 const usEasternWeekdays = [new Schedule.Range(1, 5)];
@@ -111,6 +110,7 @@ type EarningsAnnouncementConfig = {
   errorMessage: string;
   filter: "all" | "bluechips" | string;
   headline?: string;
+  headlinePlacement?: "merged" | "standalone";
   source: string;
   when: "all" | "before_open" | "during_session" | "after_close" | string;
 };
@@ -132,6 +132,23 @@ function createRecurrenceRule(config: RecurrenceRuleConfig): Schedule.Recurrence
   recurrenceRule.dayOfWeek = config.dayOfWeek;
   recurrenceRule.tz = config.tz;
   return recurrenceRule;
+}
+
+function getNextBerlinTradingWeekMonday(): moment.Moment {
+  return moment()
+    .tz(europeBerlinTimezone)
+    .startOf("isoWeek")
+    .add(1, "week");
+}
+
+function getWeeklyHeadlineWithDateRange(headline: string, weekMonday: moment.Moment): string {
+  const weekFriday = weekMonday.clone().add(4, "days");
+  const dateRange = `${getGermanDate(weekMonday)} - ${getGermanDate(weekFriday)}`;
+  return getHeadlineWithDateRange(headline, dateRange);
+}
+
+function getGermanDate(date: moment.Moment): string {
+  return date.clone().locale("de").format("D. MMMM YYYY");
 }
 
 function getCurrentNyseDate(): Date {
@@ -417,23 +434,24 @@ async function runEarningsAnnouncement(
       when: config.when,
     })
     : [];
+  const mostAnticipatedTickerSymbols = new Set(anticipatedEarningsEvents.map(event => event.ticker));
   const regularEarningsEvents = await addExpectedMovesToEarningsEvents(regularEarningsCandidates, {
     marketCapFilter: config.filter,
     when: config.when,
   });
-  const anticipatedEarningsBatch = 0 < anticipatedEarningsEvents.length
-    ? getEarningsMessages(anticipatedEarningsEvents, config.when, getHighlightedAnticipatedTickers(tickers, anticipatedEarningsEvents), {
-      maxMessageLength: EARNINGS_MAX_MESSAGE_LENGTH,
-      maxMessages: EARNINGS_MAX_MESSAGES_TIMER,
-      marketCapFilter: "all",
-    })
-    : getEmptyEarningsMessageBatch();
-  const earningsBatch = getEarningsMessages(regularEarningsEvents, config.when, tickers, {
+  const earningsEvents = [
+    ...anticipatedEarningsEvents,
+    ...regularEarningsEvents,
+  ];
+  const earningsMessageOptions: EarningsMessageOptions = {
     maxMessageLength: EARNINGS_MAX_MESSAGE_LENGTH,
     maxMessages: EARNINGS_MAX_MESSAGES_TIMER,
     marketCapFilter: config.filter,
-  });
-  logEarningsBatch(`${config.source}-anticipated`, anticipatedEarningsBatch);
+  };
+  if (0 < mostAnticipatedTickerSymbols.size) {
+    earningsMessageOptions.mostAnticipatedTickerSymbols = mostAnticipatedTickerSymbols;
+  }
+  const earningsBatch = getEarningsMessages(earningsEvents, config.when, tickers, earningsMessageOptions);
   logEarningsBatch(config.source, earningsBatch);
 
   if ("error" === earningsResult.status) {
@@ -447,23 +465,15 @@ async function runEarningsAnnouncement(
     );
   }
 
-  if (0 === anticipatedEarningsBatch.messages.length && 0 === earningsBatch.messages.length) {
+  if (0 === earningsBatch.messages.length) {
     return;
   }
 
   const channel = await getOptionalThreadTargetChannel(client, channelID, earningsExpectationsThreadID, "earnings");
-  if (0 < anticipatedEarningsBatch.messages.length) {
-    const anticipatedHeadline = config.headline
-      ? anticipatedWeeklyEarningsHeadline
-      : anticipatedEarningsHeadline;
-    await sendChunkedMessages(
-      channel,
-      prependHeadlineToFirstMessage(anticipatedEarningsBatch.messages, anticipatedHeadline, EARNINGS_MAX_MESSAGE_LENGTH),
-      "earnings",
-    );
-  }
   const earningsHeadline = config.headline ?? dailyEarningsHeadline;
-  const messages = prependHeadlineToFirstMessage(earningsBatch.messages, earningsHeadline, EARNINGS_MAX_MESSAGE_LENGTH);
+  const messages = prependHeadlineToFirstMessage(earningsBatch.messages, earningsHeadline, EARNINGS_MAX_MESSAGE_LENGTH, {
+    placement: config.headlinePlacement,
+  });
   if (0 < messages.length) {
     await sendChunkedMessages(channel, messages, "earnings");
   }
@@ -530,41 +540,8 @@ function getEarningsEventsWithoutTickerSymbols(
   return earningsEvents.filter(earningsEvent => false === tickerSymbols.has(normalizeEarningsTickerSymbol(earningsEvent.ticker)));
 }
 
-function getHighlightedAnticipatedTickers(
-  tickers: Ticker[],
-  anticipatedEarningsEvents: EarningsEvent[],
-): Ticker[] {
-  const highlightedTickers = [...tickers];
-  const highlightedTickerSymbols = new Set(tickers.map(ticker => normalizeEarningsTickerSymbol(ticker.symbol)));
-
-  for (const earningsEvent of anticipatedEarningsEvents) {
-    const normalizedTickerSymbol = normalizeEarningsTickerSymbol(earningsEvent.ticker);
-    if (true === highlightedTickerSymbols.has(normalizedTickerSymbol)) {
-      continue;
-    }
-
-    highlightedTickers.push({
-      exchange: "earnings-whispers",
-      name: earningsEvent.companyName ?? earningsEvent.ticker,
-      symbol: earningsEvent.ticker,
-    });
-    highlightedTickerSymbols.add(normalizedTickerSymbol);
-  }
-
-  return highlightedTickers;
-}
-
 function normalizeEarningsTickerSymbol(value: string): string {
   return value.trim().toUpperCase().replaceAll("/", ".").replaceAll("-", ".");
-}
-
-function getEmptyEarningsMessageBatch(): EarningsMessageBatch {
-  return {
-    includedEvents: 0,
-    messages: [],
-    totalEvents: 0,
-    truncated: false,
-  };
 }
 
 async function warmExpectedMovesForAnnouncement(config: EarningsAnnouncementConfig) {
@@ -945,19 +922,20 @@ export function startOtherTimers(
       days: 5,
       errorMessage: "Wöchentliche Earnings konnten nicht geladen werden.",
       filter: "bluechips",
-      headline: weeklyEarningsHeadline,
       source: "timer-earnings-weekly",
       when: "all",
     });
   });
 
   Schedule.scheduleJob(ruleEarningsWeekly, async () => {
+    const nextWeekMonday = getNextBerlinTradingWeekMonday();
     await runEarningsAnnouncement(client, channelID, tickers, {
       date: "tomorrow",
       days: 5,
       errorMessage: "Wöchentliche Earnings konnten nicht geladen werden.",
       filter: "bluechips",
-      headline: weeklyEarningsHeadline,
+      headline: getWeeklyHeadlineWithDateRange(weeklyEarningsHeadline, nextWeekMonday),
+      headlinePlacement: "standalone",
       source: "timer-earnings-weekly",
       when: "all",
     }, earningsExpectationsThreadID);
@@ -1063,10 +1041,7 @@ export function startOtherTimers(
   });
 
   Schedule.scheduleJob(ruleEventsWeekly, async () => {
-    const nextWeekMonday = moment()
-      .tz(europeBerlinTimezone)
-      .startOf("isoWeek")
-      .add(1, "week");
+    const nextWeekMonday = getNextBerlinTradingWeekMonday();
     const nextWeekThursday = nextWeekMonday.clone().add(3, "days");
 
     const calendarEvents1: CalendarEvent[] = await getCalendarEvents(nextWeekMonday.format("YYYY-MM-DD"), 2);
@@ -1226,6 +1201,7 @@ function prependHeadlineToFirstMessage(
   messages: string[],
   headline: string,
   maxMessageLength: number,
+  options: {placement?: "merged" | "standalone" | undefined} = {},
 ): string[] {
   if (0 === messages.length) {
     return messages;
@@ -1236,15 +1212,97 @@ function prependHeadlineToFirstMessage(
     return [headline];
   }
 
-  const firstMessageWithHeadline = getFirstMessageWithHeadline(headline, firstMessage);
+  const firstMessageWithHeadline = "standalone" === options.placement
+    ? getFirstMessageWithStandaloneHeadline(headline, firstMessage)
+    : getFirstMessageWithMergedHeadlinePlacement(headline, firstMessage);
   if (firstMessageWithHeadline.length <= maxMessageLength) {
     return [firstMessageWithHeadline, ...messages.slice(1)];
+  }
+
+  if ("standalone" === options.placement) {
+    const standaloneHeadline = getStandaloneHeadlineForFirstMessage(headline, firstMessage);
+    const firstMessageWithoutPeriod = getFirstMessageWithoutPeriodLine(firstMessage);
+    if ("" === firstMessageWithoutPeriod.trim()) {
+      return [standaloneHeadline, ...messages.slice(1)];
+    }
+
+    return [standaloneHeadline, firstMessageWithoutPeriod, ...messages.slice(1)];
   }
 
   return [headline, ...messages];
 }
 
-function getFirstMessageWithHeadline(headline: string, firstMessage: string): string {
+function getFirstMessageWithStandaloneHeadline(headline: string, firstMessage: string): string {
+  const headlineWithPeriod = getStandaloneHeadlineForFirstMessage(headline, firstMessage);
+  const restMessage = getFirstMessageWithoutPeriodLine(firstMessage);
+  if ("" === restMessage.trim()) {
+    return headlineWithPeriod;
+  }
+
+  return `${headlineWithPeriod}\n${restMessage.trimStart()}`;
+}
+
+function getStandaloneHeadlineForFirstMessage(headline: string, firstMessage: string): string {
+  const periodDateRange = getFirstMessagePeriodDateRange(firstMessage);
+  if (undefined === periodDateRange) {
+    return headline;
+  }
+
+  return getHeadlineWithDateRange(headline, periodDateRange);
+}
+
+function getFirstMessageWithoutPeriodLine(firstMessage: string): string {
+  const periodMatch = getFirstMessagePeriodLineMatch(firstMessage);
+  if (null !== periodMatch) {
+    return firstMessage.slice(periodMatch[0].length);
+  }
+
+  return firstMessage;
+}
+
+function getFirstMessagePeriodDateRange(firstMessage: string): string | undefined {
+  const periodMatch = getFirstMessagePeriodLineMatch(firstMessage);
+  if (null === periodMatch) {
+    return undefined;
+  }
+
+  const startDate = getCompactGermanDateFromFriendlyDate(periodMatch[1] ?? "");
+  const endDate = getCompactGermanDateFromFriendlyDate(periodMatch[2] ?? "");
+  if ("" === startDate || "" === endDate) {
+    return undefined;
+  }
+
+  return `${startDate} - ${endDate}`;
+}
+
+function getFirstMessagePeriodLineMatch(firstMessage: string): RegExpExecArray | null {
+  return /^\*\*Zeitraum:\*\* ([^\n]+?) bis ([^\n]+)\n?/.exec(firstMessage);
+}
+
+function getCompactGermanDateFromFriendlyDate(friendlyDate: string): string {
+  const normalizedFriendlyDate = friendlyDate.trim();
+  const weekdayMatch = /^(?:Montag|Dienstag|Mittwoch|Donnerstag|Freitag|Samstag|Sonntag),\s+(.+)$/.exec(normalizedFriendlyDate);
+  return weekdayMatch?.[1] ?? normalizedFriendlyDate;
+}
+
+function getHeadlineWithDateRange(headline: string, dateRange: string): string {
+  const headlineWithoutDateRange = getHeadlineWithoutDateRange(headline);
+  if (headlineWithoutDateRange.endsWith("**")) {
+    return `${headlineWithoutDateRange.slice(0, -2)} (${dateRange})**`;
+  }
+
+  return `${headlineWithoutDateRange} (${dateRange})`;
+}
+
+function getHeadlineWithoutDateRange(headline: string): string {
+  if (headline.endsWith("**")) {
+    return headline.replace(/ \([^()\n]+\)\*\*$/, "**");
+  }
+
+  return headline.replace(/ \([^()\n]+\)$/, "");
+}
+
+function getFirstMessageWithMergedHeadlinePlacement(headline: string, firstMessage: string): string {
   const periodMatch = /^\*\*Zeitraum:\*\* ([^\n]+)\n?/.exec(firstMessage);
   if (null !== periodMatch) {
     return getFirstMessageWithMergedHeadline(headline, firstMessage, periodMatch[1] ?? "", periodMatch[0].length);


### PR DESCRIPTION
## Summary

- Fold most-anticipated earnings into the normal earnings lists instead of sending a dedicated post.
- Prefix earnings rows with `☕`, `🌞`, or `🌙`, plus `🔥` for most-anticipated rows and `🏢` for regular rows.
- Keep all tickers in inline code formatting, with index-highlighted tickers rendered as bolded code.
- Format weekly earnings headlines with a leading `💸` and date range, while retaining the weekly calendar headline changes already in the branch.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run test:coverage`
