### PR TITLE
Unblock deploy: time-boxed Trivy ignore for base-image CVE-2026-45447

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,10 @@ jobs:
 
     if: github.ref == 'refs/heads/main'
     steps:
+      - name: Check out repository
+        # Needed so Trivy can read .trivyignore.yaml from the workspace.
+        uses: actions/checkout@v6
+
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -124,6 +128,7 @@ jobs:
           # Pin to a known-good version after the 2026-03-01 upstream release-asset incident.
           version: v0.69.2
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}
+          trivyignores: .trivyignore.yaml
           format: table
           vuln-type: os,library
           severity: HIGH,CRITICAL

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,16 @@
+# Temporary, scoped Trivy exception — DELETE once the distroless base is rebuilt.
+#
+# CVE-2026-45447 is a HIGH OpenSSL (libssl3t64) PKCS#7 / S/MIME signed-data
+# parsing issue carried by the runtime base image
+# gcr.io/distroless/nodejs24:nonroot (Debian 13.5) — not by our code or any npm
+# dependency (every node-pkg target scanned 0). Debian fixed it in
+# libssl3t64 3.5.6-1~deb13u2; the distroless image has not yet been rebuilt to
+# pick it up, which blocks image_scan -> sign -> redeploy on main.
+#
+# expired_at re-arms the scan automatically: once it passes, Trivy flags the CVE
+# again and the deploy blocks until this is resolved. Remove this entry as soon
+# as the distroless base ships the patched libssl.
+vulnerabilities:
+  - id: CVE-2026-45447
+    statement: "Base-image OpenSSL CVE; awaiting distroless nodejs24 rebuild with libssl3t64 3.5.6-1~deb13u2."
+    expired_at: 2026-07-10


### PR DESCRIPTION
## Why

The `main` CI run for the merged MNC fix ([#1765](https://github.com/hblwrk/discord-bot-ts/pull/1765)) failed at `image_scan`: Trivy flagged **CVE-2026-45447** (HIGH) in `libssl3t64` — an OpenSSL PKCS#7/S-MIME parsing issue carried by the runtime base `gcr.io/distroless/nodejs24:nonroot` (Debian 13.5), **not** our code or any npm dependency. Debian fixed it in `3.5.6-1~deb13u2`, but the distroless image hasn't been rebuilt to include it. With `ignore-unfixed: true`, the scan flips to failing the moment a fix exists upstream.

Because `image_scan` failed, `sign` and `redeploy` were skipped — **production is not being redeployed**, so the MNC fix (and anything else on `main`) isn't live.

## What this does

- Adds a scoped `.trivyignore.yaml` for **only** CVE-2026-45447, with `expired_at: 2026-07-10` so the exception **re-arms automatically** — if distroless still hasn't shipped the patch by then, the scan fails again and forces a recheck rather than silently masking the CVE forever.
- The `image_scan` job had **no checkout step**, so Trivy could never have read a repo ignore file. Adds `actions/checkout@v6` and points the action at the file via `trivyignores`.

The HIGH/CRITICAL severity filter and `ignore-unfixed` gate are unchanged — this allowlists exactly one upstream-pending base-image CVE.

## Caveats

- `image_scan` is gated to `main` (`if: github.ref == 'refs/heads/main'`), so this PR's own checks **won't exercise the ignore** — it only takes effect once merged and `main` CI re-runs.
- Remove `.trivyignore.yaml` once the distroless base ships the patched `libssl3t64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)