### PR TITLE
[codex] Avoid caching empty anticipated earnings

### DIFF
--- a/modules/earnings-whispers.test.ts
+++ b/modules/earnings-whispers.test.ts
@@ -170,4 +170,28 @@ describe("Earnings Whispers weekly tickers", () => {
 
     expect(getWithRetryFn).toHaveBeenCalledTimes(1);
   });
+
+  test("does not cache empty weekly ticker responses", async () => {
+    clearEarningsWhispersWeeklyTickerCache();
+    const getWithRetryFn = vi.fn()
+      .mockResolvedValueOnce({
+        data: "Earnings Whispers @eWhispers no matching weekly post yet.",
+      })
+      .mockResolvedValueOnce({
+        data: "The most anticipated earnings releases for the week of June 1, 2026, are Broadcom #AVGO, CrowdStrike #CRWD, Palo Alto Networks #PANW, and Hewlett Packard Enterprise #HPE.https://www.earningswhispers.com/calendar#mostanticipated #earningsseason",
+      });
+    const logger = {
+      log: vi.fn(),
+    };
+    const options = {
+      getWithRetryFn,
+      logger,
+      now: moment.tz("2026-06-01 12:00", "YYYY-MM-DD HH:mm", "US/Eastern"),
+    };
+
+    await expect(loadEarningsWhispersWeeklyTickers(options)).resolves.toEqual(new Set());
+    await expect(loadEarningsWhispersWeeklyTickers(options)).resolves.toEqual(new Set(["AVGO", "CRWD", "PANW", "HPE"]));
+
+    expect(getWithRetryFn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/modules/earnings-whispers.ts
+++ b/modules/earnings-whispers.ts
@@ -53,11 +53,13 @@ export async function loadEarningsWhispersWeeklyTickers({
 
   try {
     const tickers = await loadUncachedEarningsWhispersWeeklyTickers(getWithRetryFn, weekStart);
-    earningsWhispersWeeklyTickerCache = {
-      loadedAtMs,
-      tickers,
-      weekStartDateStamp,
-    };
+    if (0 < tickers.size) {
+      earningsWhispersWeeklyTickerCache = {
+        loadedAtMs,
+        tickers,
+        weekStartDateStamp,
+      };
+    }
     loggerInstance.log(
       "debug",
       {


### PR DESCRIPTION
## Summary
- Avoid storing empty Earnings Whispers weekly ticker results in the six-hour cache.
- Let the announcement path retry after a warmup/profile fetch returns no anticipated tickers.
- Add a regression test for an empty first response followed by a same-week non-empty response.

## Validation
- npm test -- modules/earnings-whispers.test.ts modules/timers-other.test.ts
- npm run typecheck