### PR TITLE
Replace link-only X posts with a credited fxtwitter repost

### DIFF
--- a/modules/twitter-link-rewrite.test.ts
+++ b/modules/twitter-link-rewrite.test.ts
@@ -16,10 +16,19 @@ vi.mock("./logging.ts", () => ({
 type TwitterTestMessage = {
   author?: {
     bot?: boolean;
+    globalName?: string | null;
+    username?: string;
+  };
+  channel: {
+    send: ReturnType<typeof vi.fn>;
   };
   content: string;
+  delete: ReturnType<typeof vi.fn>;
   embeds: unknown[];
   id: string;
+  member?: {
+    displayName?: string;
+  } | null;
   reply: ReturnType<typeof vi.fn>;
   suppressEmbeds: ReturnType<typeof vi.fn>;
   webhookId?: string | null;
@@ -30,7 +39,11 @@ let nextMessageId = 0;
 function createTwitterMessage(content: string): TwitterTestMessage {
   nextMessageId += 1;
   return {
+    channel: {
+      send: vi.fn().mockResolvedValue(undefined),
+    },
     content,
+    delete: vi.fn().mockResolvedValue(undefined),
     embeds: [],
     id: `message-${nextMessageId}`,
     reply: vi.fn().mockResolvedValue(undefined),
@@ -110,12 +123,13 @@ describe("addTwitterLinkRewrites", () => {
     addTwitterLinkRewrites(client);
 
     const handler = getHandler("messageCreate");
-    const message = createTwitterMessage("https://x.com/example/status/123");
+    const message = createTwitterMessage("watch https://x.com/example/status/123");
     message.embeds = [{type: "rich"}];
 
     await handler(message);
 
     expect(message.suppressEmbeds).toHaveBeenCalledWith(true);
+    expect(message.delete).not.toHaveBeenCalled();
     expect(message.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: "https://fxtwitter.com/example/status/123",
     }));
@@ -127,7 +141,7 @@ describe("addTwitterLinkRewrites", () => {
 
     const createHandler = getHandler("messageCreate");
     const updateHandler = getHandler("messageUpdate");
-    const message = createTwitterMessage("https://x.com/example/status/123");
+    const message = createTwitterMessage("watch https://x.com/example/status/123");
 
     await createHandler(message);
     await updateHandler(undefined, message);
@@ -162,7 +176,7 @@ describe("addTwitterLinkRewrites", () => {
 
       const createHandler = getHandler("messageCreate");
       const updateHandler = getHandler("messageUpdate");
-      const message = createTwitterMessage("https://x.com/example/status/123");
+      const message = createTwitterMessage("watch https://x.com/example/status/123");
 
       await createHandler(message);
       vi.advanceTimersByTime(15_000);
@@ -213,7 +227,7 @@ describe("addTwitterLinkRewrites", () => {
     addTwitterLinkRewrites(client);
 
     const handler = getHandler("messageCreate");
-    const message = createTwitterMessage("https://x.com/example/status/123");
+    const message = createTwitterMessage("watch https://x.com/example/status/123");
     message.embeds = [{type: "rich"}];
     message.suppressEmbeds.mockRejectedValue(new Error("missing permission"));
 
@@ -233,7 +247,7 @@ describe("addTwitterLinkRewrites", () => {
     addTwitterLinkRewrites(client);
 
     const handler = getHandler("messageCreate");
-    const message = createTwitterMessage("https://x.com/example/status/123");
+    const message = createTwitterMessage("watch https://x.com/example/status/123");
     message.reply.mockRejectedValue(new Error("reply failed"));
 
     await handler(message);
@@ -242,5 +256,158 @@ describe("addTwitterLinkRewrites", () => {
       "error",
       expect.stringContaining("Error sending fixed Twitter/X link"),
     );
+  });
+
+  test("deletes a link-only message and reposts it crediting the poster", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.member = {displayName: "Xeophon"};
+
+    await handler(message);
+
+    expect(message.delete).toHaveBeenCalledTimes(1);
+    expect(message.channel.send).toHaveBeenCalledWith({
+      allowedMentions: {
+        parse: [],
+      },
+      content: "From Xeophon: https://fxtwitter.com/example/status/123",
+    });
+    expect(message.reply).not.toHaveBeenCalled();
+    expect(message.suppressEmbeds).not.toHaveBeenCalled();
+  });
+
+  test("treats a link wrapped in brackets and punctuation as link-only", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("<https://x.com/example/status/123>!");
+    message.member = {displayName: "Xeophon"};
+
+    await handler(message);
+
+    expect(message.delete).toHaveBeenCalledTimes(1);
+    expect(message.channel.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "From Xeophon: https://fxtwitter.com/example/status/123",
+    }));
+  });
+
+  test("reposts every link when a link-only message holds several", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage(
+      "https://x.com/example/status/123 https://twitter.com/example/status/456",
+    );
+    message.member = {displayName: "Xeophon"};
+
+    await handler(message);
+
+    expect(message.channel.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "From Xeophon: https://fxtwitter.com/example/status/123\nhttps://fxtwitter.com/example/status/456",
+    }));
+  });
+
+  test("replies instead of deleting when the message has surrounding text", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("look at this https://x.com/example/status/123");
+
+    await handler(message);
+
+    expect(message.delete).not.toHaveBeenCalled();
+    expect(message.channel.send).not.toHaveBeenCalled();
+    expect(message.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: "https://fxtwitter.com/example/status/123",
+    }));
+  });
+
+  test("credits the global name, then the username, then a fallback", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+
+    const globalNameMessage = createTwitterMessage("https://x.com/example/status/123");
+    globalNameMessage.author = {globalName: "GlobalName"};
+    await handler(globalNameMessage);
+
+    const usernameMessage = createTwitterMessage("https://x.com/example/status/456");
+    usernameMessage.author = {globalName: null, username: "username"};
+    await handler(usernameMessage);
+
+    const anonymousMessage = createTwitterMessage("https://x.com/example/status/789");
+    await handler(anonymousMessage);
+
+    expect(globalNameMessage.channel.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "From GlobalName: https://fxtwitter.com/example/status/123",
+    }));
+    expect(usernameMessage.channel.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "From username: https://fxtwitter.com/example/status/456",
+    }));
+    expect(anonymousMessage.channel.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "From someone: https://fxtwitter.com/example/status/789",
+    }));
+  });
+
+  test("falls back to replying when deleting the link-only message fails", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.delete.mockRejectedValue(new Error("missing permission"));
+
+    await handler(message);
+
+    expect(message.channel.send).not.toHaveBeenCalled();
+    expect(message.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: "https://fxtwitter.com/example/status/123",
+    }));
+    expect(loggerMock.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("Error deleting original Twitter/X message"),
+    );
+  });
+
+  test("logs when posting the replacement message fails", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.channel.send.mockRejectedValue(new Error("send failed"));
+
+    await handler(message);
+
+    expect(message.delete).toHaveBeenCalledTimes(1);
+    expect(message.reply).not.toHaveBeenCalled();
+    expect(loggerMock.log).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("Error posting replacement Twitter/X message"),
+    );
+  });
+
+  test("falls back to replying when the credited name leaves no room for the link", async () => {
+    const {client, getHandler} = createEventClient();
+    addTwitterLinkRewrites(client);
+
+    const handler = getHandler("messageCreate");
+    const message = createTwitterMessage("https://x.com/example/status/123");
+    message.member = {displayName: "x".repeat(2_000)};
+
+    await handler(message);
+
+    expect(message.delete).not.toHaveBeenCalled();
+    expect(message.channel.send).not.toHaveBeenCalled();
+    expect(message.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: "https://fxtwitter.com/example/status/123",
+    }));
   });
 });

--- a/modules/twitter-link-rewrite.ts
+++ b/modules/twitter-link-rewrite.ts
@@ -4,6 +4,7 @@ const logger = getLogger();
 const discordMaxMessageLength = 2_000;
 const embedSuppressionWaitMs = 15_000;
 const trailingUrlPunctuation = ".,!?;:)]}";
+const linkWrapperPunctuation = "<>\"'.,!?;:()[]{}";
 const twitterUrlRegex = /https?:\/\/[^\s<>"']+/giu;
 const twitterHosts = new Set([
   "mobile.twitter.com",
@@ -16,10 +17,24 @@ const twitterHosts = new Set([
 type TwitterLinkRewriteMessage = {
   author?: {
     bot?: boolean;
+    globalName?: string | null;
+    username?: string;
+  };
+  channel: {
+    send: (payload: {
+      allowedMentions: {
+        parse: string[];
+      };
+      content: string;
+    }) => Promise<unknown> | unknown;
   };
   content: string;
+  delete: () => Promise<unknown>;
   embeds?: readonly unknown[];
   id: string;
+  member?: {
+    displayName?: string;
+  } | null;
   reply: (payload: {
     allowedMentions: {
       parse: string[];
@@ -82,13 +97,13 @@ function getFixedTwitterUrl(value: string): string | undefined {
   return `https://fxtwitter.com${parsedUrl.pathname}`;
 }
 
-function getMessageContentWithinDiscordLimit(links: string[]): string {
+function getMessageContentWithinDiscordLimit(links: string[], maxLength: number = discordMaxMessageLength): string {
   const acceptedLinks: string[] = [];
   let messageLength = 0;
 
   for (const link of links) {
     const nextLength = messageLength + (0 === acceptedLinks.length ? 0 : 1) + link.length;
-    if (nextLength > discordMaxMessageLength) {
+    if (nextLength > maxLength) {
       break;
     }
 
@@ -97,6 +112,41 @@ function getMessageContentWithinDiscordLimit(links: string[]): string {
   }
 
   return acceptedLinks.join("\n");
+}
+
+// A message "only contains the link" when removing every fixable Twitter/X URL
+// leaves nothing but whitespace and the brackets/punctuation that commonly wrap
+// a pasted URL. Those messages are deleted and reposted by the bot rather than
+// replied to, so the channel shows a single clean fxtwitter card.
+function messageIsOnlyFixableLinks(content: string): boolean {
+  let foundFixableLink = false;
+  const remainder = content.replace(twitterUrlRegex, match => {
+    if (undefined === getFixedTwitterUrl(trimTrailingUrlPunctuation(match))) {
+      return match;
+    }
+
+    foundFixableLink = true;
+    return "";
+  });
+
+  if (false === foundFixableLink) {
+    return false;
+  }
+
+  for (const character of remainder) {
+    if (false === /\s/u.test(character) && false === linkWrapperPunctuation.includes(character)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function resolvePosterName(message: TwitterLinkRewriteMessage): string {
+  return message.member?.displayName
+    ?? message.author?.globalName
+    ?? message.author?.username
+    ?? "someone";
 }
 
 function messageHasEmbeds(message: {embeds?: readonly unknown[] | null}): boolean {
@@ -129,6 +179,44 @@ async function replyWithFixedLinks(message: TwitterLinkRewriteMessage, content: 
       `Error sending fixed Twitter/X link: ${error}`,
     );
   }
+}
+
+// Delete a link-only message and repost the fixed link in the bot's name,
+// crediting the original poster ("From <name>: <link>"). Returns true when the
+// original was removed so the caller skips the reply-and-suppress path; returns
+// false (e.g. the bot lacks delete permission) to fall back to that path.
+async function replaceLinkOnlyMessage(message: TwitterLinkRewriteMessage, fixedLinks: string[]): Promise<boolean> {
+  const prefix = `From ${resolvePosterName(message)}: `;
+  const content = getMessageContentWithinDiscordLimit(fixedLinks, discordMaxMessageLength - prefix.length);
+  if ("" === content) {
+    return false;
+  }
+
+  try {
+    await message.delete();
+  } catch (error: unknown) {
+    logger.log(
+      "error",
+      `Error deleting original Twitter/X message: ${error}`,
+    );
+    return false;
+  }
+
+  try {
+    await message.channel.send({
+      allowedMentions: {
+        parse: [],
+      },
+      content: `${prefix}${content}`,
+    });
+  } catch (error: unknown) {
+    logger.log(
+      "error",
+      `Error posting replacement Twitter/X message: ${error}`,
+    );
+  }
+
+  return true;
 }
 
 export function getFixedTwitterLinks(content: string): string[] {
@@ -181,6 +269,13 @@ export function addTwitterLinkRewrites(client: TwitterLinkRewriteClient) {
     const fixedLinks = getFixedTwitterLinks(message.content);
     if (0 === fixedLinks.length) {
       return;
+    }
+
+    if (messageIsOnlyFixableLinks(message.content)) {
+      const replaced = await replaceLinkOnlyMessage(message, fixedLinks);
+      if (replaced) {
+        return;
+      }
     }
 
     const content = getMessageContentWithinDiscordLimit(fixedLinks);


### PR DESCRIPTION
## What

When a user posts a message that is **only** an X/Twitter link, the bot now **deletes the original and reposts** a single clean message crediting the poster — \`From Xeophon: https://fxtwitter.com/...\` — instead of replying alongside it. This collapses the three visible fragments (original message, its X card, and the bot's reply) down to one clean fxtwitter card.

Messages that contain a link **plus** other text keep the existing reply-and-suppress-embed behavior.

## Details

- **\`messageIsOnlyFixableLinks\`** — true when removing every fixable Twitter/X URL leaves nothing but whitespace and common wrapping punctuation (so \`<https://x.com/…>!\` counts; \`look at this https://x.com/…\` does not).
- **\`resolvePosterName\`** — guild display name → account global name → username → \`someone\`.
- **\`replaceLinkOnlyMessage\`** — deletes the original, then posts \`From <name>: <link(s)>\` with all mentions disabled. Falls back to the normal reply path when delete fails (e.g. missing Manage Messages permission) or when the credited name leaves no room within Discord's 2000-char limit.
- Delete-first ordering means there's never both the original and the repost; the bot's own repost is ignored (bot-authored + non-x.com link).

## Verification

- \`npm run typecheck\` — passes (prod + test configs)
- \`npm run lint\` — clean
- \`npm run test\` — 762 passed (8 new tests; 5 existing reply-path tests updated to non-link-only content)
- \`npm run test:coverage\` — module at 96/92/100/96; global thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)