### PR TITLE
Fix quarter-aware earnings parsing

### DIFF
--- a/modules/earnings-results-format-regressions.test.ts
+++ b/modules/earnings-results-format-regressions.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, test} from "vitest";
+import {parseEarningsDocument} from "./earnings-results-format.ts";
+
+describe("earnings result filing regressions", () => {
+  test("uses Chevron current-quarter narrative values instead of footnotes and YTD table columns", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Chevron Reports Second Quarter 2026 Results</h1>
+          <p>Chevron Corporation reported earnings of $12.1 billion ($6.11 per share - diluted) for second quarter 2026. Adjusted earnings were $12.0 billion ($6.06 per share - diluted) for second quarter 2026.</p>
+          <p>Financial information is presented in millions of dollars, except per-share amounts.</p>
+          <p>2Q 2026 | 1Q 2026 | 2Q 2025 | YTD 2026 | YTD 2025</p>
+          <p>Adjusted Earnings Per Share - Diluted (1)</p>
+          <p>6.06 | 1.41 | 1.77 | 7.46 | 3.95</p>
+          <p>Earnings Per Common Share | Basic | 6.18 | 1.14 | 1.48 | 7.29 | 3.50 | Diluted | 6.11 | 1.11 | 1.45 | 7.21 | 3.45</p>
+          <p>Sales and Other Operating Revenues | 67,199 | 44,375 | 47,728 | 114,755 | 90,476</p>
+          <p>Net Income | 12,214 | 2,515 | 2,498 | 14,507 | 6,027</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", numericValue: 6.06, value: "$6.06"}),
+      expect.objectContaining({key: "gaap_eps", numericValue: 6.11, value: "$6.11"}),
+      expect.objectContaining({key: "revenue", numericValue: 67_199_000_000, value: "$67.2B"}),
+      expect.objectContaining({key: "net_income", numericValue: 12_214_000_000, value: "$12.21B"}),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("-$1.00");
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$3.45");
+  });
+
+  test("keeps Exxon operating volumes out of revenue and binds production to its table row", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExxonMobil Announces Second-Quarter 2026 Results</h1>
+          <p>Financial information is presented in millions of dollars, except per-share amounts.</p>
+          <p>2Q26</p><p>1Q26</p><p>Change vs 1Q26</p><p>YTD 2026</p><p>YTD 2025</p>
+          <p>3.48</p><p>| 1.00</p><p>| +2.48</p>
+          <p>| Earnings Per Common Share (U.S. GAAP)</p>
+          <p>| 4.47</p><p>| 3.40</p><p>| +1.07</p>
+          <p>5,698</p><p>| 5,630</p>
+          <p>| Energy Products Sales (kbd)</p>
+          <p>| 5,664</p><p>| 5,436</p>
+          <p>Production highlights included a fifth Guyana FPSO startup on plan for 4Q26, increasing capacity by 250 Kbd.</p>
+          <p>4,514</p><p>| 4,594</p>
+          <p>| Production (koebd)</p>
+          <p>| 4,554</p><p>| 4,591</p>
+          <p>Proceeds from asset sales and returns of investments | 734 | 339 | 430 | 219</p>
+          <p>Second-quarter earnings were $14.5 billion, or $3.48 per share. Adjusted earnings were $14.7 billion, or $3.52 per share.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", numericValue: 3.52, value: "$3.52"}),
+      expect.objectContaining({key: "gaap_eps", numericValue: 3.48, value: "$3.48"}),
+      expect.objectContaining({key: "production", numericValue: 4514, value: "4,514 koebd"}),
+    ]));
+    expect(parsedDocument.metrics.find(metric => "revenue" === metric.key)).toBeUndefined();
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$4.47");
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("4 Kbd");
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("250 Kbd");
+  });
+});

--- a/modules/earnings-results-format-regressions.test.ts
+++ b/modules/earnings-results-format-regressions.test.ts
@@ -64,4 +64,46 @@ describe("earnings result filing regressions", () => {
     expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("4 Kbd");
     expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("250 Kbd");
   });
+
+  test("uses Enbridge reported Canadian-dollar EPS levels instead of prior-year values or changes", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Enbridge Reports Strong Second Quarter Results and Reaffirms 2026 Guidance</h1>
+          <p>All financial figures are unaudited and in Canadian dollars unless otherwise noted.</p>
+          <p>Second quarter GAAP earnings attributable to common shareholders of $1.4 billion or $0.64 per common share, compared with GAAP earnings attributable to common shareholders of $2.2 billion or $1.00 per common share in 2025.</p>
+          <p>Adjusted earnings of $1.4 billion or $0.63 per common share, compared with $1.4 billion or $0.65 per common share in 2025.</p>
+          <p>GAAP earnings attributable to common shareholders for the second quarter of 2026 decreased by $0.8 billion, or $0.36 per share, compared with the same period in 2025.</p>
+          <p>Adjusted earnings in the second quarter of 2026 decreased by $36 million, or $0.02 per share, compared with the same period in 2025.</p>
+          <h2>Financial Outlook</h2>
+          <p>The Company reaffirms its 2026 financial guidance for adjusted EBITDA between $20.2 billion and $20.8 billion and DCF per share between $5.70 and $6.10.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        currencyCode: "CAD",
+        key: "adjusted_eps",
+        numericValue: 0.63,
+        value: "C$0.63",
+      }),
+      expect.objectContaining({
+        currencyCode: "CAD",
+        key: "gaap_eps",
+        numericValue: 0.64,
+        value: "C$0.64",
+      }),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toEqual(expect.arrayContaining([
+      "C$0.02",
+      "C$0.36",
+      "C$1.00",
+    ]));
+    expect(parsedDocument.outlook).toEqual([
+      {key: "adjusted_ebitda", label: "Adj EBITDA", value: "C$20.2B to C$20.8B"},
+      {key: "dcf_per_share", label: "DCF/share", value: "C$5.7 to C$6.1"},
+    ]);
+  });
 });

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -1,0 +1,133 @@
+type MetricValueType = "eps" | "money" | "number";
+
+export function hasGaapNarrativeBeforeAdjustment(line: string, patterns: RegExp[]): boolean {
+  const adjustedIndex = line.search(/\badjusted\b/i);
+  const gaapText = -1 === adjustedIndex ? line : line.slice(0, adjustedIndex);
+  return patterns.some(pattern => {
+    pattern.lastIndex = 0;
+    return undefined !== pattern.exec(gaapText)?.groups?.["metricValue"];
+  });
+}
+
+export function getMetricCandidateScore({
+  lines,
+  lineIndex,
+  metricLine,
+  pattern,
+  quarterLabel,
+  valueType,
+}: {
+  lines: string[];
+  lineIndex: number;
+  metricLine: string;
+  pattern: RegExp;
+  quarterLabel: string | undefined;
+  valueType: MetricValueType;
+}): number {
+  pattern.lastIndex = 0;
+  const patternMatch = pattern.exec(metricLine);
+  let score = undefined === patternMatch?.groups?.["metricValue"] ? 0 : 80;
+  const nearbyContext = lines
+    .slice(Math.max(0, lineIndex - 2), lineIndex + 1)
+    .join(" ");
+
+  if (undefined !== quarterLabel) {
+    score += getCurrentQuarterTextScore(metricLine, quarterLabel);
+    score += Math.floor(getCurrentQuarterTextScore(nearbyContext, quarterLabel) / 2);
+  }
+
+  if (/\b(?:YTD|year[-\s]to[-\s]date|six\s+months|nine\s+months|full\s+year|annual)\b/i.test(metricLine)) {
+    score -= 60;
+  }
+
+  const pipeCount = metricLine.match(/\|/g)?.length ?? 0;
+  score -= Math.min(30, pipeCount * 2);
+  if (("eps" === valueType || "money" === valueType) && /[$€£¥]/.test(metricLine)) {
+    score += 10;
+  }
+
+  if ("eps" === valueType && /\bper\s+(?:common\s+)?(?:diluted\s+)?share\b/i.test(metricLine)) {
+    score += 10;
+  }
+
+  return score;
+}
+
+export function getPositionedQuarterValues(
+  lines: string[],
+  lineIndex: number,
+  quarterLabel: string | undefined,
+): string[] {
+  if (undefined === quarterLabel ||
+      false === isPositionedValueLine(lines[lineIndex - 1] ?? "") ||
+      false === isPositionedValueLine(lines[lineIndex + 1] ?? "") ||
+      false === hasPositionedPeriodHeaders(lines, lineIndex, quarterLabel)) {
+    return [];
+  }
+
+  const precedingValues: string[] = [];
+  for (let index = lineIndex - 1; index >= 0 && index >= lineIndex - 8; index--) {
+    const line = lines[index];
+    if (undefined === line || false === isPositionedValueLine(line)) {
+      break;
+    }
+
+    precedingValues.unshift(line);
+  }
+
+  const numericValues = precedingValues.filter(line => /\d/.test(line));
+  return 2 <= numericValues.length ? numericValues : [];
+}
+
+export function isEmbeddedAlphaNumericValue(
+  text: string,
+  startIndex: number,
+  endIndex: number,
+): boolean {
+  const characterBefore = text.slice(Math.max(0, startIndex - 1), startIndex);
+  const token = text.slice(startIndex, endIndex);
+  if (/[A-Za-z]/.test(characterBefore) && false === /^[$€£¥]/.test(token)) {
+    return true;
+  }
+
+  const textAfter = text.slice(endIndex, endIndex + 12);
+  return /^[A-Za-z]/.test(textAfter) && false === /^(?:cents?|[kmbt])\b/i.test(textAfter);
+}
+
+function getCurrentQuarterTextScore(text: string, quarterLabel: string): number {
+  const quarterMatch = /^(Q[1-4])\s+(20\d{2})$/.exec(quarterLabel);
+  if (undefined === quarterMatch?.[1] || undefined === quarterMatch[2]) {
+    return 0;
+  }
+
+  const quarterNumber = quarterMatch[1].slice(1);
+  const quarterName = ["", "first", "second", "third", "fourth"][Number.parseInt(quarterNumber, 10)] ?? "";
+  const hasQuarter = new RegExp(`\\b(?:Q${quarterNumber}|${quarterName})[\\s–—-]+quarter\\b`, "i").test(text) ||
+    new RegExp(`\\bQ${quarterNumber}\\b`, "i").test(text);
+  if (false === hasQuarter) {
+    return 0;
+  }
+
+  return new RegExp(`\\b${quarterMatch[2]}\\b`).test(text) ? 50 : 25;
+}
+
+function hasPositionedPeriodHeaders(
+  lines: string[],
+  lineIndex: number,
+  quarterLabel: string,
+): boolean {
+  const quarterMatch = /^Q([1-4])\s+(20\d{2})$/.exec(quarterLabel);
+  if (undefined === quarterMatch?.[1] || undefined === quarterMatch[2]) {
+    return false;
+  }
+
+  const yearSuffix = quarterMatch[2].slice(-2);
+  const context = lines.slice(Math.max(0, lineIndex - 240), lineIndex).join(" ");
+  return new RegExp(`\\b(?:Q${quarterMatch[1]}|${quarterMatch[1]}Q)\\s*${yearSuffix}\\b`, "i").test(context) &&
+    /\bYTD\b/i.test(context) &&
+    /\bchange\b/i.test(context);
+}
+
+function isPositionedValueLine(line: string): boolean {
+  return /^[\s|$€£¥(),.+\-\d%—–]+$/.test(line);
+}

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -40,6 +40,11 @@ export function getMetricCandidateScore({
     score -= 60;
   }
 
+  if (/\b(?:increase|decrease|improvement|decline|change)(?:d)?\s+(?:by|of)\b/i.test(metricLine) ||
+      /\b(?:rose|fell|grew|up|down)\s+by\b/i.test(metricLine)) {
+    score -= 140;
+  }
+
   const pipeCount = metricLine.match(/\|/g)?.length ?? 0;
   score -= Math.min(30, pipeCount * 2);
   if (("eps" === valueType || "money" === valueType) && /[$€£¥]/.test(metricLine)) {

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -361,8 +361,9 @@ describe("earnings result formatting", () => {
     expect(parsedDocument.quarterLabel).toBe("Q1 2026");
     expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
       expect.objectContaining({
+        currencyCode: "CAD",
         key: "gaap_eps",
-        value: "$0.77",
+        value: "C$0.77",
       }),
     ]));
     expect(parsedDocument.metrics).not.toEqual(expect.arrayContaining([
@@ -374,12 +375,12 @@ describe("earnings result formatting", () => {
       {
         key: "adjusted_ebitda",
         label: "Adj EBITDA",
-        value: "$20.2B to $20.8B",
+        value: "C$20.2B to C$20.8B",
       },
       {
         key: "dcf_per_share",
         label: "DCF/share",
-        value: "$5.7 to $6.1",
+        value: "C$5.7 to C$6.1",
       },
     ]);
   });

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -1,6 +1,12 @@
 import moment from "moment-timezone";
 import {type EarningsEvent} from "./earnings.ts";
 import {
+  getMetricCandidateScore,
+  getPositionedQuarterValues,
+  hasGaapNarrativeBeforeAdjustment,
+  isEmbeddedAlphaNumericValue,
+} from "./earnings-results-format-selection.ts";
+import {
   extractOutlookMetrics,
   type EarningsOutlookMetric,
 } from "./earnings-results-outlook.ts";
@@ -74,6 +80,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
     key: "adjusted_eps",
     label: "Adj EPS",
     patterns: [
+      /\badjusted\b(?:(?![.!?]\s)[^!?\n]){0,180}?(?<metricValue>-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share(?:\s*[-–—]\s*diluted)?\b/i,
       /\badjusted\s+(?:\d{1,2}\s+)?(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?(?:earnings\s+per\s+(?:common\s+)?share|eps)\b/i,
       /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?eps\b/i,
       /\bnon-gaap\s+(?:diluted\s+)?(?:earnings\s+per\s+share|eps)\b/i,
@@ -87,6 +94,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\b(?:diluted\s+)?(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\b/i,
       /\bdiluted\s+eps\b/i,
       /\bgaap\s+(?:diluted\s+)?eps\b/i,
+      /\b(?:reported\s+)?(?:net\s+)?earnings?\b(?:(?![.!?]\s)[^!?\n]){0,180}?(?<metricValue>-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share(?:\s*[-–—]\s*diluted)?\b/i,
       /(?<metricValue>\(?-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?(?:\s*(?:cents?|¢))?)\s+per\s+(?:fully\s+)?(?:common\s+)?diluted\s+share\b/i,
       /\beps\b/i,
     ],
@@ -102,7 +110,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\brevenues?\b/i,
       /\bsales\b/i,
     ],
-    skipPattern: /\bcost\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\bannuali[sz]ed\s+(?:revenue\s+)?run[-\s]*rate\b|\brevenue\s+run[-\s]*rate\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b|\bnot\s+recognized\s+in\s+revenue\b|\bnon-cash\s+revenues?\b|\bsales\s+volumes?\b|\b(?:external\s+power|pipeline\s+gas|hydrocarbon)\s+sales\b|\bsales\s+of\s+pipeline\s+gas\b/i,
+    skipPattern: /\bcost\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\bannuali[sz]ed\s+(?:revenue\s+)?run[-\s]*rate\b|\brevenue\s+run[-\s]*rate\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b|\bnot\s+recognized\s+in\s+revenue\b|\bnon-cash\s+revenues?\b|\bsales\s+volumes?\b|\b(?:external\s+power|pipeline\s+gas|hydrocarbon|asset)\s+sales\b|\bproceeds\s+from\b|\bsales\s+of\s+pipeline\s+gas\b|\b(?:kbd|koebd|boepd|bpd|mboed|mmboe|bcfe|mmcf|mw|gw|kt)\b/i,
     valueType: "money",
   },
   {
@@ -132,6 +140,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
     patterns: [
       /\bproduction\b/i,
     ],
+    skipPattern: /\b(?:capacity|startup|on\s+plan|guidance|outlook|forecast)\b/i,
     valueType: "number",
   },
 ];
@@ -627,10 +636,15 @@ function extractMetric(
   definition: MetricDefinition,
   quarterLabel: string | undefined,
 ): EarningsResultMetric | null {
+  let bestCandidate: {metric: EarningsResultMetric; score: number} | null = null;
   for (const [lineIndex, line] of lines.entries()) {
     const hasExplicitGaapEps = "gaap_eps" === definition.key &&
       /\bgaap\s+(?:diluted\s+)?eps\b/i.test(line);
-    if (definition.skipPattern?.test(line) && false === hasExplicitGaapEps) {
+    const hasReportedGaapEps = "gaap_eps" === definition.key &&
+      true === hasGaapNarrativeBeforeAdjustment(line, definition.patterns);
+    if (definition.skipPattern?.test(line) &&
+        false === hasExplicitGaapEps &&
+        false === hasReportedGaapEps) {
       continue;
     }
 
@@ -638,7 +652,12 @@ function extractMetric(
       continue;
     }
 
-    const metricLine = getMetricLineWithContinuation(lines, lineIndex, definition);
+    const hasMetricLabel = definition.patterns.some(pattern => pattern.test(line));
+    if (false === hasMetricLabel) {
+      continue;
+    }
+
+    const metricLine = getMetricLineWithContinuation(lines, lineIndex, definition, quarterLabel);
     const pattern = definition.patterns.find(candidatePattern => candidatePattern.test(metricLine));
     if (!pattern) {
       continue;
@@ -669,10 +688,20 @@ function extractMetric(
       value: metricLine,
       writable: false,
     });
-    return metric;
+    const score = getMetricCandidateScore({
+      lines,
+      lineIndex,
+      metricLine,
+      pattern,
+      quarterLabel,
+      valueType: definition.valueType,
+    });
+    if (null === bestCandidate || score > bestCandidate.score) {
+      bestCandidate = {metric, score};
+    }
   }
 
-  return null;
+  return bestCandidate?.metric ?? null;
 }
 
 function isPerShareOnlyNetIncomeLine(line: string): boolean {
@@ -687,8 +716,18 @@ function getMetricLineWithContinuation(
   lines: string[],
   lineIndex: number,
   definition: MetricDefinition,
+  quarterLabel: string | undefined,
 ): string {
   const baseLine = lines[lineIndex] ?? "";
+  const positionedQuarterValues = getPositionedQuarterValues(
+    lines,
+    lineIndex,
+    quarterLabel,
+  );
+  if (0 < positionedQuarterValues.length) {
+    return [baseLine, ...positionedQuarterValues].join(" ");
+  }
+
   const metricLines = [baseLine];
   const isSummaryHeading = isSummaryMetricHeading(baseLine, definition);
   for (let index = lineIndex + 1; index < lines.length && index <= lineIndex + 6; index++) {
@@ -912,6 +951,11 @@ function findEpsValue(text: string): number | null {
 }
 
 function findPerShareTableValue(text: string): number | null {
+  const hasTableSegments = /\bBasic\b/i.test(text) || 2 <= (text.match(/\|/g)?.length ?? 0);
+  if (false === hasTableSegments) {
+    return null;
+  }
+
   return getLastPerShareSegmentValue(text, "Diluted") ?? getLastPerShareSegmentValue(text, "Basic");
 }
 
@@ -1116,6 +1160,10 @@ function findNumericValueMatches(
   for (const numberMatch of numberMatches) {
     const token = numberMatch[0];
     const endIndex = numberMatch.index + token.length;
+    if (true === isEmbeddedAlphaNumericValue(text, numberMatch.index, endIndex)) {
+      continue;
+    }
+
     if (true === options.skipPercentages && "%" === text.slice(endIndex, endIndex + 1)) {
       continue;
     }

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -148,12 +148,22 @@ export function parseEarningsDocument(html: string): ParsedEarningsDocument {
   const text = htmlToText(html);
   const lines = getMeaningfulLines(text);
   const quarterLabel = getQuarterLabel(text);
+  const documentCurrencyCode = getDocumentCurrencyCode(lines);
   return {
     headline: getDocumentHeadline(lines),
-    metrics: extractEarningsMetrics(lines, quarterLabel),
-    outlook: extractOutlookMetrics(lines),
+    metrics: extractEarningsMetrics(lines, quarterLabel, documentCurrencyCode),
+    outlook: extractOutlookMetrics(lines, documentCurrencyCode),
     quarterLabel,
   };
+}
+
+function getDocumentCurrencyCode(lines: string[]): string | undefined {
+  const currencyDeclaration = lines
+    .slice(0, 60)
+    .find(line => /\b(?:Canadian|New Taiwan|U\.S\.)\s+dollars?\b|\b(?:CAD|TWD|NTD|USD|EUR|GBP|JPY)\b|NT\s*\$/i.test(line));
+  return undefined === currencyDeclaration
+    ? undefined
+    : getCurrencyCodeFromText(currencyDeclaration);
 }
 
 export function getMessageMetrics(
@@ -544,6 +554,7 @@ function getQuarterFromName(name: string): string | undefined {
 function extractEarningsMetrics(
   lines: string[],
   quarterLabel: string | undefined,
+  documentCurrencyCode: string | undefined,
 ): EarningsResultMetric[] {
   const metrics: EarningsResultMetric[] = [];
   const seenKeys = new Set<string>();
@@ -554,10 +565,15 @@ function extractEarningsMetrics(
       continue;
     }
 
-    const preferredMetric = extractMetric(preferredSelection.lines, definition, quarterLabel);
+    const preferredMetric = extractMetric(
+      preferredSelection.lines,
+      definition,
+      quarterLabel,
+      documentCurrencyCode,
+    );
     const metric = preferredMetric ?? (true === preferredSelection.exclusive
       ? null
-      : extractMetric(lines, definition, quarterLabel));
+      : extractMetric(lines, definition, quarterLabel, documentCurrencyCode));
     if (null === metric) {
       continue;
     }
@@ -635,6 +651,7 @@ function extractMetric(
   lines: string[],
   definition: MetricDefinition,
   quarterLabel: string | undefined,
+  documentCurrencyCode: string | undefined,
 ): EarningsResultMetric | null {
   let bestCandidate: {metric: EarningsResultMetric; score: number} | null = null;
   for (const [lineIndex, line] of lines.entries()) {
@@ -667,7 +684,7 @@ function extractMetric(
       metricLine,
       pattern,
       definition.valueType,
-      getContextMoney(lines, lineIndex),
+      getContextMoney(lines, lineIndex, documentCurrencyCode),
       isNearTableNoteColumn(lines, lineIndex),
       undefined !== quarterLabel && hasMixedMonthQuarterColumns(lines, lineIndex),
     );
@@ -835,7 +852,7 @@ function extractMetricValue(
     const metricText = null === perShareTableValue && null === preferredValue
       ? fallbackSearchText
       : preferredSearchText;
-    const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
+    const currencyCode = getCurrencyCodeFromText(metricText, contextMoney.currencyCode) ?? contextMoney.currencyCode;
     return {
       currencyCode,
       numericValue: value,
@@ -869,7 +886,7 @@ function extractMetricValue(
 
     const metricText = true === useFallbackValue ? fallbackSearchText : sentenceSearchText;
     const explicitScale = getExplicitMoneyScale(metricText, parsedValueMatch.endIndex);
-    const currencyCode = getCurrencyCodeFromText(metricText) ?? contextMoney.currencyCode;
+    const currencyCode = getCurrencyCodeFromText(metricText, contextMoney.currencyCode) ?? contextMoney.currencyCode;
     const amount = parsedValueMatch.value * (explicitScale ?? contextMoney.scale);
     const maximumFractionDigits = getMoneyDisplayPrecision(
       metricText,
@@ -974,8 +991,12 @@ function getLastPerShareSegmentValue(text: string, label: "Basic" | "Diluted"): 
   return values[values.length - 1] ?? null;
 }
 
-function getContextMoney(lines: string[], lineIndex: number): MoneyContext {
-  let currencyCode: string | undefined;
+function getContextMoney(
+  lines: string[],
+  lineIndex: number,
+  documentCurrencyCode: string | undefined,
+): MoneyContext {
+  let currencyCode = documentCurrencyCode;
   // Scan upward for the nearest "in millions / $ in thousands / ..." declaration
   // governing this row. Income statements interleave many empty separator rows
   // ("| |") between the unit header and the figures, so the lookback budget is
@@ -989,7 +1010,7 @@ function getContextMoney(lines: string[], lineIndex: number): MoneyContext {
       continue;
     }
 
-    currencyCode ??= getCurrencyCodeFromText(line);
+    currencyCode = getCurrencyCodeFromText(line, currencyCode) ?? currencyCode;
     const scale = getMoneyScaleFromContextText(line);
     if (null !== scale) {
       return {
@@ -1055,9 +1076,16 @@ function getMoneyScaleFromContextText(text: string): number | null {
   return null;
 }
 
-function getCurrencyCodeFromText(text: string): string | undefined {
+function getCurrencyCodeFromText(
+  text: string,
+  dollarCurrencyCode = "USD",
+): string | undefined {
   if (/NT\s*\$|\b(?:TWD|NTD)\b|\bNew Taiwan dollars?\b/i.test(text)) {
     return "TWD";
+  }
+
+  if (/(?:^|[^A-Za-z])C\s*\$/.test(text) || /\bCAD\b|\bCanadian dollars?\b/i.test(text)) {
+    return "CAD";
   }
 
   if (text.includes("€") || /\bEUR\b/i.test(text)) {
@@ -1072,8 +1100,12 @@ function getCurrencyCodeFromText(text: string): string | undefined {
     return "JPY";
   }
 
-  if (text.includes("$") || /\bUSD\b/i.test(text) || /\bdollars?\b/i.test(text)) {
+  if (/US\s*\$|\bUSD\b|\bU\.S\. dollars?\b/i.test(text)) {
     return "USD";
+  }
+
+  if (text.includes("$")) {
+    return dollarCurrencyCode;
   }
 
   return undefined;
@@ -1283,6 +1315,7 @@ export function parseNumber(value: unknown): number | null {
     .replace(/^\((.*)\)$/, "-$1")
     .replace(/^\((.*)$/, "-$1")
     .replace(/NT\s*\$/gi, "")
+    .replace(/C\s*\$/gi, "")
     .replace(/[$€£¥]/g, "")
     .replaceAll(",", "")
     .replaceAll("%", "")
@@ -1341,6 +1374,10 @@ export function formatMoneyCompact(
 function getCurrencySymbol(currencyCode: string): string {
   if ("TWD" === currencyCode) {
     return "NT$";
+  }
+
+  if ("CAD" === currencyCode) {
+    return "C$";
   }
 
   if ("EUR" === currencyCode) {

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -32,7 +32,7 @@ type OutlookSection = {
   mixedPeriods: boolean;
 };
 
-const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:[$€£¥]\s*)|(?:(?:USD|EUR|GBP|JPY)\s+))?-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:(?:trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b)?\)?`;
+const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:C\s*\$|[$€£¥])\s*|(?:(?:USD|CAD|EUR|GBP|JPY)\s+))?-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:(?:trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b)?\)?`;
 const moneyRangePattern = new RegExp(`(${moneyTokenPatternSource})\\s*(?:to|through|-|–|and)\\s*(${moneyTokenPatternSource})`, "gi");
 const singleMoneyPattern = new RegExp(moneyTokenPatternSource, "gi");
 
@@ -118,7 +118,10 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
   },
 ];
 
-export function extractOutlookMetrics(lines: string[]): EarningsOutlookMetric[] {
+export function extractOutlookMetrics(
+  lines: string[],
+  documentCurrencyCode = "USD",
+): EarningsOutlookMetric[] {
   const section = getOutlookSection(lines);
   if (0 === section.lines.length) {
     return [];
@@ -132,6 +135,7 @@ export function extractOutlookMetrics(lines: string[]): EarningsOutlookMetric[] 
       definition,
       section.mixedPeriods,
       section.heading,
+      documentCurrencyCode,
     );
     if (null === metric || true === seenKeys.has(metric.key)) {
       continue;
@@ -251,6 +255,7 @@ function extractOutlookMetric(
   definition: OutlookMetricDefinition,
   includePeriodLabel: boolean,
   sectionHeading: string | undefined,
+  documentCurrencyCode: string,
 ): EarningsOutlookMetric | null {
   let bestCandidate: OutlookMetricCandidate | null = null;
   for (const line of lines) {
@@ -263,7 +268,12 @@ function extractOutlookMetric(
         continue;
       }
 
-      const value = extractOutlookValue(line, pattern, definition.valueType);
+      const value = extractOutlookValue(
+        line,
+        pattern,
+        definition.valueType,
+        documentCurrencyCode,
+      );
       if (null === value) {
         continue;
       }
@@ -355,6 +365,7 @@ function extractOutlookValue(
   line: string,
   pattern: RegExp,
   valueType: OutlookValueType,
+  documentCurrencyCode: string,
 ): string | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
@@ -365,11 +376,11 @@ function extractOutlookValue(
     }
 
     const value = getGrowthOutlookValue(valueText) ??
-      getOutlookRangeValue(valueText, valueType) ??
+      getOutlookRangeValue(valueText, valueType, documentCurrencyCode) ??
       ("eps" === valueType ? getEpsPercentOutlookValue(valueText) : null) ??
-      ("text" === valueType ? getSingleOutlookValue(valueText, "money") : null) ??
+      ("text" === valueType ? getSingleOutlookValue(valueText, "money", documentCurrencyCode) : null) ??
       ("text" === valueType ? getNumericGrowthOutlookValue(valueText) : null) ??
-      getSingleOutlookValue(valueText, valueType);
+      getSingleOutlookValue(valueText, valueType, documentCurrencyCode);
     if (null !== value) {
       return value;
     }
@@ -438,7 +449,11 @@ function getNumericGrowthOutlookValue(value: string): string | null {
   return `${formatPercent(Number.parseFloat(percentMatch[1]))} ${getGrowthDirection(value)}`;
 }
 
-function getOutlookRangeValue(value: string, valueType: OutlookValueType): string | null {
+function getOutlookRangeValue(
+  value: string,
+  valueType: OutlookValueType,
+  documentCurrencyCode: string,
+): string | null {
   if ("eps" === valueType) {
     const percentRangeValue = getPercentRangeOutlookValue(value);
     if (null !== percentRangeValue) {
@@ -464,7 +479,7 @@ function getOutlookRangeValue(value: string, valueType: OutlookValueType): strin
       const firstValue = parseNumber(firstRangeValue);
       const secondValue = parseNumber(secondRangeValue);
       if (null !== firstValue && null !== secondValue) {
-        return `${formatEps(firstValue)} to ${formatEps(secondValue)}`;
+        return `${formatEps(firstValue, documentCurrencyCode)} to ${formatEps(secondValue, documentCurrencyCode)}`;
       }
       continue;
     }
@@ -474,9 +489,10 @@ function getOutlookRangeValue(value: string, valueType: OutlookValueType): strin
     }
 
     const inferredUnit = getMoneyUnit(secondRangeValue) ?? getMoneyUnit(firstRangeValue);
-    const inferredCurrencyCode = getCurrencyCodeFromText(secondRangeValue) ??
-      getCurrencyCodeFromText(firstRangeValue) ??
-      getCurrencyCodeFromText(value);
+    const inferredCurrencyCode = getCurrencyCodeFromText(secondRangeValue, documentCurrencyCode) ??
+      getCurrencyCodeFromText(firstRangeValue, documentCurrencyCode) ??
+      getCurrencyCodeFromText(value, documentCurrencyCode) ??
+      documentCurrencyCode;
     const firstMoneyValue = parseMoneyWithOptionalUnit(firstRangeValue, inferredUnit, inferredCurrencyCode);
     const secondMoneyValue = parseMoneyWithOptionalUnit(secondRangeValue, inferredUnit, inferredCurrencyCode);
     if (null !== firstMoneyValue && null !== secondMoneyValue) {
@@ -487,7 +503,11 @@ function getOutlookRangeValue(value: string, valueType: OutlookValueType): strin
   return null;
 }
 
-function getSingleOutlookValue(value: string, valueType: OutlookValueType): string | null {
+function getSingleOutlookValue(
+  value: string,
+  valueType: OutlookValueType,
+  documentCurrencyCode: string,
+): string | null {
   if ("percent" === valueType) {
     const percentMatch = value.match(/-?\d+(?:\.\d+)?\s*%/);
     return percentMatch ? percentMatch[0].replace(/\s+/g, "") : null;
@@ -495,11 +515,11 @@ function getSingleOutlookValue(value: string, valueType: OutlookValueType): stri
 
   if ("eps" === valueType) {
     const epsValue = findNumericValue(value, {maxAbsValue: 100, skipPercentages: true});
-    return null === epsValue ? null : formatEps(epsValue);
+    return null === epsValue ? null : formatEps(epsValue, documentCurrencyCode);
   }
 
   if ("money" === valueType) {
-    const inferredCurrencyCode = getCurrencyCodeFromText(value);
+    const inferredCurrencyCode = getCurrencyCodeFromText(value, documentCurrencyCode) ?? documentCurrencyCode;
     for (const moneyMatch of value.matchAll(singleMoneyPattern)) {
       const token = moneyMatch[0];
       if (false === hasMoneyValueCue(token)) {
@@ -582,8 +602,9 @@ function parseNumber(value: unknown): number | null {
 
   const normalizedValue = value
     .replace(/^\((.*)\)$/, "-$1")
+    .replace(/C\s*\$/g, "")
     .replace(/[€£¥$]/g, "")
-    .replace(/\b(?:usd|eur|gbp|jpy)\b/gi, "")
+    .replace(/\b(?:usd|cad|eur|gbp|jpy)\b/gi, "")
     .replaceAll(",", "")
     .replaceAll("%", "")
     .trim()
@@ -608,7 +629,7 @@ function parseMoneyWithOptionalUnit(
   }
 
   const unit = getMoneyUnit(value) ?? inferredUnit;
-  const currencyCode = getCurrencyCodeFromText(value) ?? inferredCurrencyCode;
+  const currencyCode = getCurrencyCodeFromText(value, inferredCurrencyCode) ?? inferredCurrencyCode;
   let moneyValue = parsedValue;
   if (!unit) {
     return {
@@ -634,14 +655,21 @@ function parseMoneyWithOptionalUnit(
 }
 
 function hasMoneyValueCue(value: string): boolean {
-  return /[$€£¥]|\b(?:USD|EUR|GBP|JPY)\b/i.test(value) || undefined !== getMoneyUnit(value);
+  return /[$€£¥]|\b(?:USD|CAD|EUR|GBP|JPY)\b/i.test(value) || undefined !== getMoneyUnit(value);
 }
 
 function getMoneyUnit(value: string): string | undefined {
   return value.match(/(trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b/i)?.[1]?.toLowerCase();
 }
 
-function getCurrencyCodeFromText(text: string): string | undefined {
+function getCurrencyCodeFromText(
+  text: string,
+  dollarCurrencyCode = "USD",
+): string | undefined {
+  if (/(?:^|[^A-Za-z])C\s*\$/.test(text) || /\bCAD\b|\bCanadian dollars?\b/i.test(text)) {
+    return "CAD";
+  }
+
   if (text.includes("€") || /\bEUR\b/i.test(text)) {
     return "EUR";
   }
@@ -654,16 +682,20 @@ function getCurrencyCodeFromText(text: string): string | undefined {
     return "JPY";
   }
 
-  if (text.includes("$") || /\bUSD\b/i.test(text)) {
+  if (/US\s*\$|\bUSD\b|\bU\.S\. dollars?\b/i.test(text)) {
     return "USD";
+  }
+
+  if (text.includes("$")) {
+    return dollarCurrencyCode;
   }
 
   return undefined;
 }
 
-function formatEps(value: number): string {
+function formatEps(value: number, currencyCode: string): string {
   const sign = value < 0 ? "-" : "";
-  return `${sign}$${Math.abs(value).toFixed(2).replace(/\.?0+$/, "")}`;
+  return `${sign}${getCurrencySymbol(currencyCode)}${Math.abs(value).toFixed(2).replace(/\.?0+$/, "")}`;
 }
 
 function formatMoneyCompact(value: number, currencyCode: string): string {
@@ -690,6 +722,10 @@ function formatMoneyCompact(value: number, currencyCode: string): string {
 }
 
 function getCurrencySymbol(currencyCode: string): string {
+  if ("CAD" === currencyCode) {
+    return "C$";
+  }
+
   if ("EUR" === currencyCode) {
     return "€";
   }


### PR DESCRIPTION
## Summary
- rank explicit current-quarter evidence above flattened multi-period table rows
- reconstruct visually positioned quarter columns and reject operating-volume or asset-sale rows as revenue
- add Chevron and Exxon regression fixtures for EPS, revenue, net income, and production

## Validation
- npm run test:coverage (69 files, 785 tests)
- npm run typecheck
- npm run lint
- direct in-memory parsing of both complete SEC exhibits