### PR TITLE
Fix earnings metric selection for loss captions and collapsed statements

### DIFF
--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -40,7 +40,14 @@ export function decodeHtmlEntities(value: string): string {
 export function getMeaningfulLines(text: string): string[] {
   return text
     .split("\n")
-    .map(line => stripReferenceMarkers(line).replace(/\s*\|\s*/g, " | ").replace(/\s+/g, " ").trim())
+    .map(line => stripReferenceMarkers(line)
+      // Dotted leaders align a caption with its value cell ("Revenue ....... $ 7,814").
+      // Left in place, the final dot reads as a sentence boundary and the row is cut off
+      // before any of its figures.
+      .replace(/\.{2,}|…+/g, " ")
+      .replace(/\s*\|\s*/g, " | ")
+      .replace(/\s+/g, " ")
+      .trim())
     .filter(line => line.length >= 3);
 }
 
@@ -51,7 +58,9 @@ export function getDocumentHeadline(lines: string[]): string | undefined {
 export function getDocumentCurrencyCode(lines: string[]): string | undefined {
   const headerLines = lines.slice(0, 60);
   const currencyDeclaration = headerLines
-    .find(line => /\b(?:Canadian|New Taiwan|U\.S\.)\s+dollars?\b|\b(?:CAD|TWD|NTD|USD|EUR|GBP|JPY)\b|NT\s*\$/i.test(line));
+    .find(line => /\b(?:Canadian|New Taiwan|U\.S\.)\s+dollars?\b/i.test(line) ||
+      /\b(?:CAD|TWD|NTD|USD|EUR|GBP|JPY)\b/.test(line) ||
+      /(?:^|[^A-Za-z])NT\s*\$/.test(line));
   if (undefined !== currencyDeclaration) {
     return getDominantCurrencyCode(currencyDeclaration) ??
       getCurrencyCodeFromText(currencyDeclaration);

--- a/modules/earnings-results-format-regressions.test.ts
+++ b/modules/earnings-results-format-regressions.test.ts
@@ -324,4 +324,119 @@ describe("earnings result filing regressions", () => {
     ]));
     expect(spotifyDocument.metrics.map(metric => metric.value)).not.toContain("€655M");
   });
+
+  test("reads a SpaceX-style segment breakdown from its total row and signs the loss captions", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>SpaceX Reports Second Quarter 2026 Results</h1>
+          <p>Second Quarter Financial Highlights $, in millions Three Months Ended Six Months Ended June 30, 2026 March 31, 2026 June 30, 2025 June 30, 2026 June 30, 2025 Revenue Space $962 $619 $746 $1,581 $1,611 Connectivity 4,291 3,257 2,588 7,548 5,062 AI 2,561 818 737 3,379 1,465 Total $7,814 $4,694 $4,071 $12,508 $8,138</p>
+          <!-- One unbroken statement line with dotted leaders, as this filer renders it. -->
+          <p>Consolidated Financial Statements Space Exploration Technologies Corp. Consolidated Statements of Operations (in millions, except per share data) (unaudited) Three Months Ended June 30, Six Months Ended June 30, 2026 2025 2026 2025 Revenue ............ $ 7,814 $ 4,071 $ 12,508 $ 8,138 Costs and expenses Cost of revenue ............ 3,495 2,282 5,883 4,244 Research and development ............ 3,548 1,958 7,062 3,515 Selling, general, and administrative ............ 912 606 1,658 1,099 Total costs and expenses ............ 7,957 5,041 14,594 9,081 Loss from operations ............ (143) (970) (2,086) (943) Interest expense ............ (629) (411) (1,293) (858) Interest income ............ 340 98 553 215 Loss before income taxes ............ (518) (870) (4,788) (1,384) Provision for income taxes ............ 23 138 29 152 Net loss ............ $ (541) $ (1,008) $ (4,817) $ (1,536) Net loss per share of common stock attributable to common shareholders Basic and Diluted ............ $ (0.09) $ (0.34) $ (1.12) $ (0.53) Weighted average shares used in computing net loss per share Basic and Diluted ............ 5,864 2,929 4,879 2,902</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "revenue", numericValue: 7_814_000_000}),
+      expect.objectContaining({key: "net_income", numericValue: -541_000_000}),
+      expect.objectContaining({key: "gaap_eps", numericValue: -0.09, value: "-$0.09"}),
+    ]));
+    const values = parsedDocument.metrics.map(metric => metric.value);
+    expect(values).not.toContain("$962M");
+    expect(values).not.toContain("$541M");
+  });
+
+  test("keeps Zeta full-year EPS guidance and a trailing-quarters column out of reported metrics", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Zeta Global Reports Second Quarter 2026 Results</h1>
+          <p>Achieved positive GAAP net income of $8 million, and GAAP earnings per share of $0.03. Generated $92 million of adjusted EBITDA and expanded adjusted EBITDA margin by 170 bps Y/Y to 20.7%.</p>
+          <p>Increasing full year 2026 GAAP EPS guidance to a range of $0.09 to $0.11, up $0.07 from prior guidance of $0.02 to $0.04.</p>
+          <p>(in thousands)</p>
+          <p>Three months ended June 30,</p>
+          <p>Six months ended June 30,</p>
+          <p>2026</p><p>2025</p><p>2026</p><p>2025</p>
+          <p>Revenues</p>
+          <p>$ 442,766</p><p>$ 308,442</p><p>$ 839,070</p><p>$ 572,861</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: 0.03, value: "$0.03"}),
+      expect.objectContaining({key: "revenue", numericValue: 442_766_000}),
+    ]));
+    const values = parsedDocument.metrics.map(metric => metric.value);
+    expect(values).not.toContain("$0.09");
+    expect(values).not.toContain("$337M");
+  });
+
+  test("reads Arista and Gilead non-GAAP per-share labels without taking a revenue milestone", () => {
+    const aristaDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Arista Networks, Inc. Reports Second Quarter 2026 Financial Results</h1>
+          <p>Delivered 40% growth in non-GAAP EPS year-over-year as the company achieved its first $3+ billion revenue quarter.</p>
+          <p>(In millions, except per share amounts)</p>
+          <p>Three Months Ended June 30, | Six Months Ended June 30,</p>
+          <p>2026 | 2025 | 2026 | 2025</p>
+          <p>GAAP diluted net income per share | $ | 0.95 | $ | 0.70 | $ | 1.75 | $ | 1.34</p>
+          <p>Non-GAAP diluted net income per share(1)</p>
+          <p>$ | 1.02 | $ | 0.73 | $ | 1.89 | $ | 1.40</p>
+        </body>
+      </html>
+    `);
+
+    expect(aristaDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", numericValue: 1.02, value: "$1.02"}),
+      expect.objectContaining({key: "gaap_eps", numericValue: 0.95, value: "$0.95"}),
+    ]));
+    expect(aristaDocument.metrics.map(metric => metric.value)).not.toContain("$3.00");
+
+    // A loss caption states its magnitude, so the sign comes from the caption rather than
+    // the cell — but a bracketed cell must not be negated twice.
+    const gileadDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Gilead Sciences Announces Second Quarter 2026 Financial Results</h1>
+          <p>Diluted Loss Per Share was $(8.45) and Non-GAAP Diluted Loss Per Share was $(6.75)</p>
+          <p>Merck-style magnitude wording: Non-GAAP Loss per Share Was $0.13</p>
+        </body>
+      </html>
+    `);
+
+    expect(gileadDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", numericValue: -6.75, value: "-$6.75"}),
+    ]));
+    expect(gileadDocument.metrics.map(metric => metric.value)).not.toContain("$6.75");
+    expect(gileadDocument.metrics.map(metric => metric.value)).not.toContain("$0.13");
+  });
+
+  test("keeps a dollar amount preceded by a word ending in 'nt' out of New Taiwan dollars", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>Opendoor Technologies Inc Reports Second Quarter 2026 Results</h1>
+          <p>Since 2022, we spent $400 million building our resale platform.</p>
+          <p>(in millions, except per share amounts)</p>
+          <p>Three Months Ended June 30,</p>
+          <p>2026 | 2025</p>
+          <p>Revenue | $ | 883 | $ | 1,567</p>
+          <p>Net loss | $ | (162) | $ | (29)</p>
+          <p>Net loss per share attributable to common shareholders:</p>
+          <p>Basic | $ | (0.17) | $ | (0.04)</p>
+          <p>Diluted | $ | (0.17) | $ | (0.04)</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({currencyCode: "USD", key: "revenue", value: "$883M"}),
+      expect.objectContaining({key: "net_income", numericValue: -162_000_000}),
+      expect.objectContaining({key: "gaap_eps", numericValue: -0.17, value: "-$0.17"}),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("NT$883M");
+  });
 });

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -1,11 +1,25 @@
 type MetricValueType = "eps" | "money" | "number";
 
+// The "adjusted" skip exists so an adjusted figure is never posted as the GAAP one. When
+// the GAAP statement is complete before the word appears — "GAAP earnings per share of
+// $0.03. Generated $92 million of adjusted EBITDA" — the line still reports GAAP EPS, and
+// discarding it loses the only place the figure is stated.
 export function hasGaapNarrativeBeforeAdjustment(line: string, patterns: RegExp[]): boolean {
   const adjustedIndex = line.search(/\badjusted\b/i);
-  const gaapText = -1 === adjustedIndex ? line : line.slice(0, adjustedIndex);
+  if (-1 === adjustedIndex) {
+    return false;
+  }
+
+  const gaapText = line.slice(0, adjustedIndex);
   return patterns.some(pattern => {
     pattern.lastIndex = 0;
-    return undefined !== pattern.exec(gaapText)?.groups?.["metricValue"];
+    const patternMatch = pattern.exec(gaapText);
+    if (null === patternMatch) {
+      return false;
+    }
+
+    return undefined !== patternMatch.groups?.["metricValue"] ||
+      /[$€£¥]\s*\(?-?\d+\.\d{2}\b/.test(gaapText.slice(patternMatch.index));
   });
 }
 
@@ -36,7 +50,11 @@ export function getMetricCandidateScore({
     score += Math.floor(getCurrentQuarterTextScore(nearbyContext, quarterLabel) / 2);
   }
 
-  if (/\b(?:YTD|year[-\s]to[-\s]date|six\s+months|nine\s+months|full\s+year|annual)\b/i.test(metricLine)) {
+  // A combined statement names both periods in one header ("Three Months Ended | Six Months
+  // Ended"); its quarter columns come first and are chosen by column index, so it must not
+  // be treated as a year-to-date line.
+  if (/\b(?:YTD|year[-\s]to[-\s]date|six\s+months|nine\s+months|full\s+year|annual)\b/i.test(metricLine) &&
+      "quarter" !== getPeriodEndedScope(metricLine)) {
     score -= 60;
   }
 
@@ -260,11 +278,41 @@ function getPeriodScope(
 
     const scope = getLineScope(line);
     if (undefined !== scope) {
-      return scope;
+      // A combined header may be split one cell per line ("Three Months Ended June 30,"
+      // then "Six Months Ended June 30,"), leaving the year-to-date cell nearest the row.
+      // The quarter group is still printed first, so the block as a whole is quarter-scoped.
+      return "annual" === scope && true === hasQuarterScopeInHeaderBlock(lines, index)
+        ? "quarter"
+        : scope;
     }
   }
 
   return undefined;
+}
+
+// Only the header block directly above counts. A line carrying figures ends the block, so a
+// quarter heading further up a narrative section cannot rescue a full-year one below it.
+function hasQuarterScopeInHeaderBlock(lines: string[], scopeLineIndex: number): boolean {
+  for (let index = scopeLineIndex - 1; index >= 0 && index >= scopeLineIndex - 3; index--) {
+    const line = lines[index];
+    if (undefined === line ||
+        line.length > periodScopeLineLimit ||
+        true === hasFigureCell(line)) {
+      return false;
+    }
+
+    if ("quarter" === getLineScope(line)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasFigureCell(line: string): boolean {
+  return /[$€£¥]/.test(line) ||
+    /\d[\d,]*\.\d/.test(line) ||
+    /\b\d{1,3}(?:,\d{3})+\b/.test(line);
 }
 
 function getPeriodEndedScope(line: string): PeriodScope {

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -253,11 +253,18 @@ function extractMetric(
       continue;
     }
 
+    // An explicitly GAAP-labelled line overrides the "adjusted" skip, but must never
+    // override a forward-looking one: "Increasing full year GAAP EPS guidance to a range
+    // of $0.09 to $0.11" would otherwise post the low end of an annual outlook as the
+    // reported quarter.
+    const isForwardLooking = isForwardLookingLine(line);
     const hasExplicitGaapEps = "gaap_eps" === definition.key &&
+      false === isForwardLooking &&
       /\bgaap\s+(?:diluted\s+)?eps\b/i.test(line);
     const hasReportedGaapEps = "gaap_eps" === definition.key &&
+      false === isForwardLooking &&
       true === hasGaapNarrativeBeforeAdjustment(line, definition.patterns);
-    if (definition.skipPattern?.test(line) &&
+    if (true === isSkippedMetricLine(line, definition) &&
         false === hasExplicitGaapEps &&
         false === hasReportedGaapEps) {
       continue;
@@ -320,6 +327,47 @@ function extractMetric(
   return bestCandidate?.metric ?? null;
 }
 
+// Disqualifiers are matched against the whole line, which is right for a statement row or
+// a sentence. Some filers emit an entire statement as one unbroken line, though, and there
+// a single "Cost of revenue" caption would discard every figure in the statement. For those
+// each occurrence of the label is judged on the qualifier directly ahead of it instead.
+const collapsedStatementLineLength = 600;
+const labelQualifierWindow = 60;
+
+function isSkippedMetricLine(line: string, definition: MetricDefinition): boolean {
+  const skipPattern = definition.skipPattern;
+  if (undefined === skipPattern) {
+    return false;
+  }
+
+  if (line.length <= collapsedStatementLineLength) {
+    return skipPattern.test(line);
+  }
+
+  // Testing the whole prefix would let an unrelated earlier row disqualify a later one —
+  // "Loss before income taxes" sitting above the "Net loss" row it is meant to leave alone.
+  for (const pattern of definition.patterns) {
+    const scanPattern = new RegExp(pattern.source, pattern.flags.replace("g", "") + "g");
+    for (const patternMatch of line.matchAll(scanPattern)) {
+      const windowText = line.slice(
+        Math.max(0, patternMatch.index - labelQualifierWindow),
+        patternMatch.index + patternMatch[0].length,
+      );
+      if (false === skipPattern.test(windowText)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function isForwardLookingLine(line: string): boolean {
+  return /\b(?:guidance|outlook|forecast)\b/i.test(line) ||
+    /\b(?:expects?|expecting|anticipates?)\b/i.test(line) ||
+    /\bto\s+be\s+(?:between|in\s+(?:a\s+)?range)\b/i.test(line);
+}
+
 function extractMetricValue(
   line: string,
   pattern: RegExp,
@@ -343,6 +391,15 @@ function extractMetricValue(
     ? getQuarterColumnSearchText(searchText)
     : searchText;
   const fallbackSearchText = patternMatch ? line.slice(0, patternMatch.index) : "";
+  // A row captioned as a loss states its magnitude, with the sign carried by the caption
+  // ("Net loss of $541 million", "Non-GAAP Loss per Share Was $0.13"). A bracketed cell is
+  // already negative, so only an unsigned value is flipped. Combined captions such as
+  // "(Loss) earnings per share" keep the sign of the cell instead.
+  const isLossCaption = undefined !== patternMatch?.[0] &&
+    /\bloss\b/i.test(patternMatch[0]) &&
+    false === /\b(?:income|earnings|profit)\b/i.test(patternMatch[0]);
+  const signedValue = (value: number): number =>
+    true === isLossCaption && value > 0 ? -value : value;
 
   if ("eps" === valueType) {
     const perShareTableValue = findPerShareTableValue(preferredSearchText, currentPeriodColumnIndex);
@@ -350,11 +407,12 @@ function extractMetricValue(
     const fallbackValue = true === isMetricValuePrefix(fallbackSearchText)
       ? findEpsValue(fallbackSearchText, columnIndex)
       : null;
-    const value = perShareTableValue ?? preferredValue ?? fallbackValue;
-    if (null === value) {
+    const matchedValue = perShareTableValue ?? preferredValue ?? fallbackValue;
+    if (null === matchedValue) {
       return null;
     }
 
+    const value = signedValue(matchedValue);
     const metricText = null === perShareTableValue && null === preferredValue
       ? fallbackSearchText
       : preferredSearchText;
@@ -367,7 +425,8 @@ function extractMetricValue(
   }
 
   if ("money" === valueType) {
-    const sentenceSearchText = getMetricValueSentenceText(preferredSearchText);
+    const labelSearchText = getMetricValueSentenceText(preferredSearchText);
+    const sentenceSearchText = getBreakdownTotalText(labelSearchText) ?? labelSearchText;
     const hasMetricLabelSuffixTableNote = isMetricLabelSuffixTableNote(sentenceSearchText);
     const searchValueMatch = true === hasMetricLabelSuffixTableNote ? null : findColumnValueMatch(sentenceSearchText, {
       minUncuedAbsValue: 10,
@@ -393,7 +452,7 @@ function extractMetricValue(
     const metricText = true === useFallbackValue ? fallbackSearchText : sentenceSearchText;
     const explicitScale = getExplicitMoneyScale(metricText, parsedValueMatch.endIndex);
     const currencyCode = getCurrencyCodeFromText(metricText, contextMoney.currencyCode) ?? contextMoney.currencyCode;
-    const amount = parsedValueMatch.value * (explicitScale ?? contextMoney.scale);
+    const amount = signedValue(parsedValueMatch.value) * (explicitScale ?? contextMoney.scale);
     const maximumFractionDigits = getMoneyDisplayPrecision(
       metricText,
       parsedValueMatch.endIndex,
@@ -428,6 +487,22 @@ function extractMetricValue(
 // dividends" can mislabel the next sentence's first dollar amount as net income.
 // Table rows remain intact because their label/value cells are separated by pipes,
 // not sentence-ending punctuation followed by a new sentence.
+// A group caption whose first value cell belongs to a named sub-row is a breakdown
+// ("Revenue | Space $962 ... Connectivity 4,291 ... Total $7,814"). The caption's own
+// figure is the Total row; the leading cell is the first segment's.
+function getBreakdownTotalText(text: string): string | null {
+  const firstValueMatch = /\(?-?(?:[$€£¥]\s*)?\d/.exec(text);
+  if (null === firstValueMatch ||
+      false === /[A-Za-z]{2,}/.test(text.slice(0, firstValueMatch.index))) {
+    return null;
+  }
+
+  const totalMatch = /\bTotal\b/.exec(text);
+  return null === totalMatch
+    ? null
+    : text.slice(totalMatch.index + totalMatch[0].length);
+}
+
 function getMetricValueSentenceText(text: string): string {
   const boundaryMatch = /[.!?]\s+(?=[A-Z\d$€£¥])/u.exec(text);
   if (undefined === boundaryMatch?.index) {

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -47,6 +47,9 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\badjusted\s+(?:\d{1,2}\s+)?(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?(?:earnings\s+per\s+(?:common\s+)?share|eps)\b/i,
       /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?eps\b/i,
       /\bnon-gaap\s+(?:diluted\s+)?(?:earnings\s+per\s+share|eps)\b/i,
+      // "Non-GAAP diluted net income per share" / "Non-GAAP Diluted Loss Per Share" are
+      // the reconciliation-table labels for the same measure.
+      /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?(?:earnings|net\s+income|net\s+loss|loss|\(loss\))\s+per\s+(?:common\s+)?share\b/i,
       /\badjusted\s+profit\s+per\s+(?:common\s+)?share\b/i,
     ],
     // Guidance restates the same non-GAAP measure as a forward range, so without this
@@ -61,6 +64,7 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\b(?:diluted\s+)?(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\b/i,
       /\b(?:earnings|profit|net\s+income)(?:\s*\/)?\s*\(loss(?:es)?\)\s+per\s+(?:common\s+|ordinary\s+)?share\b/i,
       /\bprofit\s+(?:\(loss\)\s+)?per\s+(?:common\s+|ordinary\s+)?(?:share|ADS)\b/i,
+      /\bnet\s+loss\s+per\s+(?:common\s+|ordinary\s+)?share\b/i,
       /\bdiluted\s+eps\b/i,
       /\bgaap\s+(?:diluted\s+)?eps\b/i,
       /\b(?:reported\s+)?(?:net\s+)?earnings?\b(?:(?![.!?]\s)[^!?\n]){0,180}?(?<metricValue>-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share(?:\s*[-–—]\s*diluted)?\b/i,
@@ -90,6 +94,9 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\bnet\s+earnings(?!\s+per\s+(?:common\s+)?share)\b/i,
       /\bnet\s+\(loss(?:es)?\)\s+income\b/i,
       /\bnet\s+income\s*\/\s*\(loss(?:es)?\)(?!\s+per\s+(?:common\s+)?share)/i,
+      // Singular only: "net losses of a customer portfolio" is risk-factor prose, not the
+      // income-statement row a loss-making filer labels "Net loss".
+      /\bnet\s+loss(?!\s*(?:es\b|\s+per\s+(?:common\s+)?share))\b/i,
     ],
     // Skip income-statement subtotals, the noncontrolling-interest component and
     // reconciliation adjustment rows so the headline "net income/earnings attributable

--- a/modules/earnings-results-money.ts
+++ b/modules/earnings-results-money.ts
@@ -203,7 +203,9 @@ function findPlausibleEpsValue(
   options: NumericValueOptions,
   columnIndex: number,
 ): number | null {
-  const values = findNumericValues(text, options);
+  const values = findNumericValueMatches(text, options)
+    .filter(valueMatch => false === isMoneyScaledValue(text, valueMatch.endIndex))
+    .map(valueMatch => valueMatch.value);
   const columnValue = values[columnIndex];
   if ("number" === typeof columnValue && false === Number.isInteger(columnValue)) {
     return columnValue;
@@ -212,6 +214,14 @@ function findPlausibleEpsValue(
   return values.find(value => false === Number.isInteger(value)) ??
     values.find(value => Math.abs(value) < 20) ??
     null;
+}
+
+// Per-share amounts are never denominated in millions or billions, so a scale word after
+// the value marks an aggregate: "its first $3+ billion revenue quarter" sitting on a line
+// about non-GAAP EPS is a revenue milestone, not $3.00 of earnings per share.
+function isMoneyScaledValue(text: string, valueEndIndex: number): boolean {
+  return /^\s*\+?\s*(?:trillions?|billions?|millions?|thousands?|tn|bn|mm)\b/i
+    .test(text.slice(valueEndIndex, valueEndIndex + 20));
 }
 
 export function findPerShareTableValue(text: string, columnIndex: number): number | null {
@@ -280,7 +290,10 @@ export function getCurrencyCodeFromText(
   text: string,
   dollarCurrencyCode = "USD",
 ): string | undefined {
-  if (/NT\s*\$|\b(?:TWD|NTD)\b|\bNew Taiwan dollars?\b/i.test(text)) {
+  // "NT$" only denotes New Taiwan dollars as a standalone symbol. Without the leading
+  // boundary it also matches inside ordinary words — "we spe(nt $)883 million" turned a
+  // US filer's revenue into NT$883M.
+  if (/(?:^|[^A-Za-z])NT\s*\$/.test(text) || /\b(?:TWD|NTD)\b|\bNew Taiwan dollars?\b/i.test(text)) {
     return "TWD";
   }
 


### PR DESCRIPTION
## Why

A second audit covering seven more filings (SPCX, ZETA, GILD, ANET, ALAB, OPEN, AMD) found **nine wrong figures across six of them**. The causes are all distinct from #1842.

| Ticker | Posted | Correct | Cause |
|---|---|---|---|
| SPCX | Rev `$962M` | `$7,814M` | segment breakdown read from its first segment row, not `Total` |
| ZETA | EPS `$0.09` | `$0.03` | full-year guidance overrode the skip via the explicit "GAAP EPS" label |
| ZETA | Rev `$337M` | `$442.8M` | statement penalised by a split period header |
| ANET | Adj EPS `$3.00` | `$1.02` | "first `$3+` billion revenue quarter" on a non-GAAP EPS line |
| OPEN | `NT$883M` | `$883M` | `NT$` matched inside "we spe**nt $**883 million" |
| MRK | Adj EPS `+$0.13` | `-$0.13` | loss caption states magnitude; sign lost |

GILD, ALAB and AMD were already correct.

## What changed

- **Forward-looking lines can no longer be rescued** by an explicit `GAAP EPS` label, so an annual outlook range is never posted as the quarter.
- **The "adjusted" skip no longer discards a completed GAAP statement** that precedes an unrelated adjusted-EBITDA mention later in the same line.
- **Loss captions carry their own sign.** "Net loss of $541 million" and "Non-GAAP Loss per Share Was $0.13" are negative; a bracketed cell is not negated twice.
- **A breakdown's group caption resolves to its `Total` row** rather than the leading segment cell.
- **Dotted leaders are stripped.** `Revenue ....... $ 7,814` previously read as a sentence boundary and the row was cut off before any figure.
- **Whole-line disqualifiers are windowed for collapsed statements.** Where a filer emits an entire statement as one unbroken line, a single "Cost of revenue" caption used to discard every figure in it; each label occurrence is now judged on the qualifier directly ahead of it.
- **A split `Three Months Ended / Six Months Ended` header** no longer leaves the year-to-date cell nearest the row, which had penalised the consolidated statement of every filer rendering the header one cell per line.
- **`NT$` requires a leading boundary.**
- Added `non-GAAP diluted net income per share` / `Non-GAAP Diluted Loss Per Share` labels, plus bare `Net loss` and `Net loss per share` rows. These recover figures that were previously **omitted**: Adj EPS for GILD (`-$6.75`), ALAB (`$0.80`) and ANET (`$1.02`), and EPS + net loss for SPCX and OPEN.

## Review notes

- Rebased onto the module split (#1846); the changes are distributed across `metrics`, `money`, `document`, `format` and `format-selection` accordingly.
- One deliberate near-miss: CAT's net income stays **omitted**. A bare `net losses` pattern would have matched risk-factor prose ("net losses of Cat Financial's customers") and reported $10M, so the pattern is singular-only — omission over a wrong number.
- Still omitted, not wrong: AMD Adj EPS (`$1.66`). Its non-GAAP EPS is labelled only by an enclosing section header, and the prose form ("GAAP and non-GAAP ... of $0.95 and $1.02") would have risked regressing ANET's now-correct value. Left alone deliberately.
- ANET's outlook shows `49%` where guidance is a 48–49% range.

## Verification

All **eighteen** filings audited across both passes re-parsed end to end and confirmed against the source documents. `npm run test:coverage`, `npm run typecheck` and `npm run lint` all pass with no thresholds altered; 801 tests. Four new regression fixtures cover each root cause above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)