### PR TITLE
Bump brace-expansion to 5.0.9 to clear high advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Why

`npm audit --audit-level=high` currently **fails on `main`**, so the required `test` check fails on every open PR — including Dependabot's and #1842.

The single high-severity finding is **`brace-expansion@5.0.8`** ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895), DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation).

Its only path is `eslint@10.6.0 → minimatch@10.2.5 → brace-expansion`, i.e. a **lint-time devDependency** — not present in the distroless production image.

## What changed

`package-lock.json` only, three fields on one entry: `5.0.8 → 5.0.9`.

- 5.0.9 is outside the vulnerable `4.0.0 - 5.0.8` range.
- It declares the **same** `dependencies` (`balanced-match: ^4.0.2`) and **same** `engines` (`20 || >=22`) as 5.0.8, and satisfies minimatch's existing `^5.0.5` range — so no other resolution changes.
- The audit gate, Trivy filters, coverage thresholds and the `undici` override are all untouched.

## Note on how it was produced

Edited directly rather than via `npm audit fix` because there is no Node 24 runtime available locally and `.npmrc` sets `engine-strict=true`, so npm refuses to operate against the pinned engine — and running npm 11/Node 26 risked unrelated lockfile churn.

The `integrity` value was taken from the registry and independently verified against the published tarball:

```
computed sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
lockfile sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
```

CI runs `npm ci` on Node 24, which is the authoritative check that the lockfile resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)