### PR TITLE
Fix REIT earnings metric parsing

### DIFF
--- a/modules/earnings-results-ai.test.ts
+++ b/modules/earnings-results-ai.test.ts
@@ -104,6 +104,56 @@ describe("AI earnings helpers", () => {
     );
   });
 
+  test("extracts AFFO per share only from explicit AFFO evidence", async () => {
+    const affoHtml = `
+      <h1>Example REIT reports second quarter 2026 results</h1>
+      <p>AFFO and AFFO per Share</p>
+      <p>AFFO was $1.168 billion and AFFO per share was $11.78.</p>
+    `;
+    const postWithRetryFn = vi.fn().mockResolvedValue({
+      data: {
+        candidates: [{
+          content: {
+            parts: [{
+              text: JSON.stringify({
+                quarterLabel: "Q2 2026",
+                metrics: [{
+                  key: "affo_per_share",
+                  numericValue: 11.78,
+                  currencyCode: "USD",
+                  sourceSnippet: "AFFO was $1.168 billion and AFFO per share was $11.78.",
+                }],
+                issues: [],
+              }),
+            }],
+          },
+        }],
+      },
+    });
+
+    const result = await extractEarningsWithAi({
+      companyName: "Example REIT",
+      filingForm: "8-K",
+      filingUrl: "https://www.sec.gov/example",
+      html: affoHtml,
+      ticker: "REIT",
+    }, {
+      logger,
+      nowMs: () => 1_000,
+      postWithRetryFn,
+      readSecretFn,
+    });
+
+    expect(result?.metrics).toEqual([{
+      currencyCode: "USD",
+      key: "affo_per_share",
+      label: "AFFO/share",
+      numericValue: 11.78,
+      sourceSnippet: "AFFO was $1.168 billion and AFFO per share was $11.78.",
+      value: "$11.78",
+    }]);
+  });
+
   test("uses default provider model and rate limit when optional provider secrets are missing", async () => {
     const postWithRetryFn = vi.fn().mockResolvedValue({
       data: {
@@ -805,6 +855,26 @@ describe("AI earnings helpers", () => {
       severity: "medium",
     }]);
     expect(hasHighSeveritySuspicion(reasons)).toBe(false);
+  });
+
+  test("compares REIT consensus against AFFO per share instead of GAAP EPS", () => {
+    const reasons = getSuspiciousEarningsReasons([{
+      key: "affo_per_share",
+      label: "AFFO/share",
+      numericValue: 11.78,
+      value: "$11.78",
+    }, {
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 4.83,
+      value: "$4.83",
+    }], {
+      consensusEps: 10.14,
+    }, getEvent({
+      epsConsensus: "$10.14",
+    }));
+
+    expect(reasons).toEqual([]);
   });
 
   test("identifies EPS that is implausibly low relative to consensus", () => {

--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -57,7 +57,7 @@ type EarningsAiQualityIssue = {
   sourceSnippet: string;
 };
 
-type AiMetricKey = "adjusted_eps" | "gaap_eps" | "revenue" | "net_income";
+type AiMetricKey = "affo_per_share" | "adjusted_eps" | "gaap_eps" | "revenue" | "net_income";
 
 type AiMetricDefinition = {
   key: AiMetricKey;
@@ -70,6 +70,11 @@ const aiRelevantContextBeforeLines = 2;
 const aiRelevantContextAfterLines = 4;
 
 const aiMetricDefinitions = new Map<AiMetricKey, AiMetricDefinition>([
+  ["affo_per_share", {
+    key: "affo_per_share",
+    label: "AFFO/share",
+    valueType: "eps",
+  }],
   ["adjusted_eps", {
     key: "adjusted_eps",
     label: "Adj EPS",
@@ -102,14 +107,14 @@ const earningsExtractionSchema = {
     },
     metrics: {
       type: "array",
-      maxItems: 4,
+      maxItems: 5,
       items: {
         type: "object",
         additionalProperties: false,
         properties: {
           key: {
             type: "string",
-            enum: ["adjusted_eps", "gaap_eps", "revenue", "net_income"],
+            enum: ["affo_per_share", "adjusted_eps", "gaap_eps", "revenue", "net_income"],
           },
           numericValue: {
             type: "number",
@@ -165,7 +170,7 @@ const qualityGateSchema = {
           },
           metricKey: {
             type: ["string", "null"],
-            enum: ["adjusted_eps", "gaap_eps", "revenue", "net_income", "nasdaq_eps", null],
+            enum: ["affo_per_share", "adjusted_eps", "gaap_eps", "revenue", "net_income", "nasdaq_eps", null],
           },
           message: {
             type: "string",
@@ -306,7 +311,8 @@ export function getSuspiciousEarningsReasons(
 ): SuspiciousEarningsReason[] {
   const reasons: SuspiciousEarningsReason[] = [];
   const consensusEps = surprise?.consensusEps ?? getNumericEventEpsConsensus(event);
-  const epsMetric = metrics.find(metric => "adjusted_eps" === metric.key) ??
+  const epsMetric = metrics.find(metric => "affo_per_share" === metric.key) ??
+    metrics.find(metric => "adjusted_eps" === metric.key) ??
     metrics.find(metric => "gaap_eps" === metric.key || "nasdaq_eps" === metric.key);
   if (undefined !== epsMetric &&
       "number" === typeof epsMetric.numericValue &&
@@ -407,7 +413,7 @@ export function hasHighSeveritySuspicion(reasons: SuspiciousEarningsReason[]): b
   return reasons.some(reason => "high" === reason.severity);
 }
 
-const epsMetricKeys = new Set(["adjusted_eps", "gaap_eps", "nasdaq_eps"]);
+const epsMetricKeys = new Set(["affo_per_share", "adjusted_eps", "gaap_eps", "nasdaq_eps"]);
 
 // A positive net income cannot produce a negative EPS, and vice versa. When an
 // EPS metric's sign contradicts net income, the value is almost certainly a
@@ -461,6 +467,7 @@ function getExtractionPrompt(input: EarningsAiExtractionInput, sourceText: strin
     "- Omit revenue when the filing excerpt does not explicitly report revenue, revenues, net sales, or third-party revenue.",
     "- Do not use Adjusted EBITDA, sales volumes, production, cash flow, or a zero placeholder as revenue.",
     "- EPS numericValue must be currency units per share. Convert cents to dollars, e.g. 77 cents becomes 0.77.",
+    "- Include AFFO per share only when the filing explicitly labels the value as AFFO per share.",
     "- Include adjusted EPS only when explicitly non-GAAP/adjusted. Include GAAP EPS only when explicitly GAAP/diluted/basic EPS.",
     "- Every metric must include a short exact sourceSnippet from the filing text that proves the metric and scale.",
     `Company: ${input.companyName}`,
@@ -587,6 +594,10 @@ function isEpsEvidenceSnippet(key: AiMetricKey, sourceSnippet: string): boolean 
 
   if (false === /\b(?:eps|earnings\s+per\s+share|per\s+share)\b/i.test(sourceSnippet)) {
     return false;
+  }
+
+  if ("affo_per_share" === key) {
+    return /\baffo\b/i.test(sourceSnippet) && /\bper\s+(?:common\s+)?share\b/i.test(sourceSnippet);
   }
 
   return "adjusted_eps" !== key || /\b(?:adjusted|non-gaap)\b/i.test(sourceSnippet);
@@ -790,6 +801,7 @@ function getNumericEventEpsConsensus(event: EarningsEvent): number | undefined {
 
 function sortEarningsMetrics(metrics: EarningsResultMetric[]): EarningsResultMetric[] {
   const preferredOrder = [
+    "affo_per_share",
     "adjusted_eps",
     "gaap_eps",
     "nasdaq_eps",

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -608,6 +608,7 @@ describe("earnings result formatting", () => {
       {
         key: "free_cash_flow",
         label: "Free cash flow",
+        periodLabel: "FY2026",
         value: "€1.3B to €1.5B",
       },
     ]);
@@ -621,7 +622,7 @@ describe("earnings result formatting", () => {
       metrics: [],
       parsedDocument,
       ticker: "PHG",
-    })).toContain("- **Free cash flow:** `€1.3B` to `€1.5B`");
+    })).toContain("- **FY2026 Free cash flow:** `€1.3B` to `€1.5B`");
   });
 
   test("does not emit outlook metrics without an outlook section", () => {
@@ -1010,6 +1011,118 @@ describe("earnings result formatting", () => {
         value: "$1.16B",
       }),
     ]));
+  });
+
+  test("keeps Equinix second-quarter results separate from mixed-period guidance", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Equinix Reports Second-Quarter Results, Raises 2026 Guidance and Long-Term Outlook</h1>
+          <h2>Second-Quarter 2026 Results Summary</h2>
+          <p>• Revenues</p>
+          <p>◦ $2.625 billion, a 4% increase over the previous quarter</p>
+          <p>• Operating Income</p>
+          <p>◦ $665 million, a 16% increase over the previous quarter</p>
+          <p>• Net Income Attributable to Common Stockholders and Net Income per Share Attributable to Common Stockholders</p>
+          <p>◦ $479 million, a 156% increase over the previous quarter</p>
+          <p>◦ $4.83 per share, a 154% increase over the previous quarter</p>
+          <p>• Adjusted EBITDA</p>
+          <p>◦ $1.396 billion, a 4% increase over the previous quarter</p>
+          <p>• AFFO and AFFO per Share</p>
+          <p>◦ $1.168 billion, a 7% increase over the previous quarter</p>
+          <p>◦ $11.78 per share, a 7% increase over the previous quarter</p>
+          <h2>2026 Guidance Summary</h2>
+          <p>For the third quarter of 2026, revenues are expected to range between $2.525 and $2.575 billion.</p>
+          <p>For the third quarter of 2026, adjusted EBITDA is expected to range between $1.275 and $1.315 billion.</p>
+          <p>For the full year of 2026, total capital expenditures are expected to range between $5.000 and $6.000 billion.</p>
+        </body>
+      </html>
+    `);
+    const event: EarningsEvent = {
+      ticker: "EQIX",
+      when: "after_close",
+      date: "2026-07-29",
+      importance: 1,
+      epsConsensus: "$10.14",
+    };
+    const metrics = getMessageMetrics(parsedDocument.metrics, {
+      consensusEps: 10.14,
+      consensusRevenue: 2_580_000_000,
+    }, event);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "affo_per_share",
+        estimate: "$10.14",
+        numericValue: 11.78,
+        outcome: "beat",
+        value: "$11.78",
+      }),
+      expect.objectContaining({
+        key: "gaap_eps",
+        numericValue: 4.83,
+        value: "$4.83",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        estimate: "$2.58B",
+        numericValue: 2_625_000_000,
+        outcome: "beat",
+        value: "$2.625B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 479_000_000,
+        value: "$479M",
+      }),
+    ]));
+    expect(metrics.find(metric => "gaap_eps" === metric.key)).not.toHaveProperty("estimate");
+    expect(metrics.find(metric => "gaap_eps" === metric.key)).not.toHaveProperty("outcome");
+    expect(parsedDocument.outlook).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        periodLabel: "Q3",
+        value: "$2.525B to $2.575B",
+      },
+      {
+        key: "adjusted_ebitda",
+        label: "Adj EBITDA",
+        periodLabel: "Q3",
+        value: "$1.275B to $1.315B",
+      },
+      {
+        key: "capex",
+        label: "Capex",
+        periodLabel: "FY2026",
+        value: "$5B to $6B",
+      },
+    ]);
+
+    expect(getEarningsResultMessage({
+      companyName: "Equinix, Inc.",
+      filing: {
+        form: "8-K",
+        items: ["2.02", "9.01"],
+      },
+      filingUrl: "https://www.sec.gov/Archives/edgar/data/1101239/000110123926000145/a991eqix-q226xpr.htm",
+      metrics,
+      parsedDocument,
+      ticker: "EQIX",
+    })).toContain([
+      "**Equinix, Inc. (`EQIX`)** - Q2 2026 - [8-K](https://www.sec.gov/Archives/edgar/data/1101239/000110123926000145/a991eqix-q226xpr.htm)",
+      "📊 **Results**",
+      "- **AFFO/share:** `$11.78` vs est. `$10.14` (🟢 beat)",
+      "- **EPS:** `$4.83`",
+      "- **Revenue:** `$2.625B` vs est. `$2.58B` (🟢 beat)",
+      "- **Net income:** `$479M`",
+      "",
+      "🔮 **Outlook**",
+      "- **Q3 Revenue:** `$2.525B` to `$2.575B`",
+      "- **Q3 Adj EBITDA:** `$1.275B` to `$1.315B`",
+      "- **FY2026 Capex:** `$5B` to `$6B`",
+    ].join("\n"));
   });
 
   test("parses cents-denominated EPS as dollars per share", () => {

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -62,6 +62,15 @@ const discordBlankLineSpacer = "\u200B";
 
 const earningsMetricDefinitions: MetricDefinition[] = [
   {
+    key: "affo_per_share",
+    label: "AFFO/share",
+    patterns: [
+      /\baffo\s+(?:and\s+affo\s+)?per\s+(?:common\s+)?share\b/i,
+      /\badjusted\s+funds?\s+from\s+operations?\s+per\s+(?:common\s+)?share\b/i,
+    ],
+    valueType: "eps",
+  },
+  {
     key: "adjusted_eps",
     label: "Adj EPS",
     patterns: [
@@ -99,7 +108,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
     key: "net_income",
     label: "Net income",
     patterns: [
-      /\bnet\s+income(?!\s+per\s+(?:common\s+)?share)(?:\s+attributable[^|,]*)?\b/i,
+      /\bnet\s+income(?!\s+per\s+(?:common\s+)?share)\b/i,
       /\bnet\s+earnings(?!\s+per\s+(?:common\s+)?share)\b/i,
     ],
     // Skip income-statement subtotals and the noncontrolling-interest component so
@@ -147,10 +156,12 @@ export function getMessageMetrics(
     normalizeEpsMetrics([...secMetrics], surprise, consensusEps),
     surprise,
   );
+  const hasAffoPerShare = metrics.some(metric => "affo_per_share" === metric.key);
   const hasAdjustedEps = metrics.some(metric => "adjusted_eps" === metric.key);
   const hasGaapEps = metrics.some(metric => "gaap_eps" === metric.key);
 
   if ("number" === typeof surprise?.actualEps &&
+      false === hasAffoPerShare &&
       false === hasAdjustedEps &&
       false === hasGaapEps) {
     metrics.unshift({
@@ -161,7 +172,8 @@ export function getMessageMetrics(
     });
   }
 
-  const epsMetric = metrics.find(metric => "adjusted_eps" === metric.key) ??
+  const epsMetric = metrics.find(metric => "affo_per_share" === metric.key) ??
+    metrics.find(metric => "adjusted_eps" === metric.key) ??
     metrics.find(metric => "nasdaq_eps" === metric.key || "gaap_eps" === metric.key);
   if (epsMetric && "number" === typeof consensusEps && true === canCompareAgainstUsdEstimate(epsMetric)) {
     epsMetric.estimate = formatEps(consensusEps);
@@ -210,7 +222,10 @@ function dropImplausibleMoneyMetrics(
 }
 
 function isEpsMetricKey(key: string): boolean {
-  return "adjusted_eps" === key || "gaap_eps" === key || "nasdaq_eps" === key;
+  return "affo_per_share" === key ||
+    "adjusted_eps" === key ||
+    "gaap_eps" === key ||
+    "nasdaq_eps" === key;
 }
 
 function canCompareAgainstUsdEstimate(metric: EarningsResultMetric): boolean {
@@ -223,9 +238,10 @@ function normalizeEpsMetrics(
   consensusEps: number | undefined,
 ): EarningsResultMetric[] {
   const actualEps = surprise?.actualEps;
+  const affoPerShareMetric = metrics.find(metric => "affo_per_share" === metric.key);
   const adjustedEpsMetric = metrics.find(metric => "adjusted_eps" === metric.key);
   const gaapEpsMetric = metrics.find(metric => "gaap_eps" === metric.key);
-  const primaryEpsMetric = adjustedEpsMetric ?? gaapEpsMetric;
+  const primaryEpsMetric = affoPerShareMetric ?? adjustedEpsMetric ?? gaapEpsMetric;
 
   if ("number" === typeof actualEps &&
       undefined !== primaryEpsMetric &&
@@ -331,7 +347,10 @@ export function getEarningsResultMessage({
     }
     lines.push("🔮 **Outlook**");
     for (const metric of parsedDocument.outlook) {
-      lines.push(`- **${metric.label}:** ${formatOutlookValue(metric.value)}`);
+      const metricLabel = metric.periodLabel
+        ? `${metric.periodLabel} ${metric.label}`
+        : metric.label;
+      lines.push(`- **${metricLabel}:** ${formatOutlookValue(metric.value)}`);
     }
   }
 
@@ -460,7 +479,7 @@ function getQuarterLabel(text: string): string | undefined {
     return `Q${ordinalQuarterMatch[1]} ${ordinalQuarterMatch[2]}`;
   }
 
-  const writtenFiscalQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter(?:\s+and\s+full)?\s+(?:fiscal\s+year|FY)\s*(20\d{2}|\d{2})\b/i);
+  const writtenFiscalQuarterMatch = text.match(/\b(first|second|third|fourth)[\s–—-]+quarter(?:\s+and\s+full)?\s+(?:fiscal\s+year|FY)\s*(20\d{2}|\d{2})\b/i);
   if (undefined !== writtenFiscalQuarterMatch?.[1] && undefined !== writtenFiscalQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenFiscalQuarterMatch[1]);
     if (quarter) {
@@ -473,7 +492,7 @@ function getQuarterLabel(text: string): string | undefined {
     return namedPeriodEndedQuarter;
   }
 
-  const writtenQuarterMatch = text.match(/\b(first|second|third|fourth)\s+quarter\s+(?:of\s+)?(20\d{2})\b/i);
+  const writtenQuarterMatch = text.match(/\b(first|second|third|fourth)[\s–—-]+quarter\s+(?:of\s+)?(20\d{2})\b/i);
   if (undefined !== writtenQuarterMatch?.[1] && undefined !== writtenQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenQuarterMatch[1]);
     if (quarter) {
@@ -496,7 +515,7 @@ function getQuarterLabel(text: string): string | undefined {
 
 function getNamedQuarterLabelFromPeriodEnded(text: string): string | undefined {
   const namedPeriodEndedMatch = text.match(
-    /\b(first|second|third|fourth)\s+quarter\s+ended\s+[A-Z][a-z]+\s+\d{1,2},\s+(20\d{2})\b/i,
+    /\b(first|second|third|fourth)[\s–—-]+quarter\s+ended\s+[A-Z][a-z]+\s+\d{1,2},\s+(20\d{2})\b/i,
   );
   if (undefined === namedPeriodEndedMatch?.[1] || undefined === namedPeriodEndedMatch[2]) {
     return undefined;
@@ -615,8 +634,8 @@ function isQuarterSpecificSectionLine(line: string): boolean {
     return false;
   }
 
-  return /^\s*(?:for\s+)?Q[1-4]\s+(?:fiscal\s+year|FY|FYE)\s*(?:20\d{2}|\d{2})(?:\s+(?:financial\s+overview|results?|earnings))?\s*:?$/i.test(line) ||
-    /^\s*(?:for\s+)?(?:the\s+)?(?:first|second|third|fourth)\s+quarter(?:\s+(?:of\s+)?(?:fiscal\s+year|FY)\s*(?:20\d{2}|\d{2}))?\s*:?$/i.test(line);
+  return /^\s*(?:for\s+)?Q[1-4]\s+(?:(?:fiscal\s+year|FY|FYE)\s*)?(?:20\d{2}|\d{2})(?:\s+(?:financial\s+overview|results?(?:\s+summary)?|earnings))?\s*:?$/i.test(line) ||
+    /^\s*(?:for\s+)?(?:the\s+)?(?:first|second|third|fourth)[\s–—-]+quarter(?:\s+(?:of\s+)?(?:(?:fiscal\s+year|FY)\s*)?(?:20\d{2}|\d{2}))?(?:\s+(?:financial\s+overview|results?(?:\s+summary)?|earnings))?\s*:?$/i.test(line);
 }
 
 function isQuarterSpecificSectionBoundary(line: string): boolean {
@@ -641,7 +660,7 @@ function extractMetric(
       continue;
     }
 
-    const metricLine = getMetricLineWithContinuation(lines, lineIndex);
+    const metricLine = getMetricLineWithContinuation(lines, lineIndex, definition);
     const pattern = definition.patterns.find(candidatePattern => candidatePattern.test(metricLine));
     if (!pattern) {
       continue;
@@ -672,24 +691,83 @@ function extractMetric(
 }
 
 function isPerShareOnlyNetIncomeLine(line: string): boolean {
+  const hasCombinedAggregateLabel =
+    /\bnet\s+income\b.*\band\b.*\bnet\s+income\s+per\s+(?:common\s+|diluted\s+)?share\b/i.test(line);
   return /\bper\s+(?:common\s+|diluted\s+)?share\b/i.test(line) &&
+    false === hasCombinedAggregateLabel &&
     false === /\b(?:trillion|billion|million|thousand)s?\b/i.test(line);
 }
 
-function getMetricLineWithContinuation(lines: string[], lineIndex: number): string {
-  const metricLines = [lines[lineIndex] ?? ""];
+function getMetricLineWithContinuation(
+  lines: string[],
+  lineIndex: number,
+  definition: MetricDefinition,
+): string {
+  const baseLine = lines[lineIndex] ?? "";
+  const metricLines = [baseLine];
+  const isSummaryHeading = isSummaryMetricHeading(baseLine, definition);
   for (let index = lineIndex + 1; index < lines.length && index <= lineIndex + 6; index++) {
     const nextLine = lines[index];
-    if (undefined === nextLine ||
-        (false === isValueOnlyLine(nextLine) &&
-        false === isPerShareMetricDetailLine(metricLines[0] ?? "", nextLine))) {
+    if (undefined === nextLine) {
       break;
     }
 
-    metricLines.push(nextLine);
+    if (true === isValueOnlyLine(nextLine) ||
+        true === isPerShareMetricDetailLine(baseLine, nextLine)) {
+      metricLines.push(nextLine);
+      continue;
+    }
+
+    if (false === isSummaryHeading || true === isSummaryMetricHeadingLine(nextLine)) {
+      break;
+    }
+
+    if ("money" === definition.valueType && true === isNarrativeMoneyDetailLine(nextLine)) {
+      metricLines.push(nextLine);
+      break;
+    }
+
+    if ("eps" === definition.valueType) {
+      if (true === isNarrativePerShareDetailLine(nextLine)) {
+        metricLines.push(nextLine);
+        break;
+      }
+
+      if (true === isNarrativeMoneyDetailLine(nextLine)) {
+        continue;
+      }
+    }
+
+    break;
   }
 
   return metricLines.join(" ");
+}
+
+function isSummaryMetricHeading(line: string, definition: MetricDefinition): boolean {
+  return line.length <= 180 &&
+    false === /[$€£¥]|\b\d+(?:[.,]\d+)?\b/.test(line) &&
+    definition.patterns.some(pattern => pattern.test(line));
+}
+
+function isSummaryMetricHeadingLine(line: string): boolean {
+  if (line.length > 180 || /[$€£¥]|\b\d+(?:[.,]\d+)?\b/.test(line)) {
+    return false;
+  }
+
+  return earningsMetricDefinitions.some(definition =>
+    definition.patterns.some(pattern => pattern.test(line))) ||
+    /\b(?:adjusted\s+ebitda|operating\s+income)\b/i.test(line);
+}
+
+function isNarrativeMoneyDetailLine(line: string): boolean {
+  return /^\s*(?:[•◦▪–—-]\s*)?(?:\(?\s*)?(?:[$€£¥]\s*)?-?\d/i.test(line) &&
+    /[$€£¥]|\b(?:trillion|billion|million|thousand)s?\b|\b(?:tn|bn|mm|[tbmk])\b/i.test(line);
+}
+
+function isNarrativePerShareDetailLine(line: string): boolean {
+  return /^\s*(?:[•◦▪–—-]\s*)?(?:\(?\s*)?(?:[$€£¥]\s*)?-?\d/i.test(line) &&
+    /\b(?:per\s+(?:common\s+)?share|eps|cents?)\b/i.test(line);
 }
 
 function isValueOnlyLine(line: string): boolean {
@@ -767,10 +845,15 @@ function extractMetricValue(
     const explicitScale = getExplicitMoneyScale(metricText, parsedValueMatch.endIndex);
     const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
     const amount = parsedValueMatch.value * (explicitScale ?? contextMoney.scale);
+    const maximumFractionDigits = getMoneyDisplayPrecision(
+      metricText,
+      parsedValueMatch.endIndex,
+      explicitScale,
+    );
     return {
       currencyCode,
       numericValue: amount,
-      value: formatMoneyCompact(amount, currencyCode),
+      value: formatMoneyCompact(amount, currencyCode, maximumFractionDigits),
     };
   }
 
@@ -988,6 +1071,20 @@ function getExplicitMoneyScale(text: string, valueEndIndex: number): number | nu
   return 1_000_000;
 }
 
+function getMoneyDisplayPrecision(
+  text: string,
+  valueEndIndex: number,
+  explicitScale: number | null,
+): number {
+  if (null === explicitScale) {
+    return 2;
+  }
+
+  const valuePrefix = text.slice(0, valueEndIndex);
+  const fractionDigits = /\.(\d+)\s*\)?$/.exec(valuePrefix)?.[1]?.length ?? 0;
+  return Math.min(3, Math.max(2, fractionDigits));
+}
+
 type NumericValueOptions = {
   maxAbsValue?: number;
   minUncuedAbsValue?: number;
@@ -1179,27 +1276,31 @@ export function formatUsdCompact(value: number): string {
   return formatMoneyCompact(value, "USD");
 }
 
-export function formatMoneyCompact(value: number, currencyCode = "USD"): string {
+export function formatMoneyCompact(
+  value: number,
+  currencyCode = "USD",
+  maximumFractionDigits = 2,
+): string {
   const symbol = getCurrencySymbol(currencyCode);
   const absoluteValue = Math.abs(value);
   const sign = value < 0 ? "-" : "";
   if (absoluteValue >= 1_000_000_000_000) {
-    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000_000_000)}T`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000_000_000, maximumFractionDigits)}T`;
   }
 
   if (absoluteValue >= 1_000_000_000) {
-    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000_000)}B`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000_000, maximumFractionDigits)}B`;
   }
 
   if (absoluteValue >= 1_000_000) {
-    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000)}M`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000_000, maximumFractionDigits)}M`;
   }
 
   if (absoluteValue >= 1_000) {
-    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000)}K`;
+    return `${sign}${symbol}${formatDecimal(absoluteValue / 1_000, maximumFractionDigits)}K`;
   }
 
-  return `${sign}${symbol}${formatDecimal(absoluteValue)}`;
+  return `${sign}${symbol}${formatDecimal(absoluteValue, maximumFractionDigits)}`;
 }
 
 function getCurrencySymbol(currencyCode: string): string {
@@ -1222,8 +1323,8 @@ function getCurrencySymbol(currencyCode: string): string {
   return "$";
 }
 
-function formatDecimal(value: number): string {
-  return value.toFixed(2).replace(/\.?0+$/, "");
+function formatDecimal(value: number, maximumFractionDigits = 2): string {
+  return value.toFixed(maximumFractionDigits).replace(/\.?0+$/, "");
 }
 
 function formatPlainNumber(value: number, unit: string | null): string {

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -270,7 +270,36 @@ describe("extractOutlookMetrics", () => {
       {
         key: "free_cash_flow",
         label: "Free cash flow",
+        periodLabel: "FY2026",
         value: "€1.3B to €1.5B",
+      },
+    ]);
+  });
+
+  test("labels mixed quarter and full-year guidance and preserves three-decimal billions", () => {
+    expect(extractOutlookMetrics([
+      "2026 Guidance Summary",
+      "For the third quarter of 2026, revenues are expected to range between $2.525 and $2.575 billion.",
+      "For the third quarter of 2026, adjusted EBITDA is expected to range between $1.275 and $1.315 billion.",
+      "For the full year of 2026, total capital expenditures are expected to range between $5.000 and $6.000 billion.",
+    ])).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        periodLabel: "Q3",
+        value: "$2.525B to $2.575B",
+      },
+      {
+        key: "adjusted_ebitda",
+        label: "Adj EBITDA",
+        periodLabel: "Q3",
+        value: "$1.275B to $1.315B",
+      },
+      {
+        key: "capex",
+        label: "Capex",
+        periodLabel: "FY2026",
+        value: "$5B to $6B",
       },
     ]);
   });

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -2,6 +2,7 @@
 export type EarningsOutlookMetric = {
   key: string;
   label: string;
+  periodLabel?: string | undefined;
   value: string;
 };
 
@@ -22,6 +23,11 @@ type OutlookMetricCandidate = {
 type ParsedMoneyValue = {
   currencyCode: string;
   value: number;
+};
+
+type OutlookSection = {
+  lines: string[];
+  mixedPeriods: boolean;
 };
 
 const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:[$€£¥]\s*)|(?:(?:USD|EUR|GBP|JPY)\s+))?-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:(?:trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b)?\)?`;
@@ -98,15 +104,15 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
 ];
 
 export function extractOutlookMetrics(lines: string[]): EarningsOutlookMetric[] {
-  const sectionLines = getOutlookSectionLines(lines);
-  if (0 === sectionLines.length) {
+  const section = getOutlookSection(lines);
+  if (0 === section.lines.length) {
     return [];
   }
 
   const metrics: EarningsOutlookMetric[] = [];
   const seenKeys = new Set<string>();
   for (const definition of outlookMetricDefinitions) {
-    const metric = extractOutlookMetric(sectionLines, definition);
+    const metric = extractOutlookMetric(section.lines, definition, section.mixedPeriods);
     if (null === metric || true === seenKeys.has(metric.key)) {
       continue;
     }
@@ -118,13 +124,15 @@ export function extractOutlookMetrics(lines: string[]): EarningsOutlookMetric[] 
   return metrics.slice(0, 6);
 }
 
-function getOutlookSectionLines(lines: string[]): string[] {
+function getOutlookSection(lines: string[]): OutlookSection {
   const sectionLines: string[] = [];
   let collecting = false;
+  let mixedPeriods = false;
 
   for (const line of lines) {
     if (true === isOutlookHeading(line)) {
       collecting = true;
+      mixedPeriods = isMixedPeriodOutlookHeading(line);
       continue;
     }
 
@@ -142,7 +150,18 @@ function getOutlookSectionLines(lines: string[]): string[] {
     }
   }
 
-  return sectionLines;
+  return {
+    lines: sectionLines,
+    mixedPeriods: mixedPeriods || hasMixedOutlookPeriods(sectionLines),
+  };
+}
+
+function hasMixedOutlookPeriods(lines: string[]): boolean {
+  const sectionText = lines.join(" ");
+  const hasQuarter = /\b(?:q[1-4]|first|second|third|fourth)[\s–—-]+quarter\b/i.test(sectionText) ||
+    /\bq[1-4]\b/i.test(sectionText);
+  const hasFullYear = /\b(?:full[\s–—-]+year|fiscal\s+year|fy)\b/i.test(sectionText);
+  return hasQuarter && hasFullYear;
 }
 
 function isOutlookHeading(line: string): boolean {
@@ -158,7 +177,13 @@ function isOutlookHeading(line: string): boolean {
     .trim();
 
   return /^(?:business\s+|financial\s+)?(?:outlook|guidance)\b/i.test(normalizedLine) ||
-    /^(?:fiscal\s+)?(?:20\d{2}|fy\s?\d{2}|q[1-4]\s+20\d{2}|quarter)\b.*\b(?:outlook|guidance)\b/i.test(normalizedLine);
+    /^(?:(?:fiscal\s+)?(?:20\d{2}|fy\s?\d{2}|q[1-4]\s+20\d{2}|quarter)|(?:first|second|third|fourth)[\s–—-]+quarter)\b.*\b(?:outlook|guidance)\b/i.test(normalizedLine);
+}
+
+function isMixedPeriodOutlookHeading(line: string): boolean {
+  return (/\bq[1-4]\b/i.test(line) ||
+    /\b(?:first|second|third|fourth)[\s–—-]+quarter\b/i.test(line)) &&
+    /\bfull[\s–—-]+year\b/i.test(line);
 }
 
 function isOutlookSectionEnd(line: string): boolean {
@@ -195,6 +220,7 @@ function isNextSectionHeading(line: string): boolean {
 function extractOutlookMetric(
   lines: string[],
   definition: OutlookMetricDefinition,
+  includePeriodLabel: boolean,
 ): EarningsOutlookMetric | null {
   let bestCandidate: OutlookMetricCandidate | null = null;
   for (const line of lines) {
@@ -212,13 +238,20 @@ function extractOutlookMetric(
         continue;
       }
 
+      const periodLabel = true === includePeriodLabel
+        ? getOutlookPeriodLabel(line)
+        : undefined;
+      const metric: EarningsOutlookMetric = {
+        key: definition.key,
+        label: definition.label,
+        value,
+      };
+      if (undefined !== periodLabel) {
+        metric.periodLabel = periodLabel;
+      }
       const candidate = {
         score: getOutlookMetricCandidateScore(line),
-        metric: {
-          key: definition.key,
-          label: definition.label,
-          value,
-        },
+        metric,
       };
       if (null === bestCandidate || candidate.score > bestCandidate.score) {
         bestCandidate = candidate;
@@ -227,6 +260,31 @@ function extractOutlookMetric(
   }
 
   return bestCandidate?.metric ?? null;
+}
+
+function getOutlookPeriodLabel(line: string): string | undefined {
+  const directQuarterMatch = /\bq([1-4])(?:\s+20\d{2})?\b/i.exec(line);
+  if (undefined !== directQuarterMatch?.[1]) {
+    return `Q${directQuarterMatch[1]}`;
+  }
+
+  const writtenQuarterMatch = /\b(first|second|third|fourth)[\s–—-]+quarter\b/i.exec(line);
+  if (undefined !== writtenQuarterMatch?.[1]) {
+    const quarterByName = new Map([
+      ["first", "Q1"],
+      ["second", "Q2"],
+      ["third", "Q3"],
+      ["fourth", "Q4"],
+    ]);
+    return quarterByName.get(writtenQuarterMatch[1].toLowerCase());
+  }
+
+  const fullYearMatch = /\b(?:full[\s–—-]+year|fiscal\s+year|fy)\s*(?:of\s+)?(20\d{2}|\d{2})\b/i.exec(line);
+  if (undefined !== fullYearMatch?.[1]) {
+    return `FY${2 === fullYearMatch[1].length ? `20${fullYearMatch[1]}` : fullYearMatch[1]}`;
+  }
+
+  return undefined;
 }
 
 function getOutlookMetricCandidateScore(line: string): number {
@@ -598,7 +656,7 @@ function getCurrencySymbol(currencyCode: string): string {
 }
 
 function formatDecimal(value: number): string {
-  return value.toFixed(2).replace(/\.?0+$/, "");
+  return value.toFixed(3).replace(/\.?0+$/, "");
 }
 
 function formatPercent(value: number): string {

--- a/modules/earnings-results-xbrl.test.ts
+++ b/modules/earnings-results-xbrl.test.ts
@@ -1,5 +1,9 @@
 import {describe, expect, test} from "vitest";
-import {extractSecXbrlMetrics, type SecCompanyFactsResponse} from "./earnings-results-xbrl.ts";
+import {
+  extractSecXbrlMetrics,
+  mergeXbrlAndHtmlMetrics,
+  type SecCompanyFactsResponse,
+} from "./earnings-results-xbrl.ts";
 
 describe("earnings result XBRL metrics", () => {
   test("extracts quarterly facts for the matching accession", () => {
@@ -144,6 +148,29 @@ describe("earnings result XBRL metrics", () => {
         key: "net_income",
         value: "-€415M",
       }),
+    ]);
+  });
+
+  test("keeps HTML-only AFFO per share ahead of XBRL GAAP EPS", () => {
+    expect(mergeXbrlAndHtmlMetrics([{
+      key: "gaap_eps",
+      label: "EPS",
+      numericValue: 4.83,
+      value: "$4.83",
+    }], [{
+      key: "affo_per_share",
+      label: "AFFO/share",
+      numericValue: 11.78,
+      value: "$11.78",
+    }, {
+      key: "revenue",
+      label: "Revenue",
+      numericValue: 2_625_000_000,
+      value: "$2.625B",
+    }]).map(metric => metric.key)).toEqual([
+      "affo_per_share",
+      "gaap_eps",
+      "revenue",
     ]);
   });
 });

--- a/modules/earnings-results-xbrl.ts
+++ b/modules/earnings-results-xbrl.ts
@@ -160,6 +160,7 @@ export function mergeXbrlAndHtmlMetrics(
   }
 
   const preferredOrder = [
+    "affo_per_share",
     "adjusted_eps",
     "gaap_eps",
     "nasdaq_eps",


### PR DESCRIPTION
## Summary
- parse hyphenated quarter headings and SEC nested result-summary bullets
- compare REIT consensus with AFFO per share while retaining GAAP EPS separately
- preserve guidance precision and label mixed quarter/full-year outlook periods
- add Equinix, AI fallback, outlook, and XBRL regression coverage

## Validation
- npm run test:coverage -- --exclude .claude/worktrees/** (780 tests passed)
- npm run typecheck
- npm run lint
- replayed the live Equinix SEC exhibit through the parser