### PR TITLE
Report adjusted EPS named as excluding certain items

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -257,6 +257,39 @@ const filingCorpus: {
     source: "2488/000000248826000121/q22026991.htm",
     ticker: "amd",
   },
+  {
+    company: "CVS Health",
+    metrics: [
+      ["adjusted_eps", "$2.58"],
+      ["gaap_eps", "$2.31"],
+      ["revenue", "$106.1B"],
+      ["net_income", "$2.98B"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "64803/000006480326000097/cvs_ex99x1q2-26.htm",
+    ticker: "cvs",
+  },
+  {
+    // A shareholder-letter release: the adjusted measure is named by what it leaves out
+    // ("diluted EPS excluding certain items"), and the quarter is a fiscal one the document
+    // states only as "fiscal Q3" against a "Q3 fiscal 2025" comparative, so no quarter
+    // label is derived rather than risking the prior year or the calendar quarter.
+    company: "Walt Disney",
+    metrics: [
+      ["adjusted_eps", "$2.06"],
+      ["gaap_eps", "$1.51"],
+      ["revenue", "$25.25B"],
+      ["net_income", "$2.64B"],
+    ],
+    outlook: [
+      ["EPS", "12% growth"],
+      ["Operating income", "$4.9B"],
+    ],
+    quarterLabel: undefined,
+    source: "1744489/000174448926000056/fy2026_q3xerxex991.htm",
+    ticker: "dis",
+  },
 ];
 
 describe("earnings result filing corpus", () => {
@@ -277,6 +310,6 @@ describe("earnings result filing corpus", () => {
   }
 
   test("covers every stored fixture", () => {
-    expect(filingCorpus).toHaveLength(18);
+    expect(filingCorpus).toHaveLength(20);
   });
 });

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -51,6 +51,9 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       // the reconciliation-table labels for the same measure.
       /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?(?:earnings|net\s+income|net\s+loss|loss|\(loss\))\s+per\s+(?:common\s+)?share\b/i,
       /\badjusted\s+profit\s+per\s+(?:common\s+)?share\b/i,
+      // Some filers name the measure by what it leaves out — "diluted EPS excluding certain
+      // items" — which their own footnote then defines as adjusted EPS.
+      /\b(?:diluted\s+)?(?:eps|earnings\s+per\s+(?:common\s+)?share)\s+excluding\s+certain\s+items\b/i,
     ],
     // Guidance restates the same non-GAAP measure as a forward range, so without this
     // the low end of a full-year outlook is posted as the reported quarter.
@@ -71,7 +74,7 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /(?<metricValue>\(?-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?(?:\s*(?:cents?|¢))?)\s+per\s+(?:fully\s+)?(?:common\s+)?diluted\s+share\b/i,
       /\beps\b/i,
     ],
-    skipPattern: /\badjusted\b|\bnon-gaap\b|\bguidance\b|\boutlook\b|\bforecast\b|\bexcept\s+(?:eps|per\s+share(?:\s+amounts?)?)\b/i,
+    skipPattern: /\badjusted\b|\bnon-gaap\b|\bexcluding\s+certain\s+items\b|\bguidance\b|\boutlook\b|\bforecast\b|\bexcept\s+(?:eps|per\s+share(?:\s+amounts?)?)\b/i,
     valueType: "eps",
   },
   {

--- a/modules/test-fixtures/earnings-filings/cvs.txt
+++ b/modules/test-fixtures/earnings-filings/cvs.txt
@@ -1,0 +1,965 @@
+EX-99.1
+2
+cvs_ex99x1q2-26.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+
+
+| | | | | |
+CVS HEALTH CORPORATION REPORTS STRONG SECOND QUARTER 2026 RESULTS
+AND RAISES FULL-YEAR 2026 GUIDANCE
+|
+| |
+• Second quarter total revenues increased to $106.1 billion, up 7.3% year-over-year
+• Second quarter GAAP diluted EPS of $2.31 and Adjusted EPS of $2.58
+• Generated year-to-date cash flow from operations of $10.6 billion
+• Raising full-year 2026 guidance:
+◦ GAAP diluted EPS guidance range to $6.84 to $7.04 from $6.24 to $6.44
+◦ Adjusted EPS guidance range to $7.90 to $8.10 from $7.30 to $7.50
+◦ Cash flow from operations guidance to at least $11.5 billion from at least $9.5 billion
+|
+
+| | | | | |
+
+
+|
+WOONSOCKET, RHODE ISLAND, August 5, 2026 - CVS Health Corporation (NYSE: CVS) today announced operating results for the three months ended June 30, 2026.
+|
+| |
+|
+“Our CVS Health colleagues build trust every day in communities across our country by making healthcare easier for millions of customers, patients and members. As our businesses work together to deliver a technology-powered care engagement experience, we continue to deliver strong performance. We uniquely enable what our customers want the most: simple, connected and convenient access to affordable, quality healthcare, where, when, and how they want it.”
+- David Joyner, CVS Health Chairman and CEO
+|
+
+
+
+| | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Year Ending
+December 31,
+|
+In billions, except per share amounts
+| 2026 | | 2025 | | 2026 Projected
+|
+Total revenues
+| $ | 106.1 | | | $ | 98.9 | | | At least $414.0
+|
+| | | | | |
+| | | | | |
+Diluted earnings per share
+| $ | 2.31 | | | $ | 0.80 | | | $6.84-$7.04
+|
+Adjusted EPS (2)
+| $ | 2.58 | | | $ | 1.81 | | | $7.90-$8.10
+|
+| | | | | |
+
+
+
+Second quarter GAAP diluted EPS of $2.31 increased from $0.80 in the prior year. Adjusted EPS of $2.58 increased from $1.81 in the prior year, primarily due to improved adjusted operating income in the Health Care Benefits segment, reflecting continued execution on the Health Care Benefits segment margin recovery plan.
+
+
+The Company is increasing its full-year 2026 GAAP diluted EPS, Adjusted EPS and cash flow from operations guidance to reflect increases in the Health Care Benefits and Pharmacy & Consumer Wellness segments, while maintaining a cautious view for the remainder of the year in light of continued elevated cost trends and the potential for macro headwinds.
+
+
+
+1
+
+
+
+
+
+
+
+Consolidated second quarter results
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+In millions, except per share amounts | 2026 | | 2025 | | Change | | 2026 | | 2025 | | Change |
+Total revenues
+| $ | 106,096 | | | $ | 98,915 | | | $ | 7,181 | | | $ | 206,522 | | | $ | 193,503 | | | $ | 13,019 | |
+Operating income
+| 4,703 | | | 2,381 | | | 2,322 | | | 9,383 | | | 5,755 | | | 3,628 | |
+Adjusted operating income (1)
+| 5,157 | | | 3,808 | | | 1,349 | | | 10,307 | | | 8,387 | | | 1,920 | |
+Net income
+| 2,995 | | | 1,013 | | | 1,982 | | | 5,952 | | | 2,795 | | | 3,157 | |
+Diluted earnings per share
+| $ | 2.31 | | | $ | 0.80 | | | $ | 1.51 | | | $ | 4.61 | | | $ | 2.21 | | | $ | 2.40 | |
+Adjusted EPS (2)
+| $ | 2.58 | | | $ | 1.81 | | | $ | 0.77 | | | $ | 5.16 | | | $ | 4.06 | | | $ | 1.10 | |
+
+
+
+For the three months ended June 30, 2026 compared to the prior year:
+• Total revenues increased 7.3% driven by revenue growth across all operating segments.
+• Operating income increased 97.5% primarily due to the increase in adjusted operating income described below and the absence of $833 million in legacy litigation charges recorded in the prior year.
+• Adjusted operating income increased 35.4% driven by increases across all operating segments. See pages 3 through 5 for additional discussion of the adjusted operating income performance of the Company’s segments.
+
+
+Operational Updates
+• CVS Health launched a comprehensive approach to GLP-1 support across its CVS Pharmacy ® and MinuteClinic ® locations. New offerings include expanded pharmacy support designed to help patients access these treatments and stay on them, and a new $29 MinuteClinic virtual visit that connects eligible adults with licensed clinicians who can evaluate and, where clinically appropriate, prescribe GLP-1 therapy. In addition, CVS Pharmacy participates in the Centers for Medicare & Medicaid Services Medicare GLP-1 Bridge program, which runs through December 31, 2027. Eligible Medicare beneficiaries can access certain GLP-1 medications for $50 per month, offering more predictable and affordable pricing for patients who qualify.
+• CVS Caremark updated its most common commercial formularies, expanding GLP-1 options for members, building on its industry-leading efforts to help patients get FDA-approved weight management medications at an affordable cost.
+• CVS Health is deploying agentic AI to simplify and streamline call center interactions for members and providers engaging with Aetna ® and CVS Caremark ® businesses on a secure call center platform.
+• Aetna launched its second generation Aetna Claims Assist Manager (“CAM”), an AI-powered agentic claims advisor platform designed to streamline claims processing and improve payment accuracy. CAM reduces processing time by over 20% for complex claims that require manual review, helping providers get paid faster and more consistently.
+2
+
+
+
+
+
+
+
+
+Health Care Benefits segment
+
+
+The Health Care Benefits segment offers a full range of insured and self-insured (“ASC”) medical, pharmacy, dental and behavioral health products and services. The segment results for the three and six months ended June 30, 2026 and 2025 were as follows:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+In millions, except percentages | 2026 | | 2025 | | Change | | 2026 | | 2025 | | Change |
+Total revenues | $ | 37,538 | | $ | 36,258 | | $ | 1,280 | | $ | 73,509 | | $ | 71,068 | | $ | 2,441 |
+Adjusted operating income (1)
+| 2,426 | | 1,308 | | 1,118 | | 5,467 | | 3,301 | | 2,166 |
+Medical benefit ratio (“MBR”) (3)
+| 87.4 | % | | 89.9 | % | | (2.5) | % | | 86.0 | % | | 88.6 | % | | (2.6) | % |
+Medical membership (4)
+| | | | | | | 26.0 | | 26.7 | | (0.7) |
+
+
+
+• Total revenues increased 3.5% for the three months ended June 30, 2026 compared to the prior year primarily driven by an increase in the Government business, partially offset by a decline as a result of the Company’s exit of the individual exchange business in 2026.
+• Adjusted operating income increased 85.5% for the three months ended June 30, 2026 compared to the prior year primarily driven by improved underlying performance in the Government business and the absence of a $471 million premium deficiency reserve recorded within the Group Medicare Advantage product line in the prior year.
+• The MBR decreased to 87.4% in the three months ended June 30, 2026 compared to 89.9% in the prior year primarily driven by improved underlying performance in the Government business and the absence of the premium deficiency reserve recorded in the prior year.
+• Medical membership as of June 30, 2026 of 26.0 million remained consistent compared with March 31, 2026.
+• Prior years’ health care costs payable estimates developed favorably by $1.2 billion during the six months ended June 30, 2026.
+• Days claims payable were 41.7 days as of June 30, 2026, a decrease of 1.2 days compared to March 31, 2026.
+3
+
+
+
+
+
+
+
+
+Health Services segment
+
+
+The Health Services segment provides a full range of pharmacy benefit management solutions, delivers health care services in its medical clinics, virtually, and in the home, and offers provider enablement solutions. The segment results for the three and six months ended June 30, 2026 and 2025 were as follows:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+In millions | 2026 | | 2025 | | Change | | 2026 | | 2025 | | Change |
+Total revenues | $ | 51,795 | | | $ | 46,453 | | | $ | 5,342 | | | $ | 100,032 | | | $ | 89,915 | | | $ | 10,117 | |
+Adjusted operating income (1)
+| 1,733 | | | 1,575 | | | 158 | | | 3,222 | | | 3,178 | | | 44 | |
+Pharmacy claims processed (5) (6)
+| 473.0 | | | 469.0 | | | 4.0 | | | 937.7 | | | 933.2 | | | 4.5 | |
+
+
+• Total revenues increased 11.5% for the three months ended June 30, 2026 compared to the prior year primarily driven by pharmacy drug mix and brand inflation, partially offset by continued pharmacy client price improvements.
+• Adjusted operating income increased 10.0% for the three months ended June 30, 2026 compared to the prior year primarily driven by improved purchasing economics, pharmacy drug mix and modest improvement in the Company’s health care delivery business. These increases were partially offset by continued pharmacy client price improvements.
+• Pharmacy claims processed remained consistent on a 30-day equivalent basis for the three months ended June 30, 2026 compared to the prior year.
+4
+
+
+
+
+
+
+
+
+Pharmacy & Consumer Wellness segment
+
+
+The Pharmacy & Consumer Wellness segment dispenses prescriptions in its retail pharmacies and through its infusion operations, provides ancillary pharmacy services including pharmacy patient care programs and vaccination administration, and sells a wide assortment of health and wellness products and general merchandise. The segment also provides pharmacy fulfillment services to support the Health Services segment’s specialty and mail order pharmacy offerings. The segment results for the three and six months ended June 30, 2026 and 2025 were as follows:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+In millions | 2026 | | 2025 | | Change | | 2026 | | 2025 | | Change |
+Total revenues | $ | 33,816 | | | $ | 33,581 | | | $ | 235 | | | $ | 65,805 | | | $ | 65,493 | | | $ | 312 | |
+Adjusted operating income (1)
+| 1,475 | | | 1,338 | | | 137 | | | 2,672 | | | 2,651 | | | 21 | |
+Prescriptions filled (5) (6)
+| 457.0 | | | 438.1 | | | 18.9 | | | 908.2 | | | 873.6 | | | 34.6 | |
+
+
+• Total revenues increased slightly for the three months ended June 30, 2026 compared to the prior year primarily driven by pharmacy drug mix, increased prescription volume, including contributions from the Company’s Rite Aid asset acquisitions which were completed during the third quarter of 2025, and brand inflation. These increases were largely offset by regulatory-related price reductions on certain drugs, the impact of recent generic drug introductions and pharmacy reimbursement pressure.
+• Adjusted operating income increased 10.2% for the three months ended June 30, 2026 compared to the prior year primarily driven by core pharmacy strength and contributions from the Company’s Rite Aid asset acquisitions. These increases were partially offset by continued business investments and the impact of consumer dynamics.
+• Prescriptions filled increased 4.3% on a 30-day equivalent basis for the three months ended June 30, 2026 compared to the prior year primarily driven by incremental volume resulting from the Company’s Rite Aid prescription file acquisitions and increased utilization, partially offset by the absence of long-term care pharmacy prescription volume following the deconsolidation of Omnicare, LLC in September 2025.
+5
+
+
+
+
+
+
+
+
+About CVS Health
+
+
+CVS Health is a leading health solutions company simplifying health care one person, one family and one community at a time. As of June 30, 2026, the Company had approximately 9,000 retail pharmacy locations, more than 1,000 walk-in and primary care medical clinics and a leading pharmacy benefits manager with approximately 87 million plan members. The Company also serves an estimated 37 million people through a broad range of health insurance products and related services. The Company’s integrated model uses personalized, technology driven services to connect people to simply better health, increasing access to quality care, delivering better outcomes, and lowering overall costs.
+
+
+Teleconference and Webcast
+
+
+The Company will be holding a conference call today for investors at 8:00 a.m. (Eastern Time) to discuss its second quarter results. An audio webcast of the call will be broadcast simultaneously for all interested parties through the Investor Relations section of the CVS Health website at http://investors.cvshealth.com. This webcast will be archived and available on the website for a one-year period following the conference call.
+
+
+Non-GAAP Financial Information
+
+
+The Company presents both GAAP and non-GAAP financial measures in this press release to assist in the comparison of the Company’s past financial performance with its current financial performance. See “Non-GAAP Financial Information” beginning on page 10 and endnotes beginning on page 20 for explanations of non-GAAP financial measures presented in this press release. See pages 12 through 14 and page 19 for reconciliations of each non-GAAP financial measure used in this release to the most directly comparable GAAP financial measure.
+
+
+Cautionary Statement Concerning Forward-looking Statements
+
+
+The Private Securities Litigation Reform Act of 1995 provides a safe harbor for forward-looking statements made by or on behalf of CVS Health Corporation. Statements in this press release that are forward-looking include, but are not limited to, the full-year 2026 guidance information, Mr. Joyner’s quotation and the information included in the reconciliations and endnotes. By their nature, all forward-looking statements are not guarantees of future performance or results and are subject to risks and uncertainties that are difficult to predict and/or quantify. Actual results may differ materially from those contemplated by the forward-looking statements due to the risks and uncertainties described in our Securities and Exchange Commission (“SEC”) filings, including those set forth in the Risk Factors section and under the heading “Cautionary Statement Concerning Forward-Looking Statements” in our most recently filed Annual Report on Form 10-K, our Quarterly Reports on Form 10-Q for the quarterly periods ended March 31, 2026 and June 30, 2026 and our Current Reports on Form 8-K.
+
+
+You are cautioned not to place undue reliance on CVS Health’s forward-looking statements. CVS Health’s forward-looking statements are and will be based upon management’s then-current views and assumptions regarding future events and operating performance, and are applicable only as of the dates of such statements. CVS Health does not assume any duty to update or revise forward-looking statements, whether as a result of new information, future events, uncertainties or otherwise.
+
+
+| | |
+|
+
+Investor Contact: Larry McGrath | Executive Vice President, Capital Markets | (800) 201-0938
+Media Contact: Ethan Slavin | Executive Director, Corporate Communications | (860) 273-6095
+
+
+- Tables Follow -
+
+
+
+6
+
+
+
+
+
+
+
+
+CVS HEALTH CORPORATION
+Condensed Consolidated Statements of Operations
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+In millions, except per share amounts | 2026 | | 2025
+| | 2026 | | 2025
+|
+Revenues: | | | | | | | |
+Products | $ | 66,219 | | | $ | 60,607 | | | $ | 128,445 | | | $ | 118,276 | |
+Premiums | 35,117 | | | 34,195 | | | 68,908 | | | 67,015 | |
+Services | 4,119 | | | 3,626 | | | 7,954 | | | 7,205 | |
+Net investment income | 641 | | | 487 | | | 1,215 | | | 1,007 | |
+Total revenues | 106,096 | | | 98,915 | | | 206,522 | | | 193,503 | |
+Operating costs: | | | | | | | |
+Cost of products sold | 58,862 | | | 54,005 | | | 114,306 | | | 105,062 | |
+Health care costs | 31,485 | | | 31,317 | | | 60,843 | | | 60,452 | |
+Operating expenses | 11,046 | | | 11,212 | | | 21,990 | | | 22,234 | |
+| | | | | | | |
+Total operating costs | 101,393 | | | 96,534 | | | 197,139 | | | 187,748 | |
+Operating income
+| 4,703 | | | 2,381 | | | 9,383 | | | 5,755 | |
+| | | | | | | |
+Interest expense | (757) | | | (763) | | | (1,531) | | | (1,548) | |
+Other income | 31 | | | 29 | | | 63 | | | 57 | |
+Income before income tax provision
+| 3,977 | | | 1,647 | | | 7,915 | | | 4,264 | |
+Income tax provision | 982 | | | 634 | | | 1,963 | | | 1,469 | |
+Net income
+| 2,995 | | | 1,013 | | | 5,952 | | | 2,795 | |
+Net (income) loss attributable to noncontrolling interests | (16) | | | 8 | | | (30) | | | 5 | |
+Net income attributable to CVS Health
+| $ | 2,979 | | | $ | 1,021 | | | $ | 5,922 | | | $ | 2,800 | |
+| | | | | | | |
+Net income per share attributable to CVS Health:
+| | | | | | | |
+Basic | $ | 2.33 | | | $ | 0.81 | | | $ | 4.64 | | | $ | 2.22 | |
+Diluted | $ | 2.31 | | | $ | 0.80 | | | $ | 4.61 | | | $ | 2.21 | |
+Weighted average shares outstanding: | | | | | | | |
+Basic | 1,279 | | | 1,266 | | | 1,276 | | | 1,264 | |
+Diluted | 1,287 | | | 1,270 | | | 1,283 | | | 1,267 | |
+
+
+
+7
+
+
+
+
+
+
+
+
+CVS HEALTH CORPORATION
+Condensed Consolidated Balance Sheets
+(Unaudited) | | | | | | | | | | | |
+In millions | June 30,
+2026 | | December 31,
+2025 |
+Assets: | | | |
+Cash and cash equivalents | $ | 11,329 | | | $ | 8,453 | |
+Investments | 2,629 | | | 2,145 | |
+Accounts receivable, net | 40,309 | | | 39,779 | |
+Inventories | 17,622 | | | 19,246 | |
+Other current assets | 3,457 | | | 5,091 | |
+Total current assets | 75,346 | | | 74,714 | |
+Long-term investments | 33,247 | | | 32,669 | |
+Property and equipment, net | 13,168 | | | 13,083 | |
+Operating lease right-of-use assets | 14,451 | | | 14,973 | |
+Goodwill | 85,478 | | | 85,478 | |
+Intangible assets, net | 24,644 | | | 25,508 | |
+Other assets | 7,434 | | | 7,113 | |
+Total assets | $ | 253,768 | | | $ | 253,538 | |
+| | | |
+Liabilities: | | | |
+Accounts payable | $ | 17,167 | | | $ | 17,641 | |
+Pharmacy claims and discounts payable | 26,203 | | | 26,344 | |
+Health care costs payable | 16,313 | | | 15,399 | |
+Accrued expenses and other current liabilities
+| 22,477 | | | 22,387 | |
+Other insurance liabilities | 1,009 | | | 1,116 | |
+Current portion of operating lease liabilities | 1,914 | | | 1,737 | |
+| | | |
+Current portion of long-term debt | 1,958 | | | 4,068 | |
+| | | |
+Total current liabilities | 87,041 | | | 88,692 | |
+Long-term operating lease liabilities | 12,982 | | | 13,643 | |
+Long-term debt | 59,452 | | | 60,502 | |
+Deferred income taxes | 3,766 | | | 3,832 | |
+Other long-term insurance liabilities | 4,516 | | | 4,716 | |
+Other long-term liabilities | 6,112 | | | 6,771 | |
+Total liabilities | 173,869 | | | 178,156 | |
+| | | |
+Shareholders’ equity: | | | |
+Preferred stock | — | | | — | |
+Common stock and capital surplus | 50,968 | | | 50,402 | |
+Treasury stock | (36,852) | | | (36,790) | |
+Retained earnings | 65,398 | | | 61,196 | |
+Accumulated other comprehensive income | 188 | | | 406 | |
+Total CVS Health shareholders’ equity | 79,702 | | | 75,214 | |
+Noncontrolling interests | 197 | | | 168 | |
+Total shareholders’ equity | 79,899 | | | 75,382 | |
+Total liabilities and shareholders’ equity | $ | 253,768 | | | $ | 253,538 | |
+
+
+
+8
+
+
+
+
+
+
+
+
+CVS HEALTH CORPORATION
+Condensed Consolidated Statements of Cash Flows
+(Unaudited)
+| | | | | | | | | | | |
+| Six Months Ended
+June 30, |
+In millions | 2026 | | 2025
+|
+Cash flows from operating activities: | | | |
+Reconciliation of net income to net cash provided by operating activities:
+| | | |
+Net income
+| $ | 5,952 | | | $ | 2,795 | |
+Adjustments required to reconcile net income to net cash provided by operating activities:
+| | | |
+Depreciation and amortization | 2,241 | | | 2,325 | |
+| | | |
+Stock-based compensation | 442 | | | 262 | |
+Loss on sale of subsidiary
+| — | | | 236 | |
+| | | |
+Deferred income taxes and other items
+| (241) | | | (283) | |
+Change in operating assets and liabilities
+| 2,200 | | | 1,118 | |
+Net cash provided by operating activities | 10,594 | | | 6,453 | |
+| | | |
+Cash flows from investing activities: | | | |
+Proceeds from sales and maturities of investments | 7,483 | | | 6,866 | |
+Purchases of investments | (8,704) | | | (7,186) | |
+Purchases of property and equipment | (1,540) | | | (1,350) | |
+Acquisitions
+| (9) | | | (139) | |
+Other | 12 | | | 23 | |
+Net cash used in investing activities | (2,758) | | | (1,786) | |
+| | | |
+Cash flows from financing activities: | | | |
+Commercial paper borrowings (repayments), net | — | | | 921 | |
+| | | |
+Repayments of long-term debt | (3,287) | | | (762) | |
+| | | |
+Dividends paid | (1,725) | | | (1,706) | |
+Proceeds from exercise of stock options | 217 | | | 191 | |
+Payments for taxes related to net share settlement of equity awards | (154) | | | (125) | |
+Other | (62) | | | (45) | |
+Net cash used in financing activities | (5,011) | | | (1,526) | |
+Net increase in cash, cash equivalents and restricted cash | 2,825 | | | 3,141 | |
+Cash, cash equivalents and restricted cash at the beginning of the period | 8,712 | | | 8,884 | |
+Cash, cash equivalents and restricted cash at the end of the period | $ | 11,537 | | | $ | 12,025 | |
+
+
+
+
+
+9
+
+
+
+
+
+
+
+
+Non-GAAP Financial Information
+
+
+The Company uses non-GAAP financial measures to analyze underlying business performance and trends. The Company believes that providing these non-GAAP financial measures enhances the Company’s and investors’ ability to compare the Company’s past financial performance with its current and expected future performance. These non-GAAP financial measures, which are included in this press release and which may be referred to on the conference call discussing the Company’s second quarter financial results, are provided as supplemental information to the financial measures presented in this press release and discussed on the conference call that are calculated and presented in accordance with GAAP. Non-GAAP financial measures should not be considered a substitute for, or superior to, financial measures determined or calculated in accordance with GAAP. The Company’s definitions of its non-GAAP financial measures may not be comparable to similarly titled measures reported by other companies.
+
+
+Non-GAAP financial measures such as consolidated adjusted operating income, adjusted earnings per share (“EPS”) and adjusted income attributable to CVS Health exclude from the relevant GAAP metrics, as applicable: amortization of intangible assets, net realized capital gains or losses and other items, if any, that neither relate to the ordinary course of the Company’s business nor reflect the Company’s underlying business performance.
+
+
+For the periods covered in this press release, the following items are excluded from the non-GAAP financial measures described above, as applicable, because the Company believes they neither relate to the ordinary course of the Company’s business nor reflect the Company’s underlying business performance:
+• The Company’s acquisition activities have resulted in the recognition of intangible assets as required under the acquisition method of accounting which consist primarily of trademarks, customer contracts/relationships, covenants not to compete, technology, provider networks and value of business acquired. Definite-lived intangible assets are amortized over their estimated useful lives and are tested for impairment when events indicate that the carrying value may not be recoverable. The amortization of intangible assets is reflected in operating expenses within each segment. Although intangible assets contribute to the Company’s revenue generation, the amortization of intangible assets does not directly relate to the underwriting of the Company’s insurance products, the services performed for the Company’s customers or the sale of the Company’s products or services. Additionally, intangible asset amortization expense typically fluctuates based on the size and timing of the Company’s acquisition activity. Accordingly, the Company believes excluding the amortization of intangible assets enhances the Company’s and investors’ ability to compare the Company’s past financial performance with its current performance and to analyze underlying business performance and trends. Intangible asset amortization excluded from the related non-GAAP financial measure represents the entire amount recorded within the Company’s GAAP financial statements, and the revenue generated by the associated intangible assets has not been excluded from the related non-GAAP financial measure. Intangible asset amortization is excluded from the related non-GAAP financial measure because the amortization, unlike the related revenue, is not affected by operations of any particular period unless an intangible asset becomes impaired or the estimated useful life of an intangible asset is revised.
+• The Company’s net realized capital gains and losses arise from various types of transactions, primarily in the course of managing a portfolio of assets that support the payment of insurance liabilities. Net realized capital gains and losses are reflected in net investment income (loss) within each segment. These capital gains and losses are the result of investment decisions, market conditions and other economic developments that are unrelated to the performance of the Company’s business, and the amount and timing of these capital gains and losses do not directly relate to the underwriting of the Company’s insurance products, the services performed for the Company’s customers or the sale of the Company’s products or services. Accordingly, the Company believes excluding net realized capital gains and losses enhances the Company’s and investors’ ability to compare the Company’s past financial performance with its current performance and to analyze underlying business performance and trends.
+• During the three and six months ended June 30, 2026 and 2025, the acquisition-related integration costs relate to the acquisitions of Signify Health, Inc. and Oak Street Health, Inc. The acquisition-related integration costs are reflected in operating expenses within the Corporate/Other segment.
+10
+
+
+
+
+
+
+
+• During the three and six months ended June 30, 2025, the Company recorded legacy litigation charges related to two court decisions associated with its past business practices. The legacy litigation charges were reflected in operating expenses within the Pharmacy & Consumer Wellness and Health Services segments.
+• During the three and six months ended June 30, 2025, the loss on the wind down and sale of Accountable Care assets represents the pre-tax loss on the divestiture of the Company’s Medicare Shared Savings Program (“MSSP”) operations, as well as costs incurred in connection with the wind down of the Company’s ACO REACH operations. The loss on Accountable Care assets was reflected in operating expenses within the Health Services segment.
+• During the three and six months ended June 30, 2025, the office real estate optimization charges primarily relate to the abandonment of leased real estate and the related right-of-use assets and property and equipment in connection with the Company’s evaluation of corporate office real estate space. The office real estate optimization charges were reflected in operating expenses within each segment.
+• The corresponding tax benefit or expense related to the items excluded from adjusted income attributable to CVS Health and Adjusted EPS above. The nature of each non-GAAP adjustment is evaluated to determine whether a discrete adjustment should be made to the adjusted income tax provision.
+
+
+See endnotes (1) and (2) on page 20 for definitions of non-GAAP financial measures. Reconciliations of each non-GAAP financial measure to the most directly comparable GAAP financial measure are presented on pages 12 through 14 and page 19 .
+11
+
+
+
+
+
+
+
+
+Reconciliations of Non-GAAP Financial Measures to the Most Directly Comparable GAAP Financial Measures
+
+
+Adjusted Operating Income
+(Unaudited)
+
+
+The following are reconciliations of consolidated operating income (GAAP measure) to consolidated adjusted operating income, as well as reconciliations of segment GAAP operating income (loss) to segment adjusted operating income (loss):
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, 2026 | | |
+In millions | Health Care
+Benefits | | Health
+Services | | Pharmacy &
+Consumer
+Wellness | | Corporate/
+Other | | Consolidated
+Totals | | |
+Operating income (loss) (GAAP measure) | $ | 2,191 | | | $ | 1,603 | | | $ | 1,411 | | | $ | (502) | | | $ | 4,703 | | | |
+Amortization of intangible assets | 237 | | | 130 | | | 64 | | | — | | | 431 | | | |
+Net realized capital (gains) losses | (2) | | | — | | | — | | | 15 | | | 13 | | | |
+Acquisition-related integration costs | — | | | — | | | — | | | 10 | | | 10 | | | |
+| | | | | | | | | | | |
+Adjusted operating income (loss) (1)
+| $ | 2,426 | | | $ | 1,733 | | | $ | 1,475 | | | $ | (477) | | | $ | 5,157 | | | |
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, 2025 |
+In millions | Health Care
+Benefits | | Health
+Services | | Pharmacy &
+Consumer
+Wellness | | Corporate/
+Other | | | | Consolidated
+Totals |
+Operating income (loss) (GAAP measure) | $ | 1,002 | | | $ | 1,102 | | | $ | 736 | | | $ | (459) | | | | | $ | 2,381 | |
+Amortization of intangible assets | 293 | | | 141 | | | 60 | | | — | | | | | 494 | |
+Net realized capital losses | 13 | | | — | | | — | | | 14 | | | | | 27 | |
+Acquisition-related integration costs
+| — | | | — | | | — | | | 28 | | | | | 28 | |
+Legacy litigation charges | — | | | 291 | | | 542 | | | — | | | | | 833 | |
+Loss on Accountable Care assets
+| — | | | 41 | | | — | | | — | | | | | 41 | |
+Office real estate optimization charges | — | | | — | | | — | | | 4 | | | | | 4 | |
+Adjusted operating income (loss) (1)
+| $ | 1,308 | | | $ | 1,575 | | | $ | 1,338 | | | $ | (413) | | | | | $ | 3,808 | |
+
+
+
+12
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Six Months Ended June 30, 2026 |
+In millions | Health Care
+Benefits | | Health
+Services | | Pharmacy &
+Consumer
+Wellness | | Corporate/
+Other | | | | Consolidated
+Totals |
+Operating income (loss) (GAAP measure)
+| $ | 4,997 | | | $ | 2,950 | | | $ | 2,545 | | | $ | (1,109) | | | | | $ | 9,383 | |
+Amortization of intangible assets | 473 | | | 272 | | | 127 | | | 1 | | | | | 873 | |
+Net realized capital (gains) losses | (3) | | | — | | | — | | | 32 | | | | | 29 | |
+Acquisition-related integration costs
+| — | | | — | | | — | | | 22 | | | | | 22 | |
+| | | | | | | | | | | |
+Adjusted operating income (loss) (1)
+| $ | 5,467 | | | $ | 3,222 | | | $ | 2,672 | | | $ | (1,054) | | | | | $ | 10,307 | |
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Six Months Ended June 30, 2025 |
+In millions | Health Care
+Benefits | | Health
+Services | | Pharmacy &
+Consumer
+Wellness | | Corporate/
+Other | | | | Consolidated
+Totals |
+Operating income (loss) (GAAP measure) | $ | 2,676 | | | $ | 2,329 | | | $ | 1,600 | | | $ | (850) | | | | | $ | 5,755 | |
+Amortization of intangible assets | 587 | | | 285 | | | 120 | | | 1 | | | | | 993 | |
+Net realized capital (gains) losses | 34 | | | (15) | | | — | | | 29 | | | | | 48 | |
+Acquisition-related integration costs
+| — | | | — | | | — | | | 73 | | | | | 73 | |
+| | | | | | | | | | | |
+Legacy litigation charges | — | | | 291 | | | 929 | | | — | | | | | 1,220 | |
+Loss on Accountable Care assets | — | | | 288 | | | — | | | — | | | | | 288 | |
+Office real estate optimization charges | 4 | | | — | | | 2 | | | 4 | | | | | 10 | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+Adjusted operating income (loss) (1)
+| $ | 3,301 | | | $ | 3,178 | | | $ | 2,651 | | | $ | (743) | | | | | $ | 8,387 | |
+
+13
+
+
+
+
+
+
+
+
+Adjusted Earnings Per Share
+(Unaudited)
+
+
+The following are reconciliations of net income attributable to CVS Health to adjusted income attributable to CVS Health and calculations of GAAP diluted EPS and Adjusted EPS:
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, 2026 | | Three Months Ended
+June 30, 2025 |
+In millions, except per share amounts | Total
+Company | | Per
+Common
+Share | | Total
+Company | | Per
+Common
+Share |
+Net income attributable to CVS Health (GAAP measure) | $ | 2,979 | | | $ | 2.31 | | | $ | 1,021 | | | $ | 0.80 | |
+Amortization of intangible assets | 431 | | | 0.33 | | | 494 | | | 0.39 | |
+Net realized capital losses | 13 | | | 0.01 | | | 27 | | | 0.02 | |
+Acquisition-related integration costs
+| 10 | | | 0.01 | | | 28 | | | 0.02 | |
+Legacy litigation charges | — | | | — | | | 833 | | | 0.66 | |
+Loss on Accountable Care assets | — | | | — | | | 41 | | | 0.03 | |
+Office real estate optimization charges | — | | | — | | | 4 | | | — | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+Tax impact of non-GAAP adjustments | (109) | | | (0.08) | | | (144) | | | (0.11) | |
+Adjusted income attributable to CVS Health (2)
+| $ | 3,324 | | | $ | 2.58 | | | $ | 2,304 | | | $ | 1.81 | |
+| | | | | | | |
+Weighted average diluted shares outstanding | | | 1,287 | | | | | 1,270 | |
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Six Months Ended
+June 30, 2026 | | Six Months Ended
+June 30, 2025 |
+In millions, except per share amounts | Total
+Company | | Per
+Common
+Share | | Total
+Company | | Per
+Common
+Share |
+Net income attributable to CVS Health (GAAP measure) | $ | 5,922 | | | $ | 4.61 | | | $ | 2,800 | | | $ | 2.21 | |
+Amortization of intangible assets | 873 | | | 0.68 | | | 993 | | | 0.78 | |
+Net realized capital losses | 29 | | | 0.02 | | | 48 | | | 0.04 | |
+Acquisition-related integration costs
+| 22 | | | 0.02 | | | 73 | | | 0.06 | |
+| | | | | | | |
+| | | | | | | |
+Legacy litigation charges | — | | | — | | | 1,220 | | | 0.96 | |
+Loss on Accountable Care assets | — | | | — | | | 288 | | | 0.23 | |
+Office real estate optimization charges | — | | | — | | | 10 | | | 0.01 | |
+| | | | | | | |
+| | | | | | | |
+Tax impact of non-GAAP adjustments | (230) | | | (0.17) | | | (284) | | | (0.23) | |
+Adjusted income attributable to CVS Health (2)
+| $ | 6,616 | | | $ | 5.16 | | | $ | 5,148 | | | $ | 4.06 | |
+| | | | | | | |
+Weighted average diluted shares outstanding
+| | | 1,283 | | | | | 1,267 | |
+
+14
+
+
+
+
+
+
+
+
+Supplemental Information
+(Unaudited)
+
+
+The following are reconciliations of financial measures of the Company’s segments to the consolidated totals:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+In millions | Health Care
+Benefits | | Health
+Services
+| | Pharmacy &
+Consumer
+Wellness | | Corporate/
+Other | | Intersegment
+Eliminations (a)
+| | Consolidated
+Totals |
+Three Months Ended | | | | | | | | | | | |
+June 30, 2026 | | | | | | | | | | | |
+Total revenues | $ | 37,538 | | | $ | 51,795 | | | $ | 33,816 | | | $ | 147 | | | $ | (17,200) | | | $ | 106,096 | |
+Adjusted operating income (loss) (1)
+| 2,426 | | | 1,733 | | | 1,475 | | | (477) | | | — | | | 5,157 | |
+June 30, 2025 | | | | | | | | | | | |
+Total revenues | $ | 36,258 | | | $ | 46,453 | | | $ | 33,581 | | | $ | 96 | | | $ | (17,473) | | | $ | 98,915 | |
+Adjusted operating income (loss) (1)
+| 1,308 | | | 1,575 | | | 1,338 | | | (413) | | | — | | | 3,808 | |
+| | | | | | | | | | | |
+Six Months Ended | | | | | | | | | | | |
+June 30, 2026 | | | | | | | | | | | |
+Total revenues | $ | 73,509 | | | $ | 100,032 | | | $ | 65,805 | | | $ | 273 | | | $ | (33,097) | | | $ | 206,522 | |
+Adjusted operating income (loss) (1)
+| 5,467 | | | 3,222 | | | 2,672 | | | (1,054) | | | — | | | 10,307 | |
+June 30, 2025 | | | | | | | | | | | |
+Total revenues | $ | 71,068 | | | $ | 89,915 | | | $ | 65,493 | | | $ | 229 | | | $ | (33,202) | | | $ | 193,503 | |
+Adjusted operating income (loss) (1)
+| 3,301 | | | 3,178 | | | 2,651 | | | (743) | | | — | | | 8,387 | |
+
+_____________________________________________
+(a) Intersegment revenue eliminations relate to intersegment revenue generating activities that occur between the Health Care Benefits segment, the Health Services segment, and/or the Pharmacy & Consumer Wellness segment.
+
+15
+
+
+
+
+
+
+
+
+Supplemental Information
+(Unaudited)
+
+
+Health Care Benefits segment
+
+
+The following table summarizes the Health Care Benefits segment’s performance for the respective periods:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | Change |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, | | Three Months Ended
+June 30,
+2026 vs 2025 | | Six Months Ended
+June 30,
+2026 vs 2025 |
+In millions, except percentages and basis points (“bps”) | 2026 | | 2025 | | 2026 | | 2025 | | $ | | % | | $ | | % |
+Revenues: | | | | | | | | | | | | | | | |
+Premiums | $ | 35,119 | | $ | 34,184 | | $ | 68,911 | | $ | 66,992 | | $ | 935 | | | 2.7 | % | | $ | 1,919 | | | 2.9 | % |
+Services | 1,911 | | 1,667 | | 3,628 | | 3,282 | | 244 | | | 14.6 | % | | 346 | | | 10.5 | % |
+Net investment income | 508 | | 407 | | 970 | | 794 | | 101 | | | 24.8 | % | | 176 | | | 22.2 | % |
+Total revenues | 37,538 | | 36,258 | | 73,509 | | 71,068 | | 1,280 | | | 3.5 | % | | 2,441 | | | 3.4 | % |
+Health care costs | 30,692 | | 30,740 | | 59,271 | | 59,377 | | (48) | | | (0.2) | % | | (106) | | | (0.2) | % |
+MBR (Health care costs as a % of premium revenues) (3)
+| 87.4 | % | | 89.9 | % | | 86.0 | % | | 88.6 | % | | (250) | | bps | | (260) | | bps |
+Operating expenses | $ | 4,655 | | $ | 4,516 | | $ | 9,241 | | $ | 9,015 | | $ | 139 | | | 3.1 | % | | $ | 226 | | | 2.5 | % |
+Operating expenses as a % of total revenues | 12.4 | % | | 12.5 | % | | 12.6 | % | | 12.7 | % | | | | | | | | |
+Operating income
+| $ | 2,191 | | $ | 1,002 | | $ | 4,997 | | $ | 2,676 | | $ | 1,189 | | | 118.7 | % | | $ | 2,321 | | | 86.7 | % |
+Operating income as a % of total revenues
+| 5.8 | % | | 2.8 | % | | 6.8 | % | | 3.8 | % | | | | | | | | |
+Adjusted operating income (1)
+| $ | 2,426 | | $ | 1,308 | | $ | 5,467 | | $ | 3,301 | | $ | 1,118 | | | 85.5 | % | | $ | 2,166 | | | 65.6 | % |
+Adjusted operating income as a % of total revenues
+| 6.5 | % | | 3.6 | % | | 7.4 | % | | 4.6 | % | | | | | | | | |
+Premium revenues (by business): | | | | | | | | | | | | | | | |
+Government | $ | 28,494 | | $ | 25,930 | | $ | 56,277 | | $ | 50,832 | | $ | 2,564 | | | 9.9 | % | | $ | 5,445 | | | 10.7 | % |
+Commercial | 6,625 | | 8,254 | | 12,634 | | 16,160 | | (1,629) | | | (19.7) | % | | (3,526) | | | (21.8) | % |
+
+
+
+The following table summarizes the Health Care Benefits segment’s medical membership for the respective periods:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| June 30, 2026 | | March 31, 2026 | | December 31, 2025 | | June 30, 2025 |
+In thousands | Insured | | ASC | | Total | | Insured | | ASC | | Total | | Insured | | ASC | | Total | | Insured | | ASC | | Total |
+Medical membership: (4)
+| | | | | | | | | | | | | | | | | | | | | | | |
+Commercial | 2,487 | | | 15,833 | | | 18,320 | | | 2,462 | | | 15,872 | | | 18,334 | | | 3,447 | | | 15,350 | | | 18,797 | | | 3,608 | | | 15,251 | | | 18,859 | |
+Medicare Advantage | 4,202 | | | — | | | 4,202 | | | 4,175 | | | — | | | 4,175 | | | 4,267 | | | — | | | 4,267 | | | 4,240 | | | — | | | 4,240 | |
+Medicare Supplement | 1,176 | | | — | | | 1,176 | | | 1,192 | | | — | | | 1,192 | | | 1,202 | | | — | | | 1,202 | | | 1,236 | | | — | | | 1,236 | |
+Medicaid | 1,964 | | | 361 | | | 2,325 | | | 1,938 | | | 366 | | | 2,304 | | | 1,952 | | | 373 | | | 2,325 | | | 1,985 | | | 401 | | | 2,386 | |
+Total medical membership | 9,829 | | | 16,194 | | | 26,023 | | | 9,767 | | | 16,238 | | | 26,005 | | | 10,868 | | | 15,723 | | | 26,591 | | | 11,069 | | | 15,652 | | | 26,721 | |
+| | | | | | | | | | | | | | | | | | | | | | | |
+Supplemental membership information: | | | | | | | | | | | | | | | | | | | | |
+Medicare Prescription Drug Plan (stand-alone) | 3,870 | | | | | | | 3,889 | | | | | | | 4,041 | | | | | | | 4,065 | |
+
+
+
+The following table summarizes the Health Care Benefits segment’s days claims payable for the respective periods:
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+| June 30, 2026 | | March 31, 2026 | | | | December 31, 2025 | | June 30, 2025 |
+Days Claims Payable (7)
+| 41.7 | | | 42.9 | | | | | 38.9 | | | 40.9 | |
+
+16
+
+
+
+
+
+
+
+
+Supplemental Information
+(Unaudited)
+
+
+Health Services segment
+
+
+The following table summarizes the Health Services segment’s performance for the respective periods:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | Change |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, | | Three Months Ended
+June 30,
+2026 vs 2025 | | Six Months Ended
+June 30,
+2026 vs 2025 |
+In millions, except percentages | 2026 | | 2025 | | 2026 | | 2025 | | $ | | % | | $ | | % |
+Revenues: | | | | | | | | | | | | | | | |
+Products | $ | 49,216 | | $ | 44,223 | | $ | 94,942 | | $ | 85,358 | | $ | 4,993 | | | 11.3 | % | | $ | 9,584 | | | 11.2 | % |
+Services | 2,580 | | 2,233 | | 5,091 | | 4,546 | | 347 | | | 15.5 | % | | 545 | | | 12.0 | % |
+Net investment income (loss) | (1) | | (3) | | (1) | | 11 | | 2 | | | 66.7 | % | | (12) | | | (109.1) | % |
+Total revenues | 51,795 | | 46,453 | | 100,032 | | 89,915 | | 5,342 | | | 11.5 | % | | 10,117 | | | 11.3 | % |
+Cost of products sold | 47,908 | | 43,080 | | 92,627 | | 83,195 | | 4,828 | | | 11.2 | % | | 9,432 | | | 11.3 | % |
+Health care costs | 1,350 | | 1,101 | | 2,652 | | 2,148 | | 249 | | | 22.6 | % | | 504 | | | 23.5 | % |
+Gross profit (8)
+| 2,537 | | 2,272 | | 4,753 | | 4,572 | | 265 | | | 11.7 | % | | 181 | | | 4.0 | % |
+Gross margin (Gross profit as a % of total revenues) (8)
+| 4.9 | % | | 4.9 | % | | 4.8 | % | | 5.1 | % | | | | | | | | |
+Operating expenses | $ | 934 | | $ | 1,170 | | $ | 1,803 | | $ | 2,243 | | $ | (236) | | | (20.2) | % | | $ | (440) | | | (19.6) | % |
+Operating expenses as a % of total revenues | 1.8 | % | | 2.5 | % | | 1.8 | % | | 2.5 | % | | | | | | | | |
+| | | | | | | | | | | | | | | |
+Operating income
+| $ | 1,603 | | $ | 1,102 | | $ | 2,950 | | $ | 2,329 | | $ | 501 | | | 45.5 | % | | $ | 621 | | | 26.7 | % |
+Operating income as a % of total revenues
+| 3.1 | % | | 2.4 | % | | 2.9 | % | | 2.6 | % | | | | | | | | |
+Adjusted operating income (1)
+| $ | 1,733 | | $ | 1,575 | | $ | 3,222 | | $ | 3,178 | | $ | 158 | | | 10.0 | % | | $ | 44 | | | 1.4 | % |
+Adjusted operating income as a % of total revenues
+| 3.3 | % | | 3.4 | % | | 3.2 | % | | 3.5 | % | | | | | | | | |
+Pharmacy claims processed (5) (6)
+| 473.0 | | 469.0 | | 937.7 | | 933.2 | | 4.0 | | | 0.9 | % | | 4.5 | | | 0.5 | % |
+
+17
+
+
+
+
+
+
+
+
+Supplemental Information
+(Unaudited)
+
+
+Pharmacy & Consumer Wellness segment
+
+
+The following table summarizes the Pharmacy & Consumer Wellness segment’s performance for the respective periods:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | Change |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, | | Three Months Ended
+June 30,
+2026 vs 2025 | | Six Months Ended
+June 30,
+2026 vs 2025 |
+In millions, except percentages | 2026 | | 2025 | | 2026 | | 2025 | | $ | | % | | $ | | % |
+Revenues: | | | | | | | | | | | | | | | |
+Products | $ | 33,152 | | $ | 32,942 | | $ | 64,491 | | $ | 64,227 | | $ | 210 | | | 0.6 | % | | $ | 264 | | | 0.4 | % |
+Services | 664 | | 639 | | 1,314 | | 1,266 | | 25 | | | 3.9 | % | | 48 | | | 3.8 | % |
+| | | | | | | | | | | | | | | |
+Total revenues | 33,816 | | 33,581 | | 65,805 | | 65,493 | | 235 | | | 0.7 | % | | 312 | | | 0.5 | % |
+Cost of products sold | 27,282 | | 27,554 | | 53,072 | | 53,358 | | (272) | | | (1.0) | % | | (286) | | | (0.5) | % |
+Gross profit (8)
+| 6,534 | | 6,027 | | 12,733 | | 12,135 | | 507 | | | 8.4 | % | | 598 | | | 4.9 | % |
+Gross margin (Gross profit as a % of total revenues) (8)
+| 19.3 | % | | 17.9 | % | | 19.3 | % | | 18.5 | % | | | | | | | | |
+Operating expenses | $ | 5,123 | | $ | 5,291 | | $ | 10,188 | | $ | 10,535 | | $ | (168) | | | (3.2) | % | | $ | (347) | | | (3.3) | % |
+Operating expenses as a % of total revenues | 15.1 | % | | 15.8 | % | | 15.5 | % | | 16.1 | % | | | | | | | | |
+Operating income | $ | 1,411 | | $ | 736 | | $ | 2,545 | | $ | 1,600 | | $ | 675 | | | 91.7 | % | | $ | 945 | | | 59.1 | % |
+Operating income as a % of total revenues
+| 4.2 | % | | 2.2 | % | | 3.9 | % | | 2.4 | % | | | | | | | | |
+Adjusted operating income (1)
+| $ | 1,475 | | $ | 1,338 | | $ | 2,672 | | $ | 2,651 | | $ | 137 | | | 10.2 | % | | $ | 21 | | | 0.8 | % |
+Adjusted operating income as a % of total revenues
+| 4.4 | % | | 4.0 | % | | 4.1 | % | | 4.0 | % | | | | | | | | |
+Revenues (by major goods/service lines): | | | | | | | | | | | | | | | |
+Pharmacy | $ | 27,781 | | $ | 27,631 | | $ | 53,904 | | $ | 53,707 | | $ | 150 | | | 0.5 | % | | $ | 197 | | | 0.4 | % |
+Front Store | 5,407 | | 5,368 | | 10,666 | | 10,611 | | 39 | | | 0.7 | % | | 55 | | | 0.5 | % |
+Other | 628 | | 582 | | 1,235 | | 1,175 | | 46 | | | 7.9 | % | | 60 | | | 5.1 | % |
+| | | | | | | | | | | | | | | |
+Prescriptions filled (5) (6)
+| 457.0 | | 438.1 | | 908.2 | | 873.6 | | 18.9 | | | 4.3 | % | | 34.6 | | | 4.0 | % |
+Same store sales increase: (9)
+| | | | | | | | | | | | | | | |
+Total | 2.6 | % | | 15.4 | % | | 2.7 | % | | 14.8 | % | | | | | | | | |
+Pharmacy | 2.9 | % | | 18.1 | % | | 3.0 | % | | 17.9 | % | | | | | | | | |
+Front Store | 1.0 | % | | 3.4 | % | | 1.1 | % | | 1.5 | % | | | | | | | | |
+Prescription volume (6)
+| 7.0 | % | | 6.4 | % | | 6.9 | % | | 6.5 | % | | | | | | | | |
+
+
+
+
+18
+
+
+
+
+
+
+
+
+Adjusted Earnings Per Share Guidance
+(Unaudited)
+
+
+The following reconciliations of projected net income attributable to CVS Health to projected adjusted income attributable to CVS Health and calculations of projected GAAP diluted EPS and projected Adjusted EPS contain forward-looking information. All forward-looking information involves risks and uncertainties. Actual results may differ materially from those contemplated by the forward-looking information for a number of reasons as described in our SEC filings, including those set forth in the Risk Factors section and under the heading “Cautionary Statement Concerning Forward-Looking Statements” in our most recently filed Annual Report on Form 10-K and our most recently filed Quarterly Report on Form 10-Q. See “Non-GAAP Financial Information” earlier in this press release and endnote (2) later in this press release for more information on how we calculate Adjusted EPS.
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Year Ending
+December 31, 2026
+|
+| Low
+| | High |
+In millions, except per share amounts | Total
+Company | | Per
+Common
+Share | | Total
+Company | | Per
+Common
+Share |
+Net income attributable to CVS Health (GAAP measure)
+| $ | 8,810 | | | $ | 6.84 | | | $ | 9,065 | | | $ | 7.04 | |
+Non-GAAP adjustments: | | | | | | | |
+Amortization of intangible assets | 1,730 | | | 1.34 | | | 1,730 | | | 1.34 | |
+Net realized capital losses | 29 | | | 0.02 | | | 29 | | | 0.02 | |
+Acquisition-related integration costs | 80 | | | 0.06 | | | 80 | | | 0.06 | |
+Tax impact of non-GAAP adjustments | (463) | | | (0.36) | | | (463) | | | (0.36) | |
+Adjusted income attributable to CVS Health (2)
+| $ | 10,186 | | | $ | 7.90 | | | $ | 10,441 | | | $ | 8.10 | |
+| | | | | | | |
+Weighted average diluted shares outstanding | | | 1,289 | | | | | 1,289 | |
+
+
+
+
+
+19
+
+
+
+
+
+
+
+
+Endnotes
+
+
+(1) The Company defines adjusted operating income as operating income (GAAP measure) excluding the impact of amortization of intangible assets, net realized capital gains or losses and other items, if any, that neither relate to the ordinary course of the Company’s business nor reflect the Company’s underlying business performance, such as acquisition-related integration costs, certain legacy litigation charges, losses on Accountable Care assets and office real estate optimization charges. The chief operating decision maker (the “CODM”) uses adjusted operating income as its principal measure of segment performance as it enhances the CODM’s ability to compare past financial performance with current performance and analyze underlying business performance and trends. The consolidated measure is not determined in accordance with GAAP and should not be considered a substitute for, or superior to, the most directly comparable GAAP measure, consolidated operating income. See “Non-GAAP Financial Information” earlier in this press release for additional information regarding the items excluded from consolidated operating income in determining consolidated adjusted operating income.
+(2) GAAP diluted earnings per share and Adjusted EPS, respectively, are calculated by dividing net income attributable to CVS Health and adjusted income attributable to CVS Health by the Company’s weighted average diluted shares outstanding. The Company defines adjusted income attributable to CVS Health as net income attributable to CVS Health (GAAP measure) excluding the impact of amortization of intangible assets, net realized capital gains or losses and other items, if any, that neither relate to the ordinary course of the Company’s business nor reflect the Company’s underlying business performance, such as acquisition-related integration costs, certain legacy litigation charges, losses on Accountable Care assets, office real estate optimization charges, as well as the corresponding income tax benefit or expense related to the items excluded from adjusted income attributable to CVS Health. See “Non-GAAP Financial Information” earlier in this press release for additional information regarding the items excluded from net income attributable to CVS Health in determining adjusted income attributable to CVS Health.
+(3) Medical benefit ratio is calculated by dividing the Health Care Benefits segment’s health care costs by premium revenues and represents the percentage of premium revenues spent on medical benefits for the segment’s insured members. Management uses MBR to assess the underlying business performance and underwriting of its insurance products, understand variances between actual results and expected results and identify trends in period-over-period results. MBR provides management and investors with information useful in assessing the operating results of the Health Care Benefits segment’s insured products.
+(4) Medical membership represents the number of members covered by the Health Care Benefits segment’s insured and ASC medical products and related services at a specified point in time. Management uses this metric to understand variances between actual medical membership and expected amounts as well as trends in period-over-period results. This metric provides management and investors with information useful in understanding the impact of medical membership on the Health Care Benefits segment’s total revenues and operating results.
+(5) Pharmacy claims processed represents the number of prescription claims processed through the Company’s pharmacy benefits manager and dispensed by either its retail network pharmacies or the Company’s mail and specialty pharmacies. Prescriptions filled represents the number of prescriptions dispensed through the Pharmacy & Consumer Wellness segment’s retail pharmacies and infusion services operations, as well as through the Omnicare long-term care pharmacies prior to their deconsolidation in September 2025. Management uses these metrics to understand variances between actual claims processed and prescriptions dispensed, respectively, and expected amounts as well as trends in period-over-period results. These metrics provide management and investors with information useful in understanding the impact of pharmacy claim volume and prescription volume, respectively, on segment total revenues and operating results.
+(6) Includes an adjustment to convert 90-day prescriptions to the equivalent of three 30-day prescriptions. This adjustment reflects the fact that these prescriptions include approximately three times the amount of product days supplied compared to a normal prescription.
+20
+
+
+
+
+
+
+
+(7) Days claims payable is calculated by dividing the Health Care Benefits segment’s health care costs payable at the end of each quarter by its average health care costs per day during such quarter. Management and investors use this metric as one of the indicators of the adequacy of the health care costs payable liability at the end of each quarter.
+(8) Gross profit is calculated as the segment’s total revenues less its cost of products sold, and, for the Health Services segment, health care costs. Gross margin is calculated by dividing the segment’s gross profit by its total revenues and represents the percentage of total revenues that remains after incurring direct costs associated with the segment’s products sold and services provided. Gross margin provides investors with information that may be useful in assessing the operating results of the Company’s Health Services and Pharmacy & Consumer Wellness segments.
+(9) Same store sales and prescription volume represent the change in revenues and prescriptions filled in the Company’s retail pharmacy stores that have been operating for greater than one year and digital sales initiated online or through mobile applications and fulfilled through the Company’s distribution centers, expressed as a percentage that indicates the increase or decrease relative to the comparable prior period. Same store metrics exclude revenues and prescriptions from infusion services operations and long-term care pharmacies. Management uses these metrics to evaluate the performance of existing stores on a comparable basis and to inform future decisions regarding existing stores and new locations. Same-store metrics provide management and investors with information useful in understanding the portion of current revenues and prescriptions resulting from organic growth in existing locations versus the portion resulting from opening new stores.
+21

--- a/modules/test-fixtures/earnings-filings/dis.txt
+++ b/modules/test-fixtures/earnings-filings/dis.txt
@@ -1,0 +1,1030 @@
+EX-99.1
+2
+fy2026_q3xerxex991.htm
+EARNINGS RELEASE
+
+
+
+
+Document
+Exhibit 99.1
+
+
+
+August 5, 2026
+To Our Shareholders and the Broader Investment Community,
+Our strong fiscal Q3 results and reiterated full-year outlook reinforce our confidence that we are uniquely well positioned. Decades of IP investment have built deep fan connections that translate into strong financial results. Our accelerating global guests growth at Experiences, Toy Story 5 's theatrical and consumer products success, and strong ESPN viewership gains all helped expand our consumer reach this quarter. Together, our results show a unique ability to engage consumers at scale, both digitally and physically, even amid macro uncertainty.
+Revenues increased 7% for the third quarter to $25.2 billion from $23.7 billion in Q3 fiscal 2025. Income before income taxes increased 14% to $3.6 billion from $3.2 billion in Q3 fiscal 2025. Total segment operating income (1) modestly exceeded our prior guidance. Total segment operating income increased 21% to $5.6 billion from $4.6 billion in Q3 fiscal 2025. Diluted earnings per share (EPS) decreased to $1.51 from $2.92 in Q3 fiscal 2025. Adjusted EPS (1) increased to $2.06 from $1.61 in Q3 fiscal 2025.
+Fiscal 2026 outlook:
+• We continue to expect fiscal 2026 adjusted EPS growth of approximately 12%, excluding the impact of the 53 rd week.
+• We continue to expect fiscal 2026 adjusted EPS growth of approximately 16%, including the impact of the 53 rd week.
+• We expect Q4 total segment operating income of approximately $4.9 billion, including the impact of the 53 rd week.
+• We are now targeting at least $9 billion in share repurchases in fiscal 2026.
+Fiscal 2027 outlook:
+• We continue to expect double-digit growth in adjusted EPS in fiscal 2027, excluding the impact of the 53 rd week. Note that in Q4 fiscal 2027 we will lap the impact of the 53 rd week in Q4 fiscal 2026.
+
+(1) Total segment operating income, diluted EPS excluding certain items (also referred to as adjusted EPS), Entertainment SVOD operating income (also referred to as SVOD operating income), SVOD operating margin and free cash flow are non-GAAP financial measures. The most comparable GAAP measures are income before income taxes, diluted EPS, Entertainment segment operating income, Entertainment segment operating margin and cash provided by operations. See the discussion on pages 23 through 27 for how we define and calculate these measures, a reconciliation thereof to the most directly comparable GAAP measures and as applicable, why the Company is not providing the forward-looking quantitative reconciliation thereof to the most comparable GAAP measures.
+1
+
+
+
+
+
+
+SUMMARIZED FINANCIAL RESULTS
+The following table summarizes third quarter results for fiscal 2026 and 2025:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended | | | | Nine Months Ended | | |
+($ in millions, except per share amounts)
+| June 27,
+2026 | | June 28,
+2025 | | Change | | June 27,
+2026 | | June 28,
+2025 | | Change |
+Revenues | $ | 25,248 | | | $ | 23,650 | | | 7 % | | $ | 76,397 | | | $ | 71,961 | | | 6 % |
+Income before income taxes
+| $ | 3,645 | | | $ | 3,211 | | | 14 % | | $ | 10,705 | | | $ | 9,958 | | | 8 % |
+Total segment operating income (1)
+| $ | 5,555 | | | $ | 4,575 | | | 21 % | | $ | 14,758 | | | $ | 14,071 | | | 5 % |
+| | | | | | | | | | | |
+Diluted EPS
+| $ | 1.51 | | | $ | 2.92 | | | (48) % | | $ | 4.12 | | | $ | 6.12 | | | (33) % |
+Diluted EPS excluding certain items (1)
+| $ | 2.06 | | | $ | 1.61 | | | 28 % | | $ | 5.25 | | | $ | 4.82 | | | 9 % |
+Cash provided by operations
+| $ | 4,866 | | | $ | 3,669 | | | 33 % | | $ | 12,515 | | | $ | 13,627 | | | (8) % |
+Free cash flow (1)
+| $ | 3,072 | | | $ | 1,889 | | | 63 % | | $ | 5,735 | | | $ | 7,519 | | | (24) % |
+
+(1) Total segment operating income, diluted EPS excluding certain items and free cash flow are non-GAAP financial measures. The most comparable GAAP measures are income before income taxes, diluted EPS and cash provided by operations, respectively. See the discussion on pages 23 through 27 for how we define and calculate these measures and a reconciliation thereof to the most directly comparable GAAP measures.
+SUMMARIZED SEGMENT FINANCIAL RESULTS
+The following table summarizes third quarter segment revenue and operating income for fiscal 2026 and 2025:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended | | | | Nine Months Ended | | |
+($ in millions) | June 27,
+2026 | | June 28,
+2025 | | Change | | June 27,
+2026 | | June 28,
+2025 | | Change |
+Revenues:
+| | | | | | | | | | | |
+Entertainment
+| $ | 11,345 | | | $ | 10,704 | | | 6 % | | $ | 34,669 | | | $ | 32,258 | | | 7 % |
+Sports
+| 4,500 | | | 4,308 | | | 4 % | | 14,018 | | | 13,692 | | | 2 % |
+Experiences
+| 9,968 | | | 9,086 | | | 10 % | | 29,461 | | | 27,390 | | | 8 % |
+Eliminations (1)
+| (565) | | | (448) | | | (26) % | | (1,751) | | | (1,379) | | | (27) % |
+Total revenues
+| $ | 25,248 | | | $ | 23,650 | | | 7 % | | $ | 76,397 | | | $ | 71,961 | | | 6 % |
+Segment operating income:
+| | | | | | | | | | |
+Entertainment
+| $ | 1,680 | | | $ | 1,022 | | | 64 % | | $ | 4,116 | | | $ | 3,983 | | | 3 % |
+Sports
+| 858 | | | 1,037 | | | (17) % | | 1,701 | | | 1,971 | | | (14) % |
+Experiences
+| 3,017 | | | 2,516 | | | 20 % | | 8,941 | | | 8,117 | | | 10 % |
+Total segment operating income (2)
+| $ | 5,555 | | | $ | 4,575 | | | 21 % | | $ | 14,758 | | | $ | 14,071 | | | 5 % |
+
+(1) Reflects fees paid by (a) the entertainment vMVPD services to the sports and entertainment linear networks for the right to air the networks on the Hulu Live TV and Fubo services and (b) the Entertainment segment to the Sports segment to program certain sports content on ABC Network and Disney+. The increase in eliminations for the quarter and nine-month period was due to the Fubo and NFL Transactions (refer to page 18).
+(2) Total segment operating income is a non-GAAP financial measure. The most comparable GAAP measure is income before income taxes. See the discussion on pages 23 through 27 for how we define and calculate this measure and a reconciliation thereof to the most directly comparable GAAP measure.
+2
+
+
+
+
+
+
+OUR STRATEGY
+Results in the quarter reflect our continued execution across our three strategic pillars:
+1. Investing in IP and creativity that breaks through, builds connections, and endures
+2. Using advanced technologies to power our storytelling and increase monetization and returns
+3. Reaching more consumers in more seamless, engaging ways around the world with a One Disney operating model
+INVESTING IN IP
+We had a solid quarter creatively, highlighted by the June 19 theatrical release of Toy Story 5 . The Toy Story franchise is an example of a uniquely Disney asset, one we continue to invest in, and one that delights audiences old and new, while generating value across our entire company. Toy Story 5 has already surpassed $1 billion in global box office, bringing the franchise's lifetime global box office to more than $4 billion.
+This film's value also extends well beyond the theatrical window. Its release further lifted the franchise on Disney+, which has over two billion hours streamed, while Toy Story merchandise helped deliver our strongest quarter of year-over-year growth in Consumer Products revenue in 20 quarters. And as our fans know well, Toy Story has a presence at every park and on every cruise ship we operate around the world. Beyond Toy Story 5 , we were pleased by the performance of The Devil Wears Prada 2 , especially internationally.
+While audience scores for both Star Wars: The Mandalorian and Grogu and fiscal Q4's live action Moana have been strong, both films underperformed our box office expectations. Even so, these franchise investments contributed to value creation beyond their theatrical releases.
+We executed our first-ever day-and-date attraction update with a new Mandalorian-themed Millennium Falcon: Smuggler's Run at Star Wars: Galaxy's Edge at Disneyland and Walt Disney World. Additionally, the film drove healthy growth in retail sales for the Star Wars franchise during the quarter. Looking ahead, we expect the live-action Moana to be a strong title on Disney+, building on the success of the original film, which is one of the most streamed movies of all time (1) , and extending the reach of the franchise, which now includes three films, a themed area at EPCOT, and a robust global merchandise business.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | |
+|
+
+(1) Source: Nielsen.
+3
+
+
+
+
+
+
+On the direct-to-consumer front, early success in our emerging international programming slate gives us confidence to further ramp investment. Rivals season 2 became the biggest EMEA region original premiere in the UK and Ireland on Disney+. The Perfect Crown became the most-watched Korean premiere on Disney+ globally to date. And Dear Killer Nannies is the #1 most viewed LATAM original premiere globally over the past year on Disney+. Across the next three years we plan to roughly triple the number of local original series on Disney+ to drive new international users to the platform and reduce churn.
+Meanwhile, we continue to bolster ESPN's place as the front door for sports fans as we build out ESPN's “marketplace of sports,” creating a single destination for fans. To date, we have relationships with the NFL, MLB, FOX One, and - launched just yesterday - the CW Network, where more than 800 annual hours of CW Sports will stream live on the ESPN app for viewers with an ESPN Unlimited subscription plan. We are encouraged that a growing number of subscribers are taking advantage of these options.
+ESPN is the #1 sports media brand with the most comprehensive rights portfolio. After unlocking a selection of ESPN content on Disney+ domestically in 2024 and expanding it globally since then, we plan to deliver a more robust subset of games for Disney+ subscribers beginning this fall, anchored by additional college football simulcasts, alongside the continued simulcast of our industry-leading college football pregame show, College GameDay . The strategy is to bring more live sports to more users and drive greater engagement on Disney+ and greater upsell to our trio bundle, which includes ESPN Unlimited.
+We're also continually looking for new ways to expand our content offering beyond traditional premium film and TV to drive engagement and fandom. Our first-of-its-kind agreement with TikTok, announced today, is a great example. The agreement will bring creators to the forefront of Disney+, with a curated feed of fan-created content featuring our characters and stories. The agreement brings a pipeline of creator content to Verts on Disney+, promotes discovery, and elevates creators through an ambassador program unique to Disney.
+
+
+4
+
+
+
+
+
+IMPROVING MONETIZATION AND RETURNS
+We want to grow annual revenue, operating income, and adjusted EPS consistently over time. In the fiscal third quarter, total revenue grew 7%, led by 11% revenue growth at our domestic parks and experiences, including the expanding Disney Cruise Line portfolio. Total Parks & Experiences revenue increased 10%, driven by roughly 6% volume and 3% rate across the global portfolio.
+We were pleased with 4% per capita spending growth at our domestic parks, reflecting the value our fans see in the parks experience and our decades of investment. We recorded approximately $100 million in a tariff refund this quarter, reversing out tariff payments earlier in the fiscal year. While we may receive additional refunds in the coming quarters, their dollar amounts are expected to be insignificant. Disney Experiences segment operating income growth was 20%, with the tariff refund representing roughly four points of that growth. There was no impact on Experiences segment revenues.
+
+Toy Story 5 and Star Wars: The Mandalorian and Grogu merchandise sales contributed to 7% growth in Consumer Products revenues when compared to the prior-year quarter. Strength at our domestic parks, Disney Cruise Line, Consumer Products, and Disneyland Paris helped offset softness at our Asia parks, which we expect to continue in fiscal Q4.
+Our Entertainment SVOD (1) revenue growth of 11% reflects subscription revenue growth of 15% relative to the prior-year quarter, driven by both rate and volume, with foreign exchange representing approximately 1%. Entertainment SVOD advertising revenues were up 3%, reflecting the impact of continued marketplace supply growth, which created a softer overall demand environment relative to fiscal Q2.
+Entertainment SVOD operating margin was 13% in fiscal Q3, benefiting, in part, from the timing of marketing and programming spend. We continue to expect double-digit Entertainment SVOD operating margin for full-year fiscal 2026, excluding the impact of the 53rd week.
+
+
+| | |
+|
+
+(1) Disney+, Hulu subscription video-on-demand and Disney+ Hotstar (through November 14, 2024) streaming services (excluding Hulu Live TV and Fubo vMVPD services) are collectively referred to as “Entertainment SVOD” or “SVOD.”
+5
+
+
+
+
+
+Entertainment segment subscription and affiliate fees increased 12% versus the prior-year quarter, with the Fubo transaction and foreign exchange representing approximately 4% and 1%, respectively. Sports segment subscription and affiliate fees increased 8% versus the prior-year quarter, with the NFL transaction representing approximately 4%. These revenue growth rates reflect the successful monetization evolution our company is executing as we scale our streaming platforms.
+Our Sports segment operating income decline of 17% versus the prior-year quarter was modestly steeper than our prior guidance of approximately 14%. Contributing to the lower-than-expected operating income were four-game sweeps in early rounds of the NBA Playoffs and the impact of a network carriage dispute.
+We see emerging technologies as a significant opportunity for our company to drive returns, one that builds on our legacy of innovating at the intersection of creativity and breakthrough technology. We've been developing AI and machine learning capabilities for decades, and we're actively investing in groundbreaking teams that have always pushed the boundaries of storytelling across Industrial Light & Magic, Pixar, Disney Research Studios, Walt Disney Imagineering, and others.
+With AI, it isn't simply about efficiency. We use it first and foremost to enhance a creative process that will always be human-centered, artist-driven, and creator-led. We've cultivated the world's richest portfolio of IP and production experience across a century of filmmaking, giving us an advantage that our peers and no new entrant can quickly replicate.
+We're already putting this into practice. At Disney Experiences, AI is accelerating how we design, build, and operate our parks and attractions. We made our J.A.R.V.I.S. AI tool available to our more than 2,000 Imagineers earlier this year, giving them instant access to over 70 years of institutional knowledge. We're using AI-powered digital twins and simulation tools to design and stress-test new attractions, including leveraging these tools for the Abu Dhabi park. And we're applying AI to simplify the booking and planning journey for our guests, while equipping our cast members with AI-assisted tools to better serve guests in the moment.
+INCREASING REACH AND ENGAGEMENT
+We are the only entertainment company with a profitable, scaled leadership position in both the physical and digital worlds. That position, built on decades of meaningful investment in storytelling and IP, creates deep consumer connections and durable growth opportunities. By operating as One Disney in a more integrated manner, we can deepen these consumer relationships and attract new fans.
+Global guests across the Experiences segment grew 4% and attendance at our domestic parks grew 3% versus the prior-year quarter. Walt Disney World had a stand-out quarter, with healthy core attendance increases from domestic tourists and annual passholders, and effective summer promotions and new experiences that further supplemented growth.
+We continued to face headwinds from international attendance at our domestic parks, but as expected, those headwinds moderated relative to the year-over-year impact observed in fiscal Q2. We also saw strong attendance growth at Disneyland Paris following the opening of World of Frozen.
+Forward bookings at Walt Disney World remain robust and we expect another quarter of global guests growth in fiscal Q4, excluding the 53rd week, despite consumer softness in Asia.
+Fiscal Q3 was the first full quarter with our two newest cruise ships, the Disney Destiny and Disney Adventure . Together, these ships increased stateroom capacity by approximately 50% compared to the prior-year quarter and we remain encouraged by current occupancy and forward bookings. We are looking forward to bringing additional cruise capacity online in the years ahead.
+6
+
+
+
+
+
+
+Below, we provide historical trending for global guests (1) . As a reminder, this metric combines attendance at our domestic and international parks with passenger cruise days. We feel this provides a lens into our increasingly global and diversified Experiences businesses, and aligns more closely with our investment initiatives around the world.
+
+
+
+| | |
+|
+
+(1) In addition to revenue, costs, and operating income, management uses the metric global guests to analyze trends and evaluate the overall performance of our theme parks and cruise businesses, and we believe this metric is useful to investors in analyzing the businesses.
+7
+
+
+
+
+
+Our Experiences segment operating margin for the nine-month period ended June 27, 2026 of approximately 30% reflects, in part, the healthy cumulative results we're generating from our investments. We expect our future capital projects, over their lifetimes, to deliver double-digit returns.
+
+Turning from the physical to the digital, our ambition is for Disney+ to become the digital centerpiece of The Walt Disney Company. This long-term strategy rests on two pillars: making the streaming experience the best in the world and connecting Disney's services into a single ecosystem. In the short-term, we are focused on continuing to improve foundational elements of our service and believe we have the opportunity to increase engagement and retention. We also believe we can bring more value to our subscribers by better leveraging sports in the U.S., completing the integration of Hulu and Disney+, and investing in international programming.
+Long-term, we aim to evolve Disney+ into a comprehensive membership ecosystem. By integrating high-value, always-on benefits with our storytelling, we can reach more fans, deepen engagement, and increase subscriber retention. These product enhancements will also allow us to further segment the market, increasing our addressable opportunity over time. We expect to begin introducing elements of this vision in Spring 2027.
+We believe our product and technology improvements are contributing to engagement growth, with much of this year's lift coming from improved search and discovery informed by a deeper understanding of user preferences. We continue to see churn reduction as a significant opportunity and we're pleased with the Q3 decline in Disney+ churn across our domestic and international services.
+This quarter we passed an important milestone in app unification, allowing Hulu Standalone and Bundle subscribers to link profiles, watch history, and manage subscriptions on Disney+. We are also making the user experience more dynamic with autoplay video on the home page, and we added social clips to Disney+ Verts, which will now be enhanced via our new agreement with TikTok.
+8
+
+
+
+
+
+
+Turning to Sports, this was an unforgettable quarter for fans, anchored by the NBA and NHL postseasons on ABC and ESPN. Ratings more than doubled for both championship series compared to the prior year (1) , with the 2026 NBA and NHL playoffs finishing as the most-viewed ever on our networks (2) . That audience strength extended beyond the NBA and NHL, with aggregate sports consumption on ESPN networks up healthy double digits overall in the key P18-49 demo (3) .
+This was the most-watched fiscal Q3 for ESPN, ESPN2, and ESPN on ABC since 2016, a remarkable sign of ESPN's relevance today given the continued fragmentation of media and the proliferation of sports content across TV and streaming. And through the lens of digital and social engagement, ESPN recorded its best month ever in June, reaching nearly 230 million unique fans and over 80% of the U.S. internet population (4) .
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | |
+|
+
+(1) Includes viewership of TNT Sports’ coverage of the Stanley Cup Finals in 2025.
+(2) Nielsen Media Research (L+SD), Big Data + Panel, P2+ Viewers.
+(3) Nielsen Media Research (L+SD), Big Data + Panel, Total Sports Minutes by Network Group, All Sports Codes, 3/29/26-6/27/26, Includes Sustainers.
+(4) Comscore Media Metrix - Total Audience (Desktop P2+ and Mobile 18+), June 2026, U.S.
+9
+
+
+
+
+
+CAPITAL ALLOCATION AND OTHER MATTERS
+We believe our shares are undervalued and we continued to lean into share repurchases during the quarter. In addition, our strategy of simplifying the company and exiting non-core assets has resulted in an agreement to sell our 50% stake in A+E Global Media to an affiliate of co-owner Hearst Corporation. We plan to use the approximately $1.2 billion in cash proceeds to repurchase additional Disney shares and now expect full year fiscal 2026 share repurchases to be at least $9 billion.
+Additionally, we intend to shift much of our Consumer Products business from our Experiences segment to our Entertainment segment, beginning in Q1 of fiscal 2027. We believe this shift will have strategic and operational benefits by bringing the monetization of our IP through consumer products closer to the studios that create that IP. Additionally, we believe this presentation will better reflect the returns our Entertainment segment is generating from the content it produces and make our Entertainment segment more comparable to peer reporting methodologies.
+We remain highly focused on reducing costs across the enterprise to create incremental capacity to invest for growth and are evaluating a variety of levers, including reductions in labor and SG&A. We are mid-stream in this work and will provide future updates on our progress.
+GUIDANCE AND THE IMPACT OF OUR 53 RD WEEK
+We expect Q4 total segment operating income of $4.9 billion, with the 53rd week contributing approximately $600 million spread across the segments. The 53rd week has a fairly proportionate impact on total revenues, with roughly a 1.5-2% lift (53/52-1). However, portions of our expense base do not increase equally with the additional week. Note that we will lap this impact across the P&L in fiscal 2027, specifically Q4 fiscal 2027.
+Our guidance reflects our expectations for continued healthy growth at Experiences, which we now believe will come in at the high end of our prior high-single-digit segment operating income guidance for the fiscal year, excluding the impact of the 53rd week. We continue to expect Sports segment operating income to grow in the mid-single digits for the year, excluding the 53rd week. We continue to expect double-digit segment operating income growth at our Entertainment segment for the fiscal year, excluding the 53rd week. However, our Q4 Entertainment segment results will reflect the impact of Moana 's box office performance coming in below our prior expectations, along with a softer than expected advertising environment, particularly in domestic SVOD.
+We reiterate our prior full-year guidance for cash provided by operations and capital expenditures of at least $19 billion and approximately $9 billion, respectively, for fiscal 2026.
+Overall, we are pleased with Q3 results and are optimistic about the remainder of the fiscal year.
+Thank you,
+Josh D’Amaro, Chief Executive Officer and Hugh Johnston, Chief Financial Officer
+10
+
+
+
+
+
+
+FORM 10-Q AND WEBCAST INFORMATION
+Please review this release in conjunction with our Form 10-Q, which can be found on our website at www.disney.com/investors. The Walt Disney Company will host a live Webcast today, August 5, 2026, at 8:30 AM EDT/5:30 AM PDT. To access the Webcast go to www.disney.com/investors . The Webcast replay will also be available on the site.
+11
+
+
+
+
+
+
+DISCUSSION OF THIRD QUARTER SEGMENT RESULTS
+
+Entertainment
+Operating results for Entertainment were as follows:
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change |
+(in millions) | June 27,
+2026 | | June 28,
+2025 | |
+Revenues | | | | | |
+Subscription and affiliate fees | $ | 7,545 | | | $ | 6,765 | | | 12 % |
+Advertising | 1,625 | | | 1,641 | | | (1) % |
+Content sales | 1,596 | | | 1,698 | | | (6) % |
+Other | 579 | | | 600 | | | (4) % |
+Total revenues | 11,345 | | | 10,704 | | | 6 % |
+Operating expenses | (7,238) | | | (7,098) | | | (2) % |
+Selling, general, administrative and other | (2,301) | | | (2,488) | | | 8 % |
+Depreciation and amortization | (218) | | | (198) | | | (10) % |
+Total costs and expenses
+| (9,757) | | | (9,784) | | | — % |
+Equity in the income of investees | 92 | | | 102 | | | (10) % |
+| | | | | |
+Operating Income | $ | 1,680 | | | $ | 1,022 | | | 64 % |
+
+Revenues - Subscription and affiliate fees
+Growth in subscription and affiliate fees was due to increases of 4% from the Fubo Transaction, 3% from higher effective rates, 3% from more subscribers and 1% from a favorable foreign exchange impact.
+Revenues - Advertising
+The decrease in advertising revenue was attributable to a decrease of 4% from lower rates, partially offset by increases of 1% from more impressions and 1% from the Fubo Transaction.
+Revenues - Content sales
+Lower content sales revenue was due to a decrease of 8% from TV/VOD and home entertainment distribution revenue .
+Revenues - Other
+The decrease in other revenue was attributable to the impact of our foreign exchange hedging program, partially offset by revenue increases including from higher intersegment allocations of revenues from the Experiences segment reflecting an increase in merchandise licensing royalties.
+12
+
+
+
+
+
+Operating Expenses
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change |
+(in millions) | June 27,
+2026 | | June 28,
+2025 | |
+Programming and production costs | $ | (5,819) | | | $ | (5,772) | | | (1) % |
+Other operating expenses | (1,419) | | | (1,326) | | | (7) % |
+| $ | (7,238) | | | $ | (7,098) | | | (2) % |
+
+Programming and production costs reflected increases of 4% from the Fubo Transaction and 2% from our streaming services, which were largely offset by decreases of 3% from lower film cost impairments and 2% from linear networks.
+The increase in other operating expenses was attributable to higher technology and distribution costs.
+Selling, general, administrative and other
+Selling, general, administrative and other costs decreased $187 million, to $2,301 million from $2,488 million, driven by lower marketing costs, partially offset by the Fubo Transaction.
+Depreciation and amortization
+Depreciation and amortization increased $20 million, to $218 million from $198 million, due to investments in technology.
+Equity in the Income of Investees
+Income from equity investees decreased $10 million, to $92 million from $102 million, due to lower income from A+E attributable to a decrease in advertising revenue.
+Operating Income from Entertainment
+Segment operating income increased $658 million, to $1,680 million from $1,022 million, due to an increase in subscription and affiliate fees.
+13
+
+
+
+
+
+Supplemental SVOD detail
+The following table provides supplemental SVOD detail:
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change
+|
+($ in millions)
+| June 27,
+2026 | | June 28,
+2025 | |
+Revenues | | | | | |
+Subscription fees | $ | 4,715 | | $ | 4,116 | | 15 % |
+Advertising | 851 | | 830 | | 3 % |
+Other | (34) | | 26 | | nm |
+Total revenues | 5,532 | | 4,972 | | 11 % |
+Programming and production costs | (2,577) | | (2,481) | | (4) % |
+Other expenses (1)
+| (2,243) | | (2,162) | | (4) % |
+Total costs and expenses
+| (4,820) | | (4,643) | | (4) % |
+Entertainment SVOD operating income (2)
+| $ | 712 | | $ | 329 | | >100 % |
+| | | | | |
+
+(1) Includes other operating expenses, selling, general and administrative expenses and depreciation and amortization.
+(2) Entertainment SVOD operating income (also referred to as SVOD operating income) is a non-GAAP financial measure. The most comparable GAAP measure is Entertainment segment operating income. See the discussion on pages 23 through 27 for how we define and calculate this measure and a reconciliation thereof to the most directly comparable GAAP measure.
+Growth in subscription fees was attributable to increases of 9% from more subscribers, 3% from higher effective rates and 1% from a favorable foreign exchange impact.
+Higher advertising revenue was due to an increase of 8% from more impressions, partially offset by a decrease of 4% from lower rates.
+The decrease in other revenue was due to the impact of our foreign exchange hedging program.
+
+Sports
+Operating results for Sports were as follows: | | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change |
+(in millions) | June 27,
+2026 | | June 28,
+2025 | |
+Revenues | | | | | |
+Subscription and affiliate fees | $ | 3,142 | | | $ | 2,899 | | | 8 % |
+Advertising | 1,204 | | | 1,148 | | | 5 % |
+Other | 154 | | | 261 | | | (41) % |
+Total revenues | 4,500 | | | 4,308 | | | 4 % |
+Operating expenses | (3,304) | | | (3,008) | | | (10) % |
+Selling, general, administrative and other | (344) | | | (276) | | | (25) % |
+Depreciation and amortization | (29) | | | (13) | | | >(100) % |
+Total costs and expenses
+| (3,677) | | | (3,297) | | | (12) % |
+Equity in the income of investees | 35 | | | 26 | | | 35 % |
+Operating Income | $ | 858 | | | $ | 1,037 | | | (17) % |
+
+14
+
+
+
+
+
+Revenues - Subscription and affiliate fees
+Growth in subscription and affiliate fees reflected increases of 5% from higher effective rates and 4% from the NFL Transaction.
+Revenues - Advertising
+Advertising revenue growth was due to higher impressions.
+Revenues - Other
+The decrease in other revenue was primarily due to the comparison to Ultimate Fighting Championship (UFC) pay-per-view revenue in the prior-year quarter. Our UFC rights expired in December 2025.
+Operating expenses
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change |
+(in millions) | June 27,
+2026 | | June 28,
+2025 | |
+Programming and production costs | $ | (3,050) | | $ | (2,762) | | (10) % |
+Other operating expenses | (254) | | (246) | | (3) % |
+| $ | (3,304) | | $ | (3,008) | | (10) % |
+
+Programming and production costs increased in the current quarter compared to the prior-year quarter primarily due to contractual rate increases, costs for new sports rights and an impact from the timing of rights costs recognition as a result of the NBA contract renewal. These increases were partially offset by the absence of certain rights costs compared to the prior-year quarter, primarily for UFC content. The NBA contract renewal resulted in a shift of costs from the first half of the year to the third quarter.
+Selling, general, administrative and other
+Selling, general, administrative and other costs increased $68 million, to $344 million from $276 million, primarily due to higher sales and marketing costs.
+Depreciation and amortization
+Depreciation and amortization increased $16 million, to $29 million from $13 million, due to investments in technology.
+Operating Income from Sports
+Segment operating income decreased $179 million, to $858 million from $1,037 million, as an increase in subscription and affiliate fees was more than offset by higher programming and production costs.
+15
+
+
+
+
+
+
+Experiences
+Operating results for Experiences were as follows:
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change |
+(in millions) | June 27,
+2026 | | June 28,
+2025 | |
+Revenues | | | | | |
+Theme park admissions | $ | 3,253 | | | $ | 2,996 | | | 9 % |
+Resorts and vacations | 2,766 | | | 2,373 | | | 17 % |
+Parks & Experiences merchandise, food and beverage | 2,284 | | | 2,143 | | | 7 % |
+Merchandise licensing and retail | 1,056 | | | 979 | | | 8 % |
+Parks licensing and other | 609 | | | 595 | | | 2 % |
+Total revenues | 9,968 | | | 9,086 | | | 10 % |
+Operating expenses | (5,065) | | | | (4,808) | | | (5) % |
+Selling, general, administrative and other | (1,065) | | | (1,051) | | | (1) % |
+Depreciation and amortization | (821) | | | (711) | | | (15) % |
+Total costs and expenses
+| (6,951) | | | (6,570) | | | (6) % |
+| | | | | |
+Operating Income | $ | 3,017 | | | $ | 2,516 | | | 20 % |
+
+Revenues - Theme park admissions
+Theme park admissions revenue growth was due to increases of 5% from higher average per capita ticket revenue and 3% from increased attendance.
+Revenues - Resorts and vacations
+Higher resorts and vacations revenue was attributable to increases of 10% from additional passenger cruise days, 2% from an increase in average daily hotel room rates and 2% from higher occupied hotel room nights. The increase in passenger cruise days reflected the launches of the Disney Destiny in November 2025 and the Disney Adventure in March 2026.
+Revenues - Parks & Experiences merchandise, food and beverage
+Parks & Experiences merchandise, food and beverage revenue growth was due to increases of 4% from volume growth and 3% from higher average guest spending.
+16
+
+
+
+
+
+Revenues - Merchandise licensing and retail
+Higher merchandise licensing and retail revenue was due to an increase of 10% from merchandise licensing, partially offset by a decrease of 2% from an unfavorable foreign exchange impact.
+Operating expenses
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change |
+(in millions) | June 27,
+2026 | | June 28,
+2025 | |
+Operating labor | $ | (2,356) | | $ | (2,284) | | (3) % |
+Infrastructure costs | (953) | | (870) | | (10) % |
+Cost of goods sold and distribution costs | (721) | | (779) | | 7 % |
+Other operating expense | (1,035) | | (875) | | (18) % |
+| $ | (5,065) | | $ | (4,808) | | (5) % |
+
+Higher operating labor was due to new guest offerings and inflation. The increase in infrastructure costs was attributable to new guest offerings and higher operations support costs. The decrease in cost of goods sold and distribution costs was due to tariff refunds, partially offset by volume growth and inflation. Higher other operating expense was primarily due to new guest offerings, volume growth and inflation. New guest offerings include the fleet expansion at Disney Cruise Line.
+Depreciation and amortization
+Depreciation and amortization increased $110 million, to $821 million from $711 million, primarily due to higher depreciation at our domestic parks and experiences attributable to an increase at Disney Cruise Line.
+Operating Income from Experiences
+Segment operating income increased $501 million, to $3,017 million from $2,516 million, due to higher revenues at Parks & Experiences and, to a lesser extent, Consumer Products, partially offset by higher costs.
+
+
+17
+
+
+
+
+
+Supplemental revenue and operating income
+The following table presents supplemental revenue and operating income detail for the Experiences segment:
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Change |
+(in millions) | June 27,
+2026 | | June 28,
+2025 | |
+Supplemental revenue detail | | | | | |
+Parks & Experiences | | | | | |
+Domestic | $ | 7,116 | | | $ | 6,403 | | | 11 % |
+International | 1,787 | | | 1,691 | | | 6 % |
+Total Parks & Experiences | 8,903 | | | 8,094 | | | 10 % |
+Consumer Products | 1,065 | | | 992 | | | 7 % |
+| $ | 9,968 | | | $ | 9,086 | | | 10 % |
+Supplemental operating income detail | | | | | |
+Parks & Experiences | | | | | |
+Domestic | $ | 2,088 | | | $ | 1,650 | | | 27 % |
+International | 369 | | | 422 | | | (13) % |
+Consumer Products | 560 | | | 444 | | | 26 % |
+| $ | 3,017 | | | $ | 2,516 | | | 20 % |
+
+Total Parks & Experiences revenue increased $809 million, to $8,903 million from $8,094 million due to increases of 6% from higher volumes and 3% from increased guest spending.
+
+OTHER DEVELOPMENTS
+In July 2026, the Company entered into an agreement to sell its 50% interest in A+E Global Media (A+E) to an affiliate of co-owner Hearst Corporation for approximately $1.2 billion in cash. Closing is currently expected by the end of fiscal 2026, subject to customary closing conditions, including regulatory approvals and government consents. In the current quarter, the Company recorded an impairment of our investment in A+E of $812 million, which is included in “Restructuring and impairment charges” in the Condensed Consolidated Statement of Income.
+On January 31, 2026, ESPN acquired NFL Network and certain other media assets owned and controlled by NFL Enterprises LLC, including the NFL RedZone channel’s pay TV distribution and NFL Fantasy (collectively the Specified Assets), from NFL Enterprises LLC in exchange for a 10% noncontrolling interest in ESPN (the NFL Transaction). Following the NFL Transaction, the Company has an effective 72% interest in ESPN and Hearst Corporation has an 18% interest. As of January 31, 2026, the operating results attributable to the Specified Assets are included in the Company’s consolidated results.
+On October 29, 2025, the Company and FuboTV Inc. (Fubo), a publicly-traded virtual multi-channel video programming distributor (vMVPD), combined certain Hulu Live TV assets with Fubo (the Fubo Transaction). The Company has a 70% interest in the combined operations on a fully diluted basis. As of October 29, 2025, the operating results attributable to Fubo are included in the Company’s consolidated results.
+18
+
+
+
+
+
+
+CASH FLOW
+Cash provided by operations and free cash flow (1) were as follows:
+| | | | | | | | | | | | | | | | | |
+| Nine Months Ended | | |
+($ in millions)
+| June 27,
+2026 | | June 28,
+2025 | | Change |
+Cash provided by operations
+| $ | 12,515 | | | $ | 13,627 | | | $ | (1,112) | |
+Investments in parks, resorts and other property | (6,780) | | | (6,108) | | | (672) | |
+Free cash flow (1)
+| $ | 5,735 | | | $ | 7,519 | | | $ | (1,784) | |
+
+(1) Free cash flow is not a financial measure defined by GAAP. The most comparable GAAP measure is cash provided by operations. See the discussion on pages 23 through 27.
+Cash provided by operations decreased $1.1 billion to $12.5 billion in the current period from $13.6 billion in the prior-year period due to higher income tax payments and, to a lesser extent, lower operating cash flows at Sports driven by higher spending on sports content. These decreases were partially offset by higher operating cash flows at Experiences and Entertainment. The current period included payment of U.S. federal and California state income tax liabilities for fiscal 2025 and a portion of fiscal 2024, which were deferred pursuant to relief related to the 2025 wildfires in California.
+Investments in parks, resorts and other property increased to $6.8 billion from $6.1 billion due to higher spending on new theme park attractions at the Experiences segment.
+19
+
+
+
+
+
+
+THE WALT DISNEY COMPANY
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(unaudited; $ in millions, except per share data)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Nine Months Ended |
+| June 27,
+2026 | | June 28,
+2025 | | June 27,
+2026 | | June 28,
+2025 |
+Revenues | $ | 25,248 | | | $ | 23,650 | | | $ | 76,397 | | | $ | 71,961 | |
+Costs and expenses | (20,488) | | | (20,005) | | | (63,973) | | | (60,732) | |
+Restructuring and impairment charges | (900) | | | (185) | | | (1,139) | | | (437) | |
+| | | | | | | |
+Interest expense, net | (298) | | | (324) | | | (813) | | | (1,037) | |
+Equity in the income of investees | 83 | | | 75 | | | 233 | | | 203 | |
+Income before income taxes
+| 3,645 | | | 3,211 | | | 10,705 | | | 9,958 | |
+Income taxes
+| (801) | | | 2,732 | | | (2,912) | | | 2,030 | |
+| | | | | | | |
+| | | | | | | |
+Net income
+| 2,844 | | | 5,943 | | | 7,793 | | | 11,988 | |
+Net income attributable to noncontrolling interests
+| (206) | | | (681) | | | (506) | | | (897) | |
+| | | | | | | |
+Net income attributable to The Walt Disney Company (Disney)
+| $ | 2,638 | | | $ | 5,262 | | | $ | 7,287 | | | $ | 11,091 | |
+| | | | | | | |
+Earnings per share attributable to Disney:
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+Diluted | $ | 1.51 | | | $ | 2.92 | | | $ | 4.12 | | | $ | 6.12 | |
+| | | | | | | |
+| | | | | | | |
+Basic
+| $ | 1.52 | | | $ | 2.92 | | | $ | 4.13 | | | $ | 6.14 | |
+| | | | | | | |
+Weighted average number of common and common equivalent shares outstanding: | | | | | | | |
+Diluted | 1,743 | | | 1,805 | | | 1,769 | | | 1,812 | |
+Basic | 1,738 | | | 1,799 | | | 1,763 | | | 1,806 | |
+| | | | | | | |
+
+20
+
+
+
+
+
+
+THE WALT DISNEY COMPANY
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(unaudited; $ in millions, except per share data) | | | | | | | | | | | |
+| June 27,
+2026 | | September 27,
+2025 |
+ASSETS | | | |
+Current assets | | | |
+Cash and cash equivalents | $ | 5,185 | | | $ | 5,695 | |
+Receivables, net | 14,553 | | | 13,217 | |
+Inventories | 2,081 | | | 2,134 | |
+Content advances | 1,934 | | | 2,063 | |
+| | | |
+Other current assets | 1,139 | | | 1,158 | |
+| | | |
+| | | |
+Total current assets | 24,892 | | | 24,267 | |
+Produced and licensed content costs | 30,193 | | | 31,327 | |
+Investments | 7,627 | | | 8,097 | |
+Parks, resorts and other property | | | |
+Attractions, buildings and equipment | 87,448 | | | 82,041 | |
+Accumulated depreciation | (49,056) | | | (48,889) | |
+| 38,392 | | | 33,152 | |
+Projects in progress | 5,169 | | | 6,911 | |
+Land | 1,183 | | | 1,192 | |
+| 44,744 | | | 41,255 | |
+Intangible assets, net | 9,786 | | | 9,272 | |
+Goodwill | 74,682 | | | 73,294 | |
+| | | |
+| | | |
+Other assets | 12,816 | | | 10,002 | |
+Total assets | $ | 204,740 | | | $ | 197,514 | |
+LIABILITIES AND EQUITY | | | |
+Current liabilities | | | |
+Accounts payable and other accrued liabilities | $ | 19,548 | | | $ | 21,203 | |
+Current portion of borrowings | 8,627 | | | 6,711 | |
+Deferred revenue and other | 6,930 | | | 6,248 | |
+| | | |
+| | | |
+Total current liabilities | 35,105 | | | 34,162 | |
+Borrowings | 37,414 | | | 35,315 | |
+Deferred income taxes | 5,219 | | | 3,524 | |
+| | | |
+| | | |
+Other long-term liabilities | 10,160 | | | 9,901 | |
+Commitments and contingencies | | | |
+| | | |
+Equity | | | |
+Preferred stock | — | | | — | |
+Common stock and additional paid-in capital, $0.01 par value, Authorized – 4.6 billion shares, Issued – 1.9 billion shares | 62,639 | | | 59,814 | |
+Retained earnings | 65,052 | | | 60,410 | |
+Accumulated other comprehensive loss | (2,908) | | | (2,914) | |
+Treasury stock, at cost, 148 million shares at June 27, 2026 and 79 million shares at September 27, 2025
+| (14,751) | | | (7,441) | |
+Total Disney Shareholders’ equity | 110,032 | | | 109,869 | |
+Noncontrolling interests | 6,810 | | | 4,743 | |
+Total equity | 116,842 | | | 114,612 | |
+Total liabilities and equity | $ | 204,740 | | | $ | 197,514 | |
+
+
+
+21
+
+
+
+
+
+
+THE WALT DISNEY COMPANY
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(unaudited; $ in millions)
+| | | | | | | | | | | |
+| Nine Months Ended |
+| June 27,
+2026 | | June 28,
+2025 |
+OPERATING ACTIVITIES | | | |
+Net income
+| $ | 7,793 | | | $ | 11,988 | |
+Depreciation and amortization | 4,135 | | | 3,932 | |
+Impairments of investments and produced content | 959 | | | 419 | |
+| | | |
+Deferred income taxes | 1,028 | | | (2,915) | |
+Equity in the income of investees | (233) | | | (203) | |
+Cash distributions received from equity investees | 191 | | | 110 | |
+Net change in produced and licensed content costs and advances | 1,106 | | | 819 | |
+| | | |
+Equity-based compensation | 1,160 | | | 1,004 | |
+| | | |
+Other, net | (121) | | | (153) | |
+Changes in operating assets and liabilities | | | |
+Receivables | (1,170) | | | (660) | |
+Inventories | 1 | | | (70) | |
+Other assets | (194) | | | (201) | |
+Accounts payable and other liabilities | (529) | | | (307) | |
+Income taxes | (1,611) | | | (136) | |
+Cash provided by operations
+| 12,515 | | | 13,627 | |
+| | | |
+INVESTING ACTIVITIES | | | |
+Investments in parks, resorts and other property | (6,780) | | | (6,108) | |
+| | | |
+Acquisitions and purchase of investments, net
+| (540) | | | (98) | |
+Other, net | 64 | | | 13 | |
+Cash used in investing activities
+| (7,256) | | | (6,193) | |
+| | | |
+FINANCING ACTIVITIES | | | |
+Commercial paper borrowings (payments), net
+| 2,268 | | | (1,498) | |
+Borrowings | 5,046 | | | 1,057 | |
+Reduction of borrowings | (3,625) | | | (2,969) | |
+Dividends | (1,337) | | | (905) | |
+Repurchases of common stock | (7,245) | | | (2,496) | |
+| | | |
+| | | |
+Acquisition of redeemable noncontrolling interests | — | | | (439) | |
+Other, net | (847) | | | (840) | |
+Cash used in financing activities
+| (5,740) | | | (8,090) | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+Impact of exchange rates on cash, cash equivalents and restricted cash | (19) | | | 31 | |
+| | | |
+Change in cash, cash equivalents and restricted cash | (500) | | | (625) | |
+Cash, cash equivalents and restricted cash, beginning of period
+| 5,799 | | | 6,102 | |
+Cash, cash equivalents and restricted cash, end of period
+| $ | 5,299 | | | $ | 5,477 | |
+
+22
+
+
+
+
+
+
+NON-GAAP FINANCIAL MEASURES
+This earnings release presents diluted EPS excluding certain items (also referred to as adjusted EPS), total segment operating income, free cash flow, Entertainment SVOD operating income and SVOD operating margin. Diluted EPS excluding certain items, total segment operating income, free cash flow, Entertainment SVOD operating income and SVOD operating margin are important financial measures for the Company but are not financial measures defined by GAAP.
+These measures should be reviewed in conjunction with the most comparable GAAP financial measures and are not presented as alternative measures of diluted EPS, income before income taxes, cash provided by operations, Entertainment segment operating income or Entertainment segment operating margin as determined in accordance with GAAP. Diluted EPS excluding certain items, total segment operating income, free cash flow, Entertainment SVOD operating income and SVOD operating margin as we have calculated them may not be comparable to similarly titled measures reported by other companies.
+Our definitions and calculations of diluted EPS excluding certain items, total segment operating income, free cash flow, Entertainment SVOD operating income and SVOD operating margin, as well as quantitative reconciliations of each of these measures to the most directly comparable GAAP financial measure, are provided below.
+The Company is not providing the forward-looking measure for diluted EPS, income before income taxes, Entertainment segment operating income or Entertainment segment operating margin, which are the most directly comparable GAAP measures to diluted EPS excluding certain items, total segment operating income, Entertainment SVOD operating income and SVOD operating margin, respectively, or reconciliations of forward-looking diluted EPS excluding certain items, total segment operating income, Entertainment SVOD operating income and SVOD operating margin to those most directly comparable GAAP measures. The Company is unable to predict or estimate with reasonable certainty the ultimate outcome of certain significant items required for such GAAP measures without unreasonable effort. Information about other adjusting items that is currently not available to the Company could have a potentially unpredictable and significant impact on future GAAP financial results.
+
+Diluted EPS excluding certain items
+The Company uses diluted EPS excluding (1) certain items affecting comparability of results from period to period and (2) amortization of intangible assets, including purchase accounting step-up adjustments for released content recognized in the fiscal 2019 acquisition of TFCF and Hulu and business acquisitions occurring after fiscal 2025 (Acquisition Amortization), to facilitate the evaluation of the performance of the Company’s operations exclusive of these items, and these adjustments reflect how senior management is evaluating segment performance.
+The Company believes that providing diluted EPS exclusive of certain items impacting comparability is useful to investors, particularly where the impact of the excluded items is significant in relation to reported earnings and because the measure allows for comparability between periods of the operating performance of the Company’s business and allows investors to evaluate the impact of these items separately.
+23
+
+
+
+
+
+The following table reconciles reported diluted EPS to diluted EPS excluding certain items for the third quarter:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+($ in millions except EPS)
+| Pre-Tax Income/Loss | | Tax Benefit/Expense (1)
+| | After-Tax Income/Loss (2)
+| | Diluted EPS (3)
+| | Change vs. prior-year period
+|
+Quarter Ended June 27, 2026 | | | | | | | | | |
+As reported | $ | 3,645 | | | $ | (801) | | | $ | 2,844 | | | $ | 1.51 | | | (48) % |
+Exclude: | | | | | | | | | |
+Restructuring and impairment charges (4)
+| 900 | | | (175) | | | 725 | | | 0.41 | | | |
+Acquisition Amortization (5)
+| 334 | | | (76) | | | 258 | | | 0.13 | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Excluding certain items | $ | 4,879 | | | $ | (1,052) | | | $ | 3,827 | | | $ | 2.06 | | | 28 % |
+| | | | | | | | | |
+Quarter Ended June 28, 2025 | | | | | | | | | |
+As reported | $ | 3,211 | | | $ | 2,732 | | | $ | 5,943 | | | $ | 2.92 | | | |
+Exclude: | | | | | | | | | |
+Hulu Transaction Impacts (6)
+| — | | | (3,277) | | | (3,277) | | | (1.56) | | | |
+| | | | | | | | | |
+Acquisition Amortization (5)
+| 395 | | | (92) | | | 303 | | | 0.16 | | | |
+Restructuring and impairment charges (4)
+| 185 | | | (43) | | | 142 | | | 0.08 | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Excluding certain items | $ | 3,791 | | | $ | (680) | | | $ | 3,111 | | | $ | 1.61 | | | |
+
+(1) Tax benefit/expense is determined using the tax rate applicable to the individual item.
+(2) Before noncontrolling interest share.
+(3) Net of noncontrolling interest share, where applicable. Total may not equal the sum of the column due to rounding.
+(4) Amounts for the current quarter included an impairment of our investment in A+E ($812 million) and severance costs ($88 million). Amounts for the prior-year quarter included an impairment of our investment in Tata Play Limited ($179 million).
+(5) For the current quarter, intangible asset amortization was $270 million and step-up amortization was $64 million. For the prior-year quarter, intangible asset amortization was $326 million, step-up amortization was $66 million and amortization of intangible assets related to an equity investee was $3 million.
+(6) Reflects a $3,277 million non-cash tax benefit recognized upon the change in Hulu’s U.S. income tax classification and $477 million recognized in “Net income attributable to noncontrolling interests” related to the acquisition of Hulu (Hulu Transaction Impacts).
+24
+
+
+
+
+
+
+The following table reconciles reported diluted EPS to diluted EPS excluding certain items for the nine-month period:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+($ in millions except EPS)
+| Pre-Tax Income/Loss | | Tax Benefit/Expense (1)
+| | After-Tax Income/Loss (2)
+| | Diluted EPS (3)
+| | Change vs. prior year
+|
+Nine Months Ended June 27, 2026
+| | | | | | | | | |
+As reported | $ | 10,705 | | | $ | (2,912) | | | $ | 7,793 | | | $ | 4.12 | | | (33) % |
+Exclude: | | | | | | | | | |
+Restructuring and impairment charges (4)
+| 1,139 | | | (197) | | | 942 | | | 0.53 | | | |
+Acquisition Amortization (5)
+| 947 | | | (216) | | | 731 | | | 0.37 | | | |
+Non-cash tax charges resulting from the Fubo and NFL Transactions
+| — | | | 422 | | | 422 | | | 0.22 | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Excluding certain items | $ | 12,791 | | | $ | (2,903) | | | $ | 9,888 | | | $ | 5.25 | | 9 % |
+| | | | | | | | | |
+Nine Months Ended June 28, 2025
+| | | | | | | | | |
+As reported | $ | 9,958 | | | $ | 2,030 | | | $ | 11,988 | | | $ | 6.12 | | | |
+Exclude: | | | | | | | | | |
+Hulu Transaction Impacts | — | | | (3,277) | | | (3,277) | | | $ | (1.55) | | | |
+Resolution of a prior-year tax matter | — | | | (1,016) | | | (1,016) | | | (0.56) | | | |
+Acquisition Amortization (5)
+| 1,188 | | | (276) | | | 912 | | | 0.49 | | | |
+Restructuring and impairment charges (4)
+| 437 | | | 145 | | | 582 | | | 0.32 | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Excluding certain items | $ | 11,583 | | | $ | (2,394) | | | $ | 9,189 | | | $ | 4.82 | | | |
+
+(1) Tax benefit/expense is determined using the tax rate applicable to the individual item.
+(2) Before noncontrolling interest share.
+(3) Net of noncontrolling interest share, where applicable. Total may not equal the sum of the column due to rounding.
+(4) Amounts for the current period included an impairment of our investment in A+E ($959 million) and severance costs ($180 million). Amounts for the prior-year period included impairment charges related to our investment in Tata Play Limited ($179 million), the formation of the India joint venture ($143 million) and content ($109 million). Tax expense includes a $99 million tax benefit on the impairment charges and a non-cash tax charge of $244 million related to the formation of the India joint venture.
+(5) For the current period, intangible asset amortization was $755 million and step-up amortization was $192 million. For the prior-year period, intangible asset amortization was $980 million, step-up amortization was $199 million and amortization of intangible assets related to an equity investee was $9 million.
+
+Total segment operating income
+The Company evaluates the performance of its operating segments based on segment operating income, and management uses total segment operating income (the sum of segment operating income from all of the Company’s segments) as a measure of the performance of operating businesses separate from non-operating factors. The Company believes that information about total segment operating income assists investors by allowing them to evaluate changes in the operating results of the Company’s portfolio of businesses separate from non-operational factors that affect net income, thus providing separate insight into both operations and other factors that affect reported results.
+25
+
+
+
+
+
+The following table reconciles income before income taxes to total segment operating income:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended | | | | Nine Months Ended | | |
+($ in millions)
+| June 27,
+2026 | | June 28,
+2025 | | Change | | June 27,
+2026 | | June 28,
+2025 | | Change |
+Income before income taxes
+| $ | 3,645 | | | $ | 3,211 | | | 14 % | | $ | 10,705 | | | $ | 9,958 | | | 8 % |
+Add (subtract): | | | | | | | | | | | |
+| | | | | | | | | | | |
+Corporate and unallocated shared expenses | 334 | | | 410 | | | 19 % | | 1,018 | | | 1,265 | | | 20 % |
+Equity in the loss of India joint venture
+| 44 | | | 50 | | | 12 % | | 136 | | | 186 | | | 27 % |
+Restructuring and impairment charges
+| 900 | | | 185 | | | >(100) % | | 1,139 | | | 437 | | | >(100) % |
+| | | | | | | | | | | |
+Interest expense, net | 298 | | | 324 | | | 8 % | | 813 | | | 1,037 | | | 22 % |
+Acquisition Amortization
+| 334 | | | 395 | | | 15 % | | 947 | | | 1,188 | | | 20 % |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+Total segment operating income | $ | 5,555 | | | $ | 4,575 | | | 21 % | | $ | 14,758 | | | $ | 14,071 | | | 5 % |
+
+
+Free cash flow
+The Company uses free cash flow (cash provided by operations less investments in parks, resorts and other property), among other measures, to evaluate the ability of its operations to generate cash that is available for purposes other than capital expenditures. Management believes that information about free cash flow provides investors with an important perspective on the cash available to service debt obligations, make strategic acquisitions and investments and pay dividends or repurchase shares.
+The following table presents a summary of the three major categories of the Company’s consolidated cash flows:
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended | | Nine Months Ended |
+($ in millions) | June 27,
+2026 | | June 28,
+2025 | | June 27,
+2026 | | June 28,
+2025 |
+Cash provided by operations | $ | 4,866 | | | $ | 3,669 | | | $ | 12,515 | | | $ | 13,627 | |
+Cash used in investing activities | (1,787) | | | (1,720) | | | (7,256) | | | (6,193) | |
+Cash used in financing activities
+| (3,578) | | | (2,537) | | | (5,740) | | | (8,090) | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+
+The following table reconciles the Company’s consolidated cash provided by operations to free cash flow:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended | | | | Nine Months Ended | | |
+($ in millions) | June 27,
+2026 | | June 28,
+2025 | | Change | | June 27,
+2026 | | June 28,
+2025 | | Change |
+Cash provided by operations | $ | 4,866 | | | $ | 3,669 | | | $ | 1,197 | | $ | 12,515 | | | $ | 13,627 | | | $ | (1,112) |
+Investments in parks, resorts and other property | (1,794) | | | (1,780) | | | (14) | | (6,780) | | | (6,108) | | | (672) |
+Free cash flow | $ | 3,072 | | | $ | 1,889 | | | $ | 1,183 | | $ | 5,735 | | | $ | 7,519 | | | $ | (1,784) |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+
+26
+
+
+
+
+
+
+Entertainment SVOD operating income
+Entertainment SVOD operating income consists of operating income for the Disney+, Hulu subscription video-on-demand and Disney+ Hotstar (through November 14, 2024) streaming services (collectively, “Entertainment SVOD” or “SVOD”), which excludes results for the Hulu Live TV and Fubo vMVPD services.
+The Company uses Entertainment SVOD operating income (and related SVOD operating margin) as a measure of the performance of Entertainment SVOD, and we believe Entertainment SVOD operating income (and related SVOD operating margin) assists investors by allowing them to evaluate the performance of Entertainment SVOD separately from our other Entertainment businesses.
+The following table reconciles Entertainment SVOD operating income to Entertainment segment operating income:
+| | | | | | | | | | | | | | | | | |
+| Quarter Ended | | |
+($ in millions)
+| June 27,
+2026 | | June 28,
+2025 | | Change |
+Entertainment segment operating income (1)
+| $ | 1,680 | | $ | 1,022 | | 64 % |
+Subtract: Other Entertainment businesses operating income
+| 968 | | 693 | | 40 % |
+Entertainment SVOD operating income (1)
+| $ | 712 | | $ | 329 | | >100 % |
+| | | | | |
+
+(1) For the current quarter, Entertainment segment operating margin and SVOD operating margin were 14.8% and 12.9%, respectively. Entertainment segment operating margin is calculated as Entertainment segment operating income divided by Entertainment segment revenue, and SVOD operating margin is calculated as Entertainment SVOD operating income divided by Entertainment SVOD revenue.
+
+
+27
+
+
+
+
+
+
+FORWARD-LOOKING STATEMENTS
+Certain statements and information in this earnings release may constitute “forward-looking statements” within the meaning of the Private Securities Litigation Reform Act of 1995, including statements regarding our expectations, beliefs, plans, financial prospects, outlook and guidance; financial or performance estimates and expectations (including estimated or expected revenues, earnings, operating income, timing of expenses, capital expenditures, margins and cash flow) and expected drivers; potential future efficiencies and cost reductions; future capital allocation, including investments, content spend, capital expenditures and share repurchases, and expected drivers; strategies, priorities and opportunities for growth, including plans for, future value of and investments in, as applicable, our IP, franchises, content offerings, businesses and assets, increasing reach and engagement and using technologies, including to increase monetization and returns and reduce churn; the completion and benefits of, as applicable, new initiatives and agreements, future projects, including at parks and experiences, and technologies, including AI; plans, expectations or drivers for growth in our streaming services and parks and experiences; anticipated demand (including, as applicable, visitation patterns) for and timing, availability or nature of our offerings, including at our parks and experiences, the content and functionality within our products and services and our content releases, including the applicable distribution channel; estimates of the financial impact of certain items, accounting treatment, events or circumstances; and other statements that are not historical in nature. Any information that is not historical in nature is subject to change. These statements are made on the basis of management’s views and assumptions regarding future events and business performance as of the time the statements are made. Management does not undertake any obligation to update these statements.
+Actual results may differ materially from those expressed or implied. Such differences may result from actions taken by the Company, including restructuring or strategic initiatives (including capital investments, asset acquisitions or dispositions, new or expanded business lines or cessation of certain operations), our execution of our business plans (including the content we create and IP we invest in, our pricing decisions, our cost structure and our management and other personnel decisions), our ability to quickly execute on cost rationalization while preserving revenue, the discovery of additional information or other business decisions, as well as from developments beyond the Company’s control, including:
+• the occurrence of subsequent events;
+• deterioration in domestic and global economic conditions or failure of conditions to improve as anticipated;
+• deterioration in or pressures from competitive conditions, including competition to create or acquire content, competition for talent and competition for advertising revenue;
+• consumer preferences for and acceptance of our content offerings and the distribution channel (including pricing and bundling of our streaming services and impact on churn and subscriber additions) and our travel destinations;
+• the market for advertising sales on our streaming services and linear networks;
+• health concerns and their impact on our businesses and productions;
+• international, including tariffs and other trade policies, political or military developments;
+• regulatory and legal developments;
+• technological developments;
+• the continued availability of our licenses;
+• labor markets and activities, including work stoppages;
+• adverse weather conditions or natural disasters; and
+• availability of content.
+Such developments may further affect entertainment, travel and leisure businesses generally and may, among other things, affect (or further affect, as applicable):
+• our operations, business plans or profitability;
+• demand for our products and services;
+• the performance of the Company’s content;
+• our ability to create or obtain desirable content at or under the value we assign the content;
+• the advertising market for programming;
+• taxation; and
+• performance of some or all Company businesses either directly or through their impact on those who distribute our products.
+28
+
+
+
+
+
+Additional factors are set forth in the Company’s most recent Annual Report on Form 10-K, including under the captions “Risk Factors,” “Management’s Discussion and Analysis of Financial Condition and Results of Operations,” and “Business,” subsequent quarterly reports on Form 10-Q, including under the captions “Risk Factors” and “Management’s Discussion and Analysis of Financial Condition and Results of Operations,” and subsequent filings with the Securities and Exchange Commission.
+The terms “Company,” “we,” and “our” are used in this report to refer collectively to the parent company and the subsidiaries through which our various businesses are actually conducted.
+
+
+
+CONTACTS:
+
+
+David Jefferson
+Corporate Communications
+818-560-4832
+
+
+
+
+Benjamin Swinburne
+Investor Relations
+818-560-4245
+
+
+
+
+
+
+
+
+29


### PR DESCRIPTION
## Checking the two messages

**CVS is correct** — all four figures verified against the filing: revenue `$106.1B`, GAAP diluted EPS `$2.31`, Adjusted EPS `$2.58`, net income attributable `$2,979M`. Added to the corpus as a passing case.

**DIS was thin because the message predates today's fixes.** It posted an Outlook block and no Results at all. Re-running the current parser over the same filing already yields EPS `$1.51`, revenue `$25.25B` and net income `$2.64B` — #1842 and #1847 fixed it. What was still missing is the adjusted figure.

## What changed

Disney names its non-GAAP per-share measure by what it leaves out — **"diluted EPS excluding certain items"** — which its own footnote defines as adjusted EPS. No pattern matched that label, so `$2.06` was dropped.

- Match it for `adjusted_eps`.
- Add the same wording to the `gaap_eps` skip, since the two rows sit adjacent in the summary table and the GAAP pattern `\bdiluted\s+eps\b` matches the excluding-certain-items caption too. Without this the guard against picking `$2.06` as reported EPS is just candidate ordering.

DIS now reports Adj EPS `$2.06`, EPS `$1.51`, Revenue `$25.25B`, Net income `$2.64B` — all verified against the filing.

## Two gaps left on DIS, deliberately

**No quarter label.** The truth is fiscal Q3 2026 (quarter ended June 27, 2026), but the release states only "fiscal Q3" and its comparative is "Q3 **fiscal 2025**". A `Q([1-4])\s+fiscal\s+(20\d{2})` pattern would read the prior year off that comparative, and deriving from the period-end month gives calendar Q2. Taking the fiscal quarter number with the period-end year would work here, but breaks for a January- or February-year-end filer, where fiscal Q3 ends in the *previous* calendar year to the fiscal one — a retailer's Q3 FY2027 ends October 2026. Since none of these is safe generically, no label is derived. Consistent with the rule that omitting beats being wrong.

**Q4 outlook renders without its period.** "We expect **Q4** total segment operating income of approximately $4.9 billion" becomes `Operating income: $4.9B`, which reads as full-year, and it is *segment* operating income rather than operating income. The outlook module supports a `periodLabel`; wiring this one up is separate work.

Also note the EPS outlook: the filing gives 12% growth excluding the 53rd week and 16% including it. `12% growth` takes the first.

## Verification

All four CI gates run locally: `npm audit`, `lint`, `test:coverage`, `typecheck`. 2,427 tests pass. Both new fixtures were confirmed to parse identically to their source HTML before being stored, and the new pattern was mutation-checked — removing it fails the DIS corpus test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)