### PR TITLE
Render MNC summary from structured fields (stop discarding good summaries)

### DIFF
--- a/modules/mnc-summary.test.ts
+++ b/modules/mnc-summary.test.ts
@@ -1,21 +1,23 @@
 import {Buffer} from "node:buffer";
 import {beforeEach, describe, expect, test, vi} from "vitest";
 import {clearAiProviderState} from "./ai-provider.ts";
-import {formatMncSummary, getMncSummary, isStructurallyValidMncSummary} from "./mnc-summary.ts";
+import {getMncSummary, renderMncSummary, type MncSummaryFields} from "./mnc-summary.ts";
 
-const validSummaryMarkdown = [
-  "**Morning News Call - TL;DR**",
-  "- Futures firm ahead of payrolls.",
-  "- Yields ease as risk appetite improves.",
-  "",
-  "**Stocks in focus**",
-  "- Apple `AAPL` rose on upgrades.",
-  "- Tesla `TSLA` slipped premarket.",
-  "- Nvidia `NVDA` led chip gains.",
-  "",
-  "**Watchlist**",
-  "- Watch the jobs report this morning.",
-].join("\n");
+const validFields: MncSummaryFields = {
+  marketSetup: [
+    "Futures firm ahead of payrolls.",
+    "Yields ease as risk appetite improves.",
+  ],
+  stocksInFocus: [
+    "Apple `AAPL` rose on upgrades.",
+    "Tesla `TSLA` slipped premarket.",
+    "Nvidia `NVDA` led chip gains.",
+    "Boeing `BA` climbed on a delivery beat.",
+  ],
+  watchlist: [
+    "Watch the jobs report this morning.",
+  ],
+};
 
 const validSummaryExpected = [
   "- Futures firm ahead of payrolls.",
@@ -25,26 +27,19 @@ const validSummaryExpected = [
   "- Apple `AAPL` rose on upgrades.",
   "- Tesla `TSLA` slipped premarket.",
   "- Nvidia `NVDA` led chip gains.",
+  "- Boeing `BA` climbed on a delivery beat.",
   "",
   "**Watchlist**",
   "- Watch the jobs report this morning.",
 ].join("\n");
 
-// Reproduces the production incident: the model lost the deal value, leaked a
-// self-correction into the answer, and never produced the section headings.
-const malformedSummaryMarkdown = [
-  "**Morning News Call - TL;DR**",
-  "- Futures firm ahead of payrolls.",
-  "- Berkshire Hathaway: agreed to buy Taylor Morrison Home for -? Wait",
-].join("\n");
-
-function geminiResponse(summaryMarkdown: string) {
+function geminiResponse(fields: unknown) {
   return {
     data: {
       candidates: [{
         content: {
           parts: [{
-            text: JSON.stringify({summaryMarkdown}),
+            text: JSON.stringify(fields),
           }],
         },
       }],
@@ -69,8 +64,8 @@ describe("MNC AI summary", () => {
     clearAiProviderState();
   });
 
-  test("summarizes the PDF with inline provider PDF data", async () => {
-    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(validSummaryMarkdown));
+  test("renders the structured summary and sends the PDF inline with the structured schema", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(validFields));
 
     const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
       logger,
@@ -93,6 +88,11 @@ describe("MNC AI summary", () => {
             text: expect.stringContaining("start with Company Name `TICKER`"),
           }],
         }],
+        generationConfig: expect.objectContaining({
+          responseJsonSchema: expect.objectContaining({
+            required: ["marketSetup", "stocksInFocus", "watchlist"],
+          }),
+        }),
       }),
       expect.objectContaining({
         headers: expect.objectContaining({
@@ -107,7 +107,7 @@ describe("MNC AI summary", () => {
         contents: [expect.objectContaining({
           parts: expect.arrayContaining([
             expect.objectContaining({
-              text: expect.stringContaining("Do not include a Morning News Call heading"),
+              text: expect.stringContaining("three string arrays"),
             }),
           ]),
         })],
@@ -117,123 +117,12 @@ describe("MNC AI summary", () => {
     );
   });
 
-  test("retries once and posts a valid summary after a malformed first attempt", async () => {
-    const postWithRetryFn = vi.fn()
-      .mockResolvedValueOnce(geminiResponse(malformedSummaryMarkdown))
-      .mockResolvedValue(geminiResponse(validSummaryMarkdown));
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBe(validSummaryExpected);
-    expect(summary).not.toContain("Wait");
-    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
-    expect(logger.log).toHaveBeenCalledWith(
-      "warn",
-      expect.objectContaining({
-        message: expect.stringContaining("Discarding malformed AI MNC summary"),
-      }),
-    );
-  });
-
-  test("discards the summary when every attempt is malformed", async () => {
-    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(malformedSummaryMarkdown));
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBeUndefined();
-    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
-    expect(logger.log).toHaveBeenCalledWith(
-      "warn",
-      expect.objectContaining({
-        message: expect.stringContaining("Discarding malformed AI MNC summary"),
-      }),
-    );
-  });
-
-  test("rejects summaries with too few bullets even when both headings are present", async () => {
-    const thinSummaryMarkdown = [
-      "**Morning News Call - TL;DR**",
-      "- Futures firm ahead of payrolls.",
-      "",
-      "**Stocks in focus**",
-      "- Apple `AAPL` rose on upgrades.",
-      "- Tesla `TSLA` slipped premarket.",
-      "",
-      "**Watchlist**",
-      "- Watch the jobs report this morning.",
-    ].join("\n");
-    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(thinSummaryMarkdown));
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBeUndefined();
-    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
-  });
-
-  test("accepts a summary whose headings and bullets only vary in formatting", async () => {
-    // Reproduces the 2026-06-03 incident: the model produced a complete summary
-    // but used title-case "Stocks in Focus:", a "## Watchlist" heading, and
-    // "*"/"•" bullet markers, which the strict gate discarded on both attempts.
-    const variantSummaryMarkdown = [
-      "📰 **Morning News Call - TL;DR**",
-      "* Futures firm ahead of payrolls.",
-      "* Yields ease as risk appetite improves.",
-      "",
-      "**Stocks in Focus:**",
-      "* Apple `AAPL` rose on upgrades.",
-      "* Tesla `TSLA` slipped premarket.",
-      "* Nvidia `NVDA` led chip gains.",
-      "",
-      "## Watchlist",
-      "• Watch the jobs report this morning.",
-    ].join("\n");
-    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(variantSummaryMarkdown));
-
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn,
-      readSecretFn,
-    });
-
-    expect(summary).toBe(validSummaryExpected);
-    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
-    expect(logger.log).not.toHaveBeenCalledWith(
-      "warn",
-      expect.objectContaining({
-        message: expect.stringContaining("Discarding malformed AI MNC summary"),
-      }),
-    );
-  });
-
-  test("accepts a summary whose section names are bold lead-in labels on bullets", async () => {
-    // Reproduces the 2026-06-10 incident: the model produced a complete 7-bullet
-    // summary but welded the section names onto the first bullet of each section
-    // ("- **Stocks in focus:** ...") instead of writing standalone headings, so
-    // the strict gate logged has_stocks_heading/has_watchlist_heading=false and
-    // discarded both deterministic (temperature 0) attempts.
-    const leadInSummaryMarkdown = [
-      "📰 **Morning News Call - TL;DR**",
-      "- **Market setup:** U.S. futures fell as tech extended losses ahead of May CPI.",
-      "- **Macro drivers:** Headline CPI seen at `4.2%`, core at `2.9%`, keeping the Fed on hold.",
-      "- **Stocks in focus:** Apple `AAPL` rose on upgrades.",
-      "- Tesla `TSLA` slipped premarket.",
-      "- Nvidia `NVDA` led chip gains.",
-      "- Boeing `BA` climbed on a delivery beat.",
-      "- **Watchlist:** Watch the May CPI release this morning.",
-    ].join("\n");
-    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(leadInSummaryMarkdown));
+  test("strips stray bullet markers and collapses multi-line entries, dropping non-strings", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse({
+      marketSetup: ["- Futures firm ahead of payrolls.", "* Yields ease\nas risk appetite improves."],
+      stocksInFocus: ["• Apple `AAPL` rose on upgrades.", "Tesla `TSLA` slipped premarket.", 42, ""],
+      watchlist: ["Watch the jobs report this morning."],
+    }));
 
     const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
       logger,
@@ -242,43 +131,66 @@ describe("MNC AI summary", () => {
     });
 
     expect(summary).toBe([
-      "- **Market setup:** U.S. futures fell as tech extended losses ahead of May CPI.",
-      "- **Macro drivers:** Headline CPI seen at `4.2%`, core at `2.9%`, keeping the Fed on hold.",
+      "- Futures firm ahead of payrolls.",
+      "- Yields ease as risk appetite improves.",
+      "",
       "**Stocks in focus**",
       "- Apple `AAPL` rose on upgrades.",
       "- Tesla `TSLA` slipped premarket.",
-      "- Nvidia `NVDA` led chip gains.",
-      "- Boeing `BA` climbed on a delivery beat.",
+      "",
       "**Watchlist**",
-      "- Watch the May CPI release this morning.",
+      "- Watch the jobs report this morning.",
     ].join("\n"));
-    expect(postWithRetryFn).toHaveBeenCalledTimes(1);
-    expect(logger.log).not.toHaveBeenCalledWith(
-      "warn",
-      expect.objectContaining({
-        message: expect.stringContaining("Discarding malformed AI MNC summary"),
-      }),
-    );
   });
 
-  test("logs structural diagnostics when discarding a malformed summary", async () => {
-    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse(malformedSummaryMarkdown));
+  test("retries once and posts after a first attempt with an empty section", async () => {
+    const postWithRetryFn = vi.fn()
+      .mockResolvedValueOnce(geminiResponse({
+        marketSetup: ["Futures firm ahead of payrolls."],
+        stocksInFocus: [],
+        watchlist: ["Watch the jobs report this morning."],
+      }))
+      .mockResolvedValue(geminiResponse(validFields));
 
-    await getMncSummary(Buffer.from("pdf-bytes"), {
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
       logger,
       postWithRetryFn,
       readSecretFn,
     });
 
+    expect(summary).toBe(validSummaryExpected);
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
     expect(logger.log).toHaveBeenCalledWith(
       "warn",
       expect.objectContaining({
-        message: expect.stringContaining("Discarding malformed AI MNC summary"),
-        has_stocks_heading: false,
-        has_watchlist_heading: false,
-        bullet_count: 2,
-        min_bullets: 5,
-        summary_preview: expect.stringContaining("Futures firm ahead of payrolls."),
+        message: expect.stringContaining("a required section is empty"),
+        stocks_in_focus_count: 0,
+      }),
+    );
+  });
+
+  test("discards and logs section counts when a section stays empty on every attempt", async () => {
+    const postWithRetryFn = vi.fn().mockResolvedValue(geminiResponse({
+      marketSetup: ["Futures firm ahead of payrolls."],
+      stocksInFocus: ["Apple `AAPL` rose on upgrades."],
+      watchlist: [],
+    }));
+
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(summary).toBeUndefined();
+    expect(postWithRetryFn).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      expect.objectContaining({
+        message: expect.stringContaining("a required section is empty"),
+        market_setup_count: 1,
+        stocks_in_focus_count: 1,
+        watchlist_count: 0,
       }),
     );
   });
@@ -339,66 +251,10 @@ describe("MNC AI summary", () => {
     );
   });
 
-  test("returns no summary for missing summaryMarkdown", async () => {
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn: vi.fn().mockResolvedValue({
-        data: {
-          candidates: [{
-            content: {
-              parts: [{
-                text: JSON.stringify({}),
-              }],
-            },
-          }],
-        },
-      }),
-      readSecretFn,
-    });
-
-    expect(summary).toBeUndefined();
-    expect(logger.log).toHaveBeenCalledWith(
-      "warn",
-      "AI MNC summary response did not contain summaryMarkdown.",
-    );
-  });
-
-  test("returns no summary for empty normalized summaries", async () => {
-    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
-      logger,
-      postWithRetryFn: vi.fn().mockResolvedValue({
-        data: {
-          candidates: [{
-            content: {
-              parts: [{
-                text: JSON.stringify({
-                  summaryMarkdown: "```markdown\n```",
-                }),
-              }],
-            },
-          }],
-        },
-      }),
-      readSecretFn,
-    });
-
-    expect(summary).toBeUndefined();
-  });
-
   test("returns no summary for AI JSON arrays", async () => {
     const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
       logger,
-      postWithRetryFn: vi.fn().mockResolvedValue({
-        data: {
-          candidates: [{
-            content: {
-              parts: [{
-                text: "[]",
-              }],
-            },
-          }],
-        },
-      }),
+      postWithRetryFn: vi.fn().mockResolvedValue(geminiResponse([])),
       readSecretFn,
     });
 
@@ -408,184 +264,47 @@ describe("MNC AI summary", () => {
       "AI MNC summary returned invalid JSON.",
     );
   });
-});
 
-describe("MNC summary structural validation", () => {
-  const validBody = [
-    "- Futures firm ahead of payrolls.",
-    "- Yields ease as risk appetite improves.",
-    "",
-    "**Stocks in focus**",
-    "- Apple `AAPL` rose on upgrades.",
-    "- Tesla `TSLA` slipped premarket.",
-    "",
-    "**Watchlist**",
-    "- Watch the jobs report this morning.",
-  ].join("\n");
+  test("discards an object that contains none of the expected sections", async () => {
+    const summary = await getMncSummary(Buffer.from("pdf-bytes"), {
+      logger,
+      postWithRetryFn: vi.fn().mockResolvedValue(geminiResponse({summaryMarkdown: "- a\n- b"})),
+      readSecretFn,
+    });
 
-  test("accepts a summary with both section headings and enough bullets", () => {
-    expect(isStructurallyValidMncSummary(validBody)).toBe(true);
-  });
-
-  test("accepts heading and bullet formatting variants", () => {
-    const body = [
-      "* Futures firm ahead of payrolls.",
-      "* Yields ease as risk appetite improves.",
-      "",
-      "**Stocks in Focus:**",
-      "* Apple `AAPL` rose on upgrades.",
-      "* Tesla `TSLA` slipped premarket.",
-      "",
-      "## Watchlist",
-      "• Watch the jobs report this morning.",
-    ].join("\n");
-    expect(isStructurallyValidMncSummary(body)).toBe(true);
-  });
-
-  test("accepts section names emitted as bold lead-in labels on bullets", () => {
-    const body = [
-      "- **Market setup:** Futures firm ahead of payrolls.",
-      "- **Macro drivers:** Yields ease as risk appetite improves.",
-      "- **Stocks in focus:** Apple `AAPL` rose on upgrades.",
-      "- Tesla `TSLA` slipped premarket.",
-      "- **Watchlist:** Watch the jobs report this morning.",
-    ].join("\n");
-    expect(isStructurallyValidMncSummary(body)).toBe(true);
-  });
-
-  test("rejects a summary missing the stocks heading", () => {
-    const body = validBody.replace("**Stocks in focus**\n", "");
-    expect(isStructurallyValidMncSummary(body)).toBe(false);
-  });
-
-  test("rejects a summary missing the watchlist heading", () => {
-    const body = validBody.replace("**Watchlist**\n", "");
-    expect(isStructurallyValidMncSummary(body)).toBe(false);
-  });
-
-  test("rejects a summary with too few bullets", () => {
-    const body = [
-      "- Futures firm ahead of payrolls.",
-      "",
-      "**Stocks in focus**",
-      "- Apple `AAPL` rose on upgrades.",
-      "",
-      "**Watchlist**",
-      "- Watch the jobs report this morning.",
-    ].join("\n");
-    expect(isStructurallyValidMncSummary(body)).toBe(false);
+    expect(summary).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      "warn",
+      expect.objectContaining({
+        market_setup_count: 0,
+        stocks_in_focus_count: 0,
+        watchlist_count: 0,
+      }),
+    );
   });
 });
 
-describe("MNC summary formatting", () => {
-  test("normalizes markdown fences and truncates long summaries", () => {
-    const longSummary = [
-      "```markdown",
-      "**Morning News Call - TL;DR**",
-      ...Array.from({length: 40}, (_value, index) => `- Market item ${index} with enough text to make the generated summary too long for Discord posting.`),
-      "```",
-    ].join("\n");
-
-    const summary = formatMncSummary(longSummary);
-
-    expect(summary).not.toContain("```");
-    expect(summary).not.toContain("**Morning News Call - TL;DR**");
-    expect(summary).not.toContain("📰 **Morning News Call - TL;DR**");
-    expect(summary.length).toBeLessThanOrEqual(1_930);
-    expect(summary).toContain("\n...");
-    expect(summary).not.toContain("\n- ...");
-  });
-
-  test("compacts sectioned summaries before falling back to a hard truncation", () => {
-    const longSectionedSummary = [
-      "📰 **Morning News Call - TL;DR**",
-      "- Futures are firmer while yields drift lower, with traders waiting for jobs data, services activity, and Fed speakers to reset rate expectations.",
-      "- Oil is softer, gold is bid, and the dollar is steady as risk appetite improves without removing the main macro and geopolitical overhangs.",
-      "",
-      "**Stocks in focus**",
-      ...Array.from({length: 7}, (_value, index) => `- Company ${index} \`CMP${index}\` moved premarket after management updated guidance, highlighted margin drivers, and flagged demand trends that could matter for today's sector rotation.`),
-      "",
-      "**Watchlist**",
-      "- Watch Treasury supply, afternoon Fed remarks, and the market reaction to services data for signs that rate-sensitive groups can keep leading.",
-      "- Also monitor energy headlines, breadth in megacap technology, and closing auction flows after a busy earnings calendar.",
-    ].join("\n");
-
-    const summary = formatMncSummary(longSectionedSummary);
-
-    expect(summary.length).toBeLessThanOrEqual(1_930);
-    expect(summary).not.toContain("Morning News Call - TL;DR");
-    expect(summary).toContain("**Stocks in focus**");
-    expect(summary).toContain("**Watchlist**");
-    expect(summary).toContain("Watch Treasury supply");
-    expect(summary).not.toContain("\n...");
-  });
-
-  test("removes generated Morning News Call headings", () => {
-    expect(formatMncSummary("📰 **Morning News Call - TL;DR**\n- Futures firm ahead of payrolls."))
-      .toBe("- Futures firm ahead of payrolls.");
-  });
-
-  test("canonicalizes heading and bullet variants to the expected shape", () => {
-    const summary = formatMncSummary([
-      "**Morning News Call - TL;DR**",
-      "* Futures firm ahead of payrolls.",
-      "* Yields ease as risk appetite improves.",
-      "",
-      "**Stocks in Focus:**",
-      "* Apple `AAPL` rose on upgrades.",
-      "* Tesla `TSLA` slipped premarket.",
-      "* Nvidia `NVDA` led chip gains.",
-      "",
-      "## Watchlist",
-      "• Watch the jobs report this morning.",
-    ].join("\n"));
-
-    expect(summary).toBe(validSummaryExpected);
-  });
-
-  test("promotes a bare bold section-label bullet to a standalone heading", () => {
-    const summary = formatMncSummary([
-      "- Futures firm ahead of payrolls.",
-      "- Yields ease as risk appetite improves.",
-      "- **Stocks in focus:**",
-      "- Apple `AAPL` rose on upgrades.",
-      "- Tesla `TSLA` slipped premarket.",
-      "- Nvidia `NVDA` led chip gains.",
-      "- **Watchlist:**",
-      "- Watch the jobs report this morning.",
-    ].join("\n"));
-
-    expect(summary).toBe([
-      "- Futures firm ahead of payrolls.",
-      "- Yields ease as risk appetite improves.",
-      "**Stocks in focus**",
-      "- Apple `AAPL` rose on upgrades.",
-      "- Tesla `TSLA` slipped premarket.",
-      "- Nvidia `NVDA` led chip gains.",
-      "**Watchlist**",
-      "- Watch the jobs report this morning.",
-    ].join("\n"));
+describe("MNC summary rendering", () => {
+  test("renders the canonical headings and bullets from structured fields", () => {
+    expect(renderMncSummary(validFields)).toBe(validSummaryExpected);
   });
 
   test("normalizes common AI Markdown rendering glitches", () => {
-    const summary = formatMncSummary([
-      "**Morning News Call - TL;DR**",
-      "- U.S. futures opened firmer while easing geopolitical तनाव and AI optimism lifted risk appetite.",
-      "- Gold jumped more than `3%`.",
-      "",
-      "**Stocks in focus**",
-      "- Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$$1.57` / `$$25.2B`, with ~`12%` FY26 EPS growth.",
-      "- Super Micro Computer `SMCI` forecast Q4 revenue of `$$11B`-`$$12.5B` and adjusted EPS of `65c`-`79c`.",
-      "- PayPal `PYPL` reported Q1 revenue of `$$8.35B`, targeting `$$1.5B` of savings over `2`-`3` years.",
-      "- Arm `ARM` guided Q1 revenue to `- $1.26B` vs `- $1.25B` est.",
-      "- Fortinet `FTNT` raised FY guidance to `-$7.71B`-`$7.87B` revenue and `-$3.10`-`$3.16` EPS.",
-      "- Block `XYZ`: raised full-year gross profit guidance to ` $12.33B` from `$ 12.20B`.",
-      "- CoreWeave `CRWV`: lifted 2026 capex to ` $31B-$35B`; Nvidia `NVDA` is investing up to ` $2.1B`.",
-      "- Cheniere `LNG` swung to a `-$3.5B` Q1 loss after a `-$4.8B` derivative hit.",
-      "",
-      "**Watchlist**",
-      "- All eyes on `ADP` April payrolls (`99K` expected).",
-    ].join("\n"));
+    const summary = renderMncSummary({
+      marketSetup: [
+        "U.S. futures opened firmer while easing geopolitical तनाव and AI optimism lifted risk appetite.",
+        "Gold jumped more than `3%`.",
+      ],
+      stocksInFocus: [
+        "Walt Disney `DIS` beat Q2 EPS/revenue estimates at `$$1.57` / `$$25.2B`, with ~`12%` FY26 EPS growth.",
+        "Super Micro Computer `SMCI` forecast Q4 revenue of `$$11B`-`$$12.5B` and adjusted EPS of `65c`-`79c`.",
+        "PayPal `PYPL` reported Q1 revenue of `$$8.35B`, targeting `$$1.5B` of savings over `2`-`3` years.",
+        "Arm `ARM` guided Q1 revenue to `- $1.26B` vs `- $1.25B` est.",
+      ],
+      watchlist: [
+        "All eyes on `ADP` April payrolls (`99K` expected).",
+      ],
+    });
 
     expect(summary).toBe([
       "- U.S. futures opened firmer while easing geopolitical and AI optimism lifted risk appetite.",
@@ -596,34 +315,70 @@ describe("MNC summary formatting", () => {
       "- Super Micro Computer `SMCI` forecast Q4 revenue of `$11B-$12.5B` and adjusted EPS of `65c-79c`.",
       "- PayPal `PYPL` reported Q1 revenue of `$8.35B`, targeting `$1.5B` of savings over `2-3` years.",
       "- Arm `ARM` guided Q1 revenue to `$1.26B` vs `$1.25B` est.",
-      "- Fortinet `FTNT` raised FY guidance to `$7.71B-$7.87B` revenue and `$3.10-$3.16` EPS.",
-      "- Block `XYZ`: raised full-year gross profit guidance to `$12.33B` from `$12.20B`.",
-      "- CoreWeave `CRWV`: lifted 2026 capex to `$31B-$35B`; Nvidia `NVDA` is investing up to `$2.1B`.",
-      "- Cheniere `LNG` swung to a `-$3.5B` Q1 loss after a `-$4.8B` derivative hit.",
       "",
       "**Watchlist**",
       "- All eyes on `ADP` April payrolls (`99K` expected).",
     ].join("\n"));
   });
 
-  test("hard-truncates summaries that cannot be compacted or split by line", () => {
-    const summary = formatMncSummary("One very long generated line without section breaks. ".repeat(80));
+  test("leaves non-metric inline-code pairs untouched", () => {
+    const summary = renderMncSummary({
+      marketSetup: ["Rotation from `tech`-`energy` continues."],
+      stocksInFocus: ["Apple `AAPL` rose on upgrades."],
+      watchlist: ["Watch the jobs report this morning."],
+    });
+
+    expect(summary).toContain("`tech`-`energy`");
+  });
+
+  test("keeps explicit negative metrics on loss bullets", () => {
+    const summary = renderMncSummary({
+      marketSetup: ["Risk-off tone as yields climb."],
+      stocksInFocus: ["Cheniere `LNG` swung to a `-$3.5B` Q1 loss after a `-$4.8B` derivative hit."],
+      watchlist: ["Watch energy headlines."],
+    });
+
+    expect(summary).toContain("`-$3.5B`");
+    expect(summary).toContain("`-$4.8B`");
+  });
+
+  test("drops trailing stock/watchlist bullets to fit, keeping every section", () => {
+    const longBullet = (prefix: string) => `${prefix} ${"with enough text to push the rendered summary past the Discord budget when every bullet is present. ".repeat(2)}`;
+    const summary = renderMncSummary({
+      marketSetup: [longBullet("Market is firmer"), longBullet("Yields drift lower")],
+      stocksInFocus: Array.from({length: 7}, (_value, index) => longBullet(`Company ${index} moved premarket`)),
+      watchlist: [longBullet("Watch Treasury supply"), longBullet("Also monitor energy headlines")],
+    });
+
+    expect(summary.length).toBeLessThanOrEqual(1_930);
+    expect(summary).toContain("**Stocks in focus**");
+    expect(summary).toContain("**Watchlist**");
+    expect(summary).not.toContain("\n...");
+  });
+
+  test("hard-truncates after a heading boundary when compaction cannot help", () => {
+    const hugeStock = (label: string) => `${label} ${"with a great deal of detail that on its own already overflows the entire Discord message budget several times over. ".repeat(15)}`;
+    const summary = renderMncSummary({
+      marketSetup: ["Market is cautious ahead of CPI.", "Yields tick higher into the print."],
+      stocksInFocus: Array.from({length: 4}, (_value, index) => hugeStock(`Company ${index}`)),
+      watchlist: ["Watch the CPI release."],
+    });
 
     expect(summary.length).toBeLessThanOrEqual(1_930);
     expect(summary).toMatch(/\n\.\.\.$/);
+    // Accumulation stops at the section heading, which is popped as dangling.
+    expect(summary).not.toMatch(/\*\*Stocks in focus\*\*$/);
+    expect(summary).toContain("- Market is cautious ahead of CPI.");
   });
 
-  test("falls back to line truncation for malformed section summaries", () => {
-    const malformedSectionSummary = [
-      "📰 **Morning News Call - TL;DR**",
-      "**Stocks in focus**",
-      "**Watchlist**",
-      "A watchlist paragraph without a bullet. ".repeat(90),
-    ].join("\n");
-
-    const summary = formatMncSummary(malformedSectionSummary);
+  test("hard-truncates a single oversized bullet with no usable line break", () => {
+    const summary = renderMncSummary({
+      marketSetup: ["A long uninterrupted market-setup sentence without section breaks. ".repeat(40)],
+      stocksInFocus: ["Apple `AAPL` rose on upgrades."],
+      watchlist: ["Watch the jobs report this morning."],
+    });
 
     expect(summary.length).toBeLessThanOrEqual(1_930);
-    expect(summary).toContain("\n...");
+    expect(summary).toMatch(/\n\.\.\.$/);
   });
 });

--- a/modules/mnc-summary.ts
+++ b/modules/mnc-summary.ts
@@ -3,44 +3,47 @@ import {callAiProviderJson, type AiProviderDependencies} from "./ai-provider.ts"
 
 export type MncSummaryDependencies = AiProviderDependencies;
 
+export type MncSummaryFields = {
+  marketSetup: string[];
+  stocksInFocus: string[];
+  watchlist: string[];
+};
+
 const maxInlinePdfBytes = 14_000_000;
 const maxDiscordSummaryLength = 1_930;
 const maxMncSummaryAttempts = 2;
-const minMncSummaryBullets = 5;
-// Long enough that a discarded summary's preview reaches the stocks/watchlist
-// region, not just the intro bullet, so a structural rejection can be diagnosed.
-const mncSummaryDiscardPreviewLength = 700;
+const stocksInFocusHeading = "**Stocks in focus**";
+const watchlistHeading = "**Watchlist**";
+// Strip a leading "-", "*", "•", or "–" bullet marker the model sometimes adds;
+// the marker must be followed by whitespace so values like "-$3.5B" are kept.
+const leadingBulletMarkerPattern = /^\s*[-*•–]\s+/;
 
-// The model is asked for "**Stocks in focus**" / "**Watchlist**" but routinely
-// varies the casing, adds a trailing colon, a leading 📰, or a Markdown "#"
-// heading marker. Match those benign variants so a usable summary is not
-// discarded, while still requiring the section to be a heading on its own line.
-const stocksInFocusHeadingPattern = /^\s*(?:#{1,3}\s*)?(?:📰\s*)?(?:\*\*|__)?\s*stocks in focus\s*:?\s*(?:\*\*|__)?\s*$/i;
-const watchlistHeadingPattern = /^\s*(?:#{1,3}\s*)?(?:📰\s*)?(?:\*\*|__)?\s*watchlist\s*:?\s*(?:\*\*|__)?\s*$/i;
-// The model also welds the section name onto the first bullet of the section as
-// a bold lead-in label instead of writing a standalone heading, e.g.
-// "- **Stocks in focus:** Apple `AAPL` ...". Promote that lead-in to a real
-// heading so the structural gate and section compaction recognise the section.
-// A bold (or "#") wrapper is required so prose that merely mentions the phrase
-// mid-bullet is not mistaken for a heading. Capture group 1 is the trailing
-// content, which becomes the section's first bullet (empty for a bare label).
-const stocksInFocusLeadInPattern = /^\s*(?:[-*•–]\s+)?(?:#{1,3}\s+)?(?:📰\s*)?(?:\*\*|__)\s*stocks in focus\s*:?\s*(?:\*\*|__)\s*:?\s*(.*)$/i;
-const watchlistLeadInPattern = /^\s*(?:[-*•–]\s+)?(?:#{1,3}\s+)?(?:📰\s*)?(?:\*\*|__)\s*watchlist\s*:?\s*(?:\*\*|__)\s*:?\s*(.*)$/i;
-// Accept "-", "*", "•", or "–" bullet markers; "**bold**" lines are not bullets
-// because the marker must be followed by whitespace.
-const bulletLinePattern = /^[-*•–]\s+\S/;
-const bulletLineCanonicalPattern = /^(\s*)[-*•–]\s+(.*)$/;
-
+// The model returns one bullet per array entry per section and the bot renders
+// the Markdown itself, so the posted message always has the expected headings
+// and bullets. This removes the class of failures where a complete free-form
+// summary was discarded only because its headings or bullet markers did not
+// match the shape the gate expected.
 const mncSummarySchema = {
   type: "object",
   additionalProperties: false,
   properties: {
-    summaryMarkdown: {
-      type: "string",
-      description: "A concise one-minute Morning News Call summary formatted in Discord-compatible Markdown.",
+    marketSetup: {
+      type: "array",
+      description: "2 short bullets on the market setup and the most important macro drivers.",
+      items: {type: "string"},
+    },
+    stocksInFocus: {
+      type: "array",
+      description: "4 short bullets of company/ticker-specific news, earnings, guidance, analyst calls, or deal headlines.",
+      items: {type: "string"},
+    },
+    watchlist: {
+      type: "array",
+      description: "1 short bullet for events, data releases, sectors, or risks traders should monitor.",
+      items: {type: "string"},
     },
   },
-  required: ["summaryMarkdown"],
+  required: ["marketSetup", "stocksInFocus", "watchlist"],
 } satisfies Record<string, unknown>;
 
 export async function getMncSummary(
@@ -56,40 +59,37 @@ export async function getMncSummary(
   }
 
   for (let attempt = 1; attempt <= maxMncSummaryAttempts; attempt++) {
-    const normalizedSummary = await requestNormalizedMncSummary(pdfBuffer, dependencies);
-    if (undefined === normalizedSummary) {
+    const fields = await requestMncSummaryFields(pdfBuffer, dependencies);
+    if (undefined === fields) {
       continue;
     }
 
-    const structure = describeMncSummaryStructure(normalizedSummary);
-    if (false === isMncSummaryStructureValid(structure)) {
+    if (false === isMncSummaryFieldsValid(fields)) {
       dependencies.logger.log(
         "warn",
         {
-          message: `Discarding malformed AI MNC summary (attempt ${attempt}/${maxMncSummaryAttempts}): missing a required section heading or too few bullets.`,
-          has_stocks_heading: structure.hasStocksHeading,
-          has_watchlist_heading: structure.hasWatchlistHeading,
-          bullet_count: structure.bulletCount,
-          min_bullets: minMncSummaryBullets,
-          summary_preview: normalizedSummary.slice(0, mncSummaryDiscardPreviewLength),
+          message: `Discarding AI MNC summary (attempt ${attempt}/${maxMncSummaryAttempts}): a required section is empty.`,
+          market_setup_count: fields.marketSetup.length,
+          stocks_in_focus_count: fields.stocksInFocus.length,
+          watchlist_count: fields.watchlist.length,
         },
       );
       continue;
     }
 
-    const finalSummary = finalizeNormalizedSummary(normalizedSummary);
-    if ("" !== finalSummary) {
-      return finalSummary;
+    const summary = renderMncSummary(fields);
+    if ("" !== summary) {
+      return summary;
     }
   }
 
   return undefined;
 }
 
-async function requestNormalizedMncSummary(
+async function requestMncSummaryFields(
   pdfBuffer: Buffer,
   dependencies: MncSummaryDependencies,
-): Promise<string | undefined> {
+): Promise<MncSummaryFields | undefined> {
   const jsonText = await callAiProviderJson(
     getMncSummaryPrompt(),
     mncSummarySchema,
@@ -123,93 +123,105 @@ async function requestNormalizedMncSummary(
     return undefined;
   }
 
-  const summaryMarkdown = parsedJson["summaryMarkdown"];
-  if ("string" !== typeof summaryMarkdown) {
-    dependencies.logger.log(
-      "warn",
-      "AI MNC summary response did not contain summaryMarkdown.",
-    );
-    return undefined;
-  }
-
-  const normalizedSummary = normalizeMarkdownSummary(summaryMarkdown);
-  return "" === normalizedSummary ? undefined : normalizedSummary;
-}
-
-export function formatMncSummary(summaryMarkdown: string): string {
-  return finalizeNormalizedSummary(normalizeMarkdownSummary(summaryMarkdown));
-}
-
-function finalizeNormalizedSummary(normalizedSummary: string): string {
-  return removeMncTldrHeading(truncateMarkdownSummary(normalizedSummary)).trim();
-}
-
-export type MncSummaryStructure = {
-  hasStocksHeading: boolean;
-  hasWatchlistHeading: boolean;
-  bulletCount: number;
-};
-
-export function describeMncSummaryStructure(summary: string): MncSummaryStructure {
-  const lines = summary.split("\n");
   return {
-    hasStocksHeading: lines.some(line => isStocksInFocusHeadingLine(line)),
-    hasWatchlistHeading: lines.some(line => isWatchlistHeadingLine(line)),
-    bulletCount: getBulletLines(lines).length,
+    marketSetup: cleanBulletArray(parsedJson["marketSetup"]),
+    stocksInFocus: cleanBulletArray(parsedJson["stocksInFocus"]),
+    watchlist: cleanBulletArray(parsedJson["watchlist"]),
   };
 }
 
-// Recognise a section whether it is a standalone heading or a bold lead-in label
-// on a bullet, so the structural gate agrees with canonicalizeSummaryStructure
-// regardless of whether the summary has been normalized yet.
-function isStocksInFocusHeadingLine(line: string): boolean {
-  return stocksInFocusHeadingPattern.test(line) || stocksInFocusLeadInPattern.test(line);
+// Assemble the structured fields into the posted Discord Markdown, then apply
+// the inline-code/metric clean-ups and the Discord length budget. Exported so
+// the rendering and normalization are covered without a provider round-trip.
+export function renderMncSummary(fields: MncSummaryFields): string {
+  let renderedSummary = "";
+  for (const candidate of getCompactionCandidates(fields)) {
+    renderedSummary = assembleSummary(candidate);
+    if (renderedSummary.length <= maxDiscordSummaryLength) {
+      return renderedSummary.trim();
+    }
+  }
+
+  return hardTruncateSummary(renderedSummary).trim();
 }
 
-function isWatchlistHeadingLine(line: string): boolean {
-  return watchlistHeadingPattern.test(line) || watchlistLeadInPattern.test(line);
+function assembleSummary(fields: MncSummaryFields): string {
+  const lines = [
+    ...fields.marketSetup.map(toBulletLine),
+    "",
+    stocksInFocusHeading,
+    ...fields.stocksInFocus.map(toBulletLine),
+    "",
+    watchlistHeading,
+    ...fields.watchlist.map(toBulletLine),
+  ];
+
+  return normalizeRenderedSummary(lines.join("\n"));
 }
 
-function isMncSummaryStructureValid(structure: MncSummaryStructure): boolean {
-  return true === structure.hasStocksHeading
-    && true === structure.hasWatchlistHeading
-    && structure.bulletCount >= minMncSummaryBullets;
+// Full summary first, then progressively fewer stock and watchlist bullets, so
+// an over-budget summary keeps every section instead of being cut mid-list.
+function* getCompactionCandidates(fields: MncSummaryFields): Generator<MncSummaryFields> {
+  yield fields;
+  for (const stockLimit of [4, 3]) {
+    for (const watchlistLimit of [2, 1]) {
+      yield {
+        marketSetup: fields.marketSetup.slice(0, 2),
+        stocksInFocus: fields.stocksInFocus.slice(0, stockLimit),
+        watchlist: fields.watchlist.slice(0, watchlistLimit),
+      };
+    }
+  }
 }
 
-export function isStructurallyValidMncSummary(summary: string): boolean {
-  return isMncSummaryStructureValid(describeMncSummaryStructure(summary));
+function isMncSummaryFieldsValid(fields: MncSummaryFields): boolean {
+  return fields.marketSetup.length >= 1
+    && fields.stocksInFocus.length >= 1
+    && fields.watchlist.length >= 1;
+}
+
+function toBulletLine(text: string): string {
+  return `- ${text}`;
+}
+
+function cleanBulletArray(value: unknown): string[] {
+  if (false === Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item): item is string => "string" === typeof item)
+    .map(item => item
+      .replace(leadingBulletMarkerPattern, "")
+      .replace(/\s*\n\s*/g, " ")
+      .trim())
+    .filter(item => "" !== item);
 }
 
 function getMncSummaryPrompt(): string {
   return [
     "Summarize this Refinitiv Morning News Call PDF for a Discord trading channel.",
-    "Return only JSON matching the schema. Do not include markdown outside the JSON string.",
-    "Write summaryMarkdown as a one-minute read in concise Discord Markdown.",
-    "Required shape:",
-    "- Exactly 2 bullets with the market setup and most important macro drivers.",
-    "",
-    "**Stocks in focus**",
-    "- Exactly 4 bullets with company/ticker-specific news, earnings, guidance, analyst calls, or deal headlines.",
-    "",
-    "**Watchlist**",
-    "- Exactly 1 bullet for events, data releases, sectors, or risks traders should monitor.",
+    "Return only JSON matching the schema: three string arrays, one entry per bullet.",
+    "Do not put Markdown headings or bullet markers inside the strings; the bot adds those.",
+    "Populate the arrays:",
+    "- marketSetup: exactly 2 bullets with the market setup and most important macro drivers.",
+    "- stocksInFocus: exactly 4 bullets with company/ticker-specific news, earnings, guidance, analyst calls, or deal headlines.",
+    "- watchlist: exactly 1 bullet for events, data releases, sectors, or risks traders should monitor.",
     "Rules:",
-    "- Keep the full summary under 1,750 characters.",
-    "- Use exactly 7 bullets total; each bullet should fit one Discord line.",
+    "- Each bullet is one concise Discord line; keep the whole summary under 1,750 characters.",
     "- Prioritize concrete, market-moving information from the PDF.",
-    "- Do not include a Morning News Call heading; the Discord message title already provides it.",
     "- Write in English only.",
     "- Format ticker symbols and quantitative metrics as inline code, e.g. `AAPL`, `$2.14`, `3.1%`, `10Y`, `250K`.",
     "- For metric ranges, write the range inside one inline-code token, e.g. `$1.26B-$1.36B`; do not turn range separators or table dashes into negative signs.",
     "- Use a negative sign only when the PDF explicitly reports a negative value, loss, charge, deficit, decline, or outflow.",
-    "- In stock-specific bullets, start with Company Name `TICKER` when the PDF explicitly provides a ticker; common short company names are fine, e.g. Apple `AAPL`.",
+    "- In stocksInFocus bullets, start with Company Name `TICKER` when the PDF explicitly provides a ticker; common short company names are fine, e.g. Apple `AAPL`.",
     "- If the PDF does not explicitly provide a ticker, start with the company name without inventing a ticker.",
     "- Do not infer or invent tickers, prices, percentages, or attributions.",
     "- Do not use code blocks, tables, links, emojis, or disclaimers.",
   ].join("\n");
 }
 
-function normalizeMarkdownSummary(value: string): string {
+function normalizeRenderedSummary(value: string): string {
   const summary = value
     .replace(/\r\n/g, "\n")
     .split("\n")
@@ -224,69 +236,11 @@ function normalizeMarkdownSummary(value: string): string {
     normalizeInlineCodeMetricSigns(
       normalizeInlineCodeRanges(
         normalizeInlineCodeWhitespace(
-          canonicalizeSummaryStructure(removeUnexpectedScriptTokens(removeMncTldrHeading(summary))),
+          removeUnexpectedScriptTokens(summary),
         ),
       ),
     ),
   ).trim();
-}
-
-// Rewrite tolerated heading and bullet variants to the canonical "**Stocks in
-// focus**" / "**Watchlist**" / "- " forms so the posted message, the structural
-// gate, and the section compaction all see one consistent shape.
-function canonicalizeSummaryStructure(value: string): string {
-  return value
-    .split("\n")
-    .flatMap(canonicalizeSummaryLine)
-    .join("\n");
-}
-
-function canonicalizeSummaryLine(line: string): string[] {
-  if (stocksInFocusHeadingPattern.test(line)) {
-    return ["**Stocks in focus**"];
-  }
-
-  if (watchlistHeadingPattern.test(line)) {
-    return ["**Watchlist**"];
-  }
-
-  const stocksLeadIn = line.match(stocksInFocusLeadInPattern);
-  if (null !== stocksLeadIn) {
-    return buildSectionHeadingLines("**Stocks in focus**", stocksLeadIn[1] ?? "");
-  }
-
-  const watchlistLeadIn = line.match(watchlistLeadInPattern);
-  if (null !== watchlistLeadIn) {
-    return buildSectionHeadingLines("**Watchlist**", watchlistLeadIn[1] ?? "");
-  }
-
-  const bulletMatch = line.match(bulletLineCanonicalPattern);
-  if (null !== bulletMatch) {
-    return [`- ${bulletMatch[2]}`];
-  }
-
-  return [line];
-}
-
-function buildSectionHeadingLines(heading: string, trailingContent: string): string[] {
-  const remainder = trailingContent.trim();
-  if ("" === remainder) {
-    return [heading];
-  }
-
-  return [heading, `- ${remainder}`];
-}
-
-function removeMncTldrHeading(value: string): string {
-  return value
-    .split("\n")
-    .filter(line => false === isMncTldrHeading(line))
-    .join("\n")
-    .trim();
-}
-
-function isMncTldrHeading(line: string): boolean {
-  return /^\s*(?:📰\s*)?\*\*Morning News Call\s*-\s*TL;?DR\*\*\s*$/i.test(line);
 }
 
 function removeUnexpectedScriptTokens(value: string): string {
@@ -369,22 +323,12 @@ function isLikelyPositiveGuidanceRangeLine(line: string): boolean {
   return /\b(?:guidance|guided|forecast|outlook|expects?|raised|revenue|sales|eps|earnings\s+per\s+share)\b/i.test(line);
 }
 
-function truncateMarkdownSummary(value: string): string {
-  if (value.length <= maxDiscordSummaryLength) {
-    return value;
-  }
-
-  const compactedSummary = getCompactedSectionSummary(value);
-  if (undefined !== compactedSummary && compactedSummary.length <= maxDiscordSummaryLength) {
-    return compactedSummary;
-  }
-
+function hardTruncateSummary(value: string): string {
   const suffix = "\n...";
   const maxBodyLength = maxDiscordSummaryLength - suffix.length;
   const lines: string[] = [];
   for (const line of value.split("\n")) {
-    const candidate = [...lines, line].join("\n");
-    if (candidate.length > maxBodyLength) {
+    if ([...lines, line].join("\n").length > maxBodyLength) {
       break;
     }
 
@@ -395,9 +339,9 @@ function truncateMarkdownSummary(value: string): string {
     lines.pop();
   }
 
-  const summary = lines.join("\n").trimEnd();
-  if ("" !== summary) {
-    return `${summary}${suffix}`;
+  const body = lines.join("\n").trimEnd();
+  if ("" !== body) {
+    return `${body}${suffix}`;
   }
 
   return `${value.slice(0, maxBodyLength).trimEnd()}${suffix}`;
@@ -406,57 +350,6 @@ function truncateMarkdownSummary(value: string): string {
 function isDanglingSummaryLine(line: string): boolean {
   const normalizedLine = line.trim();
   return "" === normalizedLine || /^\*\*[^*]+\*\*$/.test(normalizedLine);
-}
-
-function getCompactedSectionSummary(value: string): string | undefined {
-  const lines = value.split("\n");
-  for (const stockBulletLimit of [4, 3]) {
-    for (const watchlistBulletLimit of [2, 1]) {
-      const compactedSummary = buildCompactedSectionSummary(lines, stockBulletLimit, watchlistBulletLimit);
-      if (undefined !== compactedSummary && compactedSummary.length <= maxDiscordSummaryLength) {
-        return compactedSummary;
-      }
-    }
-  }
-
-  return buildCompactedSectionSummary(lines, 3, 1);
-}
-
-function buildCompactedSectionSummary(
-  lines: string[],
-  stockBulletLimit: number,
-  watchlistBulletLimit: number,
-): string | undefined {
-  const tldrHeadingIndex = lines.findIndex(line => line.includes("Morning News Call - TL;DR"));
-  const stocksHeadingIndex = lines.findIndex(line => line.trim() === "**Stocks in focus**");
-  const watchlistHeadingIndex = lines.findIndex(line => line.trim() === "**Watchlist**");
-  if (-1 === stocksHeadingIndex || -1 === watchlistHeadingIndex) {
-    return undefined;
-  }
-
-  const tldrStartIndex = -1 === tldrHeadingIndex ? 0 : tldrHeadingIndex + 1;
-  const tldrBullets = getBulletLines(lines.slice(tldrStartIndex, stocksHeadingIndex)).slice(0, 2);
-  const stockBullets = getBulletLines(lines.slice(stocksHeadingIndex + 1, watchlistHeadingIndex)).slice(0, stockBulletLimit);
-  const watchlistBullets = getBulletLines(lines.slice(watchlistHeadingIndex + 1)).slice(0, watchlistBulletLimit);
-  if (0 === tldrBullets.length || 0 === stockBullets.length || 0 === watchlistBullets.length) {
-    return undefined;
-  }
-
-  return [
-    ...tldrBullets,
-    "",
-    "**Stocks in focus**",
-    ...stockBullets,
-    "",
-    "**Watchlist**",
-    ...watchlistBullets,
-  ].join("\n").trim();
-}
-
-function getBulletLines(lines: string[]): string[] {
-  return lines
-    .map(line => line.trim())
-    .filter(line => bulletLinePattern.test(line));
 }
 
 function parseJson(value: string): unknown | null {


### PR DESCRIPTION
## Problem

The Morning News Call announcement keeps posting **only the PDF** — the AI summary text never appears. The model returns a complete summary, but it free-forms the Markdown and its heading/bullet style varies every run. The structural gate then discards anything that doesn't match the exact shape.

This has been per-day whack-a-mole — each fix taught the parser one more variant (the `Wait` garble → title-case/`##` headings → bold lead-in labels like `- **Stocks in focus:** …`), and it failed *again* on 2026-06-11 after the lead-in fix ([#1765](https://github.com/hblwrk/discord-bot-ts/pull/1765)) had deployed. The discard logs rotate before the new shape can be captured, so we're debugging blind.

## Fix — let the model return data, not formatting

The response schema now asks for three string arrays and the **bot renders the Markdown itself**:

```
{ marketSetup: string[], stocksInFocus: string[], watchlist: string[] }
```

The bot emits the canonical `**Stocks in focus**` / `**Watchlist**` headings and one `-` bullet per array entry. The model can no longer deviate on formatting, so there is nothing left to misparse — the entire heading-detection gate is gone. A summary is only discarded when a **required section comes back empty**, and that discard log reports per-section counts (`market_setup_count` / `stocks_in_focus_count` / `watchlist_count`) so any future miss is diagnosable in one line.

Kept: the inline-code/metric clean-ups (`$$` → `$`, range joining, negative-sign handling, stray non-Latin token removal). Length management now trims trailing stock/watchlist bullets on the structured fields before rendering, then hard-truncates as a last resort — which also removed the unreachable heading-detection branches the old truncation carried.

## Tests

Rewrote the suite around the structured input: rendering, stray-marker/multi-line/non-string cleaning, empty-section discard with counts, retry, oversized PDF, invalid JSON/array, and the compaction/hard-truncation paths. `modules/mnc-summary.ts` coverage is 96% stmts / 95% branch; full suite 748 tests green, typecheck clean.

## Note

I couldn't reproduce the live call locally (config behind a deny rule, secrets Docker-mounted), so this is validated by tests and by construction — the failure class is eliminated rather than another variant matched. Worth eyeballing the next MNC post to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)