### PR TITLE
Fix earnings result period and value parsing

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -171,6 +171,93 @@ describe("earnings result formatting", () => {
     ]));
   });
 
+  test("uses the quarter column and bare parenthetical scale in month-and-quarter releases", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Progressive reports June results</h1>
+          <p>The company reported the following results for the month and quarter ended June 30, 2026:</p>
+          <table>
+            <tr><th></th><th>June</th><th>Quarter</th></tr>
+            <tr><td>(millions, except per share amounts and ratios; unaudited)</td><td>2026</td><td>2025</td><td>Change</td><td>2026</td><td>2025</td><td>Change</td></tr>
+            <tr><td>Net premiums earned</td><td>$</td><td>7,100</td><td>$</td><td>6,954</td><td>2</td><td>%</td><td>$</td><td>21,573</td><td>$</td><td>20,310</td><td>6</td><td>%</td></tr>
+            <tr><td>Net income</td><td>$</td><td>779</td><td>$</td><td>1,124</td><td>(31)</td><td>%</td><td>$</td><td>3,311</td><td>$</td><td>3,175</td><td>4</td><td>%</td></tr>
+          </table>
+          <h2>Comprehensive income statement</h2>
+          <p>For the month ended June 30, 2026</p>
+          <p>(millions)</p>
+          <table>
+            <tr><td>Fees and other revenues</td><td>104</td></tr>
+            <tr><td>Total revenues</td><td>7,568</td></tr>
+            <tr><td>Net income</td><td>779</td></tr>
+          </table>
+          <h2>Comprehensive income statements</h2>
+          <p>For the year-to-date periods ended June 30, 2026</p>
+          <p>(millions)</p>
+          <table>
+            <tr><td>Total revenues</td><td>45,797</td></tr>
+            <tr><td>Net income</td><td>6,129</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(parsedDocument.metrics).toEqual([
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 3_311_000_000,
+        value: "$3.31B",
+      }),
+    ]);
+  });
+
+  test("skips EPS percentages and period-ending dates in GE-style result tables", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>GE Aerospace announces second quarter 2026 results</h1>
+          <p>Total revenue (GAAP) of $13.3B, +21%; adjusted revenue of $12.6B, +24%.</p>
+          <p>Continuing EPS (GAAP) of $2.30, +23%; adjusted EPS of $2.02, +22%.</p>
+          <p>Revenue and EPS were both up more than 20% with engine deliveries up 31%.</p>
+          <table>
+            <tr><th>Three months ended June 30</th><th>2026</th><th>2025</th></tr>
+            <tr><td>Continuing EPS</td><td>2.30</td><td>1.87</td></tr>
+            <tr><td>Adjusted EPS</td><td>2.02</td><td>1.66</td></tr>
+          </table>
+          <table>
+            <tr><td>(In millions)</td></tr>
+            <tr><th>ADJUSTED NET INCOME (LOSS) (NON-GAAP)</th><th>Three months ended June 30</th><th>Six months ended June 30</th></tr>
+            <tr><td>(In millions, diluted, per-share amounts in dollars)</td><td>2026</td><td>2025</td><td>2026</td><td>2025</td></tr>
+            <tr><td>Income</td><td>EPS</td><td>Income</td><td>EPS</td><td>Income</td><td>EPS</td><td>Income</td><td>EPS</td></tr>
+            <tr><td>Net income (loss) from continuing operations (GAAP)</td><td>$</td><td>2,405</td><td>$</td><td>2.30</td><td>$</td><td>2,007</td><td>$</td><td>1.87</td><td>$</td><td>4,335</td><td>$</td><td>4.13</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "adjusted_eps",
+        numericValue: 2.02,
+        value: "$2.02",
+      }),
+      expect.objectContaining({
+        key: "gaap_eps",
+        numericValue: 2.3,
+        value: "$2.30",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 2_405_000_000,
+        value: "$2.4B",
+      }),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$20.00");
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$30M");
+  });
+
   test("parses Shell-style revenue rows without treating sales volumes as revenue", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -53,6 +53,11 @@ type MetricDefinition = {
   valueType: MetricValueType;
 };
 
+type MetricLineSelection = {
+  exclusive: boolean;
+  lines: string[];
+};
+
 const discordBlankLineSpacer = "\u200B";
 
 const earningsMetricDefinitions: MetricDefinition[] = [
@@ -123,11 +128,12 @@ const earningsMetricDefinitions: MetricDefinition[] = [
 export function parseEarningsDocument(html: string): ParsedEarningsDocument {
   const text = htmlToText(html);
   const lines = getMeaningfulLines(text);
+  const quarterLabel = getQuarterLabel(text);
   return {
     headline: getDocumentHeadline(lines),
-    metrics: extractEarningsMetrics(lines),
+    metrics: extractEarningsMetrics(lines, quarterLabel),
     outlook: extractOutlookMetrics(lines),
-    quarterLabel: getQuarterLabel(text),
+    quarterLabel,
   };
 }
 
@@ -512,17 +518,23 @@ function getQuarterFromName(name: string): string | undefined {
   return quarterByName.get(name.toLowerCase());
 }
 
-function extractEarningsMetrics(lines: string[]): EarningsResultMetric[] {
+function extractEarningsMetrics(
+  lines: string[],
+  quarterLabel: string | undefined,
+): EarningsResultMetric[] {
   const metrics: EarningsResultMetric[] = [];
   const seenKeys = new Set<string>();
-  const preferredLines = getQuarterSpecificMetricLines(lines);
+  const preferredSelection = getQuarterSpecificMetricLines(lines);
 
   for (const definition of earningsMetricDefinitions) {
     if (true === seenKeys.has(definition.key)) {
       continue;
     }
 
-    const metric = extractMetric(preferredLines, definition) ?? extractMetric(lines, definition);
+    const preferredMetric = extractMetric(preferredSelection.lines, definition, quarterLabel);
+    const metric = preferredMetric ?? (true === preferredSelection.exclusive
+      ? null
+      : extractMetric(lines, definition, quarterLabel));
     if (null === metric) {
       continue;
     }
@@ -534,12 +546,17 @@ function extractEarningsMetrics(lines: string[]): EarningsResultMetric[] {
   return metrics;
 }
 
-function getQuarterSpecificMetricLines(lines: string[]): string[] {
-  const startIndex = lines.findIndex(isQuarterSpecificSectionLine);
+function getQuarterSpecificMetricLines(lines: string[]): MetricLineSelection {
+  const startIndex = lines.findIndex(line =>
+    isQuarterSpecificSectionLine(line) || isMixedMonthQuarterResultsLine(line));
   if (-1 === startIndex) {
-    return [];
+    return {
+      exclusive: false,
+      lines: [],
+    };
   }
 
+  const exclusive = isMixedMonthQuarterResultsLine(lines[startIndex] ?? "");
   const selectedLines: string[] = [];
   for (let index = startIndex; index < lines.length; index++) {
     const line = lines[index];
@@ -547,7 +564,9 @@ function getQuarterSpecificMetricLines(lines: string[]): string[] {
       continue;
     }
 
-    if (index > startIndex && true === isQuarterSpecificSectionBoundary(line)) {
+    if (index > startIndex &&
+        (true === isQuarterSpecificSectionBoundary(line) ||
+        (true === exclusive && true === isMixedMonthQuarterSectionBoundary(line)))) {
       break;
     }
 
@@ -557,7 +576,20 @@ function getQuarterSpecificMetricLines(lines: string[]): string[] {
     }
   }
 
-  return selectedLines;
+  return {
+    exclusive,
+    lines: selectedLines,
+  };
+}
+
+function isMixedMonthQuarterResultsLine(line: string): boolean {
+  return /\bmonth\s+and\s+quarter\s+ended\b/i.test(line) ||
+    /\bquarter\s+and\s+month\s+ended\b/i.test(line);
+}
+
+function isMixedMonthQuarterSectionBoundary(line: string): boolean {
+  return /^\s*(?:the\s+)?(?:comprehensive|consolidated)\s+(?:comprehensive\s+)?(?:income\s+)?statements?\b/i.test(line) ||
+    /^\s*for\s+the\s+(?:month|year-to-date)\b/i.test(line);
 }
 
 function isQuarterSpecificSectionLine(line: string): boolean {
@@ -578,6 +610,7 @@ function isQuarterSpecificSectionBoundary(line: string): boolean {
 function extractMetric(
   lines: string[],
   definition: MetricDefinition,
+  quarterLabel: string | undefined,
 ): EarningsResultMetric | null {
   for (const [lineIndex, line] of lines.entries()) {
     if (definition.skipPattern?.test(line)) {
@@ -600,6 +633,7 @@ function extractMetric(
       definition.valueType,
       getContextMoney(lines, lineIndex),
       isNearTableNoteColumn(lines, lineIndex),
+      undefined !== quarterLabel && hasMixedMonthQuarterColumns(lines, lineIndex),
     );
     if (null === metricValue) {
       continue;
@@ -653,22 +687,26 @@ function extractMetricValue(
   valueType: MetricValueType,
   contextMoney: MoneyContext,
   skipTableNoteRefs: boolean,
+  preferQuarterColumn: boolean,
 ): {currencyCode?: string | undefined; numericValue: number; value: string} | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
   const searchText = patternMatch ? line.slice(patternMatch.index + patternMatch[0].length) : line;
+  const preferredSearchText = true === preferQuarterColumn
+    ? getQuarterColumnSearchText(searchText)
+    : searchText;
   const fallbackSearchText = patternMatch ? line.slice(0, patternMatch.index) : "";
 
   if ("eps" === valueType) {
-    const perShareTableValue = findPerShareTableValue(searchText);
-    const value = perShareTableValue ?? findEpsValue(searchText) ??
+    const perShareTableValue = findPerShareTableValue(preferredSearchText);
+    const value = perShareTableValue ?? findEpsValue(preferredSearchText) ??
       (true === isMetricValuePrefix(fallbackSearchText) ? findEpsValue(fallbackSearchText) : null);
     return null === value ? null : {numericValue: value, value: formatEps(value)};
   }
 
   if ("money" === valueType) {
-    const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(searchText);
-    const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findNumericValueMatch(searchText, {
+    const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(preferredSearchText);
+    const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findNumericValueMatch(preferredSearchText, {
       minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
@@ -689,7 +727,7 @@ function extractMetricValue(
       return null;
     }
 
-    const metricText = true === useFallbackValue ? fallbackSearchText : searchText;
+    const metricText = true === useFallbackValue ? fallbackSearchText : preferredSearchText;
     const explicitScale = getExplicitMoneyScale(metricText, parsedValueMatch.endIndex);
     const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
     const amount = parsedValueMatch.value * (explicitScale ?? contextMoney.scale);
@@ -700,13 +738,13 @@ function extractMetricValue(
     };
   }
 
-  const value = findNumericValue(searchText, {skipPercentages: true}) ??
+  const value = findNumericValue(preferredSearchText, {skipPercentages: true}) ??
     (true === isMetricValuePrefix(fallbackSearchText) ? findNumericValue(fallbackSearchText, {skipPercentages: true}) : null);
   if (null === value) {
     return null;
   }
 
-  const trailingUnit = getTrailingUnit(searchText);
+  const trailingUnit = getTrailingUnit(preferredSearchText);
   if (null === trailingUnit) {
     return null;
   }
@@ -717,10 +755,28 @@ function extractMetricValue(
   };
 }
 
+function hasMixedMonthQuarterColumns(lines: string[], lineIndex: number): boolean {
+  const context = lines
+    .slice(Math.max(0, lineIndex - 8), lineIndex + 1)
+    .join(" ");
+  const hasMonth = /\b(?:month|january|february|march|april|may|june|july|august|september|october|november|december)\b/i.test(context);
+  return hasMonth && /\bquarter\b/i.test(context) && /\bchange\b/i.test(context);
+}
+
+function getQuarterColumnSearchText(text: string): string {
+  const groupBoundary = /\|\s*(?:%|NM|N\/A|N\.M\.)\s*\|/i.exec(text);
+  if (undefined === groupBoundary?.index) {
+    return text;
+  }
+
+  return text.slice(groupBoundary.index + groupBoundary[0].length);
+}
+
 function findEpsValue(text: string): number | null {
   const options = {
     maxAbsValue: 100,
     parseCents: true,
+    skipPercentages: true,
   };
   const currencyValue = findNumericValue(text, {
     ...options,
@@ -817,7 +873,8 @@ function getMoneyScaleFromContextText(text: string): number | null {
   // inline magnitudes as a table scale mis-scales unrelated rows.
   const declarationMatch =
     /(?:\bin\s+|[$€£¥]\s*)(thousand|million|billion)s?\b/i.exec(text) ??
-    /\b(thousand|million|billion)s?\s+of\s+dollars\b/i.exec(text);
+    /\b(thousand|million|billion)s?\s+of\s+dollars\b/i.exec(text) ??
+    /\(\s*(thousand|million|billion)s?\b/i.exec(text);
   const unit = declarationMatch?.[1]?.toLowerCase();
   if ("thousand" === unit) {
     return 1_000;
@@ -987,8 +1044,14 @@ function normalizeCentsValue(text: string, endIndex: number, token: string, valu
 function isCalendarDayValue(text: string, startIndex: number, endIndex: number): boolean {
   const beforeToken = text.slice(Math.max(0, startIndex - 16), startIndex);
   const afterToken = text.slice(endIndex, endIndex + 8);
-  return /\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+$/i.test(beforeToken) &&
-    /^\s*,?\s*(?:20\d{2})?\b/.test(afterToken);
+  const hasMonthBefore = /\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+$/i.test(beforeToken);
+  if (false === hasMonthBefore) {
+    return false;
+  }
+
+  return /^\s*(?:,\s*)?20\d{2}\b/.test(afterToken) ||
+    /^\s*\|/.test(afterToken) ||
+    /^\s*$/.test(afterToken);
 }
 
 function isLikelyTableNoteReference(text: string, startIndex: number, endIndex: number, token: string): boolean {


### PR DESCRIPTION
## Summary
- select the current-quarter value from mixed monthly and quarterly SEC result tables
- recognize bare parenthetical money scales and keep monthly or year-to-date fallbacks out of quarterly announcements
- ignore percentages and period-ending calendar dates when extracting EPS and income values
- add regression coverage for the Progressive and GE Aerospace filings

## Verification
- `npm run typecheck`
- `npx vitest run --coverage --exclude .claude/worktrees/**` (767 tests passed)