### PR TITLE
Post macro calendar alerts to the main channel as rich embeds

### DIFF
--- a/modules/startup-orchestrator.test.ts
+++ b/modules/startup-orchestrator.test.ts
@@ -217,6 +217,7 @@ describe("startBot", () => {
       earningsReminderAssets,
       undefined,
       undefined,
+      "nyse",
     );
   });
 
@@ -267,6 +268,7 @@ describe("startBot", () => {
       [],
       "earnings-expectations-thread",
       "trading-calendar-thread",
+      "nyse",
     );
   });
 

--- a/modules/startup-orchestrator.ts
+++ b/modules/startup-orchestrator.ts
@@ -276,6 +276,7 @@ export async function startBot(options: StartupOptions = {}): Promise<StartupRun
     sharedData,
     dependencies,
     startupState,
+    channelNyseId,
     channelOtherId,
     earningsExpectationsThreadId,
     tradingCalendarThreadId,

--- a/modules/startup-warmup.ts
+++ b/modules/startup-warmup.ts
@@ -69,6 +69,7 @@ export async function warmRemoteData({
   sharedData,
   dependencies,
   startupState,
+  channelNyseId,
   channelOtherId,
   earningsExpectationsThreadId,
   tradingCalendarThreadId,
@@ -78,6 +79,7 @@ export async function warmRemoteData({
   sharedData: SharedStartupData;
   dependencies: StartupDependencies;
   startupState: ReturnType<typeof createStartupState>;
+  channelNyseId: string;
   channelOtherId: string;
   earningsExpectationsThreadId?: string | undefined;
   tradingCalendarThreadId?: string | undefined;
@@ -128,6 +130,7 @@ export async function warmRemoteData({
       sharedData.earningsReminderAssets,
       earningsExpectationsThreadId,
       tradingCalendarThreadId,
+      channelNyseId,
     );
     otherTimersStarted = true;
     logger.log(

--- a/modules/test-utils/timers.ts
+++ b/modules/test-utils/timers.ts
@@ -48,11 +48,38 @@ const loggerMock = {
   log: vi.fn(),
 };
 
-vi.mock("discord.js", () => ({
-  AttachmentBuilder: function MockAttachmentBuilder(...args: [Buffer, {name: string}]) {
-    return attachmentBuilderMock(...args);
-  },
-}));
+vi.mock("discord.js", () => {
+  class MockEmbedBuilder {
+    public data: {color?: number; title?: string; description?: string; footer?: {text: string}} = {};
+
+    public setColor(color: string | number) {
+      this.data.color = "string" === typeof color ? Number.parseInt(color.replace("#", ""), 16) : color;
+      return this;
+    }
+
+    public setTitle(title: string) {
+      this.data.title = title;
+      return this;
+    }
+
+    public setDescription(description: string) {
+      this.data.description = description;
+      return this;
+    }
+
+    public setFooter(footer: {text: string}) {
+      this.data.footer = footer;
+      return this;
+    }
+  }
+
+  return {
+    AttachmentBuilder: function MockAttachmentBuilder(...args: [Buffer, {name: string}]) {
+      return attachmentBuilderMock(...args);
+    },
+    EmbedBuilder: MockEmbedBuilder,
+  };
+});
 
 vi.mock("node-schedule", () => ({
   __esModule: true,

--- a/modules/timer-reminders.test.ts
+++ b/modules/timer-reminders.test.ts
@@ -3,10 +3,10 @@ import {CalendarReminderAsset, EarningsReminderAsset} from "./assets.ts";
 import {CalendarEvent} from "./calendar.ts";
 import type {EarningsEvent} from "./earnings-types.ts";
 import {
+  buildCalendarReminderEmbed,
+  compareCalendarMetric,
   getAllowedRoleMentions,
-  getCalendarReminderMessage,
-  getCalendarReminderSummaryMessage,
-  getCalendarReminderUpdateMessage,
+  getCalendarReminderContent,
   getEarningsReminderMessage,
   getMatchedCalendarReminderEventGroups,
   getMatchedEarningsReminderEvents,
@@ -87,13 +87,30 @@ describe("timer-reminders", () => {
     expect(groups).toHaveLength(2);
     const usGroup = groups.find(group => "🇺🇸" === group.events[0]?.country);
     expect(usGroup?.events).toHaveLength(2);
-    expect(getCalendarReminderMessage("role-1", usGroup?.events ?? [])).toBe(
-      "<@&role-1> Heute wichtig: `14:30` 🇺🇸 ISM Manufacturing PMI, ISM Manufacturing PMI Final",
-    );
-    expect(getCalendarReminderMessage("role-1", [])).toBe("<@&role-1> Heute wichtig:");
+
+    const reminderEmbed = buildCalendarReminderEmbed("reminder", usGroup?.events ?? []);
+    expect(getCalendarReminderContent("role-1", "reminder")).toBe("<@&role-1> Heute wichtig");
+    expect(reminderEmbed.data.title).toBe("🇺🇸 ISM Manufacturing PMI");
+    expect(reminderEmbed.data.description).toBe("**ISM Manufacturing PMI**\n**ISM Manufacturing PMI Final**");
+    expect(reminderEmbed.data.footer?.text).toBe("🕒 14:30");
+    expect(reminderEmbed.data.color).toBe(0x0099ff);
+
+    const emptyEmbed = buildCalendarReminderEmbed("reminder", []);
+    expect(emptyEmbed.data.title).toBe("Wirtschaftsdaten");
+    expect(emptyEmbed.data.description).toBeUndefined();
+    expect(emptyEmbed.data.footer).toBeUndefined();
   });
 
-  test("formats calendar reminders with expected actual and previous values", () => {
+  test("compares actual versus forecast with neutral direction arrows", () => {
+    expect(compareCalendarMetric("4.2%", "4.0%")).toBe("▲");
+    expect(compareCalendarMetric("3.0%", "3.2%")).toBe("▼");
+    expect(compareCalendarMetric("0.5%", "0.5%")).toBe("=");
+    expect(compareCalendarMetric("333,979", "333,233")).toBe("▲");
+    expect(compareCalendarMetric("n/a", "1.0")).toBe("");
+    expect(compareCalendarMetric("1.0", "")).toBe("");
+  });
+
+  test("renders the update embed with actual, forecast and previous values", () => {
     const event = createCalendarEvent({
       actualValue: "3.4%",
       forecastValue: "3.2%",
@@ -103,24 +120,49 @@ describe("timer-reminders", () => {
 
     expect(hasCalendarReminderActualValues([event])).toBe(true);
     expect(hasCalendarReminderClearMetrics([event])).toBe(true);
-    expect(getCalendarReminderMessage("role-1", [event])).toBe(
-      "<@&role-1> Heute wichtig: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: actual `3.4%`, exp. `3.2%`, prev. `3.1%`",
+
+    const updateEmbed = buildCalendarReminderEmbed("update", [event]);
+    expect(getCalendarReminderContent("role-1", "update")).toBe("<@&role-1> Update");
+    expect(updateEmbed.data.title).toBe("🇺🇸 Consumer Price Index (CPI) y/y");
+    expect(updateEmbed.data.description).toBe("**Consumer Price Index (CPI) y/y** — `3.4%` ▲ exp. `3.2%` · prev. `3.1%`");
+    expect(updateEmbed.data.footer?.text).toBe("🕒 14:30");
+  });
+
+  test("renders forecast-only and actual-only embed lines", () => {
+    const forecastOnly = createCalendarEvent({
+      forecastValue: "3.2%",
+      previousValue: "3.1%",
+      name: "Consumer Price Index (CPI) y/y",
+    });
+    expect(buildCalendarReminderEmbed("reminder", [forecastOnly]).data.description).toBe(
+      "**Consumer Price Index (CPI) y/y** — exp. `3.2%` · prev. `3.1%`",
     );
-    expect(getCalendarReminderUpdateMessage("role-1", [event])).toBe(
-      "<@&role-1> Update: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: actual `3.4%`, exp. `3.2%`, prev. `3.1%`",
+
+    const actualOnly = createCalendarEvent({
+      actualValue: "3.4%",
+      name: "Consumer Price Index (CPI) y/y",
+    });
+    expect(buildCalendarReminderEmbed("update", [actualOnly]).data.description).toBe(
+      "**Consumer Price Index (CPI) y/y** — actual `3.4%`",
     );
   });
 
-  test("formats calendar reminder summaries for events without clear metrics", () => {
+  test("renders the summary embed for events without clear metrics", () => {
     const event = createCalendarEvent({
       name: "FOMC Statement",
     });
 
     expect(hasCalendarReminderActualValues([event])).toBe(false);
     expect(hasCalendarReminderClearMetrics([event])).toBe(false);
-    expect(getCalendarReminderSummaryMessage("role-1", [event], "Federal Reserve", "Policy remains data dependent.")).toBe(
-      "<@&role-1> Update: `14:30` 🇺🇸 FOMC Statement\nSource: Federal Reserve\nPolicy remains data dependent.",
-    );
+
+    const summaryEmbed = buildCalendarReminderEmbed("summary", [event], {
+      sourceName: "Federal Reserve",
+      summaryMarkdown: "Policy remains data dependent.",
+    });
+    expect(getCalendarReminderContent("role-1", "summary")).toBe("<@&role-1> Update");
+    expect(summaryEmbed.data.title).toBe("🇺🇸 FOMC Statement");
+    expect(summaryEmbed.data.description).toBe("**FOMC Statement**\n\nPolicy remains data dependent.");
+    expect(summaryEmbed.data.footer?.text).toBe("🕒 14:30 · Quelle: Federal Reserve");
   });
 
   test("matches earnings reminder tickers, removes duplicates and formats by time bucket", () => {

--- a/modules/timer-reminders.ts
+++ b/modules/timer-reminders.ts
@@ -1,9 +1,25 @@
+import {EmbedBuilder} from "discord.js";
 import {
   type CalendarReminderAsset,
   type EarningsReminderAsset,
 } from "./assets.ts";
 import {type CalendarEvent} from "./calendar.ts";
 import {type EarningsEvent} from "./earnings.ts";
+
+export type CalendarReminderKind = "reminder" | "update" | "summary";
+
+// Neutral embed accent — macro data has no inherent good/bad direction
+// (a hotter CPI print is not "good"), so do not colour by beat/miss.
+const calendarReminderEmbedColor = "#0099ff";
+const calendarReminderEmbedFallbackTitle = "Wirtschaftsdaten";
+const calendarReminderEmbedTitleMaxLength = 256;
+const calendarReminderEmbedDescriptionMaxLength = 4096;
+
+const calendarReminderContentLabel: Record<CalendarReminderKind, string> = {
+  reminder: "Heute wichtig",
+  update: "Update",
+  summary: "Update",
+};
 
 const earningsReminderWhenSortRank = new Map<string, number>([
   ["before_open", 0],
@@ -148,34 +164,91 @@ function getCalendarEventMetricSegments(calendarEvent: CalendarEvent): string[] 
   return segments;
 }
 
-function getCalendarReminderEventDetail(calendarEvent: CalendarEvent): string {
-  const metricSegments = getCalendarEventMetricSegments(calendarEvent);
-  if (0 === metricSegments.length) {
-    return calendarEvent.name;
+function parseCalendarMetricNumber(value: string): number | undefined {
+  const normalizedValue = value.replace(/[%,\s]/g, "");
+  if ("" === normalizedValue) {
+    return undefined;
   }
 
-  return `${calendarEvent.name}: ${metricSegments.join(", ")}`;
+  const parsedValue = Number.parseFloat(normalizedValue);
+  return Number.isFinite(parsedValue) ? parsedValue : undefined;
 }
 
-function getCalendarReminderEventDetails(calendarEvents: CalendarEvent[]): string {
-  if (false === hasCalendarReminderClearMetrics(calendarEvents)) {
-    return getCalendarReminderEventSummary(calendarEvents);
+// Direction of the actual print versus the forecast — neutral, no value judgement.
+export function compareCalendarMetric(actual: string, forecast: string): "▲" | "▼" | "=" | "" {
+  const actualNumber = parseCalendarMetricNumber(actual);
+  const forecastNumber = parseCalendarMetricNumber(forecast);
+  if (undefined === actualNumber || undefined === forecastNumber) {
+    return "";
   }
 
-  const eventDetails: string[] = [];
-  const seenEventDetails = new Set<string>();
+  if (actualNumber > forecastNumber) {
+    return "▲";
+  }
+
+  if (actualNumber < forecastNumber) {
+    return "▼";
+  }
+
+  return "=";
+}
+
+function getCalendarReminderEmbedLine(calendarEvent: CalendarEvent): string {
+  const eventName = getCalendarEventDisplayValue(calendarEvent.name);
+  const actualValue = getCalendarEventDisplayValue(calendarEvent.actualValue);
+  const forecastValue = getCalendarEventDisplayValue(calendarEvent.forecastValue);
+  const previousValue = getCalendarEventDisplayValue(calendarEvent.previousValue);
+
+  const segments: string[] = [];
+  if ("" !== actualValue && "" !== forecastValue) {
+    const arrow = compareCalendarMetric(actualValue, forecastValue);
+    const comparator = "" !== arrow ? `${arrow} ` : "";
+    segments.push(`${getDiscordMonospaceText(actualValue)} ${comparator}exp. ${getDiscordMonospaceText(forecastValue)}`);
+  } else if ("" !== actualValue) {
+    segments.push(`actual ${getDiscordMonospaceText(actualValue)}`);
+  } else if ("" !== forecastValue) {
+    segments.push(`exp. ${getDiscordMonospaceText(forecastValue)}`);
+  }
+
+  if ("" !== previousValue) {
+    segments.push(`prev. ${getDiscordMonospaceText(previousValue)}`);
+  }
+
+  if (0 === segments.length) {
+    return `**${eventName}**`;
+  }
+
+  return `**${eventName}** — ${segments.join(" · ")}`;
+}
+
+function getCalendarReminderEmbedLines(calendarEvents: CalendarEvent[]): string[] {
+  const lines: string[] = [];
+  const seenLines = new Set<string>();
 
   for (const calendarEvent of calendarEvents) {
-    const eventDetail = getCalendarReminderEventDetail(calendarEvent).trim();
-    if (!eventDetail || true === seenEventDetails.has(eventDetail)) {
+    if ("" === getCalendarEventDisplayValue(calendarEvent.name) &&
+        0 === getCalendarEventMetricSegments(calendarEvent).length) {
       continue;
     }
 
-    eventDetails.push(eventDetail);
-    seenEventDetails.add(eventDetail);
+    const line = getCalendarReminderEmbedLine(calendarEvent).trim();
+    if (true === seenLines.has(line)) {
+      continue;
+    }
+
+    lines.push(line);
+    seenLines.add(line);
   }
 
-  return eventDetails.join("; ");
+  return lines;
+}
+
+function truncateForEmbed(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1)}…`;
 }
 
 export function hasCalendarReminderActualValues(calendarEvents: CalendarEvent[]): boolean {
@@ -186,36 +259,53 @@ export function hasCalendarReminderClearMetrics(calendarEvents: CalendarEvent[])
   return calendarEvents.some(calendarEvent => 0 < getCalendarEventMetricSegments(calendarEvent).length);
 }
 
-export function getCalendarReminderMessage(roleId: string, calendarEvents: CalendarEvent[]): string {
-  const primaryEvent = calendarEvents[0];
-  if (undefined === primaryEvent) {
-    return `${getRoleMention(roleId)} Heute wichtig:`;
-  }
-
-  return `${getRoleMention(roleId)} Heute wichtig: \`${primaryEvent.time}\` ${primaryEvent.country} ${getCalendarReminderEventDetails(calendarEvents)}`;
+// Short message text that carries the role ping; the detail lives in the embed.
+// Keeping the ping in `content` (not the embed) is what triggers the notification.
+export function getCalendarReminderContent(roleId: string, kind: CalendarReminderKind): string {
+  return `${getRoleMention(roleId)} ${calendarReminderContentLabel[kind]}`;
 }
 
-export function getCalendarReminderUpdateMessage(roleId: string, calendarEvents: CalendarEvent[]): string {
-  const primaryEvent = calendarEvents[0];
-  if (undefined === primaryEvent) {
-    return `${getRoleMention(roleId)} Update:`;
-  }
-
-  return `${getRoleMention(roleId)} Update: \`${primaryEvent.time}\` ${primaryEvent.country} ${getCalendarReminderEventDetails(calendarEvents)}`;
-}
-
-export function getCalendarReminderSummaryMessage(
-  roleId: string,
+export function buildCalendarReminderEmbed(
+  kind: CalendarReminderKind,
   calendarEvents: CalendarEvent[],
-  sourceName: string,
-  summaryMarkdown: string,
-): string {
+  options: {sourceName?: string; summaryMarkdown?: string} = {},
+): EmbedBuilder {
   const primaryEvent = calendarEvents[0];
-  if (undefined === primaryEvent) {
-    return `${getRoleMention(roleId)} Update:\nSource: ${sourceName}\n${summaryMarkdown}`;
+  const embed = new EmbedBuilder().setColor(calendarReminderEmbedColor);
+
+  const flag = getCalendarEventDisplayValue(primaryEvent?.country);
+  const eventName = getCalendarEventDisplayValue(primaryEvent?.name);
+  const title = [flag, eventName].filter(part => "" !== part).join(" ");
+  embed.setTitle(truncateForEmbed("" !== title ? title : calendarReminderEmbedFallbackTitle, calendarReminderEmbedTitleMaxLength));
+
+  const summaryMarkdown = options.summaryMarkdown?.trim() ?? "";
+  if ("summary" === kind && "" !== summaryMarkdown) {
+    const eventNames = getCalendarReminderEventSummary(calendarEvents);
+    const descriptionParts = ["" !== eventNames ? `**${eventNames}**` : "", summaryMarkdown].filter(part => "" !== part);
+    embed.setDescription(truncateForEmbed(descriptionParts.join("\n\n"), calendarReminderEmbedDescriptionMaxLength));
+  } else {
+    const lines = getCalendarReminderEmbedLines(calendarEvents);
+    if (0 < lines.length) {
+      embed.setDescription(truncateForEmbed(lines.join("\n"), calendarReminderEmbedDescriptionMaxLength));
+    }
   }
 
-  return `${getRoleMention(roleId)} Update: \`${primaryEvent.time}\` ${primaryEvent.country} ${getCalendarReminderEventSummary(calendarEvents)}\nSource: ${sourceName}\n${summaryMarkdown}`;
+  const footerParts: string[] = [];
+  const time = getCalendarEventDisplayValue(primaryEvent?.time);
+  if ("" !== time) {
+    footerParts.push(`🕒 ${time}`);
+  }
+
+  const sourceName = options.sourceName?.trim() ?? "";
+  if ("summary" === kind && "" !== sourceName) {
+    footerParts.push(`Quelle: ${sourceName}`);
+  }
+
+  if (0 < footerParts.length) {
+    embed.setFooter({text: footerParts.join(" · ")});
+  }
+
+  return embed;
 }
 
 export function getMatchedCalendarReminderEventGroups(

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -82,6 +82,43 @@ function createClientWithOptionalThread(threadID: string) {
   };
 }
 
+function createClientWithThreadAndMainChannel(threadID: string, mainChannelID: string) {
+  const parentSend = vi.fn().mockResolvedValue(undefined);
+  const threadSend = vi.fn().mockResolvedValue(undefined);
+  const mainSend = vi.fn().mockResolvedValue(undefined);
+  const client = {
+    channels: {
+      cache: {
+        get: vi.fn((channelID: string) => {
+          if (threadID === channelID) {
+            return {send: threadSend};
+          }
+
+          if (mainChannelID === channelID) {
+            return {send: mainSend};
+          }
+
+          return {send: parentSend};
+        }),
+      },
+    },
+  };
+
+  return {
+    client,
+    parentSend,
+    threadSend,
+    mainSend,
+  };
+}
+
+type ReminderEmbed = {data: {title?: string; description?: string; footer?: {text?: string}}};
+type ReminderPayload = {content: string; allowedMentions: unknown; embeds: ReminderEmbed[]};
+
+function getReminderPayload(sendMock: {mock: {calls: unknown[][]}}, callIndex: number): ReminderPayload {
+  return sendMock.mock.calls[callIndex]?.[0] as ReminderPayload;
+}
+
 describe("timers: other announcements", () => {
   beforeEach(resetTimerMocks);
   afterEach(restoreTimerMocks);
@@ -177,17 +214,16 @@ describe("timers: other announcements", () => {
         parse: [],
       },
     });
-    expect(send).toHaveBeenNthCalledWith(2, {
-      content: "<@&role-123> Heute wichtig: `14:30` 🇺🇸 Consumer Price Index (CPI)",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
+    const reminder = getReminderPayload(send, 1);
+    expect(reminder.content).toBe("<@&role-123> Heute wichtig");
+    expect(reminder.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
+    expect(reminder.embeds[0]!.data.title).toBe("🇺🇸 Consumer Price Index (CPI)");
+    expect(reminder.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI)**");
+    expect(reminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
   });
 
-  test("startOtherTimers sends calendar alerts to the optional trading calendar thread", async () => {
-    const {client, parentSend, threadSend} = createClientWithOptionalThread("trading-calendar-thread");
+  test("startOtherTimers keeps the agenda in the trading calendar thread but posts macro alerts to the main channel", async () => {
+    const {client, parentSend, threadSend, mainSend} = createClientWithThreadAndMainChannel("trading-calendar-thread", "main-channel-id");
     getCalendarEventsMock
       .mockResolvedValueOnce([
         {
@@ -216,32 +252,33 @@ describe("timers: other announcements", () => {
       eventNameSubstrings: ["cpi"],
       countryFlags: ["🇺🇸"],
       roleId: "role-123",
-    })], [], undefined, "trading-calendar-thread");
+    })], [], undefined, "trading-calendar-thread", "main-channel-id");
     const dailyCalendarJob = getScheduledJobByTime(8, 30, "Europe/Berlin");
     await dailyCalendarJob.callback();
     await getScheduledDateJobs()[0]!.callback();
 
+    // Neither the OtherAnnouncement channel ("channel-id") nor any fallback is used directly.
     expect(parentSend).not.toHaveBeenCalled();
-    expect(threadSend).toHaveBeenNthCalledWith(1, {
+    // Agenda batch stays in the trading-calendar thread.
+    expect(threadSend).toHaveBeenCalledTimes(1);
+    expect(threadSend).toHaveBeenCalledWith({
       content: "calendar-text",
       allowedMentions: {
         parse: [],
       },
     });
-    expect(threadSend).toHaveBeenNthCalledWith(2, {
-      content: "<@&role-123> Heute wichtig: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: exp. `3.2%`, prev. `3.1%`",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
-    expect(threadSend).toHaveBeenNthCalledWith(3, {
-      content: "<@&role-123> Update: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: actual `3.4%`, exp. `3.2%`, prev. `3.1%`",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
+    // Role-pinged macro alerts (morning reminder + post-release update) go to the main channel.
+    expect(mainSend).toHaveBeenCalledTimes(2);
+    const morningReminder = getReminderPayload(mainSend, 0);
+    expect(morningReminder.content).toBe("<@&role-123> Heute wichtig");
+    expect(morningReminder.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
+    expect(morningReminder.embeds[0]!.data.title).toBe("🇺🇸 Consumer Price Index (CPI) y/y");
+    expect(morningReminder.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI) y/y** — exp. `3.2%` · prev. `3.1%`");
+    const releaseUpdate = getReminderPayload(mainSend, 1);
+    expect(releaseUpdate.content).toBe("<@&role-123> Update");
+    expect(releaseUpdate.embeds[0]!.data.title).toBe("🇺🇸 Consumer Price Index (CPI) y/y");
+    expect(releaseUpdate.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI) y/y** — `3.4%` ▲ exp. `3.2%` · prev. `3.1%`");
+    expect(releaseUpdate.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
   });
 
   test("startOtherTimers bundles same-minute calendar reminder matches into one reminder", async () => {
@@ -277,13 +314,12 @@ describe("timers: other announcements", () => {
     const dailyCalendarJob = getScheduledJobByTime(8, 30, "Europe/Berlin");
     await dailyCalendarJob.callback();
 
-    expect(send).toHaveBeenNthCalledWith(2, {
-      content: "<@&role-123> Heute wichtig: `14:30` 🇺🇸 CPI y/y, Core CPI y/y, CPI m/m",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
+    const bundledReminder = getReminderPayload(send, 1);
+    expect(bundledReminder.content).toBe("<@&role-123> Heute wichtig");
+    expect(bundledReminder.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
+    expect(bundledReminder.embeds[0]!.data.title).toBe("🇺🇸 CPI y/y");
+    expect(bundledReminder.embeds[0]!.data.description).toBe("**CPI y/y**\n**Core CPI y/y**\n**CPI m/m**");
+    expect(bundledReminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
   });
 
   test("startOtherTimers posts calendar actuals after the release when they become available", async () => {
@@ -336,20 +372,13 @@ describe("timers: other announcements", () => {
     ]);
     await followUpJobs[0]!.callback();
 
-    expect(send).toHaveBeenNthCalledWith(2, {
-      content: "<@&role-123> Heute wichtig: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: exp. `3.2%`, prev. `3.1%`",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
-    expect(send).toHaveBeenNthCalledWith(3, {
-      content: "<@&role-123> Update: `14:30` 🇺🇸 Consumer Price Index (CPI) y/y: actual `3.4%`, exp. `3.2%`, prev. `3.1%`",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
+    const morningReminder = getReminderPayload(send, 1);
+    expect(morningReminder.content).toBe("<@&role-123> Heute wichtig");
+    expect(morningReminder.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
+    expect(morningReminder.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI) y/y** — exp. `3.2%` · prev. `3.1%`");
+    const releaseUpdate = getReminderPayload(send, 2);
+    expect(releaseUpdate.content).toBe("<@&role-123> Update");
+    expect(releaseUpdate.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI) y/y** — `3.4%` ▲ exp. `3.2%` · prev. `3.1%`");
   });
 
   test("startOtherTimers posts official AI summary after no-metric calendar releases", async () => {
@@ -388,13 +417,12 @@ describe("timers: other announcements", () => {
         log: expect.any(Function),
       }),
     }));
-    expect(send).toHaveBeenNthCalledWith(3, {
-      content: "<@&role-123> Update: `20:00` 🇺🇸 FOMC Statement\nSource: Federal Reserve\nThe Fed emphasized inflation and labor-market risks.",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
+    const summaryUpdate = getReminderPayload(send, 2);
+    expect(summaryUpdate.content).toBe("<@&role-123> Update");
+    expect(summaryUpdate.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
+    expect(summaryUpdate.embeds[0]!.data.title).toBe("🇺🇸 FOMC Statement");
+    expect(summaryUpdate.embeds[0]!.data.description).toBe("**FOMC Statement**\n\nThe Fed emphasized inflation and labor-market risks.");
+    expect(summaryUpdate.embeds[0]!.data.footer?.text).toBe("🕒 20:00 · Quelle: Federal Reserve");
   });
 
   test("startOtherTimers skips calendar reminder assets with wrong country or invalid config", async () => {
@@ -477,20 +505,16 @@ describe("timers: other announcements", () => {
     const dailyCalendarJob = getScheduledJobByTime(8, 30, "Europe/Berlin");
     await dailyCalendarJob.callback();
 
-    expect(send).toHaveBeenNthCalledWith(2, {
-      content: "<@&role-123> Heute wichtig: `14:30` 🇺🇸 GDP q/q",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
-    expect(send).toHaveBeenNthCalledWith(3, {
-      content: "<@&role-123> Heute wichtig: `20:00` 🇺🇸 FOMC Statement",
-      allowedMentions: {
-        parse: [],
-        roles: ["role-123"],
-      },
-    });
+    const gdpReminder = getReminderPayload(send, 1);
+    expect(gdpReminder.content).toBe("<@&role-123> Heute wichtig");
+    expect(gdpReminder.embeds[0]!.data.title).toBe("🇺🇸 GDP q/q");
+    expect(gdpReminder.embeds[0]!.data.description).toBe("**GDP q/q**");
+    expect(gdpReminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
+    const fomcReminder = getReminderPayload(send, 2);
+    expect(fomcReminder.content).toBe("<@&role-123> Heute wichtig");
+    expect(fomcReminder.embeds[0]!.data.title).toBe("🇺🇸 FOMC Statement");
+    expect(fomcReminder.embeds[0]!.data.description).toBe("**FOMC Statement**");
+    expect(fomcReminder.embeds[0]!.data.footer?.text).toBe("🕒 20:00");
   });
 
   test("startOtherTimers skips Friday announcement when asset is unavailable", async () => {

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -36,10 +36,9 @@ import {getMnc} from "./mnc-downloader.ts";
 import {getMncSummary} from "./mnc-summary.ts";
 import {type Ticker} from "./tickers.ts";
 import {
+  buildCalendarReminderEmbed,
   getAllowedRoleMentions,
-  getCalendarReminderMessage,
-  getCalendarReminderSummaryMessage,
-  getCalendarReminderUpdateMessage,
+  getCalendarReminderContent,
   getEarningsReminderMessage,
   getMatchedCalendarReminderEventGroups,
   getMatchedEarningsReminderEvents,
@@ -880,7 +879,12 @@ export function startOtherTimers(
   earningsReminderAssets: EarningsReminderAsset[] = [],
   earningsExpectationsThreadID?: string,
   tradingCalendarThreadID?: string,
+  macroAlertChannelID?: string,
 ) {
+  // Role-pinged macro alerts (the morning reminder + post-release updates/
+  // summaries) post to the main channel for visibility; the daily/weekly
+  // calendar agenda batches stay in the optional trading-calendar thread.
+  const resolvedMacroAlertChannelID = macroAlertChannelID ?? channelID;
   const ruleFriday = createRecurrenceRule({
     hour: 8,
     minute: 0,
@@ -1060,14 +1064,14 @@ export function startOtherTimers(
     logCalendarBatch("timer-daily", calendarBatch);
 
     const matchedReminderGroups = getMatchedCalendarReminderEventGroups(calendarReminderAssets, calendarEvents);
-    const hasCalendarAnnouncements = 0 < calendarBatch.messages.length || 0 < matchedReminderGroups.length;
-    const calendarChannel = true === hasCalendarAnnouncements
-      ? await getOptionalThreadTargetChannel(client, channelID, tradingCalendarThreadID, "calendar")
-      : null;
     if (0 < calendarBatch.messages.length) {
+      const calendarChannel = await getOptionalThreadTargetChannel(client, channelID, tradingCalendarThreadID, "calendar");
       await sendChunkedMessages(calendarChannel, calendarBatch.messages, "calendar");
     }
 
+    const macroAlertChannel = 0 < matchedReminderGroups.length
+      ? getSendableChannel(client, resolvedMacroAlertChannelID, calendarReminderAnnouncementSource)
+      : null;
     for (const matchedReminderGroup of matchedReminderGroups) {
       const roleId = getNormalizedRoleId(matchedReminderGroup.asset.roleId);
       if (!roleId) {
@@ -1075,15 +1079,16 @@ export function startOtherTimers(
       }
 
       await sendToChannel(
-        calendarChannel,
+        macroAlertChannel,
         {
-          content: getCalendarReminderMessage(roleId, matchedReminderGroup.events),
+          content: getCalendarReminderContent(roleId, "reminder"),
+          embeds: [buildCalendarReminderEmbed("reminder", matchedReminderGroup.events)],
           allowedMentions: getAllowedRoleMentions(roleId),
         },
         calendarReminderAnnouncementSource,
       );
     }
-    scheduleCalendarReminderFollowUpJobs(client, channelID, matchedReminderGroups, tradingCalendarThreadID);
+    scheduleCalendarReminderFollowUpJobs(client, resolvedMacroAlertChannelID, matchedReminderGroups);
   });
 
   const ruleEventsWeekly = createRecurrenceRule({
@@ -1134,9 +1139,8 @@ function dedupeCalendarEvents(calendarEvents: CalendarEvent[]): CalendarEvent[] 
 
 function scheduleCalendarReminderFollowUpJobs(
   client: TimerClient,
-  channelID: string,
+  macroAlertChannelID: string,
   matchedReminderGroups: CalendarReminderGroup[],
-  tradingCalendarThreadID: string | undefined,
 ) {
   const sentFollowUpKeys = new Set<string>();
 
@@ -1167,7 +1171,7 @@ function scheduleCalendarReminderFollowUpJobs(
           return;
         }
 
-        const sent = await sendCalendarReminderFollowUp(client, channelID, matchedReminderGroup, tradingCalendarThreadID);
+        const sent = await sendCalendarReminderFollowUp(client, macroAlertChannelID, matchedReminderGroup);
         if (true === sent) {
           sentFollowUpKeys.add(followUpKey);
         }
@@ -1193,9 +1197,8 @@ function getCalendarReminderFollowUpKey(matchedReminderGroup: CalendarReminderGr
 
 async function sendCalendarReminderFollowUp(
   client: TimerClient,
-  channelID: string,
+  macroAlertChannelID: string,
   matchedReminderGroup: CalendarReminderGroup,
-  tradingCalendarThreadID: string | undefined,
 ): Promise<boolean> {
   const roleId = getNormalizedRoleId(matchedReminderGroup.asset.roleId);
   const primaryEvent = matchedReminderGroup.events[0];
@@ -1209,9 +1212,10 @@ async function sendCalendarReminderFollowUp(
 
   if (true === hasCalendarReminderActualValues(calendarEvents)) {
     await sendToChannel(
-      await getOptionalThreadTargetChannel(client, channelID, tradingCalendarThreadID, calendarReminderAnnouncementSource),
+      getSendableChannel(client, macroAlertChannelID, calendarReminderAnnouncementSource),
       {
-        content: getCalendarReminderUpdateMessage(roleId, calendarEvents),
+        content: getCalendarReminderContent(roleId, "update"),
+        embeds: [buildCalendarReminderEmbed("update", calendarEvents)],
         allowedMentions: getAllowedRoleMentions(roleId),
       },
       calendarReminderAnnouncementSource,
@@ -1223,14 +1227,13 @@ async function sendCalendarReminderFollowUp(
     const officialSummary = await getCalendarOfficialSummary(calendarEvents, {logger});
     if (undefined !== officialSummary) {
       await sendToChannel(
-        await getOptionalThreadTargetChannel(client, channelID, tradingCalendarThreadID, calendarReminderAnnouncementSource),
+        getSendableChannel(client, macroAlertChannelID, calendarReminderAnnouncementSource),
         {
-          content: getCalendarReminderSummaryMessage(
-            roleId,
-            calendarEvents,
-            officialSummary.name,
-            officialSummary.summaryMarkdown,
-          ),
+          content: getCalendarReminderContent(roleId, "summary"),
+          embeds: [buildCalendarReminderEmbed("summary", calendarEvents, {
+            sourceName: officialSummary.name,
+            summaryMarkdown: officialSummary.summaryMarkdown,
+          })],
           allowedMentions: getAllowedRoleMentions(roleId),
         },
         calendarReminderAnnouncementSource,


### PR DESCRIPTION
## What & why

Role-pinged macro economic alerts (e.g. the CPI release: `@alerts Update: 14:30 🇺🇸 CPI m/m: actual 0.5%, exp. 0.5%, prev. 0.6%; …`) posted to the optional **trading-calendar** thread as a single run-on line. Two changes:

1. **Routing** — these time-sensitive alerts now post to the **main NYSE-open channel** (`channelNyseId`, the one used for the trade-sentiment poll) for visibility, instead of the side thread.
2. **Formatting** — they render as a **Discord embed** instead of one run-on line.

## Scope

Only the role-pinged macro alerts move:
- the morning "Heute wichtig" reminder,
- the post-release "Update" (actual/exp/prev),
- the official-source summary.

The **daily/weekly calendar agenda batches stay** in the trading-calendar thread (unchanged).

## Embed

- **title**: country flag + primary event name (e.g. `🇺🇸 CPI m/m`)
- **description**: one line per metric with neutral **actual-vs-forecast** direction arrows (`▲` / `▼` / `=`) — no good/bad colouring, since a hotter print isn't "good"
- **footer**: release time (`🕒 14:30`), plus `· Quelle: <source>` for the official-summary variant
- the `@role` ping stays in the message **content** so notifications still fire

## Implementation

- `startOtherTimers` takes a new optional `macroAlertChannelID` (falls back to the existing `channelID` when unset); `channelNyseId` is threaded through `warmRemoteData` → `startOtherTimers`.
- New `buildCalendarReminderEmbed` / `getCalendarReminderContent` / `compareCalendarMetric` in `timer-reminders.ts`; the three run-on string builders are removed.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings)
- `npm run test:coverage` — 742 tests pass, thresholds met (stmts 89.2%, branches 80.4%, funcs 91.6%, lines 89.1%)

Tests updated in `timer-reminders.test.ts`, `timers-other.test.ts` (incl. a new test asserting the agenda-stays-in-thread / alerts-go-to-main split), and `startup-orchestrator.test.ts`; the `discord.js` test mock gains `EmbedBuilder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)