### PR TITLE
Flag EPS that contradicts net income sign

### DIFF
--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -806,6 +806,67 @@ describe("AI earnings helpers", () => {
     }]);
     expect(hasHighSeveritySuspicion(reasons)).toBe(false);
   });
+
+  test("flags a negative EPS reported alongside a positive net income", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: -7,
+      value: "-$7.00",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: 624_000_000,
+      value: "$624M",
+    }], null, getEvent({
+      epsConsensus: "$0.44",
+    }));
+
+    expect(reasons).toEqual([{
+      message: "EPS -$7.00 is negative while net income $624M is positive.",
+      metricKey: "gaap_eps",
+      severity: "high",
+    }]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(true);
+  });
+
+  test("flags a positive EPS reported alongside a negative net income", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "adjusted_eps",
+      label: "Adj EPS",
+      numericValue: 2.1,
+      value: "$2.10",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: -310_000_000,
+      value: "-$310M",
+    }], null, getEvent());
+
+    expect(reasons).toEqual([{
+      message: "Adj EPS $2.10 is positive while net income -$310M is negative.",
+      metricKey: "adjusted_eps",
+      severity: "high",
+    }]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(true);
+  });
+
+  test("does not flag a negative EPS that agrees with a negative net income", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: -0.5,
+      value: "-$0.50",
+    }, {
+      key: "net_income",
+      label: "Net income",
+      numericValue: -120_000_000,
+      value: "-$120M",
+    }], null, getEvent());
+
+    expect(reasons).toEqual([]);
+    expect(hasHighSeveritySuspicion(reasons)).toBe(false);
+  });
 });
 
 function getEvent(overrides: Partial<ReturnType<typeof getEventBase>> = {}) {

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -396,11 +396,57 @@ export function getSuspiciousEarningsReasons(
     });
   }
 
+  reasons.push(...getEpsNetIncomeSignContradictions(metrics, netIncomeMetric));
+
   return reasons;
 }
 
 export function hasHighSeveritySuspicion(reasons: SuspiciousEarningsReason[]): boolean {
   return reasons.some(reason => "high" === reason.severity);
+}
+
+const epsMetricKeys = new Set(["adjusted_eps", "gaap_eps", "nasdaq_eps"]);
+
+// A positive net income cannot produce a negative EPS, and vice versa. When an
+// EPS metric's sign contradicts net income, the value is almost certainly a
+// parsing artifact (wrong period, footnote fragment, or sign flip), so flag it
+// as high severity. That routes the post through the AI quality gate, which
+// re-checks the value against the filing text before anything is published.
+function getEpsNetIncomeSignContradictions(
+  metrics: EarningsResultMetric[],
+  netIncomeMetric: EarningsResultMetric | undefined,
+): SuspiciousEarningsReason[] {
+  if (undefined === netIncomeMetric ||
+      "number" !== typeof netIncomeMetric.numericValue ||
+      false === Number.isFinite(netIncomeMetric.numericValue) ||
+      0 === netIncomeMetric.numericValue) {
+    return [];
+  }
+
+  const netIncomePositive = netIncomeMetric.numericValue > 0;
+  const reasons: SuspiciousEarningsReason[] = [];
+  for (const metric of metrics) {
+    if (false === epsMetricKeys.has(metric.key) ||
+        "number" !== typeof metric.numericValue ||
+        false === Number.isFinite(metric.numericValue) ||
+        0 === metric.numericValue) {
+      continue;
+    }
+
+    if ((metric.numericValue > 0) === netIncomePositive) {
+      continue;
+    }
+
+    reasons.push({
+      message: netIncomePositive
+        ? `${metric.label} ${metric.value} is negative while net income ${netIncomeMetric.value} is positive.`
+        : `${metric.label} ${metric.value} is positive while net income ${netIncomeMetric.value} is negative.`,
+      metricKey: metric.key,
+      severity: "high",
+    });
+  }
+
+  return reasons;
 }
 
 function getExtractionPrompt(input: EarningsAiExtractionInput, sourceText: string): string {


### PR DESCRIPTION
## Problem

An earnings post showed **HPE Q2 2026 EPS: -\$7.00 vs est. \$0.44** alongside **+\$624M net income**. A positive net income cannot produce a negative EPS, so the value was a parsing artifact — but it published anyway.

It slipped through every sanity gate:
- The EPS-vs-consensus heuristic in `getSuspiciousEarningsReasons` only fires at `|EPS| >= 10` (medium) / `>= 20` (high). `|-7| = 7` falls under both, so **zero** suspicious reasons were raised.
- With zero reasons, `checkEarningsQualityWithAi` auto-allows and the filing is never re-checked.
- A sign-contradiction check existed for **revenue vs net income**, but nothing tied **EPS** to net income.

## Fix

Add `getEpsNetIncomeSignContradictions`: when any EPS metric (`adjusted_eps`/`gaap_eps`/`nasdaq_eps`) has a sign that contradicts net income, raise a **high-severity** reason.

Rather than silently dropping the post, this forces a **filing re-check** before publishing:
- Runs on the final merged metrics, so it catches the bad value regardless of source (XBRL / HTML / AI).
- A non-empty reason triggers **AI re-extraction** against the filing when the value came from the deterministic path (`earnings-results.ts:875`).
- It blocks the quality-gate auto-allow, forcing `checkEarningsQualityWithAi` to re-read the filing text; if the re-check can't confirm the value, the post is suppressed.

Scoped to the sign contradiction (the unambiguous impossible condition) rather than lowering the magnitude threshold, which would false-positive on legitimately high-EPS stocks.

## Tests

Added 3 regression tests (the HPE case, the reverse, and a both-negative no-flag case). Full suite: **733 passing**, typecheck clean, coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)