### PR TITLE
Fix earnings metric selection against source filings

### DIFF
--- a/modules/earnings-results-format-regressions.test.ts
+++ b/modules/earnings-results-format-regressions.test.ts
@@ -106,4 +106,222 @@ describe("earnings result filing regressions", () => {
       {key: "dcf_per_share", label: "DCF/share", value: "C$5.7 to C$6.1"},
     ]);
   });
+
+  test("reads Vertex-style per-share rows from the quarter column, not the trailing prior-year YTD one", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Vertex Reports Second Quarter 2026 Financial Results</h1>
+          <p>Consolidated Statements of Income</p>
+          <p>(unaudited, in millions, except per share amounts)</p>
+          <p>Three Months Ended June 30, | Six Months Ended June 30,</p>
+          <p>2026 | 2025 | 2026 | 2025</p>
+          <p>Total revenues | 3,333.9 | 2,964.7 | 6,320.8 | 5,734.9</p>
+          <p>Net income | $ | 1,099.8 | $ | 1,032.9 | $ | 2,131.2 | $ | 1,679.2</p>
+          <p>Net income per common share:</p>
+          <p>Basic | $ | 4.34 | $ | 4.02 | $ | 8.39 | $ | 6.54</p>
+          <p>Diluted | $ | 4.31 | $ | 3.99 | $ | 8.33 | $ | 6.48</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q2 2026");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: 4.31, value: "$4.31"}),
+      expect.objectContaining({key: "revenue", numericValue: 3_333_900_000}),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$6.48");
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$4.34");
+  });
+
+  test("keeps Clorox fourth-quarter figures separate from the full-year summary", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Clorox Reports Q4 and Fiscal Year 2026 Results</h1>
+          <h2>Fourth-Quarter Fiscal Year 2026 Summary</h2>
+          <p>Net sales decreased 2% to $1.95 billion. The GOJO acquisition added about 10 points.</p>
+          <p>Diluted net earnings per share (diluted EPS) decreased 50% to $1.34 from $2.68 in the year-ago quarter.</p>
+          <h2>Fiscal Year 2026 Summary</h2>
+          <p>Net sales decreased 5% to $6.72 billion, reflecting lapping of shipments in the fourth quarter.</p>
+          <p>Diluted EPS decreased 26% to $4.81 from $6.52 in the year-ago period.</p>
+          <p>Condensed Consolidated Statements of Earnings</p>
+          <p>(in millions, except per share amounts)</p>
+          <p>Three months ended | Twelve months ended</p>
+          <p>6/30/2026 | 6/30/2025 | 6/30/2026 | 6/30/2025</p>
+          <p>Net sales | $ | 1,948 | $ | 1,988 | $ | 6,720 | $ | 7,104</p>
+          <p>Net earnings attributable to Clorox | $ | 163 | $ | 332 | $ | 587 | $ | 810</p>
+          <p>Diluted net earnings per share | $ | 1.34 | $ | 2.68 | $ | 4.81 | $ | 6.52</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: 1.34, value: "$1.34"}),
+      expect.objectContaining({key: "revenue", numericValue: 1_950_000_000, value: "$1.95B"}),
+      expect.objectContaining({key: "net_income", numericValue: 163_000_000}),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$4.81");
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$6.72B");
+  });
+
+  test("keeps Merck guidance, prior-year comparatives and per-share charges out of reported metrics", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Merck Announces Second-Quarter 2026 Financial Results</h1>
+          <p>- | Total Worldwide Sales Were $16.6 Billion (5% Growth; 4% Growth ex-FX)</p>
+          <p>- | Now Expects Non-GAAP EPS To Be Between $2.66 and $2.76</p>
+          <p>$ in millions, except per share amounts</p>
+          <p>Second Quarter</p>
+          <p>2026 | 2025 | Change</p>
+          <p>Sales</p>
+          <p>$ | 16,607</p>
+          <p>$ | 15,806</p>
+          <p>GAAP net (loss) income</p>
+          <p>(1,335 | )</p>
+          <p>4,427</p>
+          <p>GAAP EPS</p>
+          <p>(0.54 | )</p>
+          <p>1.76</p>
+          <p>GAAP loss per share was $0.54 in the second quarter of 2026 compared with earnings per share of $1.76 for the second quarter of 2025.</p>
+          <p>Both the GAAP and non-GAAP loss per share were due to a charge for the acquisition of Terns of $2.31 per share.</p>
+          <p>Increase to net loss / decrease to net income | | $ | 1,005 | | | $ | 939</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: -0.54, value: "-$0.54"}),
+      expect.objectContaining({key: "revenue", numericValue: 16_607_000_000}),
+      expect.objectContaining({key: "net_income", numericValue: -1_335_000_000}),
+    ]));
+    const values = parsedDocument.metrics.map(metric => metric.value);
+    expect(values).not.toContain("$1.76");
+    expect(values).not.toContain("$2.66");
+    expect(values).not.toContain("$2.31B");
+    expect(values).not.toContain("$1B");
+  });
+
+  test("keeps McDonald's Systemwide sales out of revenue and reads the diluted EPS column", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>McDonald's Corporation Reports Second Quarter 2026 Results</h1>
+          <p>Global Systemwide sales increased 5% (4% in constant currencies) to $37 billion for the quarter</p>
+          <p>Dollars in millions, except per share data</p>
+          <p>Quarters Ended June 30,</p>
+          <p>2026 | 2025 | Inc/ (Dec)</p>
+          <p>Revenues | $ | 7,099 | | $ | 6,843 | | 4 | | % | | 2 | | %</p>
+          <p>Net income | 2,362 | | 2,253 | | 5 | | 4</p>
+          <p>Earnings per share-diluted | $ | 3.32 | | $ | 3.14 | | 6 | | % | | 5 | | %</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: 3.32, value: "$3.32"}),
+      expect.objectContaining({key: "revenue", numericValue: 7_099_000_000}),
+      expect.objectContaining({key: "net_income", numericValue: 2_362_000_000}),
+    ]));
+    const values = parsedDocument.metrics.map(metric => metric.value);
+    expect(values).not.toContain("$37B");
+    expect(values).not.toContain("$3.00");
+  });
+
+  test("reads Pfizer summary-table EPS rows instead of non-GAAP definition footnotes", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Pfizer Reports Second-Quarter 2026 Results</h1>
+          <p>($ in millions, except per share amounts)</p>
+          <p>Second-Quarter | Six Months</p>
+          <p>2026 | 2025 | % Change | 2026 | 2025 | % Change</p>
+          <p>Revenues | $ 15,034 | $ 14,653 | 3% | $ 29,484 | $ 28,367 | 4%</p>
+          <p>Reported<sup>(4)</sup> Diluted EPS/(LPS)</p>
+          <p>(0.04) | 0.51 | * | 0.43 | 1.03 | (59%)</p>
+          <p>Adjusted<sup>(3)</sup> Diluted EPS</p>
+          <p>0.77 | 0.78 | -% | 1.52 | 1.69 | (10%)</p>
+          <p>(3) Adjusted income and Adjusted diluted earnings per share (EPS) are defined as U.S. GAAP net income/(loss) attributable to Pfizer Inc. common shareholders and U.S. GAAP diluted EPS/(LPS) attributable to Pfizer Inc. common shareholders before the impact of amortization of intangible assets and certain significant items and should not be viewed as substitutes for diluted EPS/(LPS)(4).</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: -0.04, value: "-$0.04"}),
+      expect.objectContaining({key: "adjusted_eps", numericValue: 0.77, value: "$0.77"}),
+    ]));
+    const values = parsedDocument.metrics.map(metric => metric.value);
+    expect(values).not.toContain("-$4.00");
+    expect(values).not.toContain("-$3.00");
+  });
+
+  test("reports BP group revenue in its dollar reporting currency and EPS per ADS", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <p>bp-20260630 2026 Q2 BP PLC iso4217:USD iso4217:USD xbrli:shares iso4217:EUR iso4217:USD utr:bbl iso4217:USD</p>
+          <h1>Group results second quarter and first half 2026</h1>
+          <p>Second | Second | First | First</p>
+          <p>quarter | quarter | half | half</p>
+          <p>$ million | 2026 | 2025 | 2026 | 2025</p>
+          <p>Sales and other operating revenues | 69,105 | 46,627 | 121,360 | 93,532</p>
+          <p>Profit (loss) per ordinary share (cents) | 24.77 | 10.41 | 49.60 | 14.73</p>
+          <p>Profit (loss) per ADS (dollars) | 1.49 | 0.62 | 2.98 | 0.88</p>
+          <p>Earnings per share (Note 7)</p>
+          <p>In the second quarter 2026, BP Capital Markets p.l.c. exercised its option to redeem &#8364;2.5 billion of hybrid bonds.</p>
+          <p>Customers &amp; products</p>
+          <p>Sales and other operating revenues for the second quarter and half year were $57.2 billion and $100.1 billion respectively.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        currencyCode: "USD",
+        key: "revenue",
+        numericValue: 69_105_000_000,
+      }),
+      expect.objectContaining({currencyCode: "USD", key: "gaap_eps", value: "$1.49"}),
+    ]));
+    const values = parsedDocument.metrics.map(metric => metric.value);
+    expect(values).not.toContain("€69.11B");
+    expect(values).not.toContain("$57.2B");
+    expect(values).not.toContain("$7.00");
+    expect(values).not.toContain("$24.77");
+  });
+
+  test("keeps Palantir US-segment revenue and Spotify operating income out of total revenue", () => {
+    const palantirDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Palantir Reports Q2 2026 Results</h1>
+          <p>U.S. revenue grew 115% year-over-year and 23% quarter-over-quarter to $1.573 billion</p>
+          <p>U.S. commercial revenue grew 149% year-over-year to $764 million</p>
+          <p>Revenue grew 93% year-over-year and 19% quarter-over-quarter to $1.935 billion</p>
+        </body>
+      </html>
+    `);
+
+    expect(palantirDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "revenue", numericValue: 1_935_000_000}),
+    ]));
+    expect(palantirDocument.metrics.map(metric => metric.value)).not.toContain("$1.573B");
+
+    const spotifyDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Spotify Technology S.A. Announces Financial Results for Second Quarter 2026</h1>
+          <p>(&#8364;M) Total Revenue 4,193 4,533 4,777 Gross Profit 1,320 1,495 1,596</p>
+          <p>than offset music costs and Other Costs of Revenue Operating Income was &#8364;655 million in Q2 and reflected the above</p>
+          <p>Revenue of &#8364;4,777 million grew 14% Y/Y in Q2</p>
+        </body>
+      </html>
+    `);
+
+    expect(spotifyDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({currencyCode: "EUR", key: "revenue", numericValue: 4_777_000_000}),
+    ]));
+    expect(spotifyDocument.metrics.map(metric => metric.value)).not.toContain("€655M");
+  });
 });

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -45,10 +45,61 @@ export function getMetricCandidateScore({
     score -= 140;
   }
 
-  const pipeCount = metricLine.match(/\|/g)?.length ?? 0;
-  score -= Math.min(30, pipeCount * 2);
+  // The consolidated statements are the authoritative source, so a table row is
+  // preferred over narrative prose restating a figure. Prose mentions of a metric
+  // are frequently scoped to a segment, a single product, a prior-year comparative
+  // or guidance, none of which is the headline consolidated number.
+  if (2 <= (metricLine.match(/\|/g)?.length ?? 0)) {
+    score += 25;
+  }
+
+  // Whichever period header governs this row/section decides whether its leading
+  // column is the quarter or a full-year/YTD figure. A Q4 release prints both, so
+  // without this the annual column and the annual narrative bullet are picked.
+  const periodScope = getPeriodScope(lines, lineIndex, metricLine);
+  if ("quarter" === periodScope) {
+    score += 40;
+  } else if ("annual" === periodScope) {
+    score -= 80;
+  }
+
+  if (true === hasForeignPeriodAttribution(metricLine, quarterLabel)) {
+    score -= 150;
+  }
+
+  // "X and Y in the first and second quarter, respectively" maps values to periods
+  // positionally, so the leading value is not the reported quarter.
+  if (/\brespectively\b/i.test(metricLine)) {
+    score -= 100;
+  }
+
   if (("eps" === valueType || "money" === valueType) && /[$€£¥]/.test(metricLine)) {
     score += 10;
+  }
+
+  if ("eps" === valueType) {
+    // Diluted is the headline per-share measure. Statements print the basic row first,
+    // so without this preference the basic figure wins on document order.
+    if (/\bdiluted\b/i.test(metricLine)) {
+      score += 30;
+    } else if (/\bbasic\b/i.test(metricLine)) {
+      score -= 40;
+    }
+
+    // A foreign private issuer reports per-ordinary-share earnings in minor units and
+    // per-ADS in dollars; the ADS figure is the one comparable to a US-listed EPS.
+    if (/\bper\s+ADS\b/i.test(metricLine)) {
+      score += 60;
+    } else if (/\(\s*cents(?:\s+per\s+share)?\s*\)/i.test(metricLine)) {
+      score -= 60;
+    }
+
+    // An EPS reconciliation restates the aggregate numerator first ("Diluted earnings
+    // per share | Net income attributable to ... | 545"), so the leading values on such
+    // a line are whole-currency amounts rather than per-share ones.
+    if (/\bper\s+(?:common\s+|ordinary\s+)?share\b[\s\S]{0,80}?\bnet\s+(?:income|loss|earnings)\b/i.test(metricLine)) {
+      score -= 120;
+    }
   }
 
   if ("eps" === valueType && /\bper\s+(?:common\s+)?(?:diluted\s+)?share\b/i.test(metricLine)) {
@@ -97,6 +148,182 @@ export function isEmbeddedAlphaNumericValue(
 
   const textAfter = text.slice(endIndex, endIndex + 12);
   return /^[A-Za-z]/.test(textAfter) && false === /^(?:cents?|[kmbt])\b/i.test(textAfter);
+}
+
+// Superscript footnote markers survive HTML-to-text conversion glued to their label
+// ("Reported(4) Diluted EPS", "Earnings per share (Note 7)"). Left in place they parse
+// as parenthesised negatives, so "(4)" becomes -$4.00.
+export function stripReferenceMarkers(line: string): string {
+  const withoutParenthesisedMarkers = line
+    .replace(/\(\s*Note\s+\d{1,2}\s*\)/gi, " ")
+    .replace(/([A-Za-z]) ?\(\d{1,2}\)/g, "$1");
+
+  // A bare superscript trailing a label ("Profit per common share - diluted 2") is a
+  // footnote too. Only strip it where the line carries no value cell of its own, so a
+  // real figure is never mistaken for a marker.
+  return /[|$€£¥]/.test(withoutParenthesisedMarkers)
+    ? withoutParenthesisedMarkers
+    : withoutParenthesisedMarkers.replace(/([A-Za-z]) \d{1,2}\s*$/, "$1");
+}
+
+// Boilerplate that defines a non-GAAP measure states no figures for the period; any
+// number it contains is a footnote marker or a cross-reference.
+export function isDefinitionalLine(line: string): boolean {
+  return /\b(?:is|are)\s+defined\s+as\b/i.test(line) ||
+    /\bshould\s+not\s+be\s+(?:viewed|considered)\b/i.test(line) ||
+    /^\s*\(\d{1,2}\)\s*[A-Z]/.test(line);
+}
+
+// Statement columns are not ordered consistently across filers: most lead with the
+// reported period, but some print the prior year first ("2025 | 2026"). The year header
+// governing the row is the only reliable way to know which cell to read.
+export function getCurrentPeriodColumnIndex(
+  lines: string[],
+  lineIndex: number,
+  quarterLabel: string | undefined,
+): number {
+  const reportedYear = /\bQ[1-4]\s+(20\d{2})\b/.exec(quarterLabel ?? "")?.[1];
+  if (undefined === reportedYear) {
+    return 0;
+  }
+
+  for (let index = lineIndex - 1, examined = 0; index >= 0 && examined < 12; index--, examined++) {
+    const line = lines[index];
+    if (undefined === line) {
+      continue;
+    }
+
+    const headerYears = getColumnHeaderYears(line);
+    if (0 === headerYears.length) {
+      continue;
+    }
+
+    // Combined tables repeat the year across the quarter and year-to-date groups; the
+    // quarter group is printed first, so its occurrence is the one to read.
+    const columnIndex = headerYears.indexOf(reportedYear);
+    return -1 === columnIndex ? 0 : columnIndex;
+  }
+
+  return 0;
+}
+
+// A column header ends in a run of year cells ("... Three Months Ended March 31 2025
+// 2026", "$ million | 2026 | 2025 | 2026 | 2025"). Requiring the years to be separated
+// by nothing but cell punctuation keeps prose such as "between 2025 and 2026" out.
+function getColumnHeaderYears(line: string): string[] {
+  const yearMatches = [...line.matchAll(/\b20\d{2}\b/g)];
+  if (2 > yearMatches.length) {
+    return [];
+  }
+
+  let runStartIndex = yearMatches.length - 1;
+  while (runStartIndex > 0) {
+    const previousMatch = yearMatches[runStartIndex - 1];
+    const currentMatch = yearMatches[runStartIndex];
+    if (undefined === previousMatch || undefined === currentMatch) {
+      break;
+    }
+
+    const gapText = line.slice(previousMatch.index + previousMatch[0].length, currentMatch.index);
+    if (false === /^[\s|$€£¥(),.:;%*\-–—/]*$/.test(gapText)) {
+      break;
+    }
+
+    runStartIndex--;
+  }
+
+  const runYears = yearMatches.slice(runStartIndex).map(yearMatch => yearMatch[0]);
+  return 2 <= runYears.length ? runYears : [];
+}
+
+type PeriodScope = "annual" | "quarter" | undefined;
+
+const periodScopeLineLimit = 130;
+
+function getPeriodScope(
+  lines: string[],
+  lineIndex: number,
+  metricLine: string,
+): PeriodScope {
+  // A row inside an explicit "months ended" table carries its own scope, even when a
+  // section heading further up says otherwise.
+  const ownScope = getPeriodEndedScope(metricLine);
+  if (undefined !== ownScope) {
+    return ownScope;
+  }
+
+  for (let index = lineIndex - 1, examined = 0; index >= 0 && examined < 40; index--, examined++) {
+    const line = lines[index];
+    if (undefined === line || line.length > periodScopeLineLimit) {
+      continue;
+    }
+
+    const scope = getLineScope(line);
+    if (undefined !== scope) {
+      return scope;
+    }
+  }
+
+  return undefined;
+}
+
+function getPeriodEndedScope(line: string): PeriodScope {
+  if (/\b(?:three|3)\s+months?\s+ended\b/i.test(line) || /\bquarters?\s+ended\b/i.test(line)) {
+    return "quarter";
+  }
+
+  if (/\b(?:twelve|12|six|6|nine|9)\s+months?\s+ended\b/i.test(line) ||
+      /\byear\s+ended\b/i.test(line)) {
+    return "annual";
+  }
+
+  return undefined;
+}
+
+// A heading naming both scopes ("Three Months Ended | Twelve Months Ended",
+// "Fourth-Quarter Fiscal Year 2026") introduces quarter columns first, so it counts
+// as quarter scope.
+function getLineScope(line: string): PeriodScope {
+  const periodEndedScope = getPeriodEndedScope(line);
+  if ("quarter" === periodEndedScope) {
+    return "quarter";
+  }
+
+  if (/\b(?:first|second|third|fourth)[\s–—-]+quarter\b/i.test(line) || /\bQ[1-4]\b/.test(line)) {
+    return "quarter";
+  }
+
+  if (undefined !== periodEndedScope ||
+      /\bfiscal\s+year\b/i.test(line) ||
+      /\bfull[-\s]year\b/i.test(line) ||
+      /\byear[-\s]to[-\s]date\b/i.test(line) ||
+      /\bYTD\b/i.test(line)) {
+    return "annual";
+  }
+
+  return undefined;
+}
+
+// "compared with earnings per share of $1.76 for the second quarter of 2025" states a
+// prior-year figure; the leading value on such a line is not the reported quarter.
+function hasForeignPeriodAttribution(
+  metricLine: string,
+  quarterLabel: string | undefined,
+): boolean {
+  const quarterYear = /\bQ[1-4]\s+(20\d{2})\b/.exec(quarterLabel ?? "")?.[1];
+  if (undefined === quarterYear) {
+    return false;
+  }
+
+  const attributionPattern =
+    /\b(?:for|in)\s+(?:the\s+)?(?:first|second|third|fourth)[\s–—-]+quarter\s+(?:of\s+)?(20\d{2})\b/gi;
+  for (const attributionMatch of metricLine.matchAll(attributionPattern)) {
+    if (attributionMatch[1] !== quarterYear) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function getCurrentQuarterTextScore(text: string, quarterLabel: string): number {

--- a/modules/earnings-results-format.test.ts
+++ b/modules/earnings-results-format.test.ts
@@ -659,10 +659,12 @@ describe("earnings result formatting", () => {
     `);
 
     expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      // The statement row supplies the reported quarter at full precision; the prior-year
+      // comparison column ($97,792) must not be selected.
       expect.objectContaining({
         key: "revenue",
-        numericValue: 121_100_000,
-        value: "$121.1M",
+        numericValue: 121_144_000,
+        value: "$121.14M",
       }),
       expect.objectContaining({
         key: "net_income",
@@ -1247,15 +1249,17 @@ describe("earnings result formatting", () => {
         numericValue: 5.75,
         value: "$5.75",
       }),
+      // Taken from the consolidated statement rather than the rounded narrative, so the
+      // quarter column of a prior-year-first table ("2025 | 2026") must be selected.
       expect.objectContaining({
         key: "revenue",
-        numericValue: 200_600_000_000,
-        value: "$200.6B",
+        numericValue: 200_606_000_000,
+        value: "$200.61B",
       }),
       expect.objectContaining({
         key: "net_income",
-        numericValue: 62_600_000_000,
-        value: "$62.6B",
+        numericValue: 62_647_000_000,
+        value: "$62.65B",
       }),
     ]));
     expect(parsedDocument.metrics).not.toEqual(expect.arrayContaining([

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -1,10 +1,13 @@
 import moment from "moment-timezone";
 import {type EarningsEvent} from "./earnings.ts";
 import {
+  getCurrentPeriodColumnIndex,
   getMetricCandidateScore,
   getPositionedQuarterValues,
   hasGaapNarrativeBeforeAdjustment,
+  isDefinitionalLine,
   isEmbeddedAlphaNumericValue,
+  stripReferenceMarkers,
 } from "./earnings-results-format-selection.ts";
 import {
   extractOutlookMetrics,
@@ -84,7 +87,11 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\badjusted\s+(?:\d{1,2}\s+)?(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?(?:earnings\s+per\s+(?:common\s+)?share|eps)\b/i,
       /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?eps\b/i,
       /\bnon-gaap\s+(?:diluted\s+)?(?:earnings\s+per\s+share|eps)\b/i,
+      /\badjusted\s+profit\s+per\s+(?:common\s+)?share\b/i,
     ],
+    // Guidance restates the same non-GAAP measure as a forward range, so without this
+    // the low end of a full-year outlook is posted as the reported quarter.
+    skipPattern: /\bguidance\b|\boutlook\b|\bforecast\b|\bexpects?\s+(?:non-gaap\s+)?(?:eps|adjusted)\b|\bto\s+be\s+(?:between|in\s+(?:a\s+)?range)\b/i,
     valueType: "eps",
   },
   {
@@ -92,6 +99,8 @@ const earningsMetricDefinitions: MetricDefinition[] = [
     label: "EPS",
     patterns: [
       /\b(?:diluted\s+)?(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\b/i,
+      /\b(?:earnings|profit|net\s+income)(?:\s*\/)?\s*\(loss(?:es)?\)\s+per\s+(?:common\s+|ordinary\s+)?share\b/i,
+      /\bprofit\s+(?:\(loss\)\s+)?per\s+(?:common\s+|ordinary\s+)?(?:share|ADS)\b/i,
       /\bdiluted\s+eps\b/i,
       /\bgaap\s+(?:diluted\s+)?eps\b/i,
       /\b(?:reported\s+)?(?:net\s+)?earnings?\b(?:(?![.!?]\s)[^!?\n]){0,180}?(?<metricValue>-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share(?:\s*[-–—]\s*diluted)?\b/i,
@@ -110,7 +119,7 @@ const earningsMetricDefinitions: MetricDefinition[] = [
       /\brevenues?\b/i,
       /\bsales\b/i,
     ],
-    skipPattern: /\bcost\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\bannuali[sz]ed\s+(?:revenue\s+)?run[-\s]*rate\b|\brevenue\s+run[-\s]*rate\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b|\bnot\s+recognized\s+in\s+revenue\b|\bnon-cash\s+revenues?\b|\bsales\s+volumes?\b|\b(?:external\s+power|pipeline\s+gas|hydrocarbon|asset)\s+sales\b|\bproceeds\s+from\b|\bsales\s+of\s+pipeline\s+gas\b|\b(?:kbd|koebd|boepd|bpd|mboed|mmboe|bcfe|mmcf|mw|gw|kt)\b/i,
+    skipPattern: /\bcosts?\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsystemwide\s+sales\b|\b(?:U\.S\.|U\.K\.|US|international|domestic|non-US|segment)\s+(?:commercial\s+|government\s+)?revenues?\b|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\bannuali[sz]ed\s+(?:revenue\s+)?run[-\s]*rate\b|\brevenue\s+run[-\s]*rate\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b|\bnot\s+recognized\s+in\s+revenue\b|\bnon-cash\s+revenues?\b|\bsales\s+volumes?\b|\b(?:external\s+power|pipeline\s+gas|hydrocarbon|asset)\s+sales\b|\bproceeds\s+from\b|\bsales\s+of\s+pipeline\s+gas\b|\b(?:kbd|koebd|boepd|bpd|mboed|mmboe|bcfe|mmcf|mw|gw|kt)\b/i,
     valueType: "money",
   },
   {
@@ -119,11 +128,14 @@ const earningsMetricDefinitions: MetricDefinition[] = [
     patterns: [
       /\bnet\s+income(?!\s+per\s+(?:common\s+)?share)\b/i,
       /\bnet\s+earnings(?!\s+per\s+(?:common\s+)?share)\b/i,
+      /\bnet\s+\(loss(?:es)?\)\s+income\b/i,
+      /\bnet\s+income\s*\/\s*\(loss(?:es)?\)(?!\s+per\s+(?:common\s+)?share)/i,
     ],
-    // Skip income-statement subtotals and the noncontrolling-interest component so
-    // the headline "net income/earnings attributable to <company>" row wins rather
-    // than "net earnings before income tax" or "net earnings including NCI".
-    skipPattern: /\beps\b|\bbefore\s+(?:income\s+)?tax(?:es)?\b|\b(?:including|attributable\s+to)\s+noncontrolling\b/i,
+    // Skip income-statement subtotals, the noncontrolling-interest component and
+    // reconciliation adjustment rows so the headline "net income/earnings attributable
+    // to <company>" row wins rather than "net earnings before income tax", "net
+    // earnings including NCI" or "increase to net loss / decrease to net income".
+    skipPattern: /\beps\b|\bbefore\s+(?:income\s+)?tax(?:es)?\b|\b(?:including|attributable\s+to)\s+noncontrolling\b|\b(?:increase|decrease)\s+to\s+net\b/i,
     valueType: "money",
   },
   {
@@ -158,12 +170,50 @@ export function parseEarningsDocument(html: string): ParsedEarningsDocument {
 }
 
 function getDocumentCurrencyCode(lines: string[]): string | undefined {
-  const currencyDeclaration = lines
-    .slice(0, 60)
+  const headerLines = lines.slice(0, 60);
+  const currencyDeclaration = headerLines
     .find(line => /\b(?:Canadian|New Taiwan|U\.S\.)\s+dollars?\b|\b(?:CAD|TWD|NTD|USD|EUR|GBP|JPY)\b|NT\s*\$/i.test(line));
-  return undefined === currencyDeclaration
+  if (undefined !== currencyDeclaration) {
+    return getDominantCurrencyCode(currencyDeclaration) ??
+      getCurrencyCodeFromText(currencyDeclaration);
+  }
+
+  // A non-dollar reporting currency is often declared only as a column scale ("(€M)",
+  // "(in € millions)"). It still governs statement rows that carry no symbol of their
+  // own, which would otherwise be rendered as dollars.
+  const scaleSymbolDeclaration = headerLines.find(line =>
+    /\(\s*[€£¥]\s*(?:M|B|K|millions?|billions?|thousands?)\b/i.test(line) ||
+    /\bin\s+[€£¥]\s*(?:millions?|billions?|thousands?)\b/i.test(line));
+  return undefined === scaleSymbolDeclaration
     ? undefined
-    : getCurrencyCodeFromText(currencyDeclaration);
+    : getCurrencyCodeFromText(scaleSymbolDeclaration);
+}
+
+// An inline-XBRL context header lists every unit the filing references
+// ("iso4217:USD ... iso4217:EUR ... iso4217:USD"), so the reporting currency is the one
+// named most often rather than whichever is checked first.
+function getDominantCurrencyCode(text: string): string | undefined {
+  const declaredCodes = [...text.matchAll(/\biso4217:([A-Z]{3})\b/g)]
+    .map(codeMatch => codeMatch[1] ?? "");
+  if (2 > declaredCodes.length) {
+    return undefined;
+  }
+
+  const countByCode = new Map<string, number>();
+  for (const code of declaredCodes) {
+    countByCode.set(code, (countByCode.get(code) ?? 0) + 1);
+  }
+
+  let dominantCode: string | undefined;
+  let dominantCount = 0;
+  for (const [code, count] of countByCode) {
+    if (count > dominantCount) {
+      dominantCode = code;
+      dominantCount = count;
+    }
+  }
+
+  return dominantCode;
 }
 
 export function getMessageMetrics(
@@ -456,7 +506,7 @@ export function decodeHtmlEntities(value: string): string {
 function getMeaningfulLines(text: string): string[] {
   return text
     .split("\n")
-    .map(line => line.replace(/\s*\|\s*/g, " | ").replace(/\s+/g, " ").trim())
+    .map(line => stripReferenceMarkers(line).replace(/\s*\|\s*/g, " | ").replace(/\s+/g, " ").trim())
     .filter(line => line.length >= 3);
 }
 
@@ -617,8 +667,22 @@ function getQuarterSpecificMetricLines(lines: string[]): MetricLineSelection {
 
   return {
     exclusive,
-    lines: selectedLines,
+    lines: [...getGoverningScaleDeclarations(lines, startIndex), ...selectedLines],
   };
+}
+
+// The unit declaration governing a section's figures ("$ in millions") usually sits above
+// the section heading. Selecting the section alone hides it, and every money value in the
+// window is then read at face value — a $16.6B quarter rendered as $16.61K.
+function getGoverningScaleDeclarations(lines: string[], startIndex: number): string[] {
+  for (let index = startIndex - 1; index >= 0 && index >= startIndex - 40; index--) {
+    const line = lines[index];
+    if (undefined !== line && null !== getMoneyScaleFromContextText(line)) {
+      return [line];
+    }
+  }
+
+  return [];
 }
 
 function isMixedMonthQuarterResultsLine(line: string): boolean {
@@ -655,6 +719,10 @@ function extractMetric(
 ): EarningsResultMetric | null {
   let bestCandidate: {metric: EarningsResultMetric; score: number} | null = null;
   for (const [lineIndex, line] of lines.entries()) {
+    if (true === isDefinitionalLine(line)) {
+      continue;
+    }
+
     const hasExplicitGaapEps = "gaap_eps" === definition.key &&
       /\bgaap\s+(?:diluted\s+)?eps\b/i.test(line);
     const hasReportedGaapEps = "gaap_eps" === definition.key &&
@@ -687,6 +755,7 @@ function extractMetric(
       getContextMoney(lines, lineIndex, documentCurrencyCode),
       isNearTableNoteColumn(lines, lineIndex),
       undefined !== quarterLabel && hasMixedMonthQuarterColumns(lines, lineIndex),
+      getCurrentPeriodColumnIndex(lines, lineIndex, quarterLabel),
     );
     if (null === metricValue) {
       continue;
@@ -747,7 +816,11 @@ function getMetricLineWithContinuation(
 
   const metricLines = [baseLine];
   const isSummaryHeading = isSummaryMetricHeading(baseLine, definition);
-  for (let index = lineIndex + 1; index < lines.length && index <= lineIndex + 6; index++) {
+  // A per-share block spans a basic and a diluted row of several period columns, each
+  // rendered as its own line; stopping too early truncates the diluted row and leaves
+  // only the basic figure to read.
+  const continuationLimit = "eps" === definition.valueType ? 12 : 6;
+  for (let index = lineIndex + 1; index < lines.length && index <= lineIndex + continuationLimit; index++) {
     const nextLine = lines[index];
     if (undefined === nextLine) {
       break;
@@ -811,13 +884,22 @@ function isNarrativePerShareDetailLine(line: string): boolean {
     /\b(?:per\s+(?:common\s+)?share|eps|cents?)\b/i.test(line);
 }
 
+// Summary tables mark not-meaningful comparisons with "*", "--" or a bare "%", so those
+// cells must not end the run of value cells belonging to the label above.
 function isValueOnlyLine(line: string): boolean {
-  return /^[\s|$€£¥(),.\-\d%—–]+$/.test(line);
+  return /^[\s|$€£¥(),.\-*\d%—–]+$/.test(line);
 }
 
 function isPerShareMetricDetailLine(baseLine: string, line: string): boolean {
-  return /\bper\s+(?:common\s+)?share\b/i.test(baseLine) &&
-    /^\s*(?:basic|diluted)\b/i.test(line);
+  if (false === /\bper\s+(?:common\s+|ordinary\s+)?share\b/i.test(baseLine)) {
+    return false;
+  }
+
+  // A label wrapped across table cells leaves its tail word ahead of the value columns
+  // ("... per share attributable to owners of the" / "parent Basic 2.65 ... Diluted 2.61"),
+  // so the per-share row is only reachable by joining the orphaned continuation.
+  return /^\s*(?:basic|diluted)\b/i.test(line) ||
+    /^\s*[A-Za-z]{1,12}\s+(?:basic|diluted)\b/i.test(line);
 }
 
 function extractMetricValue(
@@ -827,7 +909,13 @@ function extractMetricValue(
   contextMoney: MoneyContext,
   skipTableNoteRefs: boolean,
   preferQuarterColumn: boolean,
+  currentPeriodColumnIndex: number,
 ): {currencyCode?: string | undefined; numericValue: number; value: string} | null {
+  // Narrative prose states the reported figure first, whatever the surrounding table
+  // layout is, so only rows with explicit value cells are read by column. A basic or
+  // diluted per-share segment is a column run by construction and is always read by
+  // column, which is what makes prior-year-first statements resolve correctly.
+  const columnIndex = 2 <= (line.match(/\|/g)?.length ?? 0) ? currentPeriodColumnIndex : 0;
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
   const capturedMetricValue = patternMatch?.groups?.["metricValue"];
@@ -839,10 +927,10 @@ function extractMetricValue(
   const fallbackSearchText = patternMatch ? line.slice(0, patternMatch.index) : "";
 
   if ("eps" === valueType) {
-    const perShareTableValue = findPerShareTableValue(preferredSearchText);
-    const preferredValue = findEpsValue(preferredSearchText);
+    const perShareTableValue = findPerShareTableValue(preferredSearchText, currentPeriodColumnIndex);
+    const preferredValue = findEpsValue(preferredSearchText, columnIndex);
     const fallbackValue = true === isMetricValuePrefix(fallbackSearchText)
-      ? findEpsValue(fallbackSearchText)
+      ? findEpsValue(fallbackSearchText, columnIndex)
       : null;
     const value = perShareTableValue ?? preferredValue ?? fallbackValue;
     if (null === value) {
@@ -863,12 +951,12 @@ function extractMetricValue(
   if ("money" === valueType) {
     const sentenceSearchText = getMetricValueSentenceText(preferredSearchText);
     const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(sentenceSearchText);
-    const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findNumericValueMatch(sentenceSearchText, {
+    const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findColumnValueMatch(sentenceSearchText, {
       minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
       skipTableNoteRefs,
       skipPercentages: true,
-    });
+    }, columnIndex);
     const fallbackValueMatch = true === isMetricValuePrefix(fallbackSearchText) ? findNumericValueMatch(fallbackSearchText, {
       minUncuedAbsValue: 10,
       requireMoneyCue: 1 === contextMoney.scale,
@@ -948,35 +1036,62 @@ function getQuarterColumnSearchText(text: string): string {
   return text.slice(groupBoundary.index + groupBoundary[0].length);
 }
 
-function findEpsValue(text: string): number | null {
+function findEpsValue(text: string, columnIndex: number): number | null {
   const options = {
     maxAbsValue: 100,
     parseCents: true,
     skipPercentages: true,
   };
-  const currencyValue = findNumericValue(text, {
+  const currencyValue = findPlausibleEpsValue(text, {
     ...options,
     requireMoneyCue: true,
-  });
+  }, columnIndex);
   if (null !== currencyValue) {
     return currencyValue;
   }
 
   return true === isMetricLabelSuffixTableNote(text)
     ? null
-    : findNumericValue(text, options);
+    : findPlausibleEpsValue(text, options, columnIndex);
 }
 
-function findPerShareTableValue(text: string): number | null {
+// Filings quote per-share amounts to the cent, so a fractional value in a per-share
+// position is the figure. A large whole number there is an aggregate numerator from a
+// reconciliation row ("... per share | Net income | 545 | 721 | (86)") or a leftover
+// marker, and publishing it would misstate EPS by orders of magnitude.
+function findPlausibleEpsValue(
+  text: string,
+  options: NumericValueOptions,
+  columnIndex: number,
+): number | null {
+  const values = findNumericValues(text, options);
+  const columnValue = values[columnIndex];
+  if ("number" === typeof columnValue && false === Number.isInteger(columnValue)) {
+    return columnValue;
+  }
+
+  return values.find(value => false === Number.isInteger(value)) ??
+    values.find(value => Math.abs(value) < 20) ??
+    null;
+}
+
+function findPerShareTableValue(text: string, columnIndex: number): number | null {
   const hasTableSegments = /\bBasic\b/i.test(text) || 2 <= (text.match(/\|/g)?.length ?? 0);
   if (false === hasTableSegments) {
     return null;
   }
 
-  return getLastPerShareSegmentValue(text, "Diluted") ?? getLastPerShareSegmentValue(text, "Basic");
+  return getPerShareSegmentValue(text, "Diluted", columnIndex) ??
+    getPerShareSegmentValue(text, "Basic", columnIndex);
 }
 
-function getLastPerShareSegmentValue(text: string, label: "Basic" | "Diluted"): number | null {
+// Read the reported period's cell out of the per-share row. Remaining cells are the
+// prior-year quarter, the year-to-date pair and sometimes percentage changes.
+function getPerShareSegmentValue(
+  text: string,
+  label: "Basic" | "Diluted",
+  columnIndex: number,
+): number | null {
   const segmentMatch = new RegExp(`\\b${label}\\b([\\s\\S]*?)(?:\\b(?:Basic|Diluted|Weighted-average)\\b|$)`, "i")
     .exec(text);
   const segment = segmentMatch?.[1];
@@ -987,8 +1102,9 @@ function getLastPerShareSegmentValue(text: string, label: "Basic" | "Diluted"): 
   const values = findNumericValues(segment, {
     maxAbsValue: 100,
     parseCents: true,
+    skipPercentages: true,
   });
-  return values[values.length - 1] ?? null;
+  return values[columnIndex] ?? values[0] ?? null;
 }
 
 function getContextMoney(
@@ -996,7 +1112,7 @@ function getContextMoney(
   lineIndex: number,
   documentCurrencyCode: string | undefined,
 ): MoneyContext {
-  let currencyCode = documentCurrencyCode;
+  const currencyCode = documentCurrencyCode;
   // Scan upward for the nearest "in millions / $ in thousands / ..." declaration
   // governing this row. Income statements interleave many empty separator rows
   // ("| |") between the unit header and the figures, so the lookback budget is
@@ -1010,11 +1126,14 @@ function getContextMoney(
       continue;
     }
 
-    currencyCode = getCurrencyCodeFromText(line, currencyCode) ?? currencyCode;
     const scale = getMoneyScaleFromContextText(line);
     if (null !== scale) {
+      // Take the currency from the unit declaration that governs this table ("$ million",
+      // "in € millions"). Reading it from any line scanned on the way up lets an incidental
+      // prose mention — a euro-denominated bond redemption in a dollar-reporting filer —
+      // relabel every figure below it.
       return {
-        currencyCode,
+        currencyCode: getCurrencyCodeFromText(line, currencyCode) ?? currencyCode,
         scale,
       };
     }
@@ -1176,6 +1295,15 @@ function findNumericValueMatch(
   return findNumericValueMatches(text, options)[0] ?? null;
 }
 
+function findColumnValueMatch(
+  text: string,
+  options: NumericValueOptions,
+  columnIndex: number,
+): NumericValueMatch | null {
+  const matches = findNumericValueMatches(text, options);
+  return matches[columnIndex] ?? matches[0] ?? null;
+}
+
 function findNumericValues(
   text: string,
   options: NumericValueOptions = {},
@@ -1231,7 +1359,14 @@ function findNumericValueMatches(
       continue;
     }
 
-    if (value >= 1900 && value <= 2100) {
+    // Skip bare calendar years in column headers ("2026 | 2025"). A grouped or
+    // decimal token, or one carrying a money cue, is a figure that merely happens to
+    // fall in that range — dropping it silently shifts the row to a later column
+    // (e.g. "$ | 1,948" for a $1.95B quarter yielding the full-year column instead).
+    if (value >= 1900 && value <= 2100 &&
+        false === token.includes(",") &&
+        false === token.includes(".") &&
+        false === hasMoneyCue(text, numberMatch.index, endIndex, token)) {
       continue;
     }
 


### PR DESCRIPTION
## Why

Audited the eleven most recent posted earnings messages against their SEC filings. **Nine published at least one wrong figure.**

Candidate scoring penalised pipe-rich lines (`score -= pipeCount * 2`) and rewarded any prose naming the quarter (+50). Financial statements *are* pipe-rich, and prose naming the quarter is routinely scoped to a segment, a single product, a prior year or guidance — so narrative commentary outranked the consolidated statements it restates.

| Ticker | Posted | Correct | Cause |
|---|---|---|---|
| PLTR | Rev `$1.573B` | `$1.935B` | US segment revenue |
| VRTX | EPS `$6.48` | `$4.31` | last column = prior-year six-month |
| CLX | EPS `$4.81`, Rev `$6.72B` | `$1.34`, `$1.95B` | full-year section in a Q4 release |
| SPOT | Rev `€655M` | `€4,777M` | operating income |
| MRK | all four | `-$0.13` / `-$0.54` / `$16.6B` / `-$1.335B` | FY guidance; prior-year; the *$2.31 per share* charge read as revenue; a reconciliation row |
| MCD | EPS `$3.00`, Rev `$37B` | `$3.32`, `$7.1B` | footnote digit; Systemwide sales |
| W | EPS `-$0.77` | `-$0.01` | last column |
| PFE | both EPS `-$4.00` | `-$0.04`, `+$0.77` | `(4)` footnote marker parsed as −4 |
| BP | EPS `€7.00`, Rev `€57.2B` | `$1.49`, `$69.1B` | `(Note 7)`; segment revenue; EUR from an XBRL header |

## What changed

Prefer statement rows over narrative, then resolve which cell to read:

- **Column selection from the governing year header.** Most filers lead with the reported period, but some print the prior year first (`2025 | 2026`), so neither end of the row is reliable alone.
- **Quarter vs annual scope** from the nearest period header, keeping a Q4 release's full-year section out of its quarterly metrics.
- Prefer **diluted over basic**, and **per-ADS over per-ordinary-share** minor units.
- Reject prior-year attributions, guidance ranges for adjusted EPS, reconciliation adjustment rows, and non-GAAP definition boilerplate.
- Exclude Systemwide sales, segment/geographic revenue and cost-of-revenue lines from total revenue.
- Strip footnote markers before parsing, so `(4)` no longer reads as `-$4.00`.
- Take currency from the unit declaration governing the row; read reporting currency from the **dominant** code in an inline-XBRL header rather than the first matched.

### Two value-selection defects also fixed

- The `1900..2100` year guard **silently discarded real figures** in that range, shifting a row to a later column — a `$1,948M` quarter became the full-year `$6,720M` column. Affected any filer with a figure in that range.
- A quarter-section window **excluded the `$ in millions` declaration above it**, so every figure in the window was read unscaled — a `$16.6B` quarter as `$16.61K`. Latent; a new fixture hit it immediately.

## Review notes

- **Two existing expectations changed.** Both now read the statement row instead of the rounded narrative — same figure at higher precision (`$200.6B`→`$200.61B`, `$121.1M`→`$121.14M`). Each test's actual guard (`not $8.53` YTD, `not $169B` run-rate, prior-year column) is untouched.
- **Still incomplete, not wrong:** MCD Adj EPS (`$3.38`) and CAT/SPOT net income remain omitted. Left alone rather than add pattern coverage that could regress the above.
- `earnings-results-format.ts` is now 1581 lines against the ~800 guideline (already 1447 before this work). Split tracked separately.
- Snyk needs interactive auth, so no scan ran. Changes are pure string parsing; one ambiguous-backtracking pattern introduced during the work was removed, since these run over untrusted filing HTML.

## Verification

All eleven filings re-parsed end to end and confirmed against the source documents. `npm run test:coverage` and `npm run typecheck` pass; no thresholds altered. Seven new regression fixtures cover each root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)