### PR TITLE
[codex] add fxtwitter link previews

### DIFF
--- a/modules/startup-orchestrator.test.ts
+++ b/modules/startup-orchestrator.test.ts
@@ -160,6 +160,7 @@ describe("startBot", () => {
     );
     expect(mocks.addInlineResponses).toHaveBeenCalledTimes(1);
     expect(mocks.addTriggerResponses).toHaveBeenCalledTimes(1);
+    expect(mocks.addTwitterLinkRewrites).toHaveBeenCalledTimes(1);
     expect(mocks.interactSlashCommands).toHaveBeenCalledTimes(1);
   });
 

--- a/modules/startup-orchestrator.ts
+++ b/modules/startup-orchestrator.ts
@@ -14,6 +14,7 @@ import {createStartupState} from "./startup-state.ts";
 import {getTickers} from "./tickers.ts";
 import {startMncTimers, startNyseTimers, startOtherTimers} from "./timers.ts";
 import {addTriggerResponses} from "./trigger-response.ts";
+import {addTwitterLinkRewrites} from "./twitter-link-rewrite.ts";
 import {runStartupPreflight} from "./startup-preflight.ts";
 import {
   type SharedStartupData,
@@ -65,6 +66,7 @@ function createDependencies(options: StartupOptions): StartupDependencies {
     interactSlashCommands: options.interactSlashCommands ?? interactSlashCommands,
     addInlineResponses: options.addInlineResponses ?? addInlineResponses,
     addTriggerResponses: options.addTriggerResponses ?? addTriggerResponses,
+    addTwitterLinkRewrites: options.addTwitterLinkRewrites ?? addTwitterLinkRewrites,
     getGenericAssets: options.getGenericAssets ?? getGenericAssets,
     getAssets: options.getAssets ?? getAssets,
     getTickers: options.getTickers ?? getTickers,
@@ -239,6 +241,7 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     });
     dependencies.addInlineResponses(client, sharedData.assets, sharedData.assetCommands);
     dependencies.addTriggerResponses(client, sharedData.assets, sharedData.assetCommandsWithPrefix, sharedData.whatIsAssets, sharedData.paywallAssets);
+    dependencies.addTwitterLinkRewrites(client);
     dependencies.interactSlashCommands(client, sharedData.assets, sharedData.assetCommands, sharedData.whatIsAssets, sharedData.tickers, sharedData.paywallAssets);
     startupState.markHandlersAttached();
 

--- a/modules/startup-types.ts
+++ b/modules/startup-types.ts
@@ -22,6 +22,7 @@ import {type StartupStateSnapshot} from "./startup-state.ts";
 import {type getTickers, type Ticker} from "./tickers.ts";
 import {type startMncTimers, type startNyseTimers, type startOtherTimers} from "./timers.ts";
 import {type addTriggerResponses} from "./trigger-response.ts";
+import {type addTwitterLinkRewrites} from "./twitter-link-rewrite.ts";
 
 export type Logger = {
   level?: string;
@@ -42,6 +43,7 @@ export type StartupDependencies = {
   interactSlashCommands: typeof interactSlashCommands;
   addInlineResponses: typeof addInlineResponses;
   addTriggerResponses: typeof addTriggerResponses;
+  addTwitterLinkRewrites: typeof addTwitterLinkRewrites;
   getGenericAssets: typeof getGenericAssets;
   getAssets: typeof getAssets;
   getTickers: typeof getTickers;

--- a/modules/test-utils/startup-orchestrator.ts
+++ b/modules/test-utils/startup-orchestrator.ts
@@ -241,6 +241,9 @@ export function createDependencies(overrides = {}) {
   const addTriggerResponses = vi.fn(() => {
     events.push("trigger");
   });
+  const addTwitterLinkRewrites = vi.fn(() => {
+    events.push("twitter-link-rewrite");
+  });
   const interactSlashCommands = vi.fn(() => {
     events.push("slash-interact");
   });
@@ -293,6 +296,7 @@ export function createDependencies(overrides = {}) {
       runHealthCheck,
       addInlineResponses,
       addTriggerResponses,
+      addTwitterLinkRewrites,
       interactSlashCommands,
       clownboard,
       startNyseTimers,
@@ -320,6 +324,7 @@ export function createDependencies(overrides = {}) {
       runHealthCheck,
       addInlineResponses,
       addTriggerResponses,
+      addTwitterLinkRewrites,
       interactSlashCommands,
       clownboard,
       startNyseTimers,

--- a/modules/twitter-link-rewrite.test.ts
+++ b/modules/twitter-link-rewrite.test.ts
@@ -1,0 +1,161 @@
+import {beforeEach, describe, expect, test, vi} from "vitest";
+import {createEventClient} from "./test-utils/discord-mocks.ts";
+import {
+  addTwitterLinkRewrites,
+  getFixedTwitterLinks,
+} from "./twitter-link-rewrite.ts";
+
+const loggerMock = vi.hoisted(() => ({
+  log: vi.fn(),
+}));
+
+vi.mock("./logging.ts", () => ({
+  getLogger: () => loggerMock,
+}));
+
+type TwitterTestMessage = {
+  author?: {
+    bot?: boolean;
+  };
+  content: string;
+  reply: ReturnType<typeof vi.fn>;
+  suppressEmbeds: ReturnType<typeof vi.fn>;
+  webhookId?: string | null;
+};
+
+function createTwitterMessage(content: string): TwitterTestMessage {
+  return {
+    content,
+    reply: vi.fn().mockResolvedValue(undefined),
+    suppressEmbeds: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("getFixedTwitterLinks", () => {
+  test("rewrites Twitter and X links to clean fxtwitter URLs", () => {
+    expect(getFixedTwitterLinks(
+      "Watch https://x.com/example/status/123?s=20#anchor and https://twitter.com/example/status/456?ref=home.",
+    )).toEqual([
+      "https://fxtwitter.com/example/status/123",
+      "https://fxtwitter.com/example/status/456",
+    ]);
+  });
+
+  test("supports mobile and www hosts", () => {
+    expect(getFixedTwitterLinks(
+      "https://mobile.twitter.com/example/status/123 https://www.x.com/example/status/456",
+    )).toEqual([
+      "https://fxtwitter.com/example/status/123",
+      "https://fxtwitter.com/example/status/456",
+    ]);
+  });
+
+  test("ignores duplicate, non-twitter, existing fxtwitter, and bare host links", () => {
+    expect(getFixedTwitterLinks(
+      "https://x.com/example/status/123 https://x.com/example/status/123 https://fxtwitter.com/example/status/456 https://example.com https://x.com",
+    )).toEqual([
+      "https://fxtwitter.com/example/status/123",
+    ]);
+  });
+
+  test("trims common trailing punctuation around links", () => {
+    expect(getFixedTwitterLinks(
+      "tweet (https://x.com/example/status/123), and <https://twitter.com/example/status/456>!",
+    )).toEqual([
+      "https://fxtwitter.com/example/status/123",
+      "https://fxtwitter.com/example/status/456",
+    ]);
+  });
+});
+
+describe("addTwitterLinkRewrites", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("suppresses the original embed and replies with the clean link", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("watch https://x.com/example/status/123?s=20");
+
+    await handler(message);
+
+    expect(message.suppressEmbeds).toHaveBeenCalledWith(true);
+    expect(message.reply).toHaveBeenCalledWith({
+      allowedMentions: {
+        parse: [],
+        repliedUser: false,
+      },
+      content: "https://fxtwitter.com/example/status/123",
+    });
+  });
+
+  test("ignores bot-authored and webhook messages", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+    const handler = getHandler("messageCreate");
+
+    const botMessage = createTwitterMessage("https://x.com/example/status/123");
+    botMessage.author = {bot: true};
+    await handler(botMessage);
+
+    const webhookMessage = createTwitterMessage("https://x.com/example/status/123");
+    webhookMessage.webhookId = "webhook-id";
+    await handler(webhookMessage);
+
+    expect(botMessage.suppressEmbeds).not.toHaveBeenCalled();
+    expect(botMessage.reply).not.toHaveBeenCalled();
+    expect(webhookMessage.suppressEmbeds).not.toHaveBeenCalled();
+    expect(webhookMessage.reply).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when there are no fixable Twitter or X links", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://fxtwitter.com/example/status/123");
+
+    await handler(message);
+
+    expect(message.suppressEmbeds).not.toHaveBeenCalled();
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+
+  test("still replies when suppressing the original embed fails", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.suppressEmbeds.mockRejectedValue(new Error("missing permission"));
+
+    await handler(message);
+
+    expect(message.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: "https://fxtwitter.com/example/status/123",
+    }));
+    expect(loggerMock.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("Error suppressing Twitter/X embed"),
+    );
+  });
+
+  test("logs reply failures without throwing", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.reply.mockRejectedValue(new Error("reply failed"));
+
+    await handler(message);
+
+    expect(loggerMock.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("Error sending fixed Twitter/X link"),
+    );
+  });
+});

--- a/modules/twitter-link-rewrite.ts
+++ b/modules/twitter-link-rewrite.ts
@@ -1,0 +1,149 @@
+import {getLogger} from "./logging.ts";
+
+const logger = getLogger();
+const discordMaxMessageLength = 2_000;
+const trailingUrlPunctuation = ".,!?;:)]}";
+const twitterUrlRegex = /https?:\/\/[^\s<>"']+/giu;
+const twitterHosts = new Set([
+  "mobile.twitter.com",
+  "mobile.x.com",
+  "m.twitter.com",
+  "twitter.com",
+  "x.com",
+]);
+
+type TwitterLinkRewriteMessage = {
+  author?: {
+    bot?: boolean;
+  };
+  content: string;
+  reply: (payload: {
+    allowedMentions: {
+      parse: string[];
+      repliedUser: boolean;
+    };
+    content: string;
+  }) => Promise<unknown> | unknown;
+  suppressEmbeds: (suppress?: boolean) => Promise<unknown>;
+  webhookId?: string | null;
+};
+
+type TwitterLinkRewriteClient = {
+  on: (eventName: "messageCreate", handler: (message: TwitterLinkRewriteMessage) => Promise<void>) => unknown;
+};
+
+function trimTrailingUrlPunctuation(value: string): string {
+  let trimmed = value;
+  while ("" !== trimmed && trailingUrlPunctuation.includes(trimmed.at(-1) ?? "")) {
+    trimmed = trimmed.slice(0, -1);
+  }
+
+  return trimmed;
+}
+
+function normalizeTwitterHostname(hostname: string): string {
+  const normalizedHostname = hostname.toLowerCase();
+  return normalizedHostname.startsWith("www.")
+    ? normalizedHostname.slice(4)
+    : normalizedHostname;
+}
+
+function getFixedTwitterUrl(value: string): string | undefined {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(value);
+  } catch {
+    return undefined;
+  }
+
+  if (false === twitterHosts.has(normalizeTwitterHostname(parsedUrl.hostname))) {
+    return undefined;
+  }
+
+  if ("/" === parsedUrl.pathname) {
+    return undefined;
+  }
+
+  return `https://fxtwitter.com${parsedUrl.pathname}`;
+}
+
+function getMessageContentWithinDiscordLimit(links: string[]): string {
+  const acceptedLinks: string[] = [];
+  let messageLength = 0;
+
+  for (const link of links) {
+    const nextLength = messageLength + (0 === acceptedLinks.length ? 0 : 1) + link.length;
+    if (nextLength > discordMaxMessageLength) {
+      break;
+    }
+
+    acceptedLinks.push(link);
+    messageLength = nextLength;
+  }
+
+  return acceptedLinks.join("\n");
+}
+
+async function suppressOriginalEmbeds(message: TwitterLinkRewriteMessage) {
+  try {
+    await message.suppressEmbeds(true);
+  } catch (error: unknown) {
+    logger.log(
+      "error",
+      `Error suppressing Twitter/X embed: ${error}`,
+    );
+  }
+}
+
+async function replyWithFixedLinks(message: TwitterLinkRewriteMessage, content: string) {
+  try {
+    await message.reply({
+      allowedMentions: {
+        parse: [],
+        repliedUser: false,
+      },
+      content,
+    });
+  } catch (error: unknown) {
+    logger.log(
+      "error",
+      `Error sending fixed Twitter/X link: ${error}`,
+    );
+  }
+}
+
+export function getFixedTwitterLinks(content: string): string[] {
+  const fixedLinks = new Set<string>();
+  const matches = content.matchAll(twitterUrlRegex);
+
+  for (const match of matches) {
+    const rawUrl = match[0];
+    const fixedUrl = getFixedTwitterUrl(trimTrailingUrlPunctuation(rawUrl));
+    if (fixedUrl) {
+      fixedLinks.add(fixedUrl);
+    }
+  }
+
+  return [...fixedLinks];
+}
+
+export function addTwitterLinkRewrites(client: TwitterLinkRewriteClient) {
+  client.on("messageCreate", async message => {
+    if (true === message.author?.bot || Boolean(message.webhookId)) {
+      return;
+    }
+
+    const fixedLinks = getFixedTwitterLinks(message.content);
+    if (0 === fixedLinks.length) {
+      return;
+    }
+
+    const content = getMessageContentWithinDiscordLimit(fixedLinks);
+    if ("" === content) {
+      return;
+    }
+
+    await suppressOriginalEmbeds(message);
+    await replyWithFixedLinks(message, content);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a Discord message handler that rewrites Twitter/X links to clean fxtwitter.com URLs so previews and video playback continue to work.

The handler suppresses the original message embed, replies with deduplicated clean URLs, and avoids pinging the original author or mentioned users. It ignores bot and webhook messages.

## Impact

Users can post normal twitter.com or x.com links. The bot posts a clean fxtwitter.com reply and attempts to hide the broken original embed.

If Discord denies embed suppression, the bot logs the failure and still posts the clean URL.

## Validation

- npm test
- npm run typecheck
- npm run lint
