### PR TITLE
Bump transitive brace-expansion to 5.0.6 to clear audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,9 +1784,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Why

`npm audit` flagged a moderate advisory in **brace-expansion 5.0.5** — large numeric range defeats the documented `max` DoS protection ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)). It's transitive; the patched **5.0.6** is within the existing range, so this is a lockfile-only refresh with no manifest or `overrides` changes.

## Verification

- `npm audit` → **0 vulnerabilities** after the bump.
- `npm audit --audit-level=high` → exit 0.
- Lockfile-only change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)