### PR TITLE
Fix Kroger-style earnings mis-parse: bogus revenue and unscaled net income

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -978,4 +978,75 @@ describe("earnings result formatting", () => {
     expect(normalizeCik("abc")).toBeNull();
     expect(normalizeCik(null)).toBeNull();
   });
+
+  test("parses Kroger-style highlight bullets and a distant income-statement scale header", () => {
+    // Reproduces a real Kroger 8-K mis-parse: the revenue extractor latched onto a
+    // marketing bullet ("eCommerce sales grew +19% 2", footnote "2" x a stray scale)
+    // rendering "$2M", and net income kept the figure but lost its "(in millions)"
+    // scale (130 separator rows below the header) rendering "$903" instead of "$903M".
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>The Kroger Co. Reports First Quarter 2026 Results</h1>
+          <p>First Quarter</p>
+          <p>Highlights</p>
+          <p>Identical Sales without fuel increased 1.0% 1</p>
+          <p>Operating Profit of $1,407 million; EPS of $1.46</p>
+          <p>Adjusted FIFO Operating Profit of $1,544 million and Adjusted EPS of $1.58</p>
+          <p>Adjusted eCommerce sales grew +19% 2 ; Kroger Precision Marketing profit grew over 20%</p>
+          <p>ID Sales (1) (Table 4) | 1.0% | 3.2%</p>
+          <p>THE KROGER CO.</p>
+          <p>CONSOLIDATED STATEMENTS OF OPERATIONS</p>
+          <p>(in millions, except per share amounts)</p>
+          <table>
+            <tr><td>SALES</td><td>$</td><td>46,121</td><td>$</td><td>45,118</td></tr>
+            <tr><td>MERCHANDISE COSTS</td><td>36,058</td><td>35,200</td></tr>
+            <tr><td>OPERATING PROFIT</td><td>1,407</td><td>1,322</td></tr>
+            <tr><td>NET EARNINGS BEFORE INCOME TAX EXPENSE</td><td>1,177</td><td>1,090</td></tr>
+            ${"<tr><td></td><td></td></tr>".repeat(90)}
+            <tr><td>NET EARNINGS INCLUDING NONCONTROLLING INTERESTS</td><td>904</td><td>868</td></tr>
+            <tr><td>NET INCOME ATTRIBUTABLE TO NONCONTROLLING INTERESTS</td><td>1</td><td>2</td></tr>
+            <tr><td>NET EARNINGS ATTRIBUTABLE TO THE KROGER CO.</td><td>$</td><td>903</td><td>$</td><td>866</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q1 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", value: "$1.58"}),
+      expect.objectContaining({key: "gaap_eps", value: "$1.46"}),
+      expect.objectContaining({key: "revenue", numericValue: 46_121_000_000, value: "$46.12B"}),
+      expect.objectContaining({key: "net_income", numericValue: 903_000_000, value: "$903M"}),
+    ]));
+    // None of the mis-parses: marketing-bullet revenue, pre-tax/NCI net income, or
+    // the unscaled bare-dollar net income.
+    const valuesByKey = new Map(parsedDocument.metrics.map(metric => [metric.key, metric.value]));
+    expect(valuesByKey.get("revenue")).not.toBe("$2M");
+    expect(valuesByKey.get("revenue")).not.toBe("-$1M");
+    expect(valuesByKey.get("net_income")).not.toBe("$903");
+    expect(valuesByKey.get("net_income")).not.toBe("$1.18B");
+  });
+
+  test("drops sub-million revenue/net income that lost their scale when a real EPS is present", () => {
+    const event: EarningsEvent = {
+      ticker: "KR",
+      when: "before_open",
+      date: "2026-06-18",
+      importance: 1,
+    };
+
+    const guarded = getMessageMetrics([
+      {key: "gaap_eps", label: "EPS", numericValue: 1.46, value: "$1.46"},
+      {key: "net_income", label: "Net income", numericValue: 903, value: "$903"},
+    ], {actualEps: 1.46}, event);
+    expect(guarded.some(metric => "net_income" === metric.key)).toBe(false);
+    expect(guarded.some(metric => "gaap_eps" === metric.key)).toBe(true);
+
+    // The guard stays out of the way when there is no EPS signal to anchor scale.
+    const unguarded = getMessageMetrics([
+      {key: "net_income", label: "Net income", numericValue: 903, value: "$903"},
+    ], null, event);
+    expect(unguarded.some(metric => "net_income" === metric.key)).toBe(true);
+  });
 });

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -97,7 +97,10 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\bnet\s+income(?!\s+per\s+(?:common\s+)?share)(?:\s+attributable[^|,]*)?\b/i,
       /\bnet\s+earnings(?!\s+per\s+(?:common\s+)?share)\b/i,
     ],
-    skipPattern: /\beps\b/i,
+    // Skip income-statement subtotals and the noncontrolling-interest component so
+    // the headline "net income/earnings attributable to <company>" row wins rather
+    // than "net earnings before income tax" or "net earnings including NCI".
+    skipPattern: /\beps\b|\bbefore\s+(?:income\s+)?tax(?:es)?\b|\b(?:including|attributable\s+to)\s+noncontrolling\b/i,
     valueType: "money",
   },
   {
@@ -134,7 +137,10 @@ export function getMessageMetrics(
   event: EarningsEvent,
 ): EarningsResultMetric[] {
   const consensusEps = surprise?.consensusEps ?? parseNumber(event.epsConsensus) ?? undefined;
-  const metrics = normalizeEpsMetrics([...secMetrics], surprise, consensusEps);
+  const metrics = dropImplausibleMoneyMetrics(
+    normalizeEpsMetrics([...secMetrics], surprise, consensusEps),
+    surprise,
+  );
   const hasAdjustedEps = metrics.some(metric => "adjusted_eps" === metric.key);
   const hasGaapEps = metrics.some(metric => "gaap_eps" === metric.key);
 
@@ -165,6 +171,40 @@ export function getMessageMetrics(
   }
 
   return metrics.slice(0, 7);
+}
+
+// Plausibility guard: a company that reports per-share earnings has enough shares
+// outstanding that its aggregate revenue and net income are at least in the millions.
+// A sub-$1M revenue/net-income figure alongside a real EPS is therefore a scale or
+// parse error (e.g. a dropped "(in millions)" header rendering "$903" for $903M), so
+// omit it rather than post a wrong number.
+function dropImplausibleMoneyMetrics(
+  metrics: EarningsResultMetric[],
+  surprise: NasdaqSurprise | null,
+): EarningsResultMetric[] {
+  const hasPlausibleEps =
+    ("number" === typeof surprise?.actualEps && 0.01 <= Math.abs(surprise.actualEps)) ||
+    metrics.some(metric => isEpsMetricKey(metric.key) &&
+      "number" === typeof metric.numericValue &&
+      Number.isFinite(metric.numericValue) &&
+      0.01 <= Math.abs(metric.numericValue));
+  if (false === hasPlausibleEps) {
+    return metrics;
+  }
+
+  return metrics.filter(metric => {
+    if (false === ("revenue" === metric.key || "net_income" === metric.key)) {
+      return true;
+    }
+
+    return false === ("number" === typeof metric.numericValue &&
+      Number.isFinite(metric.numericValue) &&
+      Math.abs(metric.numericValue) < 1_000_000);
+  });
+}
+
+function isEpsMetricKey(key: string): boolean {
+  return "adjusted_eps" === key || "gaap_eps" === key || "nasdaq_eps" === key;
 }
 
 function canCompareAgainstUsdEstimate(metric: EarningsResultMetric): boolean {
@@ -634,11 +674,13 @@ function extractMetricValue(
   if ("money" === valueType) {
     const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(searchText);
     const searchValue = true === hasMetricLabelSuffixTableNote ? null : findNumericValue(searchText, {
+      minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
       skipPercentages: true,
     });
     const fallbackValue = true === isMetricValuePrefix(fallbackSearchText) ? findNumericValue(fallbackSearchText, {
+      minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
       skipPercentages: true,
@@ -699,7 +741,14 @@ function getLastPerShareSegmentValue(text: string, label: "Basic" | "Diluted"): 
 
 function getContextMoney(lines: string[], lineIndex: number): MoneyContext {
   let currencyCode: string | undefined;
-  for (let index = lineIndex; index >= 0 && index >= lineIndex - 80; index--) {
+  // Scan upward for the nearest "in millions / $ in thousands / ..." declaration
+  // governing this row. Income statements interleave many empty separator rows
+  // ("| |") between the unit header and the figures, so the lookback budget is
+  // spent on content (letter-bearing) lines only — otherwise a header a few real
+  // rows up but 100+ separator rows away is missed and the scale wrongly defaults
+  // to 1 (rendering e.g. "$903" instead of "$903M").
+  let contentLinesScanned = 0;
+  for (let index = lineIndex; index >= 0 && contentLinesScanned <= 80; index--) {
     const line = lines[index];
     if (undefined === line) {
       continue;
@@ -712,6 +761,10 @@ function getContextMoney(lines: string[], lineIndex: number): MoneyContext {
         currencyCode,
         scale,
       };
+    }
+
+    if (/[A-Za-z]/.test(line)) {
+      contentLinesScanned++;
     }
   }
 
@@ -742,15 +795,24 @@ function isNearTableNoteColumn(lines: string[], lineIndex: number): boolean {
 }
 
 function getMoneyScaleFromContextText(text: string): number | null {
-  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?thousands?(?:\s+of\s+dollars)?\b/i.test(text)) {
+  // Match a column/table-scale declaration ("(in millions)", "$ in thousands",
+  // "($ millions)", "millions of dollars") but NOT an inline prose magnitude such
+  // as "Operating Profit of $1,407 million" — there a digit immediately precedes
+  // the unit, and that figure belongs to one line, not the whole table. Treating
+  // inline magnitudes as a table scale mis-scales unrelated rows.
+  const declarationMatch =
+    /(?:\bin\s+|[$€£¥]\s*)(thousand|million|billion)s?\b/i.exec(text) ??
+    /\b(thousand|million|billion)s?\s+of\s+dollars\b/i.exec(text);
+  const unit = declarationMatch?.[1]?.toLowerCase();
+  if ("thousand" === unit) {
     return 1_000;
   }
 
-  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?millions?(?:\s+of\s+dollars)?\b/i.test(text)) {
+  if ("million" === unit) {
     return 1_000_000;
   }
 
-  if (/\b(?:\$|amounts?|dollars?)?\s*(?:in\s+)?billions?(?:\s+of\s+dollars)?\b/i.test(text)) {
+  if ("billion" === unit) {
     return 1_000_000_000;
   }
 
@@ -830,6 +892,7 @@ function getCompactMoneySuffixScale(text: string): number | null {
 
 type NumericValueOptions = {
   maxAbsValue?: number;
+  minUncuedAbsValue?: number;
   parseCents?: boolean;
   requireMoneyCue?: boolean;
   skipPercentages?: boolean;
@@ -869,6 +932,15 @@ function findNumericValues(
     }
 
     if (true === options.requireMoneyCue &&
+        false === hasMoneyCue(text, numberMatch.index, endIndex, token)) {
+      continue;
+    }
+
+    // A tiny number with no money cue ($, explicit unit) next to a metric label is
+    // a footnote/superscript reference ("eCommerce sales grew +19% 2", "Sales (1)"),
+    // not a financial figure. Real revenue/income figures are either $-cued or large.
+    if ("number" === typeof options.minUncuedAbsValue &&
+        Math.abs(value) < options.minUncuedAbsValue &&
         false === hasMoneyCue(text, numberMatch.index, endIndex, token)) {
       continue;
     }


### PR DESCRIPTION
## Problem

Leopold posted Kroger Q1 2026 (8-K) with two obviously wrong figures:

```
Revenue: $2M        (actual ~$46B)
Net income: $903     (actual $903M)
```

EPS was correct because it's cross-checked against Nasdaq's actual EPS. Revenue and net income come from the SEC-HTML metric parser, which had three latent flaws that all surfaced on this filing. Reproduced against the real exhibit (accession `0001104659-26-075395`, `tm2618219d1_ex99-1.htm`).

## Root causes

1. **Revenue grabbed a marketing bullet.** `\bsales\b` matched `"eCommerce sales grew +19% 2"`, took the footnote superscript `2` as the value, and applied a bogus `×1,000,000` scale lifted from the unrelated prose line `"Operating Profit of $1,407 million"` → `$2M`. The real `SALES … $46,121` row was never reached.
2. **Net income lost its scale.** The `(in millions)` header sits ~130 rows above the figure — mostly empty `| |` table-separator rows — past `getContextMoney`'s 80-line lookback, so the scale defaulted to 1 → `$903` instead of `$903M`.
3. **Subtotal ambiguity** (uncovered while fixing #2): several `NET EARNINGS …` rows (pre-tax, incl. NCI) competed for the net-income slot.

## Fix (`modules/earnings-results-format.ts`)

- Scale detection matches genuine table declarations only (`in millions`, `$ millions`, `millions of dollars`), not inline prose magnitudes like `$1,407 million`.
- Context lookback counts content (letter-bearing) lines so a unit header survives long runs of `| |` separator rows.
- Tiny, non-`$`-cued footnote/superscript numbers (`2`, `(1)`) are no longer treated as money values.
- Net-income row selection skips `before income tax` and noncontrolling-interest subtotals so the headline "attributable to *company*" row wins.
- Plausibility guard drops sub-$1M revenue/net income when a real EPS is present — a structurally impossible combination that signals a lost scale.

## Verification

- Real Kroger filing now parses to `revenue $46.12B`, `net income $903M`, `Adj EPS $1.58`, `EPS $1.46`.
- 2 new regression tests (faithful reproduction incl. 90 separator rows + a direct guard test).
- `npm run typecheck` ✅ · `npm run lint` ✅ · full suite **754/754** ✅ · coverage thresholds hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
