### PR TITLE
Fix earnings revenue scale and EPS footnotes

### DIFF
--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -807,6 +807,23 @@ describe("AI earnings helpers", () => {
     expect(hasHighSeveritySuspicion(reasons)).toBe(false);
   });
 
+  test("identifies EPS that is implausibly low relative to consensus", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 1,
+      value: "$1.00",
+    }], null, getEvent({
+      epsConsensus: "$14.47",
+    }));
+
+    expect(reasons).toEqual([{
+      message: "EPS $1.00 is unusually far from consensus $14.47.",
+      metricKey: "gaap_eps",
+      severity: "medium",
+    }]);
+  });
+
   test("flags a negative EPS reported alongside a positive net income", () => {
     const reasons = getSuspiciousEarningsReasons([{
       key: "gaap_eps",

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -315,13 +315,15 @@ export function getSuspiciousEarningsReasons(
       true === Number.isFinite(consensusEps)) {
     const absoluteConsensus = Math.abs(consensusEps);
     const absoluteEps = Math.abs(epsMetric.numericValue);
-    if (absoluteEps >= 20 && absoluteConsensus < 5) {
+    if ((absoluteEps >= 20 && absoluteConsensus < 5) ||
+        (absoluteConsensus >= 20 && absoluteEps < 5)) {
       reasons.push({
         message: `${epsMetric.label} ${epsMetric.value} is extremely far from consensus ${formatEps(consensusEps)}.`,
         metricKey: epsMetric.key,
         severity: "high",
       });
-    } else if (absoluteEps >= 10 && absoluteConsensus < 5) {
+    } else if ((absoluteEps >= 10 && absoluteConsensus < 5) ||
+        (absoluteConsensus >= 10 && absoluteEps < 5)) {
       reasons.push({
         message: `${epsMetric.label} ${epsMetric.value} is unusually far from consensus ${formatEps(consensusEps)}.`,
         metricKey: epsMetric.key,

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -85,6 +85,28 @@ describe("earnings result formatting", () => {
     })).toContain("**Exxon Mobil (`XOM`)** - Q1 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/34088/example/ex-991.htm)");
   });
 
+  test("ignores an EPS footnote marker and prefers the reported currency value", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Goldman Sachs Reports Second Quarter 2026 Earnings Results</h1>
+          <p>EPS 1</p>
+          <p>2Q26</p>
+          <p>$20.98</p>
+          <p>Diluted earnings per common share (EPS) 1 was $20.98 for the second quarter of 2026.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "gaap_eps",
+        numericValue: 20.98,
+        value: "$20.98",
+      }),
+    ]));
+  });
+
   test("prefers ARM-style Q4 FYE section metrics over full-year figures", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>
@@ -121,6 +143,30 @@ describe("earnings result formatting", () => {
       expect.objectContaining({
         key: "revenue",
         value: "$4.92B",
+      }),
+    ]));
+  });
+
+  test("uses table scale instead of an unrelated later unit on a flattened filing page", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <p>
+            Bank of America Financial Highlights ($ in billions, except per share data)
+            2Q26 1Q26 2Q25
+            Total revenue, net of interest expense $31.6 $30.3 $27.4
+            Net income 9.1 8.6 7.2
+            Our $3.5 trillion balance sheet remained a source of strength.
+          </p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 31_600_000_000,
+        value: "$31.6B",
       }),
     ]));
   });

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -661,41 +661,38 @@ function extractMetricValue(
 
   if ("eps" === valueType) {
     const perShareTableValue = findPerShareTableValue(searchText);
-    const value = perShareTableValue ?? findNumericValue(searchText, {
-      maxAbsValue: 100,
-      parseCents: true,
-    }) ?? (true === isMetricValuePrefix(fallbackSearchText) ? findNumericValue(fallbackSearchText, {
-      maxAbsValue: 100,
-      parseCents: true,
-    }) : null);
+    const value = perShareTableValue ?? findEpsValue(searchText) ??
+      (true === isMetricValuePrefix(fallbackSearchText) ? findEpsValue(fallbackSearchText) : null);
     return null === value ? null : {numericValue: value, value: formatEps(value)};
   }
 
   if ("money" === valueType) {
     const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(searchText);
-    const searchValue = true === hasMetricLabelSuffixTableNote ? null : findNumericValue(searchText, {
+    const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findNumericValueMatch(searchText, {
       minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
       skipPercentages: true,
     });
-    const fallbackValue = true === isMetricValuePrefix(fallbackSearchText) ? findNumericValue(fallbackSearchText, {
+    const fallbackValueMatch = true === isMetricValuePrefix(fallbackSearchText) ? findNumericValueMatch(fallbackSearchText, {
       minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
       skipPercentages: true,
     }) : null;
-    const useFallbackValue = null !== fallbackValue &&
-      (null === searchValue || true === hasMetricLabelSuffixTableNote);
-    const parsedValue = true === useFallbackValue ? fallbackValue : searchValue ?? fallbackValue;
-    if (null === parsedValue) {
+    const useFallbackValue = null !== fallbackValueMatch &&
+      (null === searchValueMatch || true === hasMetricLabelSuffixTableNote);
+    const parsedValueMatch = true === useFallbackValue
+      ? fallbackValueMatch
+      : searchValueMatch ?? fallbackValueMatch;
+    if (null === parsedValueMatch) {
       return null;
     }
 
     const metricText = true === useFallbackValue ? fallbackSearchText : searchText;
-    const explicitScale = getExplicitMoneyScale(metricText);
+    const explicitScale = getExplicitMoneyScale(metricText, parsedValueMatch.endIndex);
     const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
-    const amount = parsedValue * (explicitScale ?? contextMoney.scale);
+    const amount = parsedValueMatch.value * (explicitScale ?? contextMoney.scale);
     return {
       currencyCode,
       numericValue: amount,
@@ -718,6 +715,24 @@ function extractMetricValue(
     numericValue: value,
     value: formatPlainNumber(value, trailingUnit),
   };
+}
+
+function findEpsValue(text: string): number | null {
+  const options = {
+    maxAbsValue: 100,
+    parseCents: true,
+  };
+  const currencyValue = findNumericValue(text, {
+    ...options,
+    requireMoneyCue: true,
+  });
+  if (null !== currencyValue) {
+    return currencyValue;
+  }
+
+  return true === isMetricLabelSuffixTableNote(text)
+    ? null
+    : findNumericValue(text, options);
 }
 
 function findPerShareTableValue(text: string): number | null {
@@ -775,7 +790,7 @@ function getContextMoney(lines: string[], lineIndex: number): MoneyContext {
 }
 
 function isMetricLabelSuffixTableNote(text: string): boolean {
-  return /^\s*\d{1,2}\s*$/.test(text);
+  return /^\s*\(?\d{1,2}\)?\s*$/.test(text);
 }
 
 function isMetricValuePrefix(text: string): boolean {
@@ -839,55 +854,27 @@ function getCurrencyCodeFromText(text: string): string | undefined {
   return undefined;
 }
 
-function getExplicitMoneyScale(text: string): number | null {
-  const compactScale = getCompactMoneySuffixScale(text);
-  if (null !== compactScale) {
-    return compactScale;
-  }
-
-  const unitMatch = text.match(/\b(trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands)\b/i);
+function getExplicitMoneyScale(text: string, valueEndIndex: number): number | null {
+  const afterValue = text.slice(valueEndIndex, valueEndIndex + 24);
+  const unitMatch = afterValue.match(/^\s*(trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands|[kmbt])\b/i);
   const unit = unitMatch?.[1]?.toLowerCase();
   if (!unit) {
     return null;
   }
 
-  if ("trillion" === unit || "trillions" === unit || "tn" === unit) {
+  if ("trillion" === unit || "trillions" === unit || "tn" === unit || "t" === unit) {
     return 1_000_000_000_000;
   }
 
-  if ("billion" === unit || "billions" === unit || "bn" === unit) {
+  if ("billion" === unit || "billions" === unit || "bn" === unit || "b" === unit) {
     return 1_000_000_000;
   }
 
-  if ("thousand" === unit || "thousands" === unit) {
+  if ("thousand" === unit || "thousands" === unit || "k" === unit) {
     return 1_000;
   }
 
   return 1_000_000;
-}
-
-function getCompactMoneySuffixScale(text: string): number | null {
-  const suffixMatch = text.match(
-    /(?:[$€£¥]\s*)?\(?-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?\s*([KMBT])\b/i,
-  );
-  const suffix = suffixMatch?.[1]?.toUpperCase();
-  if (undefined === suffix) {
-    return null;
-  }
-
-  if ("T" === suffix) {
-    return 1_000_000_000_000;
-  }
-
-  if ("B" === suffix) {
-    return 1_000_000_000;
-  }
-
-  if ("M" === suffix) {
-    return 1_000_000;
-  }
-
-  return 1_000;
 }
 
 type NumericValueOptions = {
@@ -899,18 +886,37 @@ type NumericValueOptions = {
   skipTableNoteRefs?: boolean;
 };
 
+type NumericValueMatch = {
+  endIndex: number;
+  value: number;
+};
+
 function findNumericValue(
   text: string,
   options: NumericValueOptions = {},
 ): number | null {
-  return findNumericValues(text, options)[0] ?? null;
+  return findNumericValueMatch(text, options)?.value ?? null;
+}
+
+function findNumericValueMatch(
+  text: string,
+  options: NumericValueOptions = {},
+): NumericValueMatch | null {
+  return findNumericValueMatches(text, options)[0] ?? null;
 }
 
 function findNumericValues(
   text: string,
   options: NumericValueOptions = {},
 ): number[] {
-  const values: number[] = [];
+  return findNumericValueMatches(text, options).map(match => match.value);
+}
+
+function findNumericValueMatches(
+  text: string,
+  options: NumericValueOptions = {},
+): NumericValueMatch[] {
+  const values: NumericValueMatch[] = [];
   const numberMatches = text.matchAll(/\(?-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?/g);
   for (const numberMatch of numberMatches) {
     const token = numberMatch[0];
@@ -958,7 +964,10 @@ function findNumericValues(
       continue;
     }
 
-    values.push(value);
+    values.push({
+      endIndex,
+      value,
+    });
   }
 
   return values;


### PR DESCRIPTION
## Summary

- binds explicit money units to the selected numeric value so unrelated text cannot turn billions into trillions
- ignores EPS footnote markers and prefers currency-backed EPS values
- flags implausibly low actual EPS relative to consensus

## Verification

- npm run test:coverage (3,043 tests)
- npm run typecheck
- npm run lint
- exact BAC and Goldman Q2 2026 filing replays