### PR TITLE
Fix MNC summary never posting: accept bold lead-in section labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,11 @@ Coding guidance for this repo. Extracts the rules a contributor (human or agent)
 - Separate workflows run CodeQL, njsscan, and Semgrep. Treat their findings as blocking.
 - Don't loosen any of: `coverageThreshold`, `npm audit --audit-level=high`, Trivy severity filters, Checkov framework scope, image signing, or the staging readiness gate. If one is genuinely the wrong fit, raise it explicitly rather than editing it through.
 
+## Commit signing
+
+- Commits and tags in this repo are **SSH-signed, not GPG-signed**. The repo-local git config sets `gpg.format=ssh`, `commit.gpgsign=true`, and `tag.gpgsign=true`. Don't switch `gpg.format` to `openpgp`/GPG, and don't disable signing to make a commit go through — if signing fails, fix the key setup instead.
+- No PII in commits. The author/committer identity must be a GitHub handle plus that account's `…@users.noreply.github.com` privacy email — never a real name or a real-domain email. The SSH signature embeds only the public key bytes, not the key file's comment, so no name leaks through signing; keep it that way (don't switch to a key whose material or required metadata carries a name).
+
 ## Codex sandbox
 
 - Codex sessions for this repo commonly require `require_escalated` for commands that write git metadata or access GitHub credentials. Use escalation proactively for `git add`, `git commit`, `git switch -c`, `git push`, and GitHub CLI commands such as `gh auth status`, `gh repo view`, and `gh pr create`, because sandboxed runs cannot reliably create `.git/*.lock` files or access keyring-backed GitHub tokens.

--- a/modules/mnc-summary.test.ts
+++ b/modules/mnc-summary.test.ts
@@ -217,6 +217,50 @@ describe("MNC AI summary", () => {
     );
   });
 
+  test("accepts a summary whose section names are bold lead-in labels on bullets", async () => {
+    // Reproduces the 2026-06-10 incident: the model produced a complete 7-bullet
+    // summary but welded the section names onto the first bullet of each section
+    // ("- **Stocks in focus:** ...") instead of writing standalone headings, so
+    // the strict gate logged has_stocks_heading/has_watchlist_heading=false and
+    // discarded both deterministic (temperature 0) attempts.
+    const leadInSummaryMarkdown = [
+      "📰 **Morning News Call - TL;DR**",
+      "- **Market setup:** U.S. futures fell as tech extended losses ahead of May CPI.",
+      "- **Macro drivers:** Headline CPI seen at `4.2%`, core at `2.9%`, keeping the Fed on hold.",
+      "- **Stocks in focus:** Apple `AAPL` rose on upgrades.",
+      "- Tesla `TSLA` slipped premarket.",
+      "- Nvidia `NVDA` led chip gains.",
+      "- Boeing `BA` climbed on a delivery beat.",
+      "- **Watchlist:** Watch the May CPI release this morning.",
+    ].join("\n");
+    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(leadInSummaryMarkdown));
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBe([
+      "- **Market setup:** U.S. futures fell as tech extended losses ahead of May CPI.",
+      "- **Macro drivers:** Headline CPI seen at `4.2%`, core at `2.9%`, keeping the Fed on hold.",
+      "**Stocks in focus**",
+      "- Apple `AAPL` rose on upgrades.",
+      "- Tesla `TSLA` slipped premarket.",
+      "- Nvidia `NVDA` led chip gains.",
+      "- Boeing `BA` climbed on a delivery beat.",
+      "**Watchlist**",
+      "- Watch the May CPI release this morning.",
+    ].join("\n"));
+    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      "warn",
+      expect.objectContaining({
+        message: expect.stringContaining("Discarding malformed AI MNC summary"),
+      }),
+    );
+  });
+
   test("logs structural diagnostics when discarding a malformed summary", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(malformedSummaryMarkdown));
 
@@ -398,6 +442,17 @@ describe("MNC summary structural validation", () => {
     expect(isStructurallyValidMncSummary(body)).toBe(true);
   });
 
+  test("accepts section names emitted as bold lead-in labels on bullets", () => {
+    const body = [
+      "- **Market setup:** Futures firm ahead of payrolls.",
+      "- **Macro drivers:** Yields ease as risk appetite improves.",
+      "- **Stocks in focus:** Apple `AAPL` rose on upgrades.",
+      "- Tesla `TSLA` slipped premarket.",
+      "- **Watchlist:** Watch the jobs report this morning.",
+    ].join("\n");
+    expect(isStructurallyValidMncSummary(body)).toBe(true);
+  });
+
   test("rejects a summary missing the stocks heading", () => {
     const body = validBody.replace("**Stocks in focus**\n", "");
     expect(isStructurallyValidMncSummary(body)).toBe(false);
@@ -486,6 +541,30 @@ describe("MNC summary formatting", () => {
     ].join("\n"));
 
     expect(summary).toBe(validSummaryExpected);
+  });
+
+  test("promotes a bare bold section-label bullet to a standalone heading", () => {
+    const summary = formatMncSummary([
+      "- Futures firm ahead of payrolls.",
+      "- Yields ease as risk appetite improves.",
+      "- **Stocks in focus:**",
+      "- Apple `AAPL` rose on upgrades.",
+      "- Tesla `TSLA` slipped premarket.",
+      "- Nvidia `NVDA` led chip gains.",
+      "- **Watchlist:**",
+      "- Watch the jobs report this morning.",
+    ].join("\n"));
+
+    expect(summary).toBe([
+      "- Futures firm ahead of payrolls.",
+      "- Yields ease as risk appetite improves.",
+      "**Stocks in focus**",
+      "- Apple `AAPL` rose on upgrades.",
+      "- Tesla `TSLA` slipped premarket.",
+      "- Nvidia `NVDA` led chip gains.",
+      "**Watchlist**",
+      "- Watch the jobs report this morning.",
+    ].join("\n"));
   });
 
   test("normalizes common AI Markdown rendering glitches", () => {

--- a/modules/mnc-summary.ts
+++ b/modules/mnc-summary.ts
@@ -7,7 +7,9 @@ const maxInlinePdfBytes = 14_000_000;
 const maxDiscordSummaryLength = 1_930;
 const maxMncSummaryAttempts = 2;
 const minMncSummaryBullets = 5;
-const mncSummaryDiscardPreviewLength = 200;
+// Long enough that a discarded summary's preview reaches the stocks/watchlist
+// region, not just the intro bullet, so a structural rejection can be diagnosed.
+const mncSummaryDiscardPreviewLength = 700;
 
 // The model is asked for "**Stocks in focus**" / "**Watchlist**" but routinely
 // varies the casing, adds a trailing colon, a leading 📰, or a Markdown "#"
@@ -15,6 +17,15 @@ const mncSummaryDiscardPreviewLength = 200;
 // discarded, while still requiring the section to be a heading on its own line.
 const stocksInFocusHeadingPattern = /^\s*(?:#{1,3}\s*)?(?:📰\s*)?(?:\*\*|__)?\s*stocks in focus\s*:?\s*(?:\*\*|__)?\s*$/i;
 const watchlistHeadingPattern = /^\s*(?:#{1,3}\s*)?(?:📰\s*)?(?:\*\*|__)?\s*watchlist\s*:?\s*(?:\*\*|__)?\s*$/i;
+// The model also welds the section name onto the first bullet of the section as
+// a bold lead-in label instead of writing a standalone heading, e.g.
+// "- **Stocks in focus:** Apple `AAPL` ...". Promote that lead-in to a real
+// heading so the structural gate and section compaction recognise the section.
+// A bold (or "#") wrapper is required so prose that merely mentions the phrase
+// mid-bullet is not mistaken for a heading. Capture group 1 is the trailing
+// content, which becomes the section's first bullet (empty for a bare label).
+const stocksInFocusLeadInPattern = /^\s*(?:[-*•–]\s+)?(?:#{1,3}\s+)?(?:📰\s*)?(?:\*\*|__)\s*stocks in focus\s*:?\s*(?:\*\*|__)\s*:?\s*(.*)$/i;
+const watchlistLeadInPattern = /^\s*(?:[-*•–]\s+)?(?:#{1,3}\s+)?(?:📰\s*)?(?:\*\*|__)\s*watchlist\s*:?\s*(?:\*\*|__)\s*:?\s*(.*)$/i;
 // Accept "-", "*", "•", or "–" bullet markers; "**bold**" lines are not bullets
 // because the marker must be followed by whitespace.
 const bulletLinePattern = /^[-*•–]\s+\S/;
@@ -142,10 +153,21 @@ export type MncSummaryStructure = {
 export function describeMncSummaryStructure(summary: string): MncSummaryStructure {
   const lines = summary.split("\n");
   return {
-    hasStocksHeading: lines.some(line => stocksInFocusHeadingPattern.test(line)),
-    hasWatchlistHeading: lines.some(line => watchlistHeadingPattern.test(line)),
+    hasStocksHeading: lines.some(line => isStocksInFocusHeadingLine(line)),
+    hasWatchlistHeading: lines.some(line => isWatchlistHeadingLine(line)),
     bulletCount: getBulletLines(lines).length,
   };
+}
+
+// Recognise a section whether it is a standalone heading or a bold lead-in label
+// on a bullet, so the structural gate agrees with canonicalizeSummaryStructure
+// regardless of whether the summary has been normalized yet.
+function isStocksInFocusHeadingLine(line: string): boolean {
+  return stocksInFocusHeadingPattern.test(line) || stocksInFocusLeadInPattern.test(line);
+}
+
+function isWatchlistHeadingLine(line: string): boolean {
+  return watchlistHeadingPattern.test(line) || watchlistLeadInPattern.test(line);
 }
 
 function isMncSummaryStructureValid(structure: MncSummaryStructure): boolean {
@@ -215,25 +237,44 @@ function normalizeMarkdownSummary(value: string): string {
 function canonicalizeSummaryStructure(value: string): string {
   return value
     .split("\n")
-    .map(canonicalizeSummaryLine)
+    .flatMap(canonicalizeSummaryLine)
     .join("\n");
 }
 
-function canonicalizeSummaryLine(line: string): string {
+function canonicalizeSummaryLine(line: string): string[] {
   if (stocksInFocusHeadingPattern.test(line)) {
-    return "**Stocks in focus**";
+    return ["**Stocks in focus**"];
   }
 
   if (watchlistHeadingPattern.test(line)) {
-    return "**Watchlist**";
+    return ["**Watchlist**"];
+  }
+
+  const stocksLeadIn = line.match(stocksInFocusLeadInPattern);
+  if (null !== stocksLeadIn) {
+    return buildSectionHeadingLines("**Stocks in focus**", stocksLeadIn[1] ?? "");
+  }
+
+  const watchlistLeadIn = line.match(watchlistLeadInPattern);
+  if (null !== watchlistLeadIn) {
+    return buildSectionHeadingLines("**Watchlist**", watchlistLeadIn[1] ?? "");
   }
 
   const bulletMatch = line.match(bulletLineCanonicalPattern);
   if (null !== bulletMatch) {
-    return `- ${bulletMatch[2]}`;
+    return [`- ${bulletMatch[2]}`];
   }
 
-  return line;
+  return [line];
+}
+
+function buildSectionHeadingLines(heading: string, trailingContent: string): string[] {
+  const remainder = trailingContent.trim();
+  if ("" === remainder) {
+    return [heading];
+  }
+
+  return [heading, `- ${remainder}`];
 }
 
 function removeMncTldrHeading(value: string): string {


### PR DESCRIPTION
## Problem

The daily Morning News Call announcement posts only the PDF — the AI summary text is **never** included. Production logs confirm the model returns a complete summary (`bullet_count:7`, matching the prompt's 2+4+1) but with `has_stocks_heading:false` / `has_watchlist_heading:false`, so the structural gate (`isMncSummaryStructureValid`) discards it on every attempt.

Root cause: the model welds the section names onto the first bullet of each section as **bold lead-in labels** (e.g. `- **Stocks in focus:** Apple ...`) instead of writing standalone `**Stocks in focus**` / `**Watchlist**` headings. The heading patterns only match a heading alone on its line, so the labels were never recognised. Because the request uses `temperature: 0`, both attempts produce the same shape and both are discarded.

## Fix

- Canonicalize a bolded section label at the start of a line (with or without a bullet marker) into a real `**Stocks in focus**` / `**Watchlist**` heading plus the bullet of trailing content. Bold/`#` is required so prose merely mentioning the phrase isn't mistaken for a heading.
- Make `describeMncSummaryStructure` lead-in-aware so the structural gate and the canonicalizer agree whether or not the text has been normalized.
- Raise the discard preview from 200 → 700 chars so a future structural rejection reaches the stocks/watchlist region in the log instead of cutting off after the intro bullet.

## Tests

Adds cases reproducing the 2026-06-10 incident (bold lead-in labels, 7 bullets, no standalone headings) at both the `getMncSummary` and structural-validator levels, plus a bare-label bullet case. `modules/mnc-summary.ts` coverage stays at 96/85/98/96.

## Also

Documents the repo's **SSH commit signing** policy (not GPG) and the no-PII committer-identity rule in CLAUDE.md.

> [!NOTE]
> Reproducing the live model call wasn't possible locally (config behind a deny rule; secrets are Docker-mounted), so the fix is inferred from the logged output shape. The bumped discard preview makes any remaining mismatch directly visible in the next log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)