### PR TITLE
Fix duplicate macro alert when follow-up jobs overlap

### DIFF
--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -381,6 +381,62 @@ describe("timers: other announcements", () => {
     expect(releaseUpdate.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI) y/y** — `3.4%` ▲ exp. `3.2%` · prev. `3.1%`");
   });
 
+  test("startOtherTimers posts only one update when two follow-up jobs overlap", async () => {
+    const {client, send} = createClientWithChannel();
+    const releasedEvents = [
+      {
+        actualValue: "3.4%",
+        date: "2025-02-19",
+        time: "14:30",
+        country: "🇺🇸",
+        forecastValue: "3.2%",
+        name: "Consumer Price Index (CPI) y/y",
+        previousValue: "3.1%",
+      },
+    ];
+    let resolveFollowUpFetch: (events: unknown[]) => void = () => undefined;
+    const pendingFollowUpFetch = new Promise<unknown[]>(resolve => {
+      resolveFollowUpFetch = resolve;
+    });
+    getCalendarEventsMock
+      .mockResolvedValueOnce([
+        {
+          date: "2025-02-19",
+          time: "14:30",
+          country: "🇺🇸",
+          forecastValue: "3.2%",
+          name: "Consumer Price Index (CPI) y/y",
+          previousValue: "3.1%",
+        },
+      ])
+      .mockReturnValueOnce(pendingFollowUpFetch)
+      .mockResolvedValue(releasedEvents);
+
+    startOtherTimers(client, "channel-id", [], [], [createCalendarReminderAsset({
+      name: "us-cpi-1h",
+      eventNameSubstrings: ["cpi"],
+      countryFlags: ["🇺🇸"],
+      roleId: "role-123",
+    })], []);
+    const dailyCalendarJob = getScheduledJobByTime(8, 30, "Europe/Berlin");
+    await dailyCalendarJob.callback();
+
+    const followUpJobs = getScheduledDateJobs();
+    // Start the first follow-up but leave its actuals fetch in flight (not awaited).
+    const firstFollowUp = followUpJobs[0]!.callback();
+    // A second follow-up fires while the first is mid-flight; it must skip, not duplicate.
+    await followUpJobs[1]!.callback();
+    // Let the first follow-up complete and post the single update.
+    resolveFollowUpFetch(releasedEvents);
+    await firstFollowUp;
+
+    // 1 agenda + 1 morning reminder + exactly 1 release update (no duplicate).
+    expect(send).toHaveBeenCalledTimes(3);
+    const releaseUpdate = getReminderPayload(send, 2);
+    expect(releaseUpdate.content).toBe("<@&role-123> Update");
+    expect(releaseUpdate.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI) y/y** — `3.4%` ▲ exp. `3.2%` · prev. `3.1%`");
+  });
+
   test("startOtherTimers posts official AI summary after no-metric calendar releases", async () => {
     const {client, send} = createClientWithChannel();
     getCalendarEventsMock.mockResolvedValueOnce([

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -1143,6 +1143,11 @@ function scheduleCalendarReminderFollowUpJobs(
   matchedReminderGroups: CalendarReminderGroup[],
 ) {
   const sentFollowUpKeys = new Set<string>();
+  // Follow-up jobs fire at staggered delays; once actuals are out, two jobs can
+  // overlap because sendCalendarReminderFollowUp awaits a network fetch. Claim the
+  // key synchronously (before any await) so an overlapping job skips instead of
+  // posting a duplicate. Released on failure so a later job can still retry.
+  const inFlightFollowUpKeys = new Set<string>();
 
   for (const matchedReminderGroup of matchedReminderGroups) {
     if (false === shouldScheduleCalendarReminderFollowUp(matchedReminderGroup)) {
@@ -1167,13 +1172,18 @@ function scheduleCalendarReminderFollowUpJobs(
       }
 
       Schedule.scheduleJob(scheduledDateTime.toDate(), async () => {
-        if (true === sentFollowUpKeys.has(followUpKey)) {
+        if (true === sentFollowUpKeys.has(followUpKey) || true === inFlightFollowUpKeys.has(followUpKey)) {
           return;
         }
 
-        const sent = await sendCalendarReminderFollowUp(client, macroAlertChannelID, matchedReminderGroup);
-        if (true === sent) {
-          sentFollowUpKeys.add(followUpKey);
+        inFlightFollowUpKeys.add(followUpKey);
+        try {
+          const sent = await sendCalendarReminderFollowUp(client, macroAlertChannelID, matchedReminderGroup);
+          if (true === sent) {
+            sentFollowUpKeys.add(followUpKey);
+          }
+        } finally {
+          inFlightFollowUpKeys.delete(followUpKey);
         }
       });
     }


### PR DESCRIPTION
## Symptom

The post-release macro alert ("Update" embed) occasionally posts **twice** — two identical messages at the same minute (observed on a PPI m/m release).

## Root cause

`scheduleCalendarReminderFollowUpJobs` schedules follow-up jobs at staggered delays (`[5, 10, 20, 30, 60, …]` seconds) after a release. Each job dedups via a shared `sentFollowUpKeys` set, but the key is added **after** the `await`:

```js
if (sentFollowUpKeys.has(followUpKey)) return;
const sent = await sendCalendarReminderFollowUp(...);   // awaits a calendar fetch
if (sent) sentFollowUpKeys.add(followUpKey);            // marked only after the await
```

Once actuals are published, two closely-spaced jobs (e.g. +5s and +10s) can both pass the guard while the first is still awaiting its fetch, so both send the same embed.

## Fix

Claim the key in a separate `inFlightFollowUpKeys` set **synchronously, before the await**, so an overlapping job skips instead of duplicating. The key is released in a `finally` block so a later job can still retry when an earlier one finds no actuals yet.

## Test

Adds a regression test that leaves the first follow-up's fetch in flight, fires the second, then resolves — asserting exactly one update is posted. Verified it fails without the fix (`expected 3 sends, got 4`) and passes with it.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings)
- `npm run test:coverage` — 759 tests pass, thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)