### PR TITLE
[codex] Adjust weekly post heading date ranges

### DIFF
--- a/modules/calendar.test.ts
+++ b/modules/calendar.test.ts
@@ -182,7 +182,7 @@ describe("getCalendarMessages", () => {
     ];
 
     const batch = getCalendarMessages(calendarEvents, {
-      title: "📅 **Wichtige Termine der nächsten Handelswoche (11. Mai 2026 - 15. Mai 2026)**",
+      title: "📅 **Wichtige Termine der nächsten Handelswoche** (11. Mai 2026 - 15. Mai 2026)",
       titlePlacement: "standalone",
       maxMessageLength: 1800,
       maxMessages: 6,
@@ -190,11 +190,11 @@ describe("getCalendarMessages", () => {
     });
 
     expect(batch.messages[0]!).toContain(
-      "📅 **Wichtige Termine der nächsten Handelswoche (11. Mai 2026 - 15. Mai 2026)**\n**Montag, 11. Mai 2026**\n`16:00` 🇺🇸 Existing Home Sales",
+      "📅 **Wichtige Termine der nächsten Handelswoche** (11. Mai 2026 - 15. Mai 2026)\n**Montag, 11. Mai 2026**\n`16:00` 🇺🇸 Existing Home Sales",
     );
     expect(batch.messages[0]!).not.toContain(")**\n\n**Montag");
     expect(batch.messages[0]!).toContain("**Dienstag, 12. Mai 2026**\n`01:30` 🇯🇵 Household Spending m/m");
-    expect(batch.messages[0]!).not.toContain("**Wichtige Termine der nächsten Handelswoche (11. Mai 2026 - 15. Mai 2026)** (Montag");
+    expect(batch.messages[0]!).not.toContain("**Wichtige Termine der nächsten Handelswoche** (11. Mai 2026 - 15. Mai 2026) (Montag");
   });
 
   test("chunks by day boundaries across multiple days", () => {

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -929,7 +929,7 @@ describe("timers: other announcements", () => {
       marketCapFilter: "bluechips",
     });
     expect(send).toHaveBeenNthCalledWith(1, {
-      content: "💸 **Earnings der nächsten Handelswoche (24. Februar 2025 - 27. Februar 2025)**\n**Montag, 24. Februar 2025**\nweekly-earnings-1",
+      content: "💸 **Earnings der nächsten Handelswoche** (24. Februar 2025 - 27. Februar 2025)\n**Montag, 24. Februar 2025**\nweekly-earnings-1",
       allowedMentions: {
         parse: [],
       },
@@ -1014,7 +1014,7 @@ describe("timers: other announcements", () => {
     );
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
-      content: "💸 **Earnings der nächsten Handelswoche (24. Februar 2025 - 28. Februar 2025)**\n**Montag, 24. Februar 2025**\nweekly-folded",
+      content: "💸 **Earnings der nächsten Handelswoche** (24. Februar 2025 - 28. Februar 2025)\n**Montag, 24. Februar 2025**\nweekly-folded",
       allowedMentions: {
         parse: [],
       },
@@ -1262,7 +1262,8 @@ describe("timers: other announcements", () => {
       maxMessageLength: 1800,
       maxMessages: 8,
       keepDayTogether: true,
-      title: "📅 **Wichtige Termine der nächsten Handelswoche:**",
+      title: "📅 **Wichtige Termine der nächsten Handelswoche** (24. Februar 2025 - 26. Februar 2025)",
+      titlePlacement: "standalone",
     }));
     expect(send).toHaveBeenNthCalledWith(1, expect.objectContaining({
       content: "week-1",

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -64,7 +64,7 @@ const calendarReminderFollowUpDelaySeconds = [5, 10, 20, 30, 60, 120, 180, 300, 
 const usEasternTimezone = "US/Eastern";
 const dailyEarningsHeadline = "**Earnings**";
 const weeklyEarningsHeadline = "💸 **Earnings der nächsten Handelswoche**";
-const weeklyCalendarHeadline = "📅 **Wichtige Termine der nächsten Handelswoche:**";
+const weeklyCalendarHeadline = "📅 **Wichtige Termine der nächsten Handelswoche**";
 const europeBerlinTimezone = "Europe/Berlin";
 const usEasternWeekdays = [new Schedule.Range(1, 5)];
 const gainsAndLossesThreadName = "Heutige Gains&Losses";
@@ -146,6 +146,29 @@ function getWeeklyHeadlineWithDateRange(headline: string, weekMonday: moment.Mom
   const weekFriday = weekMonday.clone().add(4, "days");
   const dateRange = `${getGermanDate(weekMonday)} - ${getGermanDate(weekFriday)}`;
   return getHeadlineWithDateRange(headline, dateRange);
+}
+
+function getWeeklyCalendarHeadlineWithDateRange(headline: string, calendarEvents: CalendarEvent[]): string {
+  const dateRange = getCalendarEventsDateRange(calendarEvents);
+  if (undefined === dateRange) {
+    return headline;
+  }
+
+  return getHeadlineWithDateRange(headline, dateRange);
+}
+
+function getCalendarEventsDateRange(calendarEvents: CalendarEvent[]): string | undefined {
+  const eventDates = calendarEvents
+    .map(calendarEvent => moment.tz(calendarEvent.date, "YYYY-MM-DD", true, europeBerlinTimezone))
+    .filter(eventDate => eventDate.isValid())
+    .sort((first, second) => first.valueOf() - second.valueOf());
+  const firstEventDate = eventDates[0];
+  const lastEventDate = eventDates[eventDates.length - 1];
+  if (undefined === firstEventDate || undefined === lastEventDate) {
+    return undefined;
+  }
+
+  return `${getGermanDate(firstEventDate)} - ${getGermanDate(lastEventDate)}`;
 }
 
 function getGermanDate(date: moment.Moment): string {
@@ -1082,7 +1105,8 @@ export function startOtherTimers(
       maxMessageLength: CALENDAR_MAX_MESSAGE_LENGTH,
       maxMessages: CALENDAR_MAX_MESSAGES_TIMER,
       keepDayTogether: true,
-      title: weeklyCalendarHeadline,
+      title: getWeeklyCalendarHeadlineWithDateRange(weeklyCalendarHeadline, calendarEvents),
+      titlePlacement: "standalone",
     });
     logCalendarBatch("timer-weekly", calendarBatch);
 
@@ -1317,19 +1341,18 @@ function getCompactGermanDateFromFriendlyDate(friendlyDate: string): string {
 
 function getHeadlineWithDateRange(headline: string, dateRange: string): string {
   const headlineWithoutDateRange = getHeadlineWithoutDateRange(headline);
-  if (headlineWithoutDateRange.endsWith("**")) {
-    return `${headlineWithoutDateRange.slice(0, -2)} (${dateRange})**`;
-  }
-
   return `${headlineWithoutDateRange} (${dateRange})`;
 }
 
 function getHeadlineWithoutDateRange(headline: string): string {
-  if (headline.endsWith("**")) {
-    return headline.replace(/ \([^()\n]+\)\*\*$/, "**");
+  const headlineWithoutTrailingDateRange = headline.replace(/ \([^()\n]+\)$/, "");
+  if (headlineWithoutTrailingDateRange.endsWith("**")) {
+    return headlineWithoutTrailingDateRange
+      .replace(/ \([^()\n]+\)\*\*$/, "**")
+      .replace(/:\*\*$/, "**");
   }
 
-  return headline.replace(/ \([^()\n]+\)$/, "");
+  return headlineWithoutTrailingDateRange.replace(/:$/, "");
 }
 
 function getFirstMessageWithMergedHeadlinePlacement(headline: string, firstMessage: string): string {


### PR DESCRIPTION
## Summary
- Keep weekly earnings date ranges outside bolded headline text.
- Give weekly calendar posts a compact first-to-last event date range and render the first day as its own bold header.
- Update timer/calendar tests for the new Discord output.

## Validation
- npm test -- modules/timers-other.test.ts modules/calendar.test.ts
- npm run typecheck