### PR TITLE
Disable Express X-Powered-By header on health-check server

### DIFF
--- a/modules/health-check.test.ts
+++ b/modules/health-check.test.ts
@@ -4,6 +4,7 @@ import {runHealthCheck} from "./health-check.ts";
 import {afterAll, beforeEach, describe, expect, test, vi} from "vitest";
 
 const {
+  mockAppDisable,
   mockCreateServer,
   mockExpress,
   mockListen,
@@ -12,6 +13,7 @@ const {
   mockRouteHandlers,
 } = vi.hoisted(() => {
   const mockRouteHandlers = new Map<string, (...args: unknown[]) => unknown>();
+  const mockAppDisable = vi.fn();
   const mockAppUse = vi.fn();
   const mockRouterUse = vi.fn();
   const mockRouterGet = vi.fn((path: string, handler: (...args: unknown[]) => unknown) => {
@@ -24,6 +26,7 @@ const {
     listen: mockListen,
   }));
   const mockExpress = vi.fn(() => ({
+    disable: mockAppDisable,
     use: mockAppUse,
   }));
   (mockExpress as Mock & {Router: Mock}).Router = vi.fn(() => ({
@@ -35,6 +38,7 @@ const {
   };
 
   return {
+    mockAppDisable,
     mockCreateServer,
     mockExpress,
     mockListen,
@@ -133,6 +137,7 @@ describe("runHealthCheck", () => {
     runHealthCheck(() => createState(), mockLogger);
 
     expect(mockCreateServer).toHaveBeenCalledTimes(1);
+    expect(mockAppDisable).toHaveBeenCalledWith("x-powered-by");
     expect(mockOn).toHaveBeenCalledWith("error", expect.any(Function));
     expect(mockListen).toHaveBeenCalledWith(11312, "127.0.0.1");
 

--- a/modules/health-check.ts
+++ b/modules/health-check.ts
@@ -30,6 +30,8 @@ export function runHealthCheck(
   logger: HealthcheckLogger = getLogger(),
 ) {
   const app = express();
+  // Don't advertise the framework; trims an information-disclosure header.
+  app.disable("x-powered-by");
   const router = express.Router();
 
   router.use((_request, response, next) => {


### PR DESCRIPTION
## What

Disable the default `X-Powered-By: Express` response header on the health-check HTTP server via `app.disable("x-powered-by")`.

## Why

Snyk Code (SAST) flagged the header as **Information Exposure – X-Powered-By Header** (CWE-200, Medium). Advertising the framework gives no functional benefit and is low-effort to remove.

## Scope / safety

- Affects only the internal, `127.0.0.1`-bound liveness server. `/api/v1/health` and the rest of the routes are unchanged, so `healthcheck.js` keeps working.
- Test mock updated to expose `app.disable`, with an assertion that `x-powered-by` is disabled.
- `npm run typecheck` and the health-check tests pass.

## Notes

The other Snyk Code findings in this scan are being closed as not-actionable in the Snyk UI:
- `health-check.ts` cleartext HTTP — localhost-only Docker probe (won't fix, by design).
- 3× `market-data.ts` "Insufficient postMessage Validation" — server-side `ws` handlers, not browser `postMessage`; `event.origin` does not apply (false positives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)