### PR TITLE
Pin earnings value-selection guards with direct tests

### DIFF
--- a/modules/earnings-results-format-regressions.test.ts
+++ b/modules/earnings-results-format-regressions.test.ts
@@ -439,4 +439,47 @@ describe("earnings result filing regressions", () => {
     ]));
     expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("NT$883M");
   });
+
+  test("prefers the diluted per-share row over the basic row printed above it", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Reports Second Quarter 2026 Results</h1>
+          <p>(in millions, except per share amounts)</p>
+          <p>Three Months Ended June 30,</p>
+          <!-- Captions that do not start with basic/diluted stay separate candidates, so
+               the choice between them rests on scoring rather than row continuation. -->
+          <p>Earnings per share attributable to common stockholders, basic | $ | 0.44</p>
+          <p>Earnings per share attributable to common stockholders, diluted | $ | 0.41</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: 0.41, value: "$0.41"}),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$0.44");
+  });
+
+  test("prefers a per-share row over an EPS reconciliation that restates the numerator", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Announces Financial Results for Second Quarter 2026</h1>
+          <p>(in € millions, except share and per share data)</p>
+          <p>Three months ended June 30, 2026</p>
+          <p>Diluted earnings per share Net income attributable to owners of the parent 545 721 (86) Shares used in computation 208,858,469</p>
+          <p>Earnings per share attributable to owners of the parent Basic 2.65 3.50 (0.42) Diluted 2.61 3.45 (0.42)</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({currencyCode: "EUR", key: "gaap_eps", numericValue: 2.61}),
+    ]));
+    const values = parsedDocument.metrics.map(metric => metric.value);
+    expect(values).not.toContain("-€86.00");
+    expect(values).not.toContain("€2.65");
+  });
+
 });

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -111,13 +111,6 @@ export function getMetricCandidateScore({
     } else if (/\(\s*cents(?:\s+per\s+share)?\s*\)/i.test(metricLine)) {
       score -= 60;
     }
-
-    // An EPS reconciliation restates the aggregate numerator first ("Diluted earnings
-    // per share | Net income attributable to ... | 545"), so the leading values on such
-    // a line are whole-currency amounts rather than per-share ones.
-    if (/\bper\s+(?:common\s+|ordinary\s+)?share\b[\s\S]{0,80}?\bnet\s+(?:income|loss|earnings)\b/i.test(metricLine)) {
-      score -= 120;
-    }
   }
 
   if ("eps" === valueType && /\bper\s+(?:common\s+)?(?:diluted\s+)?share\b/i.test(metricLine)) {

--- a/modules/earnings-results-money.test.ts
+++ b/modules/earnings-results-money.test.ts
@@ -1,6 +1,12 @@
 import {describe, expect, test} from "vitest";
 import {getMessageMetrics, parseEarningsDocument} from "./earnings-results-format.ts";
-import {formatEps, formatUsdCompact, parseNumber} from "./earnings-results-money.ts";
+import {
+  findEpsValue,
+  findNumericValue,
+  formatEps,
+  formatUsdCompact,
+  parseNumber,
+} from "./earnings-results-money.ts";
 import {type EarningsEvent} from "./earnings.ts";
 
 describe("earnings result money parsing", () => {
@@ -488,5 +494,45 @@ describe("earnings result money parsing", () => {
     expect(valuesByKey.get("revenue")).not.toBe("-$1M");
     expect(valuesByKey.get("net_income")).not.toBe("$903");
     expect(valuesByKey.get("net_income")).not.toBe("$1.18B");
+  });
+
+  // These guards are load-bearing but easy to lose, because a realistic filing usually
+  // offers a second candidate that happens to be right. Pinned directly so a regression
+  // fails here rather than surfacing as a wrong posted figure.
+  describe("per-share value plausibility", () => {
+    test("rejects a value denominated in a money scale", () => {
+      // A revenue milestone sharing a line with a non-GAAP EPS label is not $3.00 of EPS.
+      expect(findEpsValue(" as the company achieved its first $3+ billion revenue quarter.", 0))
+        .toBeNull();
+      expect(findEpsValue(" of $1.6 billion", 0)).toBeNull();
+    });
+
+    test("rejects a large whole number in a per-share position", () => {
+      // Without this an aggregate on the line is published as EPS: AMD reported -$30.00.
+      expect(findEpsValue(" of 30 and 2,760", 0)).toBeNull();
+      expect(findEpsValue(" | Net income | 545 | 721 | (86)", 0)).toBeNull();
+    });
+
+    test("keeps a fractional or small per-share value", () => {
+      expect(findEpsValue(" was $1.66.", 0)).toBe(1.66);
+      expect(findEpsValue(" $ | (0.04) | 0.51", 0)).toBe(-0.04);
+      expect(findEpsValue(" of 5", 0)).toBe(5);
+    });
+  });
+
+  describe("calendar-year exclusion", () => {
+    const scanOptions = {minUncuedAbsValue: 10, skipPercentages: true};
+
+    test("keeps a figure that merely falls in the calendar-year range", () => {
+      // "$ | 1,948" is a $1.95B quarter. Discarding it as a year shifts the row to a
+      // later column and reports the full year instead.
+      expect(findNumericValue(" | $ | 1,948 | $ | 1,988", scanOptions)).toBe(1948);
+      expect(findNumericValue(" | $ | 2,026", scanOptions)).toBe(2026);
+      expect(findNumericValue(" | 1,950.5", scanOptions)).toBe(1950.5);
+    });
+
+    test("still skips a bare year in a column header", () => {
+      expect(findNumericValue(" 2026 | 2025", scanOptions)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Why

Prompted by a fair question: does every parsing fix have a regression test? I measured it instead of assuming, by reverting each guard and running the suite.

**The fixtures pin filings, not guards.** Every fix in this series (and earlier ones) shipped with a document-level fixture asserting final metric values. But a realistic filing usually offers a second candidate that happens to be right, so removing any single guard is masked and the suite stays green.

Sampled 8 guards from this series — **6 reverted with all tests passing**. Sampled 8 older guards (#1698–#1838) — **6 reverted with all 2,406 tests passing**.

Worst case: reverting the per-share plausibility guard makes AMD report **Adj EPS of `-$30.00`** with a fully green suite.

## What changed

Direct tests for the guards that stand between a real filing and a wrong posted figure:

| Guard | Without it |
|---|---|
| money-scaled per-share value rejected | ANET Adj EPS `$3.00` from "first `$3+` billion revenue quarter" |
| large whole number in per-share position rejected | AMD Adj EPS `-$30.00` |
| grouped/money-cued figure kept inside the calendar-year range | CLX `$1,948M` discarded as a year → full-year column |
| diluted preferred over basic | PLTR EPS `$0.44` instead of `$0.41` |

The diluted case needed captions that do not begin with basic/diluted — otherwise row continuation merges them and the scoring rule is never exercised. Note that rule is a bonus/penalty pair, so single-sided mutation stays masked by design; the test pins removal of both halves.

Also **removes the EPS reconciliation score penalty** added earlier in this series. It cannot be shown to affect any outcome — the per-share maximum and the whole-number guard already reject the aggregate cells it targeted — and removing it leaves the suite and all eighteen audited filings unchanged. Unexercised scoring is worse than none.

## Known remaining gaps

Reported rather than silently left:

- `isCalendarDayValue` **is** load-bearing — without it AMD reports a bogus Adj EPS `$4.00` from "August 4, 2026" — but I could not reduce it to a faithful minimal fixture (the dateline paragraph is skipped for GAAP EPS, so the bogus candidate arises elsewhere in the full document). Not pinned; worth a follow-up.
- `isLikelyTableNoteReference`, `isEmbeddedAlphaNumericValue`, `isMetricLabelSuffixTableNote`, `isNearTableNoteColumn` and `isImplausibleSecondaryGaapEps` are unpinned and inert across all eighteen filings. They may still protect documents outside this corpus, so they are left in place rather than removed on the strength of one corpus.

## Verification

2,406 tests pass; `typecheck`, `lint` and `test:coverage` all clean with no thresholds altered. Each new test was confirmed to **fail** when its guard is reverted, and all eighteen previously audited filings produce byte-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)