### PR TITLE
Fix cross-sentence earnings metric parsing

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -973,6 +973,45 @@ describe("earnings result formatting", () => {
     ]);
   });
 
+  test("does not scan into a later sentence for a net earnings value", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>General Dynamics Reports Second-Quarter 2026 Financial Results</h1>
+          <p>Revenue $14.1 billion, up 8.1% versus prior year</p>
+          <p>Diluted EPS $4.24, up 13.4% versus prior year</p>
+          <p>Net cash provided by operating activities in the quarter totaled $1.9 billion, or 162% of net earnings. During the quarter, the company paid $429 million in dividends, invested $234 million in capital expenditures, and reduced total debt by $498 million.</p>
+          <div>CONSOLIDATED STATEMENT OF EARNINGS - (UNAUDITED)</div>
+          <div>DOLLARS IN MILLIONS, EXCEPT PER SHARE AMOUNTS</div>
+          <table>
+            <tr><td>Three Months Ended</td></tr>
+            <tr><td>Revenue</td><td>$</td><td>14,094</td><td>$</td><td>13,037</td></tr>
+            <tr><td>Net earnings</td><td>$</td><td>1,160</td><td>$</td><td>1,014</td></tr>
+            <tr><td>Earnings per share—diluted</td><td>$</td><td>4.24</td><td>$</td><td>3.74</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "gaap_eps",
+        numericValue: 4.24,
+        value: "$4.24",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 14_100_000_000,
+        value: "$14.1B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 1_160_000_000,
+        value: "$1.16B",
+      }),
+    ]));
+  });
+
   test("parses cents-denominated EPS as dollars per share", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -740,8 +740,9 @@ function extractMetricValue(
   }
 
   if ("money" === valueType) {
-    const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(preferredSearchText);
-    const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findNumericValueMatch(preferredSearchText, {
+    const sentenceSearchText = getMetricValueSentenceText(preferredSearchText);
+    const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(sentenceSearchText);
+    const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findNumericValueMatch(sentenceSearchText, {
       minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
@@ -762,7 +763,7 @@ function extractMetricValue(
       return null;
     }
 
-    const metricText = true === useFallbackValue ? fallbackSearchText : preferredSearchText;
+    const metricText = true === useFallbackValue ? fallbackSearchText : sentenceSearchText;
     const explicitScale = getExplicitMoneyScale(metricText, parsedValueMatch.endIndex);
     const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
     const amount = parsedValueMatch.value * (explicitScale ?? contextMoney.scale);
@@ -788,6 +789,20 @@ function extractMetricValue(
     numericValue: value,
     value: formatPlainNumber(value, trailingUnit),
   };
+}
+
+// A metric value must be in the same sentence as its label. Otherwise prose such
+// as "162% of net earnings. During the quarter, the company paid $429 million in
+// dividends" can mislabel the next sentence's first dollar amount as net income.
+// Table rows remain intact because their label/value cells are separated by pipes,
+// not sentence-ending punctuation followed by a new sentence.
+function getMetricValueSentenceText(text: string): string {
+  const boundaryMatch = /[.!?]\s+(?=[A-Z\d$€£¥])/u.exec(text);
+  if (undefined === boundaryMatch?.index) {
+    return text;
+  }
+
+  return text.slice(0, boundaryMatch.index + 1);
 }
 
 function hasMixedMonthQuarterColumns(lines: string[], lineIndex: number): boolean {


### PR DESCRIPTION
Summary:
- keep monetary metric extraction within the sentence containing its label
- prevent dividend payments in later prose from being mislabeled as net income
- add a General Dynamics Q2 2026 regression test

Verification:
- live SEC exhibit parses EPS 4.24, revenue 14.1B, and net income 1.16B
- 775 tests pass with coverage
- npm run typecheck
- npm run lint