### PR TITLE
Defer Twitter/X embed suppression until the card is generated

### DIFF
--- a/modules/twitter-link-rewrite.test.ts
+++ b/modules/twitter-link-rewrite.test.ts
@@ -18,14 +18,21 @@ type TwitterTestMessage = {
     bot?: boolean;
   };
   content: string;
+  embeds: unknown[];
+  id: string;
   reply: ReturnType<typeof vi.fn>;
   suppressEmbeds: ReturnType<typeof vi.fn>;
   webhookId?: string | null;
 };
 
+let nextMessageId = 0;
+
 function createTwitterMessage(content: string): TwitterTestMessage {
+  nextMessageId += 1;
   return {
     content,
+    embeds: [],
+    id: `message-${nextMessageId}`,
     reply: vi.fn().mockResolvedValue(undefined),
     suppressEmbeds: vi.fn().mockResolvedValue(undefined),
   };
@@ -73,16 +80,16 @@ describe("addTwitterLinkRewrites", () => {
     vi.clearAllMocks();
   });
 
-  test("suppresses the original embed and replies with the clean link", async () => {
+  test("replies immediately but defers suppression until the X card appears", async () => {
     const {client, getHandler} = createEventClient();
     addTwitterLinkRewrites(client);
 
-    const handler = getHandler("messageCreate");
+    const createHandler = getHandler("messageCreate");
+    const updateHandler = getHandler("messageUpdate");
     const message = createTwitterMessage("watch https://x.com/example/status/123?s=20");
 
-    await handler(message);
+    await createHandler(message);
 
-    expect(message.suppressEmbeds).toHaveBeenCalledWith(true);
     expect(message.reply).toHaveBeenCalledWith({
       allowedMentions: {
         parse: [],
@@ -90,6 +97,83 @@ describe("addTwitterLinkRewrites", () => {
       },
       content: "https://fxtwitter.com/example/status/123",
     });
+    expect(message.suppressEmbeds).not.toHaveBeenCalled();
+
+    message.embeds = [{type: "rich"}];
+    await updateHandler(undefined, message);
+
+    expect(message.suppressEmbeds).toHaveBeenCalledWith(true);
+  });
+
+  test("suppresses immediately when the card is already attached at create time", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.embeds = [{type: "rich"}];
+
+    await handler(message);
+
+    expect(message.suppressEmbeds).toHaveBeenCalledWith(true);
+    expect(message.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: "https://fxtwitter.com/example/status/123",
+    }));
+  });
+
+  test("keeps waiting when a messageUpdate arrives without the embed", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const createHandler = getHandler("messageCreate");
+    const updateHandler = getHandler("messageUpdate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+
+    await createHandler(message);
+    await updateHandler(undefined, message);
+
+    expect(message.suppressEmbeds).not.toHaveBeenCalled();
+
+    message.embeds = [{type: "rich"}];
+    await updateHandler(undefined, message);
+    await updateHandler(undefined, message);
+
+    expect(message.suppressEmbeds).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores messageUpdate for messages it is not tracking", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const updateHandler = getHandler("messageUpdate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.embeds = [{type: "rich"}];
+
+    await updateHandler(undefined, message);
+
+    expect(message.suppressEmbeds).not.toHaveBeenCalled();
+  });
+
+  test("stops waiting once the embed timeout elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const {client, getHandler} = createEventClient();
+      addTwitterLinkRewrites(client);
+
+      const createHandler = getHandler("messageCreate");
+      const updateHandler = getHandler("messageUpdate");
+      const message = createTwitterMessage("https://x.com/example/status/123");
+
+      await createHandler(message);
+      vi.advanceTimersByTime(15_000);
+
+      message.embeds = [{type: "rich"}];
+      await updateHandler(undefined, message);
+
+      expect(message.suppressEmbeds).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("ignores bot-authored and webhook messages", async () => {
@@ -130,6 +214,7 @@ describe("addTwitterLinkRewrites", () => {
 
     const handler = getHandler("messageCreate");
     const message = createTwitterMessage("https://x.com/example/status/123");
+    message.embeds = [{type: "rich"}];
     message.suppressEmbeds.mockRejectedValue(new Error("missing permission"));
 
     await handler(message);

--- a/modules/twitter-link-rewrite.ts
+++ b/modules/twitter-link-rewrite.ts
@@ -2,6 +2,7 @@ import {getLogger} from "./logging.ts";
 
 const logger = getLogger();
 const discordMaxMessageLength = 2_000;
+const embedSuppressionWaitMs = 15_000;
 const trailingUrlPunctuation = ".,!?;:)]}";
 const twitterUrlRegex = /https?:\/\/[^\s<>"']+/giu;
 const twitterHosts = new Set([
@@ -17,6 +18,8 @@ type TwitterLinkRewriteMessage = {
     bot?: boolean;
   };
   content: string;
+  embeds?: readonly unknown[];
+  id: string;
   reply: (payload: {
     allowedMentions: {
       parse: string[];
@@ -28,8 +31,20 @@ type TwitterLinkRewriteMessage = {
   webhookId?: string | null;
 };
 
+// Discord generates link embeds asynchronously and delivers them via
+// messageUpdate, so the suppression path only needs the message identity,
+// its embeds, and the suppress call — not the full create-time shape.
+type TwitterLinkSuppressibleMessage = {
+  embeds?: readonly unknown[] | null;
+  id: string;
+  suppressEmbeds: (suppress?: boolean) => Promise<unknown>;
+};
+
 type TwitterLinkRewriteClient = {
-  on: (eventName: "messageCreate", handler: (message: TwitterLinkRewriteMessage) => Promise<void>) => unknown;
+  on: {
+    (eventName: "messageCreate", handler: (message: TwitterLinkRewriteMessage) => Promise<void>): unknown;
+    (eventName: "messageUpdate", handler: (oldMessage: unknown, newMessage: TwitterLinkSuppressibleMessage) => Promise<void>): unknown;
+  };
 };
 
 function trimTrailingUrlPunctuation(value: string): string {
@@ -84,7 +99,11 @@ function getMessageContentWithinDiscordLimit(links: string[]): string {
   return acceptedLinks.join("\n");
 }
 
-async function suppressOriginalEmbeds(message: TwitterLinkRewriteMessage) {
+function messageHasEmbeds(message: {embeds?: readonly unknown[] | null}): boolean {
+  return Array.isArray(message.embeds) && 0 < message.embeds.length;
+}
+
+async function suppressOriginalEmbeds(message: TwitterLinkSuppressibleMessage) {
   try {
     await message.suppressEmbeds(true);
   } catch (error: unknown) {
@@ -128,6 +147,32 @@ export function getFixedTwitterLinks(content: string): string[] {
 }
 
 export function addTwitterLinkRewrites(client: TwitterLinkRewriteClient) {
+  // Discord attaches the X/Twitter card after the message is created, arriving
+  // as a separate messageUpdate. Suppressing at messageCreate races that update
+  // and the card slips through, so we wait for the embed to appear before
+  // suppressing. Track the message ids whose embeds are still pending, with a
+  // timeout that drops ids whose card never materialises.
+  const pendingEmbedSuppressions = new Map<string, ReturnType<typeof setTimeout>>();
+
+  function stopTrackingMessage(messageId: string): void {
+    const pendingTimeout = pendingEmbedSuppressions.get(messageId);
+    if (undefined === pendingTimeout) {
+      return;
+    }
+
+    clearTimeout(pendingTimeout);
+    pendingEmbedSuppressions.delete(messageId);
+  }
+
+  function trackMessageForEmbedSuppression(messageId: string): void {
+    stopTrackingMessage(messageId);
+    const pendingTimeout = setTimeout(() => {
+      pendingEmbedSuppressions.delete(messageId);
+    }, embedSuppressionWaitMs);
+    pendingTimeout.unref();
+    pendingEmbedSuppressions.set(messageId, pendingTimeout);
+  }
+
   client.on("messageCreate", async message => {
     if (true === message.author?.bot || Boolean(message.webhookId)) {
       return;
@@ -143,7 +188,25 @@ export function addTwitterLinkRewrites(client: TwitterLinkRewriteClient) {
       return;
     }
 
-    await suppressOriginalEmbeds(message);
+    if (messageHasEmbeds(message)) {
+      await suppressOriginalEmbeds(message);
+    } else {
+      trackMessageForEmbedSuppression(message.id);
+    }
+
     await replyWithFixedLinks(message, content);
+  });
+
+  client.on("messageUpdate", async (_oldMessage, newMessage) => {
+    if (false === pendingEmbedSuppressions.has(newMessage.id)) {
+      return;
+    }
+
+    if (false === messageHasEmbeds(newMessage)) {
+      return;
+    }
+
+    stopTrackingMessage(newMessage.id);
+    await suppressOriginalEmbeds(newMessage);
   });
 }


### PR DESCRIPTION
## Problem

The channel sometimes showed **two embeds** for the same tweet: the original X card on the user's message, plus the bot's fxtwitter repost.

Root cause is a timing race. The handler suppressed the original embed at `messageCreate`, but Discord attaches the link card asynchronously and delivers it via a separate `messageUpdate`. Suppressing before the card exists let it slip through — hence the intermittent ("sometimes") double embed: fine when Discord generated the card fast, broken when it was slow. Permissions were confirmed good, so suppression wasn't failing — it was firing too early.

## Fix

Wait for the embed to appear before suppressing:

- On `messageCreate`: reply with the fixed fxtwitter link immediately (good embed shows fast). If the card is already attached, suppress now; otherwise register the message id as pending.
- On `messageUpdate`: when a tracked message's embeds become non-empty, suppress and stop tracking.
- A bounded, `unref()`'d timeout drops ids whose card never materialises, so the pending map can't leak (e.g. links that produce no card).

Per-handler state lives in a `Map` scoped to the `addTwitterLinkRewrites` call — no module globals. Error handling is unchanged (a failed suppress still lets the reply through).

The client already has the `GuildMessages` + `MessageContent` intents and `Partials.Message`, so `messageUpdate` events are delivered.

## Tests

- `npm run typecheck` — passes (added a `messageUpdate` overload and a narrow `TwitterLinkSuppressibleMessage` type that tolerates partial messages).
- `npm run test:coverage` — passes; module at 96/88/100/96, above the global bar.
- New cases: deferred-then-suppress, immediate-suppress when the card is present at create time, keeps-waiting on embed-less updates, ignores untracked messages, and timeout-drops-tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)