### PR TITLE
Credit fxtwitter reposts by mention instead of plaintext name

### DIFF
--- a/modules/twitter-link-rewrite.test.ts
+++ b/modules/twitter-link-rewrite.test.ts
@@ -16,8 +16,7 @@ vi.mock("./logging.ts", () => ({
 type TwitterTestMessage = {
   author?: {
     bot?: boolean;
-    globalName?: string | null;
-    username?: string;
+    id?: string;
   };
   channel: {
     send: ReturnType<typeof vi.fn>;
@@ -26,9 +25,6 @@ type TwitterTestMessage = {
   delete: ReturnType<typeof vi.fn>;
   embeds: unknown[];
   id: string;
-  member?: {
-    displayName?: string;
-  } | null;
   reply: ReturnType<typeof vi.fn>;
   suppressEmbeds: ReturnType<typeof vi.fn>;
   webhookId?: string | null;
@@ -39,6 +35,7 @@ let nextMessageId = 0;
 function createTwitterMessage(content: string): TwitterTestMessage {
   nextMessageId += 1;
   return {
+    author: {id: `author-${nextMessageId}`},
     channel: {
       send: vi.fn().mockResolvedValue(undefined),
     },
@@ -258,13 +255,13 @@ describe("addTwitterLinkRewrites", () => {
     );
   });
 
-  test("deletes a link-only message and reposts it crediting the poster", async () => {
+  test("deletes a link-only message and reposts it crediting the poster by mention", async () => {
     const {client, getHandler} = createEventClient();
     addTwitterLinkRewrites(client);
 
     const handler = getHandler("messageCreate");
     const message = createTwitterMessage("https://x.com/example/status/123");
-    message.member = {displayName: "Xeophon"};
+    message.author = {id: "111222333"};
 
     await handler(message);
 
@@ -273,7 +270,7 @@ describe("addTwitterLinkRewrites", () => {
       allowedMentions: {
         parse: [],
       },
-      content: "From Xeophon: https://fxtwitter.com/example/status/123",
+      content: "From <@111222333>: https://fxtwitter.com/example/status/123",
     });
     expect(message.reply).not.toHaveBeenCalled();
     expect(message.suppressEmbeds).not.toHaveBeenCalled();
@@ -285,13 +282,13 @@ describe("addTwitterLinkRewrites", () => {
 
     const handler = getHandler("messageCreate");
     const message = createTwitterMessage("<https://x.com/example/status/123>!");
-    message.member = {displayName: "Xeophon"};
+    message.author = {id: "111222333"};
 
     await handler(message);
 
     expect(message.delete).toHaveBeenCalledTimes(1);
     expect(message.channel.send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "From Xeophon: https://fxtwitter.com/example/status/123",
+      content: "From <@111222333>: https://fxtwitter.com/example/status/123",
     }));
   });
 
@@ -303,12 +300,12 @@ describe("addTwitterLinkRewrites", () => {
     const message = createTwitterMessage(
       "https://x.com/example/status/123 https://twitter.com/example/status/456",
     );
-    message.member = {displayName: "Xeophon"};
+    message.author = {id: "111222333"};
 
     await handler(message);
 
     expect(message.channel.send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "From Xeophon: https://fxtwitter.com/example/status/123\nhttps://fxtwitter.com/example/status/456",
+      content: "From <@111222333>: https://fxtwitter.com/example/status/123\nhttps://fxtwitter.com/example/status/456",
     }));
   });
 
@@ -328,28 +325,22 @@ describe("addTwitterLinkRewrites", () => {
     }));
   });
 
-  test("credits the global name, then the username, then a fallback", async () => {
+  test("credits the poster by mention, falling back to a neutral label without an author id", async () => {
     const {client, getHandler} = createEventClient();
     addTwitterLinkRewrites(client);
 
     const handler = getHandler("messageCreate");
 
-    const globalNameMessage = createTwitterMessage("https://x.com/example/status/123");
-    globalNameMessage.author = {globalName: "GlobalName"};
-    await handler(globalNameMessage);
-
-    const usernameMessage = createTwitterMessage("https://x.com/example/status/456");
-    usernameMessage.author = {globalName: null, username: "username"};
-    await handler(usernameMessage);
+    const mentionMessage = createTwitterMessage("https://x.com/example/status/123");
+    mentionMessage.author = {id: "987654321"};
+    await handler(mentionMessage);
 
     const anonymousMessage = createTwitterMessage("https://x.com/example/status/789");
+    anonymousMessage.author = {};
     await handler(anonymousMessage);
 
-    expect(globalNameMessage.channel.send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "From GlobalName: https://fxtwitter.com/example/status/123",
-    }));
-    expect(usernameMessage.channel.send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "From username: https://fxtwitter.com/example/status/456",
+    expect(mentionMessage.channel.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "From <@987654321>: https://fxtwitter.com/example/status/123",
     }));
     expect(anonymousMessage.channel.send).toHaveBeenCalledWith(expect.objectContaining({
       content: "From someone: https://fxtwitter.com/example/status/789",
@@ -394,13 +385,13 @@ describe("addTwitterLinkRewrites", () => {
     );
   });
 
-  test("falls back to replying when the credited name leaves no room for the link", async () => {
+  test("falls back to replying when the credit prefix leaves no room for the link", async () => {
     const {client, getHandler} = createEventClient();
     addTwitterLinkRewrites(client);
 
     const handler = getHandler("messageCreate");
     const message = createTwitterMessage("https://x.com/example/status/123");
-    message.member = {displayName: "x".repeat(2_000)};
+    message.author = {id: "1".repeat(2_000)};
 
     await handler(message);
 

--- a/modules/twitter-link-rewrite.ts
+++ b/modules/twitter-link-rewrite.ts
@@ -17,8 +17,7 @@ const twitterHosts = new Set([
 type TwitterLinkRewriteMessage = {
   author?: {
     bot?: boolean;
-    globalName?: string | null;
-    username?: string;
+    id?: string;
   };
   channel: {
     send: (payload: {
@@ -32,9 +31,6 @@ type TwitterLinkRewriteMessage = {
   delete: () => Promise<unknown>;
   embeds?: readonly unknown[];
   id: string;
-  member?: {
-    displayName?: string;
-  } | null;
   reply: (payload: {
     allowedMentions: {
       parse: string[];
@@ -142,11 +138,17 @@ function messageIsOnlyFixableLinks(content: string): boolean {
   return true;
 }
 
-function resolvePosterName(message: TwitterLinkRewriteMessage): string {
-  return message.member?.displayName
-    ?? message.author?.globalName
-    ?? message.author?.username
-    ?? "someone";
+// Credit the poster with a Discord mention (<@id>) rather than their plaintext
+// name. The replacement is posted in the bot's name, so a user-controlled name
+// string could be used to impersonate someone else ("From <victim>: <link>").
+// A mention is resolved by Discord to the real account captured at post time —
+// it cannot be spoofed and stays clickable. With allowedMentions.parse empty it
+// renders without pinging. Fall back to a neutral label if no author id exists.
+function resolvePosterCredit(message: TwitterLinkRewriteMessage): string {
+  const authorId = message.author?.id;
+  return undefined === authorId || "" === authorId
+    ? "someone"
+    : `<@${authorId}>`;
 }
 
 function messageHasEmbeds(message: {embeds?: readonly unknown[] | null}): boolean {
@@ -182,11 +184,11 @@ async function replyWithFixedLinks(message: TwitterLinkRewriteMessage, content: 
 }
 
 // Delete a link-only message and repost the fixed link in the bot's name,
-// crediting the original poster ("From <name>: <link>"). Returns true when the
-// original was removed so the caller skips the reply-and-suppress path; returns
-// false (e.g. the bot lacks delete permission) to fall back to that path.
+// crediting the original poster by mention ("From <@id>: <link>"). Returns true
+// when the original was removed so the caller skips the reply-and-suppress path;
+// returns false (e.g. the bot lacks delete permission) to fall back to that path.
 async function replaceLinkOnlyMessage(message: TwitterLinkRewriteMessage, fixedLinks: string[]): Promise<boolean> {
-  const prefix = `From ${resolvePosterName(message)}: `;
+  const prefix = `From ${resolvePosterCredit(message)}: `;
   const content = getMessageContentWithinDiscordLimit(fixedLinks, discordMaxMessageLength - prefix.length);
   if ("" === content) {
     return false;


### PR DESCRIPTION
## Problem

The link-only fxtwitter repost is posted in the **bot's** name (a trusted sender), but the `From <name>:` credit was built from the poster's `member.displayName ?? globalName ?? username` — all strings the user fully controls. A malicious user could set their display name to impersonate someone else, making the bot vouch for a faked "From \<victim\>:" attribution.

## Fix

Credit the poster with a Discord **mention** (`<@id>`) instead of a plaintext name:

- Discord resolves `<@id>` to the **real account** captured at post time — unspoofable and clickable.
- `allowedMentions.parse: []` (already in place) keeps the mention **silent** — it renders without pinging the poster, preserving the prior no-notification behavior.
- Dropped the now-unused `member`/`globalName`/`username` fields from the message type; added `author.id`.
- Neutral `"someone"` fallback covers the effectively-impossible no-author-id case without reintroducing a spoofable name.

## Verification

- `npm run typecheck` — clean
- `npm run test:coverage` — 762/762 pass; `twitter-link-rewrite.ts` at 96% stmts / 92% branches / 100% funcs; global thresholds met
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)