### PR TITLE
Defer unsupported TypeScript 7 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions: [">=25"]
+      # typescript-eslint supports TypeScript versions below 6.1.
+      - dependency-name: "typescript"
+        versions: [">=7 <8"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- ignore TypeScript 7 Dependabot updates while the lint toolchain supports TypeScript below 6.1
- keep TypeScript 6 updates and future coordinated upgrades available

## Context
PR #1816 fails npm ci because typescript-eslint rejects TypeScript 7. Both the latest stable and canary releases retain the same peer ceiling.

## Verification
- Dependabot YAML parses as version 2
- TypeScript ignore range parses as valid semver
- npm run lint
- npm run typecheck
- npm run test:coverage -- --exclude .claude/**