### PR TITLE
Fix Taiwan dollar earnings formatting

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -771,6 +771,67 @@ describe("earnings result formatting", () => {
     ]);
   });
 
+  test("preserves Taiwan dollars and the named current quarter", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>TSMC Reports Second Quarter EPS of NT$27.25</h1>
+          <p>TSMC announced consolidated revenue of NT$1,270.38 billion, net income of NT$706.56 billion, and diluted earnings per share of NT$27.25 (US$4.31 per ADR unit) for the second quarter ended June 30, 2026.</p>
+          <p>Compared to first quarter 2026, second quarter results represented an increase in revenue and net income.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        currencyCode: "TWD",
+        key: "gaap_eps",
+        numericValue: 27.25,
+        value: "NT$27.25",
+      }),
+      expect.objectContaining({
+        currencyCode: "TWD",
+        key: "revenue",
+        numericValue: 1_270_380_000_000,
+        value: "NT$1.27T",
+      }),
+      expect.objectContaining({
+        currencyCode: "TWD",
+        key: "net_income",
+        numericValue: 706_560_000_000,
+        value: "NT$706.56B",
+      }),
+    ]));
+
+    const messageMetrics = getMessageMetrics(parsedDocument.metrics, {
+      actualEps: 4.31,
+      consensusEps: 4.10,
+      consensusRevenue: 40_000_000_000,
+    }, {
+      ticker: "TSM",
+      when: "before_open",
+      date: "2026-07-16",
+      importance: 1,
+      epsConsensus: "$4.10",
+    });
+    expect(messageMetrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        currencyCode: "TWD",
+        key: "gaap_eps",
+        numericValue: 27.25,
+        value: "NT$27.25",
+      }),
+      expect.objectContaining({
+        currencyCode: "TWD",
+        key: "revenue",
+        value: "NT$1.27T",
+      }),
+    ]));
+    expect(messageMetrics.find(metric => "gaap_eps" === metric.key)?.estimate).toBeUndefined();
+    expect(messageMetrics.find(metric => "revenue" === metric.key)?.estimate).toBeUndefined();
+  });
+
   test("prefers quarter metrics when a Q4 release lists full-year results first", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>
@@ -1095,11 +1156,13 @@ describe("earnings result formatting", () => {
     expect(parseNumber(Number.NaN)).toBeNull();
     expect(parseNumber("(1,234.5)")).toBe(-1234.5);
     expect(parseNumber("24c")).toBe(0.24);
+    expect(parseNumber("NT$27.25")).toBe(27.25);
     expect(parseNumber("--")).toBeNull();
     expect(parseNumber({})).toBeNull();
 
     expect(formatEps(5.6)).toBe("$5.60");
     expect(formatEps(-1.2)).toBe("-$1.20");
+    expect(formatEps(27.25, "TWD")).toBe("NT$27.25");
     expect(formatUsdCompact(-1_250_000_000_000)).toBe("-$1.25T");
     expect(formatUsdCompact(12_300_000)).toBe("$12.3M");
     expect(formatUsdCompact(750_000)).toBe("$750K");

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -229,6 +229,7 @@ function normalizeEpsMetrics(
 
   if ("number" === typeof actualEps &&
       undefined !== primaryEpsMetric &&
+      true === canCompareAgainstUsdEstimate(primaryEpsMetric) &&
       true === isImplausibleSecEps(primaryEpsMetric.numericValue, actualEps, consensusEps)) {
     primaryEpsMetric.numericValue = actualEps;
     primaryEpsMetric.value = formatEps(actualEps);
@@ -467,6 +468,11 @@ function getQuarterLabel(text: string): string | undefined {
     }
   }
 
+  const namedPeriodEndedQuarter = getNamedQuarterLabelFromPeriodEnded(text);
+  if (undefined !== namedPeriodEndedQuarter) {
+    return namedPeriodEndedQuarter;
+  }
+
   const writtenQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter\s+(?:of\s+)?(20\d{2})\b/i);
   if (undefined !== writtenQuarterMatch?.[1] && undefined !== writtenQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenQuarterMatch[1]);
@@ -486,6 +492,18 @@ function getQuarterLabel(text: string): string | undefined {
   }
 
   return undefined;
+}
+
+function getNamedQuarterLabelFromPeriodEnded(text: string): string | undefined {
+  const namedPeriodEndedMatch = text.match(
+    /\b(first|second|third|fourth)\s+quarter\s+ended\s+[A-Z][a-z]+\s+\d{1,2},\s+(20\d{2})\b/i,
+  );
+  if (undefined === namedPeriodEndedMatch?.[1] || undefined === namedPeriodEndedMatch[2]) {
+    return undefined;
+  }
+
+  const quarter = getQuarterFromName(namedPeriodEndedMatch[1]);
+  return quarter ? `${quarter} ${namedPeriodEndedMatch[2]}` : undefined;
 }
 
 function normalizeFiscalYear(value: string): string {
@@ -699,9 +717,24 @@ function extractMetricValue(
 
   if ("eps" === valueType) {
     const perShareTableValue = findPerShareTableValue(preferredSearchText);
-    const value = perShareTableValue ?? findEpsValue(preferredSearchText) ??
-      (true === isMetricValuePrefix(fallbackSearchText) ? findEpsValue(fallbackSearchText) : null);
-    return null === value ? null : {numericValue: value, value: formatEps(value)};
+    const preferredValue = findEpsValue(preferredSearchText);
+    const fallbackValue = true === isMetricValuePrefix(fallbackSearchText)
+      ? findEpsValue(fallbackSearchText)
+      : null;
+    const value = perShareTableValue ?? preferredValue ?? fallbackValue;
+    if (null === value) {
+      return null;
+    }
+
+    const metricText = null === perShareTableValue && null === preferredValue
+      ? fallbackSearchText
+      : preferredSearchText;
+    const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
+    return {
+      currencyCode,
+      numericValue: value,
+      value: formatEps(value, currencyCode),
+    };
   }
 
   if ("money" === valueType) {
@@ -892,6 +925,10 @@ function getMoneyScaleFromContextText(text: string): number | null {
 }
 
 function getCurrencyCodeFromText(text: string): string | undefined {
+  if (/NT\s*\$|\b(?:TWD|NTD)\b|\bNew Taiwan dollars?\b/i.test(text)) {
+    return "TWD";
+  }
+
   if (text.includes("€") || /\bEUR\b/i.test(text)) {
     return "EUR";
   }
@@ -1096,6 +1133,7 @@ export function parseNumber(value: unknown): number | null {
   const normalizedValue = value
     .replace(/^\((.*)\)$/, "-$1")
     .replace(/^\((.*)$/, "-$1")
+    .replace(/NT\s*\$/gi, "")
     .replace(/[$€£¥]/g, "")
     .replaceAll(",", "")
     .replaceAll("%", "")
@@ -1148,6 +1186,10 @@ export function formatMoneyCompact(value: number, currencyCode = "USD"): string 
 }
 
 function getCurrencySymbol(currencyCode: string): string {
+  if ("TWD" === currencyCode) {
+    return "NT$";
+  }
+
   if ("EUR" === currencyCode) {
     return "€";
   }


### PR DESCRIPTION
## Summary
- recognize NT$, TWD, and NTD as Taiwan dollars before generic dollar detection
- preserve TWD on EPS, revenue, and net-income output and avoid USD estimate normalization
- prefer an explicitly named quarter-ended period over comparison-quarter text

## Verification
- reproduced against the referenced TSM Q2 2026 SEC filing
- npm run lint
- npm run typecheck
- npx vitest run --coverage --exclude .claude/worktrees/** (768 tests passed)