### PR TITLE
Fix Trane earnings metric parsing

### DIFF
--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -1125,6 +1125,88 @@ describe("earnings result formatting", () => {
     ].join("\n"));
   });
 
+  test("parses Trane continuing EPS and comma-separated table scale without reading Q2 as EPS", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Trane Technologies Reports Strong Second Quarter Results; Raises Full-Year Revenue and EPS Guidance</h1>
+          <h2>Second-Quarter 2026 Results</h2>
+          <p>Financial Comparisons - Second-Quarter Continuing Operations</p>
+          <table>
+            <tr><td>$, millions except EPS</td><td>Q2 2026</td><td>Q2 2025</td><td>Y-O-Y Change</td><td>Organic Y-O-Y Change</td></tr>
+            <tr><td>Bookings</td><td>$7,818</td><td>$5,626</td><td>39%</td><td>37%</td></tr>
+            <tr><td>Net Revenues</td><td>$6,354</td><td>$5,746</td><td>11%</td><td>9%</td></tr>
+            <tr><td>GAAP Operating Income</td><td>$1,224</td><td>$1,164</td><td>5%</td></tr>
+            <tr><td>Adjusted Operating Income</td><td>$1,253</td><td>$1,166</td><td>7%</td></tr>
+            <tr><td>GAAP Continuing EPS</td><td>$4.20</td><td>$3.87</td><td>9%</td></tr>
+            <tr><td>Adjusted Continuing EPS</td><td>$4.31</td><td>$3.88</td><td>11%</td></tr>
+          </table>
+          <h2>Company Raises Full-Year 2026 Guidance</h2>
+          <p>The Company expects full-year 2026 reported revenue growth of approximately 11.5 percent and organic revenue growth of approximately 9 percent versus full-year 2025.</p>
+          <p>The Company expects GAAP continuing EPS for full-year 2026 of approximately $15.00 to $15.10, including $0.20 for non-GAAP adjustments. The Company expects adjusted continuing EPS for full-year 2026 of $15.20 to $15.30.</p>
+          <p>($ in millions)</p>
+          <table>
+            <tr><td>Net earnings</td><td>935.3</td><td>878.9</td></tr>
+          </table>
+        </body>
+      </html>
+    `);
+    const event: EarningsEvent = {
+      ticker: "TT",
+      when: "before_open",
+      date: "2026-07-30",
+      importance: 1,
+      epsConsensus: "$4.27",
+    };
+    const metrics = getMessageMetrics(parsedDocument.metrics, {
+      consensusEps: 4.27,
+    }, event);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: "adjusted_eps",
+        estimate: "$4.27",
+        numericValue: 4.31,
+        outcome: "beat",
+        value: "$4.31",
+      }),
+      expect.objectContaining({
+        key: "gaap_eps",
+        numericValue: 4.2,
+        value: "$4.20",
+      }),
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 6_354_000_000,
+        value: "$6.35B",
+      }),
+      expect.objectContaining({
+        key: "net_income",
+        numericValue: 935_300_000,
+        value: "$935.3M",
+      }),
+    ]));
+    expect(metrics.find(metric => "gaap_eps" === metric.key)).not.toHaveProperty("estimate");
+    expect(parsedDocument.outlook).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        value: "11.5% growth",
+      },
+      {
+        key: "adjusted_eps",
+        label: "Adj EPS",
+        value: "$15.2 to $15.3",
+      },
+      {
+        key: "eps",
+        label: "EPS",
+        value: "$15 to $15.1",
+      },
+    ]);
+  });
+
   test("parses cents-denominated EPS as dollars per share", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -74,7 +74,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
     key: "adjusted_eps",
     label: "Adj EPS",
     patterns: [
-      /\badjusted\s+(?:\d{1,2}\s+)?(?:diluted\s+)?(?:earnings\s+per\s+(?:common\s+)?share|eps)\b/i,
+      /\badjusted\s+(?:\d{1,2}\s+)?(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?(?:earnings\s+per\s+(?:common\s+)?share|eps)\b/i,
       /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?eps\b/i,
       /\bnon-gaap\s+(?:diluted\s+)?(?:earnings\s+per\s+share|eps)\b/i,
     ],
@@ -89,7 +89,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\bgaap\s+(?:diluted\s+)?eps\b/i,
       /\beps\b/i,
     ],
-    skipPattern: /\badjusted\b|\bnon-gaap\b|\bguidance\b|\boutlook\b|\bforecast\b/i,
+    skipPattern: /\badjusted\b|\bnon-gaap\b|\bguidance\b|\boutlook\b|\bforecast\b|\bexcept\s+(?:eps|per\s+share(?:\s+amounts?)?)\b/i,
     valueType: "eps",
   },
   {
@@ -640,6 +640,7 @@ function isQuarterSpecificSectionLine(line: string): boolean {
 
 function isQuarterSpecificSectionBoundary(line: string): boolean {
   return /^\s*(?:outlook|guidance|financial\s+outlook|business\s+outlook|use\s+of\s+non-gaap|forward-looking|supplemental\s+financial\s+information)\b/i.test(line) ||
+    /^\s*(?:the\s+)?company\s+(?:raises?|updates?|reaffirms?|provides?|issues?)\b.*\b(?:guidance|outlook)\b/i.test(line) ||
     /^\s*(?:fiscal\s+year|FY|FYE)\s*(?:20\d{2}|\d{2})\b/i.test(line) ||
     /^\s*for\s+fiscal\s+year\s+(?:20\d{2}|\d{2})\s*:?$/i.test(line);
 }
@@ -1005,7 +1006,7 @@ function getMoneyScaleFromContextText(text: string): number | null {
   // the unit, and that figure belongs to one line, not the whole table. Treating
   // inline magnitudes as a table scale mis-scales unrelated rows.
   const declarationMatch =
-    /(?:\bin\s+|[$€£¥]\s*)(thousand|million|billion)s?\b/i.exec(text) ??
+    /(?:\bin\s+|[$€£¥]\s*,?\s*)(thousand|million|billion)s?\b/i.exec(text) ??
     /\b(thousand|million|billion)s?\s+of\s+dollars\b/i.exec(text) ??
     /\(\s*(thousand|million|billion)s?\b/i.exec(text);
   const unit = declarationMatch?.[1]?.toLowerCase();

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -304,6 +304,30 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  test("extracts Trane-style full-year growth and continuing EPS guidance", () => {
+    expect(extractOutlookMetrics([
+      "Company Raises Full-Year 2026 Guidance",
+      "The Company expects full-year 2026 reported revenue growth of approximately 11.5 percent and organic revenue growth of approximately 9 percent versus full-year 2025.",
+      "The Company expects GAAP continuing EPS for full-year 2026 of approximately $15.00 to $15.10, including $0.20 for non-GAAP adjustments. The Company expects adjusted continuing EPS for full-year 2026 of $15.20 to $15.30.",
+    ])).toEqual([
+      {
+        key: "revenue",
+        label: "Revenue",
+        value: "11.5% growth",
+      },
+      {
+        key: "adjusted_eps",
+        label: "Adj EPS",
+        value: "$15.2 to $15.3",
+      },
+      {
+        key: "eps",
+        label: "EPS",
+        value: "$15 to $15.1",
+      },
+    ]);
+  });
+
   test("limits outlook scanning and ignores unusable fallback values", () => {
     const lines = [
       "Business Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -42,9 +42,22 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
     valueType: "text",
   },
   {
+    key: "adjusted_eps",
+    label: "Adj EPS",
+    patterns: [
+      /\badjusted\s+continuing(?:\s+operations?)?\s+(?:diluted\s+)?eps\b/i,
+      /\badjusted\s+continuing(?:\s+operations?)?\s+earnings\s+per\s+(?:common\s+)?share\b/i,
+    ],
+    valueType: "eps",
+  },
+  {
     key: "eps",
     label: "EPS",
-    patterns: [/\b(?:diluted\s+)?eps\b/i, /\bearnings\s+per\s+(?:common\s+)?share\b/i],
+    patterns: [
+      /\bgaap\s+(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b/i,
+      /\b(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b/i,
+      /\bearnings\s+per\s+(?:common\s+)?share\b/i,
+    ],
     valueType: "eps",
   },
   {
@@ -177,6 +190,7 @@ function isOutlookHeading(line: string): boolean {
     .trim();
 
   return /^(?:business\s+|financial\s+)?(?:outlook|guidance)\b/i.test(normalizedLine) ||
+    /^(?:the\s+)?company\s+(?:raises?|updates?|reaffirms?|provides?|issues?)\b.*\b(?:outlook|guidance)\b/i.test(normalizedLine) ||
     /^(?:(?:fiscal\s+)?(?:20\d{2}|fy\s?\d{2}|q[1-4]\s+20\d{2}|quarter)|(?:first|second|third|fourth)[\s–—-]+quarter)\b.*\b(?:outlook|guidance)\b/i.test(normalizedLine);
 }
 
@@ -196,7 +210,12 @@ function isOutlookSectionEnd(line: string): boolean {
     return true;
   }
 
-  if (/\b(?:conference\s+call|about\s+|press\s+contact|investor\s+relations|condensed\s+consolidated|financial\s+statements?|non-gaap|reconciliation)\b/i.test(line)) {
+  if (/\b(?:conference\s+call|about\s+|press\s+contact|investor\s+relations|condensed\s+consolidated|financial\s+statements?)\b/i.test(line)) {
+    return true;
+  }
+
+  if (line.length <= 140 &&
+      /^\s*(?:use\s+of\s+)?(?:non-gaap|reconciliation)\b/i.test(line)) {
     return true;
   }
 
@@ -328,6 +347,7 @@ function extractOutlookValue(
       getOutlookRangeValue(valueText, valueType) ??
       ("eps" === valueType ? getEpsPercentOutlookValue(valueText) : null) ??
       ("text" === valueType ? getSingleOutlookValue(valueText, "money") : null) ??
+      ("text" === valueType ? getNumericGrowthOutlookValue(valueText) : null) ??
       getSingleOutlookValue(valueText, valueType);
     if (null !== value) {
       return value;
@@ -343,7 +363,7 @@ function getOutlookValueSegments(line: string, patternMatch: RegExpExecArray | n
   }
 
   const rawValueText = line.slice(patternMatch.index + patternMatch[0].length);
-  const nextMetricMatch = /\b(?:adjusted\s+eps|diluted\s+eps|eps|earnings\s+per\s+(?:common\s+)?share|revenues?|net\s+sales|sales|gross\s+margin|operating\s+margin|operating\s+income|operating\s+expenses?|opex|tax\s+rate|capex|capital\s+expenditures?|free\s+cash\s+flow|dcf\s+per\s+share|distributable\s+cash\s+flow\s+per\s+share|adjusted\s+ebitda|ebitda)\b/i.exec(rawValueText);
+  const nextMetricMatch = /\b(?:adjusted\s+(?:continuing\s+)?eps|gaap\s+(?:continuing\s+)?eps|diluted\s+eps|eps|earnings\s+per\s+(?:common\s+)?share|revenues?|net\s+sales|sales|gross\s+margin|operating\s+margin|operating\s+income|operating\s+expenses?|opex|tax\s+rate|capex|capital\s+expenditures?|free\s+cash\s+flow|dcf\s+per\s+share|distributable\s+cash\s+flow\s+per\s+share|adjusted\s+ebitda|ebitda)\b/i.exec(rawValueText);
   const endIndex = nextMetricMatch?.index ?? rawValueText.length;
   const previousValueText = getPreviousOutlookValueSegment(line, patternMatch.index);
   return [
@@ -386,6 +406,15 @@ function getGrowthOutlookValue(value: string): string | null {
 
 function getGrowthDirection(value: string): "growth" | "decline" {
   return /\bdecline|decrease|down\b/i.test(value) ? "decline" : "growth";
+}
+
+function getNumericGrowthOutlookValue(value: string): string | null {
+  const percentMatch = /(-?\d+(?:\.\d+)?)\s*(?:%|percent)\b/i.exec(value);
+  if (undefined === percentMatch?.[1]) {
+    return null;
+  }
+
+  return `${formatPercent(Number.parseFloat(percentMatch[1]))} ${getGrowthDirection(value)}`;
 }
 
 function getOutlookRangeValue(value: string, valueType: OutlookValueType): string | null {


### PR DESCRIPTION
## Summary
- recognize adjusted continuing EPS and prevent quarter headers from becoming EPS values
- support comma-separated table scale declarations such as dollar-comma-millions
- recognize company guidance headings and retain non-GAAP text inside guidance sentences
- extract reported revenue growth plus GAAP and adjusted continuing EPS outlook
- add Trane live-shape result and outlook regressions

## Validation
- npm run test:coverage -- --exclude .claude/worktrees/** (782 tests passed)
- npm run typecheck
- npm run lint
- replayed the live Trane SEC exhibit through the parser