### PR TITLE
Fix dense earnings Markdown rendering

### DIFF
--- a/modules/earnings-format-render.test.ts
+++ b/modules/earnings-format-render.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, test} from "vitest";
+import {appendToMarkdownWithinLimit, getMarkdownSpanCount} from "./earnings-format-render.ts";
+
+function expectBalancedMarkdown(content: string) {
+  expect((content.match(/`/g)?.length ?? 0) % 2).toBe(0);
+  expect((content.match(/\*\*/g)?.length ?? 0) % 2).toBe(0);
+}
+
+describe("earnings Markdown rendering", () => {
+  test("counts inline-code and bold spans", () => {
+    expect(getMarkdownSpanCount("**Heading**\n**`RTX`** MCap: `$261.7B`")).toBe(4);
+  });
+
+  test("appends a suffix without changing content that fits", () => {
+    expect(appendToMarkdownWithinLimit("**Heading**", "\nmore", 40)).toBe("**Heading**\nmore");
+  });
+
+  test("closes Markdown markers when the suffix requires truncation", () => {
+    const content = "**Heading**\n☕ 🏢 **`RTX`** 💰 MCap: `$261.7B` 🔮 EPS: `$1.66`";
+    const suffix = "\n... more";
+    const result = appendToMarkdownWithinLimit(content, suffix, 54);
+
+    expect(result.length).toBeLessThanOrEqual(54);
+    expect(result.endsWith(suffix)).toBe(true);
+    expectBalancedMarkdown(result);
+  });
+
+  test("uses a shortened suffix when no formatted content fits", () => {
+    expect(appendToMarkdownWithinLimit("**Heading**", "\n... more", 4)).toBe("... ");
+  });
+});

--- a/modules/earnings-format-render.ts
+++ b/modules/earnings-format-render.ts
@@ -122,18 +122,99 @@ export function canAppendToEarningsChunk(
   highlightedTickerSymbols: Set<string>,
   mostAnticipatedTickerSymbols: ReadonlySet<string>,
   maxMessageLength: number,
+  maxMarkdownSpans: number,
   title: string,
   continuationLabel: string
 ): boolean {
   const candidateChunk = cloneEarningsChunk(chunk);
   appendToEarningsChunk(candidateChunk, section);
-  return getEarningsChunkText(
+  const candidateText = getEarningsChunkText(
     candidateChunk,
     title,
     highlightedTickerSymbols,
     mostAnticipatedTickerSymbols,
     continuationLabel
-  ).length <= maxMessageLength;
+  );
+  return candidateText.length <= maxMessageLength
+    && getMarkdownSpanCount(candidateText) <= maxMarkdownSpans;
+}
+
+export function getMarkdownSpanCount(content: string): number {
+  const markdownMarkers = content.match(/\*\*|`/g);
+  return (markdownMarkers?.length ?? 0) / 2;
+}
+
+export function appendToMarkdownWithinLimit(
+  content: string,
+  suffix: string,
+  maxLength: number
+): string {
+  if (content.length + suffix.length <= maxLength) {
+    return `${content}${suffix}`;
+  }
+
+  if (maxLength <= suffix.length) {
+    return suffix.trimStart().slice(0, maxLength);
+  }
+
+  const availableContentLength = maxLength - suffix.length;
+  let prefixLength = Math.min(content.length, availableContentLength);
+  while (0 < prefixLength) {
+    const prefix = getSafeMarkdownPrefix(content, prefixLength);
+    const closingMarkers = getOpenMarkdownMarkers(prefix)
+      .reverse()
+      .join("");
+    if (prefix.length + closingMarkers.length <= availableContentLength) {
+      return `${prefix}${closingMarkers}${suffix}`;
+    }
+
+    prefixLength--;
+  }
+
+  return suffix.trimStart().slice(0, maxLength);
+}
+
+function getSafeMarkdownPrefix(content: string, maxLength: number): string {
+  let prefix = content.slice(0, maxLength).trimEnd();
+  if (prefix.endsWith("*") && "*" === content[prefix.length]) {
+    prefix = prefix.slice(0, -1);
+  }
+
+  const finalCodeUnit = prefix.charCodeAt(prefix.length - 1);
+  if (0xD800 <= finalCodeUnit && finalCodeUnit <= 0xDBFF) {
+    prefix = prefix.slice(0, -1);
+  }
+
+  return prefix;
+}
+
+function getOpenMarkdownMarkers(content: string): string[] {
+  const openMarkers: string[] = [];
+  for (let index = 0; index < content.length; index++) {
+    if ("`" === content[index]) {
+      if ("`" === openMarkers.at(-1)) {
+        openMarkers.pop();
+      } else {
+        openMarkers.push("`");
+      }
+      continue;
+    }
+
+    if ("`" === openMarkers.at(-1)) {
+      continue;
+    }
+
+    if ("*" === content[index] && "*" === content[index + 1]) {
+      if ("**" === openMarkers.at(-1)) {
+        openMarkers.pop();
+      } else {
+        openMarkers.push("**");
+      }
+      index++;
+    }
+  }
+
+  return openMarkers;
 }
 
 export function appendToEarningsChunk(
@@ -192,6 +273,7 @@ export function getTruncatedEarningsSectionRow(
   highlightedTickerSymbols: Set<string>,
   mostAnticipatedTickerSymbols: ReadonlySet<string>,
   maxMessageLength: number,
+  maxMarkdownSpans: number,
   title: string,
   continuationLabel: string
 ): EarningsSectionRow {
@@ -224,6 +306,7 @@ export function getTruncatedEarningsSectionRow(
       highlightedTickerSymbols,
       mostAnticipatedTickerSymbols,
       maxMessageLength,
+      maxMarkdownSpans,
       title,
       continuationLabel
     )) {
@@ -245,11 +328,7 @@ function truncateEarningsLine(line: string, maxLength: number): string {
     return line;
   }
 
-  if (maxLength <= 3) {
-    return line.slice(0, maxLength);
-  }
-
-  return `${line.slice(0, maxLength - 3)}...`;
+  return appendToMarkdownWithinLimit(line, "...", maxLength);
 }
 
 function getEarningsEventLine(

--- a/modules/earnings-format.ts
+++ b/modules/earnings-format.ts
@@ -3,6 +3,7 @@ import {type Ticker} from "./tickers.ts";
 import {
   bluechipMinMarketCap,
   EARNINGS_CONTINUATION_LABEL,
+  EARNINGS_MAX_MARKDOWN_SPANS,
   EARNINGS_MAX_MESSAGE_LENGTH,
   earningsTruncationNote,
   earningsWhenSortRankByWhen,
@@ -12,6 +13,7 @@ import {
   type EarningsWhen,
 } from "./earnings-types.ts";
 import {
+  appendToMarkdownWithinLimit,
   appendToEarningsChunk,
   canAppendToEarningsChunk,
   cloneEarningsChunk,
@@ -43,6 +45,7 @@ export function getEarningsText(
   const earningsBatch = getEarningsMessages(earningsEvents, when, tickers, {
     maxMessageLength: Number.MAX_SAFE_INTEGER,
     maxMessages: 1,
+    maxMarkdownSpans: Number.POSITIVE_INFINITY,
   });
   if (0 === earningsBatch.messages.length) {
     return "none";
@@ -59,6 +62,7 @@ export function getEarningsMessages(
 ): EarningsMessageBatch {
   const maxMessageLength = options.maxMessageLength ?? EARNINGS_MAX_MESSAGE_LENGTH;
   const maxMessages = options.maxMessages ?? Number.POSITIVE_INFINITY;
+  const maxMarkdownSpans = options.maxMarkdownSpans ?? EARNINGS_MAX_MARKDOWN_SPANS;
   const continuationLabel = options.continuationLabel ?? EARNINGS_CONTINUATION_LABEL;
   const selectedWhen = getSelectedEarningsWhen(when);
   const selectedMarketCapFilter = getSelectedEarningsMarketCapFilter(options.marketCapFilter);
@@ -90,6 +94,7 @@ export function getEarningsMessages(
     {
       maxMessageLength,
       maxMessages,
+      maxMarkdownSpans,
       continuationLabel,
     }
   );
@@ -105,6 +110,7 @@ export function getEarningsMessages(
     {
       maxMessageLength,
       maxMessages,
+      maxMarkdownSpans,
       continuationLabel,
     }
   );
@@ -119,6 +125,7 @@ export function getEarningsMessages(
     {
       maxMessageLength,
       maxMessages,
+      maxMarkdownSpans,
       continuationLabel,
     }
   );
@@ -132,10 +139,11 @@ function buildEarningsMessageBatch(
   options: {
     maxMessageLength: number;
     maxMessages: number;
+    maxMarkdownSpans: number;
     continuationLabel: string;
   }
 ): EarningsMessageBatch {
-  const {maxMessageLength, maxMessages, continuationLabel} = options;
+  const {maxMessageLength, maxMessages, maxMarkdownSpans, continuationLabel} = options;
   const sections = getEarningsSections(
     filteredAndSortedEvents
   );
@@ -160,7 +168,7 @@ function buildEarningsMessageBatch(
       section.rows,
       false
     );
-    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, maxMarkdownSpans, title, continuationLabel)) {
       appendToEarningsChunk(currentChunk, fullSection);
       continue;
     }
@@ -170,7 +178,7 @@ function buildEarningsMessageBatch(
       currentChunk = getEmptyEarningsMessageChunk(chunks.length);
     }
 
-    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+    if (true === canAppendToEarningsChunk(currentChunk, fullSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, maxMarkdownSpans, title, continuationLabel)) {
       appendToEarningsChunk(currentChunk, fullSection);
       continue;
     }
@@ -192,7 +200,7 @@ function buildEarningsMessageBatch(
           continuation
         );
 
-        if (canAppendToEarningsChunk(currentChunk, candidateSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, title, continuationLabel)) {
+        if (canAppendToEarningsChunk(currentChunk, candidateSection, highlightedTickerSymbols, mostAnticipatedTickerSymbols, maxMessageLength, maxMarkdownSpans, title, continuationLabel)) {
           sectionRows.push(nextRow);
           rowIndex++;
         } else {
@@ -220,6 +228,7 @@ function buildEarningsMessageBatch(
           highlightedTickerSymbols,
           mostAnticipatedTickerSymbols,
           maxMessageLength,
+          maxMarkdownSpans,
           title,
           continuationLabel
         );
@@ -293,6 +302,7 @@ function getMarketCapBalancedEventsForMultiDayFit(
   options: {
     maxMessageLength: number;
     maxMessages: number;
+    maxMarkdownSpans: number;
     continuationLabel: string;
   }
 ): EarningsEvent[] | null {
@@ -521,17 +531,7 @@ function appendEarningsTruncationNote(
   maxMessageLength: number
 ): string {
   const suffix = `\n${earningsTruncationNote}`;
-  if (content.length + suffix.length <= maxMessageLength) {
-    return `${content}${suffix}`;
-  }
-
-  const messageLengthWithoutSuffix = maxMessageLength - suffix.length;
-  if (messageLengthWithoutSuffix <= 0) {
-    return earningsTruncationNote.slice(0, maxMessageLength);
-  }
-
-  const trimmedContent = content.slice(0, messageLengthWithoutSuffix).trimEnd();
-  return `${trimmedContent}${suffix}`;
+  return appendToMarkdownWithinLimit(content, suffix, maxMessageLength);
 }
 
 export function compareEarningsEventsForDisplay(first: EarningsEvent, second: EarningsEvent): number {

--- a/modules/earnings-types.ts
+++ b/modules/earnings-types.ts
@@ -26,6 +26,7 @@ export type EarningsLoadResult = {
 export const EARNINGS_MAX_MESSAGE_LENGTH = 1800;
 export const EARNINGS_MAX_MESSAGES_TIMER = 8;
 export const EARNINGS_MAX_MESSAGES_SLASH = 6;
+export const EARNINGS_MAX_MARKDOWN_SPANS = 40;
 export const EARNINGS_CONTINUATION_LABEL = "(Fortsetzung)";
 
 export type EarningsMessageBatch = {
@@ -38,6 +39,7 @@ export type EarningsMessageBatch = {
 export type EarningsMessageOptions = {
   maxMessageLength?: number;
   maxMessages?: number;
+  maxMarkdownSpans?: number;
   continuationLabel?: string;
   marketCapFilter?: "all" | "bluechips" | string;
   mostAnticipatedTickerSymbols?: ReadonlySet<string>;

--- a/modules/earnings.test.ts
+++ b/modules/earnings.test.ts
@@ -1,5 +1,5 @@
 import type {MockedFunction} from "vitest";
-import {clearEarningsScheduleCache, type EarningsEvent, getEarnings, getEarningsMessages, getEarningsResult, getEarningsText} from "./earnings.ts";
+import {clearEarningsScheduleCache, EARNINGS_MAX_MARKDOWN_SPANS, type EarningsEvent, getEarnings, getEarningsMessages, getEarningsResult, getEarningsText} from "./earnings.ts";
 import {Ticker} from "./tickers.ts";
 import axios from "axios";
 import {beforeEach, describe, expect, test, vi} from "vitest";
@@ -65,6 +65,15 @@ function parseEarningsLine(
     marketCap: `${match[5]}${match[6]}`,
     eps: match[7]!,
   };
+}
+
+function getMarkdownSpanCount(content: string): number {
+  return (content.match(/\*\*|`/g)?.length ?? 0) / 2;
+}
+
+function expectBalancedMarkdown(content: string) {
+  expect((content.match(/`/g)?.length ?? 0) % 2).toBe(0);
+  expect((content.match(/\*\*/g)?.length ?? 0) % 2).toBe(0);
 }
 
 describe("getEarnings/getEarningsResult", () => {
@@ -845,6 +854,35 @@ describe("getEarningsMessages", () => {
     }
   });
 
+  test("splits dense output before Discord falls back to raw Markdown", () => {
+    const manyFormattedEvents: EarningsEvent[] = [];
+    const highlightedTickers: Ticker[] = [];
+    for (let index = 0; index < 24; index++) {
+      const ticker = `F${index}`;
+      manyFormattedEvents.push(getEarningsEvent({
+        ticker,
+        marketCap: 1_000_000_000 - index,
+        expectedMove: 1.25,
+        expectedMoveActualDte: 7,
+        expectedMoveUnderlyingPrice: 25,
+      }));
+      highlightedTickers.push(getTicker(ticker));
+    }
+
+    const batch = getEarningsMessages(manyFormattedEvents, "all", highlightedTickers, {
+      maxMessageLength: 1800,
+      maxMessages: 10,
+    });
+
+    expect(batch.messages.length).toBeGreaterThan(1);
+    expect(batch.truncated).toBe(false);
+    expect(batch.includedEvents).toBe(24);
+    for (const message of batch.messages) {
+      expect(getMarkdownSpanCount(message)).toBeLessThanOrEqual(EARNINGS_MAX_MARKDOWN_SPANS);
+      expectBalancedMarkdown(message);
+    }
+  });
+
   test("adds truncation note when maxMessages is reached", () => {
     const manyEvents: EarningsEvent[] = [];
     for (let index = 0; index < 40; index++) {
@@ -869,5 +907,6 @@ describe("getEarningsMessages", () => {
     expect(batch.messages).toHaveLength(2);
     expect(batch.includedEvents).toBeLessThan(batch.totalEvents);
     expect(batch.messages[1]!).toContain("... weitere Earnings konnten wegen Discord-Limits nicht angezeigt werden.");
+    expectBalancedMarkdown(batch.messages[1]!);
   });
 });


### PR DESCRIPTION
Splits dense earnings messages before Discord falls back to raw Markdown, keeps truncation markers balanced, and adds regression coverage. Verification: lint, production and test typechecks, 65 test files / 773 tests, and coverage thresholds.