### PR TITLE
Validate MNC summary structure before posting

### DIFF
--- a/modules/mnc-summary.test.ts
+++ b/modules/mnc-summary.test.ts
@@ -1,7 +1,56 @@
 import {Buffer} from "node:buffer";
 import {beforeEach, describe, expect, test, vi} from "vitest";
 import {clearAiProviderState} from "./ai-provider.ts";
-import {getMncSummary} from "./mnc-summary.ts";
+import {formatMncSummary, getMncSummary, isStructurallyValidMncSummary} from "./mnc-summary.ts";
+
+const validSummaryMarkdown = [
+  "**Morning News Call - TL;DR**",
+  "- Futures firm ahead of payrolls.",
+  "- Yields ease as risk appetite improves.",
+  "",
+  "**Stocks in focus**",
+  "- Apple `AAPL` rose on upgrades.",
+  "- Tesla `TSLA` slipped premarket.",
+  "- Nvidia `NVDA` led chip gains.",
+  "",
+  "**Watchlist**",
+  "- Watch the jobs report this morning.",
+].join("\n");
+
+const validSummaryExpected = [
+  "- Futures firm ahead of payrolls.",
+  "- Yields ease as risk appetite improves.",
+  "",
+  "**Stocks in focus**",
+  "- Apple `AAPL` rose on upgrades.",
+  "- Tesla `TSLA` slipped premarket.",
+  "- Nvidia `NVDA` led chip gains.",
+  "",
+  "**Watchlist**",
+  "- Watch the jobs report this morning.",
+].join("\n");
+
+// Reproduces the production incident: the model lost the deal value, leaked a
+// self-correction into the answer, and never produced the section headings.
+const malformedSummaryMarkdown = [
+  "**Morning News Call - TL;DR**",
+  "- Futures firm ahead of payrolls.",
+  "- Berkshire Hathaway: agreed to buy Taylor Morrison Home for -? Wait",
+].join("\n");
+
+function geminiResponse(summaryMarkdown: string) {
+  return {
+    data: {
+      candidates: [{
+        content: {
+          parts: [{
+            text: JSON.stringify({summaryMarkdown}),
+          }],
+        },
+      }],
+    },
+  };
+}
 
 describe("MNC AI summary", () => {
   const logger = {
@@ -21,19 +70,7 @@ describe("MNC AI summary", () => {
   });
 
   test("summarizes the PDF with inline provider PDF data", async () => {
-    const postWithRetryFn = vi.fn().mockResolvedValue({
-      data: {
-        candidates: [{
-          content: {
-            parts: [{
-              text: JSON.stringify({
-                summaryMarkdown: "**Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.",
-              }),
-            }],
-          },
-        }],
-      },
-    });
+    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(validSummaryMarkdown));
 
     const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
       logger,
@@ -41,7 +78,8 @@ describe("MNC AI summary", () => {
       readSecretFn,
     });
 
-    expect(summary).toBe("- Futures firm ahead of payrolls.");
+    expect(summary).toBe(validSummaryExpected);
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
     expect(postWithRetryFn).toHaveBeenCalledWith(
       expect.stringContaining("gemini-2.5-flash-lite:generateContent"),
       expect.objectContaining({
@@ -79,6 +117,67 @@ describe("MNC AI summary", () => {
     );
   });
 
+  test("retries once and posts a valid summary after a malformed first attempt", async () => {
+    const postWithRetryFn = vi.fn()
+      .mockResolvedValueOnce(geminiResponse(malformedSummaryMarkdown))
+      .mockResolvedValue(geminiResponse(validSummaryMarkdown));
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBe(validSummaryExpected);
+    expect(summary).not.toContain("Wait");
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("Discarding malformed AI MNC summary"),
+    );
+  });
+
+  test("discards the summary when every attempt is malformed", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(malformedSummaryMarkdown));
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBeUndefined();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("Discarding malformed AI MNC summary"),
+    );
+  });
+
+  test("rejects summaries with too few bullets even when both headings are present", async () => {
+    const thinSummaryMarkdown = [
+      "**Morning News Call - TL;DR**",
+      "- Futures firm ahead of payrolls.",
+      "",
+      "**Stocks in focus**",
+      "- Apple `AAPL` rose on upgrades.",
+      "- Tesla `TSLA` slipped premarket.",
+      "",
+      "**Watchlist**",
+      "- Watch the jobs report this morning.",
+    ].join("\n");
+    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(thinSummaryMarkdown));
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBeUndefined();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+  });
+
   test("stays disabled when the active provider API key is missing", async () => {
     const postWithRetryFn = vi.fn();
 
@@ -109,223 +208,6 @@ describe("MNC AI summary", () => {
       "warn",
       "Skipping MNC AI summary: PDF is too large for inline provider processing.",
     );
-  });
-
-  test("normalizes markdown fences and truncates long summaries", async () => {
-    const longSummary = [
-      "```markdown",
-      "**Morning News Call - TL;DR**",
-      ...Array.from({length: 40}, (_value, index) => `- Market item ${index} with enough text to make the generated summary too long for Discord posting.`),
-      "```",
-    ].join("\n");
-    const postWithRetryFn = vi.fn().mockResolvedValue({
-      data: {
-        candidates: [{
-          content: {
-            parts: [{
-              text: JSON.stringify({
-                summaryMarkdown: longSummary,
-              }),
-            }],
-          },
-        }],
-      },
-    });
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBeDefined();
-    expect(summary).not.toContain("```");
-    expect(summary).not.toContain("**Morning News Call - TL;DR**");
-    expect(summary).not.toContain("📰 **Morning News Call - TL;DR**");
-    expect(summary!.length).toBeLessThanOrEqual(1_930);
-    expect(summary).toContain("\n...");
-    expect(summary).not.toContain("\n- ...");
-  });
-
-  test("compacts sectioned summaries before falling back to a hard truncation", async () => {
-    const longSectionedSummary = [
-      "📰 **Morning News Call - TL;DR**",
-      "- Futures are firmer while yields drift lower, with traders waiting for jobs data, services activity, and Fed speakers to reset rate expectations.",
-      "- Oil is softer, gold is bid, and the dollar is steady as risk appetite improves without removing the main macro and geopolitical overhangs.",
-      "",
-      "**Stocks in focus**",
-      ...Array.from({length: 7}, (_value, index) => `- Company ${index} \`CMP${index}\` moved premarket after management updated guidance, highlighted margin drivers, and flagged demand trends that could matter for today's sector rotation.`),
-      "",
-      "**Watchlist**",
-      "- Watch Treasury supply, afternoon Fed remarks, and the market reaction to services data for signs that rate-sensitive groups can keep leading.",
-      "- Also monitor energy headlines, breadth in megacap technology, and closing auction flows after a busy earnings calendar.",
-    ].join("\n");
-    const postWithRetryFn = vi.fn().mockResolvedValue({
-      data: {
-        candidates: [{
-          content: {
-            parts: [{
-              text: JSON.stringify({
-                summaryMarkdown: longSectionedSummary,
-              }),
-            }],
-          },
-        }],
-      },
-    });
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBeDefined();
-    expect(summary!.length).toBeLessThanOrEqual(1_930);
-    expect(summary).not.toContain("Morning News Call - TL;DR");
-    expect(summary).toContain("**Stocks in focus**");
-    expect(summary).toContain("**Watchlist**");
-    expect(summary).toContain("Watch Treasury supply");
-    expect(summary).not.toContain("\n...");
-  });
-
-  test("removes generated Morning News Call headings", async () => {
-    const postWithRetryFn = vi.fn().mockResolvedValue({
-      data: {
-        candidates: [{
-          content: {
-            parts: [{
-              text: JSON.stringify({
-                summaryMarkdown: "📰 **Morning News Call - TL;DR**\n- Futures firm ahead of payrolls.",
-              }),
-            }],
-          },
-        }],
-      },
-    });
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBe("- Futures firm ahead of payrolls.");
-  });
-
-  test("normalizes common AI Markdown rendering glitches", async () => {
-    const postWithRetryFn = vi.fn().mockResolvedValue({
-      data: {
-        candidates: [{
-          content: {
-            parts: [{
-              text: JSON.stringify({
-                summaryMarkdown: [
-                  "**Morning News Call - TL;DR**",
-                  "- U.S. futures opened firmer while easing geopolitical तनाव and AI optimism lifted risk appetite.",
-                  "- Gold jumped more than `3%`.",
-                  "",
-                  "**Stocks in focus**",
-                  "- Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$$1.57` / `$$25.2B`, with ~`12%` FY26 EPS growth.",
-                  "- Super Micro Computer `SMCI` forecast Q4 revenue of `$$11B`-`$$12.5B` and adjusted EPS of `65c`-`79c`.",
-                  "- PayPal `PYPL` reported Q1 revenue of `$$8.35B`, targeting `$$1.5B` of savings over `2`-`3` years.",
-                  "- Arm `ARM` guided Q1 revenue to `- $1.26B` vs `- $1.25B` est.",
-                  "- Fortinet `FTNT` raised FY guidance to `-$7.71B`-`$7.87B` revenue and `-$3.10`-`$3.16` EPS.",
-                  "- Block `XYZ`: raised full-year gross profit guidance to ` $12.33B` from `$ 12.20B`.",
-                  "- CoreWeave `CRWV`: lifted 2026 capex to ` $31B-$35B`; Nvidia `NVDA` is investing up to ` $2.1B`.",
-                  "- Cheniere `LNG` swung to a `-$3.5B` Q1 loss after a `-$4.8B` derivative hit.",
-                  "",
-                  "**Watchlist**",
-                  "- All eyes on `ADP` April payrolls (`99K` expected).",
-                ].join("\n"),
-              }),
-            }],
-          },
-        }],
-      },
-    });
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBe([
-      "- U.S. futures opened firmer while easing geopolitical and AI optimism lifted risk appetite.",
-      "- Gold jumped more than `3%`.",
-      "",
-      "**Stocks in focus**",
-      "- Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$1.57` / `$25.2B`, with ~`12%` FY26 EPS growth.",
-      "- Super Micro Computer `SMCI` forecast Q4 revenue of `$11B-$12.5B` and adjusted EPS of `65c-79c`.",
-      "- PayPal `PYPL` reported Q1 revenue of `$8.35B`, targeting `$1.5B` of savings over `2-3` years.",
-      "- Arm `ARM` guided Q1 revenue to `$1.26B` vs `$1.25B` est.",
-      "- Fortinet `FTNT` raised FY guidance to `$7.71B-$7.87B` revenue and `$3.10-$3.16` EPS.",
-      "- Block `XYZ`: raised full-year gross profit guidance to `$12.33B` from `$12.20B`.",
-      "- CoreWeave `CRWV`: lifted 2026 capex to `$31B-$35B`; Nvidia `NVDA` is investing up to `$2.1B`.",
-      "- Cheniere `LNG` swung to a `-$3.5B` Q1 loss after a `-$4.8B` derivative hit.",
-      "",
-      "**Watchlist**",
-      "- All eyes on `ADP` April payrolls (`99K` expected).",
-    ].join("\n"));
-  });
-
-  test("hard-truncates summaries that cannot be compacted or split by line", async () => {
-    const postWithRetryFn = vi.fn().mockResolvedValue({
-      data: {
-        candidates: [{
-          content: {
-            parts: [{
-              text: JSON.stringify({
-                summaryMarkdown: "One very long generated line without section breaks. ".repeat(80),
-              }),
-            }],
-          },
-        }],
-      },
-    });
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBeDefined();
-    expect(summary!.length).toBeLessThanOrEqual(1_930);
-    expect(summary).toMatch(/\n\.\.\.$/);
-  });
-
-  test("falls back to line truncation for malformed section summaries", async () => {
-    const malformedSectionSummary = [
-      "📰 **Morning News Call - TL;DR**",
-      "**Stocks in focus**",
-      "**Watchlist**",
-      "A watchlist paragraph without a bullet. ".repeat(90),
-    ].join("\n");
-    const postWithRetryFn = vi.fn().mockResolvedValue({
-      data: {
-        candidates: [{
-          content: {
-            parts: [{
-              text: JSON.stringify({
-                summaryMarkdown: malformedSectionSummary,
-              }),
-            }],
-          },
-        }],
-      },
-    });
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBeDefined();
-    expect(summary!.length).toBeLessThanOrEqual(1_930);
-    expect(summary).toContain("\n...");
   });
 
   test("returns no summary for invalid AI JSON", async () => {
@@ -420,5 +302,155 @@ describe("MNC AI summary", () => {
       "warn",
       "AI MNC summary returned invalid JSON.",
     );
+  });
+});
+
+describe("MNC summary structural validation", () => {
+  const validBody = [
+    "- Futures firm ahead of payrolls.",
+    "- Yields ease as risk appetite improves.",
+    "",
+    "**Stocks in focus**",
+    "- Apple `AAPL` rose on upgrades.",
+    "- Tesla `TSLA` slipped premarket.",
+    "",
+    "**Watchlist**",
+    "- Watch the jobs report this morning.",
+  ].join("\n");
+
+  test("accepts a summary with both section headings and enough bullets", () => {
+    expect(isStructurallyValidMncSummary(validBody)).toBe(true);
+  });
+
+  test("rejects a summary missing the stocks heading", () => {
+    const body = validBody.replace("**Stocks in focus**\n", "");
+    expect(isStructurallyValidMncSummary(body)).toBe(false);
+  });
+
+  test("rejects a summary missing the watchlist heading", () => {
+    const body = validBody.replace("**Watchlist**\n", "");
+    expect(isStructurallyValidMncSummary(body)).toBe(false);
+  });
+
+  test("rejects a summary with too few bullets", () => {
+    const body = [
+      "- Futures firm ahead of payrolls.",
+      "",
+      "**Stocks in focus**",
+      "- Apple `AAPL` rose on upgrades.",
+      "",
+      "**Watchlist**",
+      "- Watch the jobs report this morning.",
+    ].join("\n");
+    expect(isStructurallyValidMncSummary(body)).toBe(false);
+  });
+});
+
+describe("MNC summary formatting", () => {
+  test("normalizes markdown fences and truncates long summaries", () => {
+    const longSummary = [
+      "```markdown",
+      "**Morning News Call - TL;DR**",
+      ...Array.from({length: 40}, (_value, index) => `- Market item ${index} with enough text to make the generated summary too long for Discord posting.`),
+      "```",
+    ].join("\n");
+
+    const summary = formatMncSummary(longSummary);
+
+    expect(summary).not.toContain("```");
+    expect(summary).not.toContain("**Morning News Call - TL;DR**");
+    expect(summary).not.toContain("📰 **Morning News Call - TL;DR**");
+    expect(summary.length).toBeLessThanOrEqual(1_930);
+    expect(summary).toContain("\n...");
+    expect(summary).not.toContain("\n- ...");
+  });
+
+  test("compacts sectioned summaries before falling back to a hard truncation", () => {
+    const longSectionedSummary = [
+      "📰 **Morning News Call - TL;DR**",
+      "- Futures are firmer while yields drift lower, with traders waiting for jobs data, services activity, and Fed speakers to reset rate expectations.",
+      "- Oil is softer, gold is bid, and the dollar is steady as risk appetite improves without removing the main macro and geopolitical overhangs.",
+      "",
+      "**Stocks in focus**",
+      ...Array.from({length: 7}, (_value, index) => `- Company ${index} \`CMP${index}\` moved premarket after management updated guidance, highlighted margin drivers, and flagged demand trends that could matter for today's sector rotation.`),
+      "",
+      "**Watchlist**",
+      "- Watch Treasury supply, afternoon Fed remarks, and the market reaction to services data for signs that rate-sensitive groups can keep leading.",
+      "- Also monitor energy headlines, breadth in megacap technology, and closing auction flows after a busy earnings calendar.",
+    ].join("\n");
+
+    const summary = formatMncSummary(longSectionedSummary);
+
+    expect(summary.length).toBeLessThanOrEqual(1_930);
+    expect(summary).not.toContain("Morning News Call - TL;DR");
+    expect(summary).toContain("**Stocks in focus**");
+    expect(summary).toContain("**Watchlist**");
+    expect(summary).toContain("Watch Treasury supply");
+    expect(summary).not.toContain("\n...");
+  });
+
+  test("removes generated Morning News Call headings", () => {
+    expect(formatMncSummary("📰 **Morning News Call - TL;DR**\n- Futures firm ahead of payrolls."))
+      .toBe("- Futures firm ahead of payrolls.");
+  });
+
+  test("normalizes common AI Markdown rendering glitches", () => {
+    const summary = formatMncSummary([
+      "**Morning News Call - TL;DR**",
+      "- U.S. futures opened firmer while easing geopolitical तनाव and AI optimism lifted risk appetite.",
+      "- Gold jumped more than `3%`.",
+      "",
+      "**Stocks in focus**",
+      "- Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$$1.57` / `$$25.2B`, with ~`12%` FY26 EPS growth.",
+      "- Super Micro Computer `SMCI` forecast Q4 revenue of `$$11B`-`$$12.5B` and adjusted EPS of `65c`-`79c`.",
+      "- PayPal `PYPL` reported Q1 revenue of `$$8.35B`, targeting `$$1.5B` of savings over `2`-`3` years.",
+      "- Arm `ARM` guided Q1 revenue to `- $1.26B` vs `- $1.25B` est.",
+      "- Fortinet `FTNT` raised FY guidance to `-$7.71B`-`$7.87B` revenue and `-$3.10`-`$3.16` EPS.",
+      "- Block `XYZ`: raised full-year gross profit guidance to ` $12.33B` from `$ 12.20B`.",
+      "- CoreWeave `CRWV`: lifted 2026 capex to ` $31B-$35B`; Nvidia `NVDA` is investing up to ` $2.1B`.",
+      "- Cheniere `LNG` swung to a `-$3.5B` Q1 loss after a `-$4.8B` derivative hit.",
+      "",
+      "**Watchlist**",
+      "- All eyes on `ADP` April payrolls (`99K` expected).",
+    ].join("\n"));
+
+    expect(summary).toBe([
+      "- U.S. futures opened firmer while easing geopolitical and AI optimism lifted risk appetite.",
+      "- Gold jumped more than `3%`.",
+      "",
+      "**Stocks in focus**",
+      "- Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$1.57` / `$25.2B`, with ~`12%` FY26 EPS growth.",
+      "- Super Micro Computer `SMCI` forecast Q4 revenue of `$11B-$12.5B` and adjusted EPS of `65c-79c`.",
+      "- PayPal `PYPL` reported Q1 revenue of `$8.35B`, targeting `$1.5B` of savings over `2-3` years.",
+      "- Arm `ARM` guided Q1 revenue to `$1.26B` vs `$1.25B` est.",
+      "- Fortinet `FTNT` raised FY guidance to `$7.71B-$7.87B` revenue and `$3.10-$3.16` EPS.",
+      "- Block `XYZ`: raised full-year gross profit guidance to `$12.33B` from `$12.20B`.",
+      "- CoreWeave `CRWV`: lifted 2026 capex to `$31B-$35B`; Nvidia `NVDA` is investing up to `$2.1B`.",
+      "- Cheniere `LNG` swung to a `-$3.5B` Q1 loss after a `-$4.8B` derivative hit.",
+      "",
+      "**Watchlist**",
+      "- All eyes on `ADP` April payrolls (`99K` expected).",
+    ].join("\n"));
+  });
+
+  test("hard-truncates summaries that cannot be compacted or split by line", () => {
+    const summary = formatMncSummary("One very long generated line without section breaks. ".repeat(80));
+
+    expect(summary.length).toBeLessThanOrEqual(1_930);
+    expect(summary).toMatch(/\n\.\.\.$/);
+  });
+
+  test("falls back to line truncation for malformed section summaries", () => {
+    const malformedSectionSummary = [
+      "📰 **Morning News Call - TL;DR**",
+      "**Stocks in focus**",
+      "**Watchlist**",
+      "A watchlist paragraph without a bullet. ".repeat(90),
+    ].join("\n");
+
+    const summary = formatMncSummary(malformedSectionSummary);
+
+    expect(summary.length).toBeLessThanOrEqual(1_930);
+    expect(summary).toContain("\n...");
   });
 });

--- a/modules/mnc-summary.ts
+++ b/modules/mnc-summary.ts
@@ -5,6 +5,8 @@ export type MncSummaryDependencies = AiProviderDependencies;
 
 const maxInlinePdfBytes = 14_000_000;
 const maxDiscordSummaryLength = 1_930;
+const maxMncSummaryAttempts = 2;
+const minMncSummaryBullets = 5;
 
 const mncSummarySchema = {
   type: "object",
@@ -30,6 +32,33 @@ export async function getMncSummary(
     return undefined;
   }
 
+  for (let attempt = 1; attempt <= maxMncSummaryAttempts; attempt++) {
+    const normalizedSummary = await requestNormalizedMncSummary(pdfBuffer, dependencies);
+    if (undefined === normalizedSummary) {
+      continue;
+    }
+
+    if (false === isStructurallyValidMncSummary(normalizedSummary)) {
+      dependencies.logger.log(
+        "warn",
+        `Discarding malformed AI MNC summary (attempt ${attempt}/${maxMncSummaryAttempts}): missing a required section heading or too few bullets.`,
+      );
+      continue;
+    }
+
+    const finalSummary = finalizeNormalizedSummary(normalizedSummary);
+    if ("" !== finalSummary) {
+      return finalSummary;
+    }
+  }
+
+  return undefined;
+}
+
+async function requestNormalizedMncSummary(
+  pdfBuffer: Buffer,
+  dependencies: MncSummaryDependencies,
+): Promise<string | undefined> {
   const jsonText = await callAiProviderJson(
     getMncSummaryPrompt(),
     mncSummarySchema,
@@ -73,13 +102,26 @@ export async function getMncSummary(
   }
 
   const normalizedSummary = normalizeMarkdownSummary(summaryMarkdown);
-  if ("" === normalizedSummary) {
-    return undefined;
+  return "" === normalizedSummary ? undefined : normalizedSummary;
+}
+
+export function formatMncSummary(summaryMarkdown: string): string {
+  return finalizeNormalizedSummary(normalizeMarkdownSummary(summaryMarkdown));
+}
+
+function finalizeNormalizedSummary(normalizedSummary: string): string {
+  return removeMncTldrHeading(truncateMarkdownSummary(normalizedSummary)).trim();
+}
+
+export function isStructurallyValidMncSummary(summary: string): boolean {
+  const lines = summary.split("\n");
+  const hasStocksHeading = lines.some(line => "**Stocks in focus**" === line.trim());
+  const hasWatchlistHeading = lines.some(line => "**Watchlist**" === line.trim());
+  if (false === hasStocksHeading || false === hasWatchlistHeading) {
+    return false;
   }
 
-  const truncatedSummary = truncateMarkdownSummary(normalizedSummary);
-  const finalSummary = removeMncTldrHeading(truncatedSummary).trim();
-  return "" === finalSummary ? undefined : finalSummary;
+  return getBulletLines(lines).length >= minMncSummaryBullets;
 }
 
 function getMncSummaryPrompt(): string {


### PR DESCRIPTION
## Problem

Today's Morning News Call posted a broken AI summary: the last bullet trailed off mid-sentence ("…agreed to buy Taylor Morrison Home for `-` `?` Wait"), both required section headings (`**Stocks in focus**`, `**Watchlist**`) were missing, and only 4 of the expected 7 bullets were present.

The active provider is OpenAI. Its Responses API with `strict: true` json_schema guarantees the response **parses**, but not that it's **semantically complete** — the model lost the deal value, leaked a self-correction into the answer, and closed out the JSON. `getMncSummary` accepted it because it only validated types, never structure.

## Fix

- **`isStructurallyValidMncSummary`** — requires both section headings and at least 5 bullets.
- **`getMncSummary`** now attempts the AI call up to twice: a malformed (or failed) summary is logged (`Discarding malformed AI MNC summary (attempt N/2)…`) and retried once; if both attempts fail it returns `undefined`, so the bot posts **title + PDF only** rather than broken text. This matches the module's existing defensive `return undefined` style.
- **`formatMncSummary`** is exposed so the normalization/truncation unit tests can target the formatting composition directly — they intentionally use header-less fixtures to exercise the non-compaction paths the new gate would otherwise block.

Today's exact output now fails the gate and would never reach Discord.

## Verification

- `npm run typecheck` — passes
- `npm run test:coverage` — 730/730 pass; `mnc-summary.ts` at 95.3% statements / 97.6% functions, thresholds hold.

## Note

This is a recurring fragile area (see `cc21bbb`, `a9e473b`, `a746bed` fixing MNC dash/metric handling). The gate stops broken *posts*; the underlying trigger is the model mishandling table dashes in the Refinitiv PDF. A prompt-level tightening could be a useful follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)