### PR TITLE
Fix earnings period labels and non-GAAP outlook selection

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -143,7 +143,7 @@ const filingCorpus: {
     ],
     outlook: [
       ["FY2026 Revenue", "$60.5B to $62.5B"],
-      ["FY2026 EPS", "$2.8 to $3"]
+      ["FY2026 Adj EPS", "$2.8 to $3"]
     ],
     quarterLabel: "Q2 2026",
     source: "78003/000007800326000094/pfe-6282026xex99.htm",
@@ -209,6 +209,7 @@ const filingCorpus: {
     ],
     outlook: [
       ["Revenue", "$3.3B"],
+      ["Adj EPS", "$1.06 to $1.08"],
       ["Operating margin", "49%"]
     ],
     quarterLabel: "Q2 2026",
@@ -272,9 +273,9 @@ const filingCorpus: {
   },
   {
     // A shareholder-letter release: the adjusted measure is named by what it leaves out
-    // ("diluted EPS excluding certain items"), and the quarter is a fiscal one the document
-    // states only as "fiscal Q3" against a "Q3 fiscal 2025" comparative, so no quarter
-    // label is derived rather than risking the prior year or the calendar quarter.
+    // ("diluted EPS excluding certain items"), the fiscal quarter is stated only as "third
+    // quarter results for fiscal 2026", and the outlook mixes a full-year per-share range
+    // with a single-quarter segment figure.
     company: "Walt Disney",
     metrics: [
       ["adjusted_eps", "$2.06"],
@@ -283,12 +284,56 @@ const filingCorpus: {
       ["net_income", "$2.64B"],
     ],
     outlook: [
-      ["EPS", "12% growth"],
-      ["Operating income", "$4.9B"],
+      ["FY2026 Adj EPS", "12% growth"],
+      ["Q4 Operating income", "$4.9B"],
     ],
-    quarterLabel: undefined,
+    quarterLabel: "Q3 2026",
     source: "1744489/000174448926000056/fy2026_q3xerxex991.htm",
     ticker: "dis",
+  },
+  {
+    // Prior-year-first columns with the year header more than twenty rows above the
+    // per-share row, and an outlook stating the figure and its growth in one breath.
+    company: "Uber Technologies",
+    metrics: [
+      ["adjusted_eps", "$0.81"],
+      ["gaap_eps", "$1.17"],
+      ["revenue", "$14.19B"],
+      ["net_income", "$2.39B"],
+    ],
+    outlook: [
+      ["Adj EPS", "$0.84 to $0.88"],
+      ["Adj EBITDA", "$2.86B to $2.96B"]
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1543151/000154315126000027/uberq226earningspressrelea.htm",
+    ticker: "uber",
+  },
+  {
+    // The reporting period is stated only as the period the statements ended, while the
+    // guidance section names a later quarter; per-share figures live in a separate
+    // supplemental and are correctly absent.
+    company: "Shopify",
+    metrics: [
+      ["revenue", "$3.58B"],
+      ["net_income", "$1.5B"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1594805/000159480526000046/exhibit991pressreleaseq220.htm",
+    ticker: "shop",
+  },
+  {
+    company: "1stdibs.com",
+    metrics: [
+      ["gaap_eps", "-$0.03"],
+      ["revenue", "$23.3M"],
+      ["net_income", "-$1.02M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1600641/000160064126000032/ex991q2fy26earningsrelease.htm",
+    ticker: "dibs",
   },
 ];
 
@@ -310,6 +355,6 @@ describe("earnings result filing corpus", () => {
   }
 
   test("covers every stored fixture", () => {
-    expect(filingCorpus).toHaveLength(20);
+    expect(filingCorpus).toHaveLength(23);
   });
 });

--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -115,7 +115,11 @@ export function getQuarterLabel(text: string): string | undefined {
     return `Q${ordinalQuarterMatch[1]} ${ordinalQuarterMatch[2]}`;
   }
 
-  const writtenFiscalQuarterMatch = text.match(/\b(first|second|third|fourth)[\s–—-]+quarter(?:\s+and\s+full)?\s+(?:fiscal\s+year|FY)\s*(20\d{2}|\d{2})\b/i);
+  // A shareholder letter names the period as "third quarter results for fiscal 2026":
+  // written quarter, a caption word, then a bare "fiscal". Only a short caption is allowed
+  // through, so the match cannot reach across prose into a prior-year comparative such as
+  // "for the third quarter to $25.2 billion from $23.7 billion in Q3 fiscal 2025".
+  const writtenFiscalQuarterMatch = text.match(/\b(first|second|third|fourth)[\s–—-]+quarter(?:\s+and\s+full)?(?:\s+(?:results?|segment\s+\w+(?:\s+and\s+\w+)?))?\s+(?:for\s+)?(?:fiscal(?:\s+year)?|FY)\s*(20\d{2}|\d{2})\b/i);
   if (undefined !== writtenFiscalQuarterMatch?.[1] && undefined !== writtenFiscalQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenFiscalQuarterMatch[1]);
     if (quarter) {
@@ -128,17 +132,22 @@ export function getQuarterLabel(text: string): string | undefined {
     return namedPeriodEndedQuarter;
   }
 
+  // The period the statements cover is stated as the period they ended, and it outranks a
+  // written quarter elsewhere in the document: a release for the quarter ended June 30 also
+  // says "For the third quarter of 2026, we expect", and that guidance period must not
+  // become the reporting period. A fiscal filer whose quarter number differs from the
+  // calendar one is already resolved by the fiscal patterns above.
+  const periodEndedQuarter = getQuarterLabelFromPeriodEnded(text);
+  if (undefined !== periodEndedQuarter) {
+    return periodEndedQuarter;
+  }
+
   const writtenQuarterMatch = text.match(/\b(first|second|third|fourth)[\s–—-]+quarter\s+(?:of\s+)?(20\d{2})\b/i);
   if (undefined !== writtenQuarterMatch?.[1] && undefined !== writtenQuarterMatch[2]) {
     const quarter = getQuarterFromName(writtenQuarterMatch[1]);
     if (quarter) {
       return `${quarter} ${writtenQuarterMatch[2]}`;
     }
-  }
-
-  const periodEndedQuarter = getQuarterLabelFromPeriodEnded(text);
-  if (undefined !== periodEndedQuarter) {
-    return periodEndedQuarter;
   }
 
   const directQuarterMatch = text.match(/\b(Q[1-4])\s+(20\d{2})\b/i);

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -198,10 +198,23 @@ export function getCurrentPeriodColumnIndex(
     return 0;
   }
 
-  for (let index = lineIndex - 1, examined = 0; index >= 0 && examined < 12; index--, examined++) {
+  // An income statement puts twenty or more rows between its year header and the per-share
+  // rows at the bottom, so a short lookback misses the header entirely and the row is read
+  // as though the reported period came first. The nearest header still wins, which keeps a
+  // row below one table from picking up the header of another.
+  for (let index = lineIndex - 1, examined = 0; index >= 0 && examined < 40; index--, examined++) {
     const line = lines[index];
     if (undefined === line) {
       continue;
+    }
+
+    // A header naming its columns by period end ("June 30, 2026 | March 31, 2026 |
+    // December 31, 2025") does not map onto a year run — and where such a table also carries
+    // a year-to-date pair, those bare years look like a run that starts at the wrong column.
+    // The row's own header decides the layout either way, so stop here rather than adopting
+    // the columns of an unrelated table further up.
+    if (true === isPeriodHeaderLine(line)) {
+      return 0;
     }
 
     const headerYears = getColumnHeaderYears(line);
@@ -221,6 +234,14 @@ export function getCurrentPeriodColumnIndex(
 // A column header ends in a run of year cells ("... Three Months Ended March 31 2025
 // 2026", "$ million | 2026 | 2025 | 2026 | 2025"). Requiring the years to be separated
 // by nothing but cell punctuation keeps prose such as "between 2025 and 2026" out.
+// A column header names a period per column, either as a bare year or as a period-end date.
+function isPeriodHeaderLine(line: string): boolean {
+  const dateColumns = line.match(
+    /\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2},?\s*(?:20\d{2})?/gi,
+  );
+  return 2 <= (dateColumns?.length ?? 0);
+}
+
 function getColumnHeaderYears(line: string): string[] {
   const yearMatches = [...line.matchAll(/\b20\d{2}\b/g)];
   if (2 > yearMatches.length) {

--- a/modules/earnings-results-money.test.ts
+++ b/modules/earnings-results-money.test.ts
@@ -500,6 +500,7 @@ describe("earnings result money parsing", () => {
   // offers a second candidate that happens to be right. Pinned directly so a regression
   // fails here rather than surfacing as a wrong posted figure.
   describe("per-share value plausibility", () => {
+
     test("rejects a value denominated in a money scale", () => {
       // A revenue milestone sharing a line with a non-GAAP EPS label is not $3.00 of EPS.
       expect(findEpsValue(" as the company achieved its first $3+ billion revenue quarter.", 0))

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -137,6 +137,13 @@ describe("extractOutlookMetrics", () => {
       "The Company is updating its estimates for the year ending December 31, 2026, which reflects the addition of PayneCrest. Net income is expected to be between $223.0 million and $234.0 million. Earnings per Share (EPS) is expected to be between $4.05 and $4.25 per fully diluted share. Adjusted EPS is estimated in the range of $4.80 to $5.00, and Adjusted EBITDA for the full year 2026 is expected to range from $480.0 to $500.0 million.",
       "The Company is targeting SG&A expenses as a percentage of revenue in the mid-to-high 5% range for full year 2026. The Company's targeted gross margins by segment are as follows: Utilities in the range of 10 to 12%; Energy in the range of 9 to 11%.",
     ])).toEqual([
+      // The sentence guides on both per-share measures, so both are reported under their
+      // own labels rather than the adjusted figure appearing as the GAAP one.
+      {
+        key: "adjusted_eps",
+        label: "Adj EPS",
+        value: "$4.8 to $5",
+      },
       {
         key: "eps",
         label: "EPS",
@@ -231,8 +238,8 @@ describe("extractOutlookMetrics", () => {
         value: "high single-digit growth",
       },
       {
-        key: "eps",
-        label: "EPS",
+        key: "adjusted_eps",
+        label: "Adj EPS",
         value: "12% growth",
       },
     ]);
@@ -249,8 +256,8 @@ describe("extractOutlookMetrics", () => {
         value: "$690M to $710M",
       },
       {
-        key: "eps",
-        label: "EPS",
+        key: "adjusted_eps",
+        label: "Adj EPS",
         value: "$3.65 to $3.85",
       },
       {

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -49,6 +49,9 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
     patterns: [
       /\badjusted\s+continuing(?:\s+operations?)?\s+(?:diluted\s+)?eps\b/i,
       /\badjusted\s+continuing(?:\s+operations?)?\s+earnings\s+per\s+(?:common\s+)?share\b/i,
+      /\badjusted\s+(?:diluted\s+)?eps\b/i,
+      /\badjusted\s+(?:diluted\s+)?(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\b/i,
+      /\bnon-gaap\s+(?:diluted\s+)?(?:eps|(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share)\b/i,
     ],
     valueType: "eps",
   },
@@ -56,9 +59,17 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
     key: "eps",
     label: "EPS",
     patterns: [
-      /\bgaap\s+(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b/i,
-      /\b(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b/i,
-      /\bearnings\s+per\s+(?:common\s+)?share\b/i,
+      // "non-" ends a word, so a bare \bgaap here also matches inside "Non-GAAP EPS" and
+      // reports the adjusted guidance a second time under the GAAP label.
+      /(?<!non-)\bgaap\s+(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b/i,
+      // Guidance for a non-GAAP per-share measure must not be posted under the GAAP label,
+      // so an occurrence carrying that qualifier is passed over. One sentence often guides
+      // on both measures ("Earnings per Share (EPS) is expected to be between $4.05 and
+      // $4.25 ... Adjusted EPS is estimated in the range of $4.80 to $5.00"), so this
+      // rejects the qualified occurrence rather than the whole line, which would discard
+      // the GAAP figure alongside it.
+      /(?<!\b(?:adjusted|non-gaap)\s)(?<!\b(?:adjusted|non-gaap)\s\w{1,14}\s)\b(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b/i,
+      /(?<!\b(?:adjusted|non-gaap)\s)(?<!\b(?:adjusted|non-gaap)\s\w{1,14}\s)\bearnings\s+per\s+(?:common\s+)?share\b/i,
     ],
     valueType: "eps",
   },
@@ -187,7 +198,11 @@ function hasMixedOutlookPeriods(lines: string[]): boolean {
   const sectionText = lines.join(" ");
   const hasQuarter = /\b(?:q[1-4]|first|second|third|fourth)[\s–—-]+quarter\b/i.test(sectionText) ||
     /\bq[1-4]\b/i.test(sectionText);
-  const hasFullYear = /\b(?:full[\s–—-]+year|fiscal\s+year|fy)\b/i.test(sectionText);
+  // "fiscal 2026" states an annual period just as "fiscal year 2026" does. Without the bare
+  // form a section mixing it with a quarter item reads as single-period, and every item is
+  // then rendered without the period it belongs to.
+  const hasFullYear = /\b(?:full[\s–—-]+year|fiscal\s+year|fy)\b/i.test(sectionText) ||
+    /\bfiscal\s+20\d{2}\b/i.test(sectionText);
   return hasQuarter && hasFullYear;
 }
 
@@ -329,7 +344,7 @@ function getOutlookPeriodLabel(line: string): string | undefined {
     return quarterByName.get(writtenQuarterMatch[1].toLowerCase());
   }
 
-  const fullYearMatch = /\b(?:full[\s–—-]+year|fiscal\s+year|fy)\s*(?:of\s+)?(20\d{2}|\d{2})\b/i.exec(line);
+  const fullYearMatch = /\b(?:full[\s–—-]+year|fiscal(?:\s+year)?|fy)\s*(?:of\s+)?(20\d{2}|\d{2})\b/i.exec(line);
   if (undefined !== fullYearMatch?.[1]) {
     return `FY${2 === fullYearMatch[1].length ? `20${fullYearMatch[1]}` : fullYearMatch[1]}`;
   }
@@ -375,7 +390,13 @@ function extractOutlookValue(
       continue;
     }
 
-    const value = getGrowthOutlookValue(valueText) ??
+    // A per-share range is the figure being guided to, so it wins over a growth rate quoted
+    // in the same breath ("Non-GAAP EPS of $0.84 to $0.88, representing growth of 28% to
+    // 35%"). Guidance given only as growth still falls through to the growth reading.
+    const value = ("eps" === valueType
+      ? getOutlookRangeValue(valueText, valueType, documentCurrencyCode)
+      : null) ??
+      getGrowthOutlookValue(valueText) ??
       getOutlookRangeValue(valueText, valueType, documentCurrencyCode) ??
       ("eps" === valueType ? getEpsPercentOutlookValue(valueText) : null) ??
       ("text" === valueType ? getSingleOutlookValue(valueText, "money", documentCurrencyCode) : null) ??
@@ -449,12 +470,27 @@ function getNumericGrowthOutlookValue(value: string): string | null {
   return `${formatPercent(Number.parseFloat(percentMatch[1]))} ${getGrowthDirection(value)}`;
 }
 
+function getEpsMoneyRangeValue(value: string, documentCurrencyCode: string): string | null {
+  for (const moneyRangeMatch of value.matchAll(moneyRangePattern)) {
+    const firstValue = parseNumber(moneyRangeMatch[1]);
+    const secondValue = parseNumber(moneyRangeMatch[2]);
+    if (null !== firstValue && null !== secondValue) {
+      return `${formatEps(firstValue, documentCurrencyCode)} to ${formatEps(secondValue, documentCurrencyCode)}`;
+    }
+  }
+
+  return null;
+}
+
 function getOutlookRangeValue(
   value: string,
   valueType: OutlookValueType,
   documentCurrencyCode: string,
 ): string | null {
-  if ("eps" === valueType) {
+  // A per-share range is read before a percentage one, so guidance that states the figure
+  // and its growth together ("$0.84 to $0.88, representing growth of 28% to 35%") reports
+  // the figure. Guidance given only as growth still falls through to the percentage below.
+  if ("eps" === valueType && null === getEpsMoneyRangeValue(value, documentCurrencyCode)) {
     const percentRangeValue = getPercentRangeOutlookValue(value);
     if (null !== percentRangeValue) {
       return withPercentGrowthDirection(percentRangeValue, value);

--- a/modules/test-fixtures/earnings-filings/dibs.txt
+++ b/modules/test-fixtures/earnings-filings/dibs.txt
@@ -1,0 +1,376 @@
+EX-99.1
+2
+ex991q2fy26earningsrelease.htm
+EX-99.1
+
+
+
+
+Document
+Exhibit 99.1
+
+1stDibs Reports Second Quarter 2026 Financial Results
+
+
+New York, NY — August 5, 2026 — 1stdibs.com, Inc. (NASDAQ: DIBS), a leading online marketplace for luxury design products ("1stDibs" or the "Company"), today reported financial results for its second quarter ended June 30, 2026.
+Second Quarter 2026 Financial Highlights
+• Net revenue was $23.3 million, an increase o f 5% year-over-year.
+• Gross profit was $17.2 million, an increase of 8% year-over-year.
+• Gross margin was 73.9%, compared to 71.8% in the second quarter 2025.
+• GAAP net loss was $1.0 million compared to a net loss of $4.3 million in the second quarter 2025.
+• Non-GAAP Adjusted EBITDA and Adjusted EBITDA Margin was $1.3 million and 5.6%, respectively, compared to $(1.8) million and (7.9)%, respectively, in the second quarter 2025.
+• Cash, cash equivalents and short-term investments totaled $67.7 million as of June 30, 2026.
+
+
+
+“The second quarter was a proof point for our product, our platform, and our plan," said David Rosenblatt, 1stDibs CEO. "GMV of $96.0 million came in above the high end of guidance, up 7%, our strongest growth rate since late 2024. We believe we gained market share in spite of having reduced Sales and Marketing spend, a combination that tells us our product roadmap is driving structural improvement in our competitive position.”
+
+
+"The second quarter demonstrated exactly what our reengineered cost structure was designed to do," said Tom Etergino, 1stDibs Chief Financial Officer. "GMV and revenue both beat the high end of guidance, and Adjusted EBITDA margin of approximately 6%, also well above our guidance range, improved over 13 percentage points versus a year ago. The lower cost structure we built from 2022 through 2025 is converting revenue upside directly into margin expansion.”
+
+
+Other Recent Business Highlights and Second Quarter Key Operating Metrics
+• Gross Merchandise Value ("GMV") was $96.0 million, an increase of 7% year-over-year.
+• Number of Orders was approximately 32K, a decrease of 4% year-over-year.
+• Active Buyers was approximately 58K, a decrease of 10% year-over-year.
+
+
+1
+
+
+
+
+
+Financial Guidance and Outlook
+The Company’s third quarter 2026 guidance is below.
+| | | | | | | | | |
+| Q3 2026 Guidance
+| | | | |
+GMV | $89.0 million - $94.0 million | | | | |
+Net revenue | $22.0 million - $22.9 million | | | | |
+Adjusted EBITDA margin (non-GAAP) | (1%) - 2% | | | | |
+
+
+
+Actual results may differ materially from our Financial Guidance and Outlook as a result of, among other things, the factors described under “Forward-Looking Statements” below.
+A GAAP reconciliation to our non-GAAP guidance measure (adjusted EBITDA) is not available on a forward-looking basis without unreasonable effort due to the potential variability and uncertainty of expenses that may be incurred in the future. Stock-based compensation expense is impacted by the timing of employee stock transactions, the future fair market value of our common stock, and our future hiring and retention needs, all of which are difficult to predict and subject to change. We have provided a reconciliation of GAAP to non-GAAP financial measures in the financial statement tables for our historical non-GAAP financial results included in this press release.
+
+
+Webcast Information
+1stDibs will host a webcast to discuss its second quarter 2026 financial results toda y at 8:00 a.m. Eastern Time. Investors and participants can access the webcast at the 1stDibs Investor Relations website (investors.1stdibs.com). A replay of the webcast will be available through the same link following the webcast, for one year thereafter.
+
+
+Disclosure Information
+In compliance with disclosure obligations under Regulation FD, 1stDibs announces material information to the public through a variety of means, including filings with the Securities and Exchange Commission, press releases, company blog posts, public conference calls and webcasts, as well as the investor relations website.
+
+
+Final Results
+The financial results discussed herein are presented on a preliminary basis; final data will be included in 1stDibs's Quarterly Report on Form 10−Q for the peri od ended June 30, 2026 .
+
+
+About 1stDibs
+1stDibs is a leading online marketplace for connecting design lovers with highly coveted sellers and makers of vintage, antique, and contemporary furniture, home décor, art, jewelry, watches and fashion.
+
+
+2
+
+
+
+
+
+Investor Relations Contact:
+Kevin LaBuz
+investors@1stdibs.com
+3
+
+
+
+
+
+Forward-Looking Statements
+This press release contains or references "forward-looking statements" and "forward-looking information" within the meaning of applicable federal and state securities laws (collectively, "forward-looking statements"). Forward-looking statements include statements relating to our financial guidance for the third quarter of 2026 and underlying assumptions; our ability to improve customer engagement and frequency; our ability to align our resources with strategic growth and profitability; and the impact of our marketing efforts. Any statements in this press release, other than statements of historical fact, including statements regarding our future results of operations and financial position, business strategy and plans, objectives of management for future operations, long term operating expenses, and expectations for capital requirements, may be deemed to be forward-looking statements. In some cases, you can identify forward-looking statements by terms such as: "accelerate," "anticipate," "believe," "can," "contemplate," "continue," "could," "demand," "estimate," "expand," "expect," "focus," "intend," "may," "might," "objective," "ongoing," "opportunity," "outlook," "plan," "potential," "predict," "progress," "project," "should," "target," "will," "would," or the negative of these terms, or other comparable terminology or similar expressions intended to identify statements about the future.
+
+
+These statements involve known and unknown risks, uncertainties, and other factors that may cause our actual results, performance, or achievements to be materially different from the information expressed or implied by these forward-looking statements. These forward-looking statements include, but are not limited to, statements regarding the following: (1) our continued efforts to lay the foundation for future growth and deepen our lead in the luxury market; (2) our focus on efficiency and steps to align our expenses to current demand and the impact thereof; (3) our progress towards reaccelerating sustainable growth, reducing our cost, increasing operating leverage, and re-engineering our cost base; and (4) our future results of operations and financial position, including our financial guidance and outlook and our targets for positive Adjusted EBITDA and free cash flow. We cannot guarantee that any forward-looking statement will be accurate. Forward-looking statements are based on current expectations of future events and if these prove to be inaccurate, actual results could vary materially from our expectations and projections. Investors are therefore cautioned not to place undue reliance on any forward-looking statements. These forward-looking statements are subject to risks, uncertainties, and other factors that could cause actual results to vary materially from those discussed or implied in the forward-looking statements. These risks and uncertainties include but are not limited to the following: (1) our ability to execute our business plan and strategies to achieve our strategic initiatives; (2) our ability to achieve future growth; (3) our ability to enhance GMV growth and shareholder value; (4) our ability to effectively manage and reduce operating costs, maintain a structurally leaner cost base, and realign investment priorities; (5) our ability to execute our stock repurchase program; and (6) macroeconomic conditions or geopolitical events or similar risks, as well as other risks, uncertainties, and other factors discussed in our filings with the Securities and Exchange Commission (the “SEC”), including our Form 10-K for the year ended December 31, 2025 and other periodic reports and filings we make with the SEC. We qualify all of our forward-looking statements by these cautionary statements. Moreover, we operate in a very competitive and rapidly changing environment. New risks emerge from time to time. It is not possible for our management to predict all risks, nor can we assess the impact of all factors on our business or the extent to which any factor, or combination of factors, may cause actual results to differ materially from those contained in any forward-looking statements we may make. In light of these risks, uncertainties, and assumptions, we cannot guarantee future results, levels of activity, performance, achievements, or events
+4
+
+
+
+
+
+and circumstances reflected in the forward-looking statements will occur. These forward-looking statements speak only as of the date of this press release and we undertake no obligation to publicly update or revise any forward-looking statements contained herein, whether as a result of any new information, future events, or otherwise, except as required by law.
+
+
+
+
+Key Operating Metrics Definitions
+Gross Merchandise Value
+We define Gross Merchandise Value ("GMV") as the total dollar value from items sold by our sellers through 1stDibs in a given month, minus cancellations within that month, and excluding shipping and applicable taxes. GMV includes all sales reported to us by our sellers, whether transacted through the 1stDibs marketplace or reported as an offline sale. We view GMV as a measure of the total economic activity generated by our online marketplace, and as an indicator of the scale and growth of our online marketplace and the health of our ecosystem. Our historical performance for GMV may not be indicative of future performance in GMV.
+Number of Orders
+We define Number of Orders as the total number of orders placed or reported through the 1stDibs marketplace in a given month, minus cancellations within that month. Our historical performance for Number of Orders may not be indicative of future performance in Number of Orders.
+Active Buyers
+We define Active Buyers as buyers who have made at least one purchase through our online marketplace during the 12 months ended on the last day of the period presented, net of cancellations. A buyer is identified by a unique email address; thus an Active Buyer could have more than one account if they were to use a separate unique email address to set up each account. We believe this metric reflects scale, engagement and brand awareness, and our ability to convert user activity on our online marketplace into transactions. Our historical performance for Active Buyers may not be indicative of future performance in new Active Buyers.
+5
+
+
+
+
+
+
+1STDIBS.COM, INC.
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(Amounts in thousands, except share and per share amounts)
+| | | | | | | | | | | |
+| June 30, 2026 | | December 31, 2025 |
+Assets | (Unaudited) | | |
+Current assets: | | | |
+Cash and cash equivalents | $ | 18,873 | | | $ | 22,880 | |
+| | | |
+Short-term investments | 48,846 | | | 72,157 | |
+Accounts receivable, net of allowance for doubtful accounts of $75 and $72 at June 30, 2026 and December 31, 2025, respectively
+| 598 | | | 422 | |
+Prepaid expenses | 3,935 | | | 3,203 | |
+Receivables from payment processors and seller accounts | 9,392 | | | 1,990 | |
+Other current assets | 1,550 | | | 1,631 | |
+Total current assets | 83,194 | | | 102,283 | |
+Restricted cash, non-current | 3,716 | | | 3,704 | |
+Property and equipment, net | 2,527 | | | 2,731 | |
+Operating lease right-of-use assets | 14,728 | | | 16,665 | |
+Goodwill | 4,293 | | | 4,306 | |
+Other assets | 1,907 | | | 2,418 | |
+Total assets | $ | 110,365 | | | $ | 132,107 | |
+Liabilities and Stockholders’ Equity | | | |
+Current liabilities: | | | |
+Accounts payable | $ | 1,077 | | | $ | 1,765 | |
+Payables due to sellers | 7,394 | | | 6,649 | |
+Accrued expenses | 9,031 | | | 9,461 | |
+Operating lease liabilities, current | 4,586 | | | 4,447 | |
+Other current liabilities | 2,723 | | | 2,059 | |
+Total current liabilities | 24,811 | | | 24,381 | |
+Operating lease liabilities, non-current | 11,812 | | | 14,141 | |
+Other liabilities | 4 | | | 4 | |
+Total liabilities | 36,627 | | | 38,526 | |
+Commitments and contingencies | | | |
+Stockholders’ equity: | | | |
+Preferred stock, $0.01 par value; 10,000,000 shares authorized as of June 30, 2026 and December 31, 2025; zero shares issued and outstanding as of June 30, 2026 and December 31, 2025
+| — | | | — | |
+Common stock, $0.01 par value; 400,000,000 shares authorized as of June 30, 2026 and December 31, 2025; 44,994,373 and 44,086,361 shares issued as of June 30, 2026 and December 31, 2025, respectively; and 33,615,293 and 36,848,301 outstanding as of June 30, 2026 and December 31, 2025, respectively | 450 | | | 441 | |
+Treasury stock, at cost; 11,379,080 and 7,238,060 shares as of June 30, 2026 and December 31, 2025, respectively
+| (55,707) | | | (34,977) | |
+Additional paid-in capital | 478,273 | | | 474,288 | |
+Accumulated deficit | (349,215) | | | (346,018) | |
+Accumulated other comprehensive loss | (63) | | | (153) | |
+Total stockholders’ equity | 73,738 | | | 93,581 | |
+Total liabilities and stockholders’ equity | $ | 110,365 | | | $ | 132,107 | |
+
+
+
+
+
+
+
+6
+
+
+
+
+
+
+1STDIBS.COM, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(Amounts in thousands, except share and per share amounts)
+(Unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+2026 | | 2025 | | 2026 | | 2025 |
+Net revenue | $ | 23,317 | | | $ | 22,135 | | | $ | 45,705 | | | $ | 44,680 | |
+Cost of revenue | 6,086 | | | 6,237 | | | 11,809 | | | 12,460 | |
+Gross profit | 17,231 | | | 15,898 | | | 33,896 | | | 32,220 | |
+Operating expenses: | | | | | | | |
+Sales and marketing | 5,385 | | | 8,142 | | | 11,670 | | | 17,258 | |
+Technology development | 6,322 | | | 5,902 | | | 12,504 | | | 11,514 | |
+General and administrative | 6,658 | | | 6,606 | | | 13,501 | | | 13,558 | |
+Provision for transaction losses | 929 | | | 965 | | | 1,603 | | | 1,862 | |
+| | | | | | | |
+Total operating expenses | 19,294 | | | 21,615 | | | 39,278 | | | 44,192 | |
+Loss from operations | (2,063) | | | (5,717) | | | (5,382) | | | (11,972) | |
+Other income, net: | | | | | | | |
+Interest income | 711 | | | 989 | | | 1,558 | | | 2,088 | |
+| | | | | | | |
+Other, net | 363 | | | 434 | | | 665 | | | 788 | |
+Total other income, net | 1,074 | | | 1,423 | | | 2,223 | | | 2,876 | |
+Net loss before income taxes | (989) | | | (4,294) | | | (3,159) | | | (9,096) | |
+Provision for income taxes | (34) | | | (19) | | | (38) | | | (23) | |
+Net loss | $ | (1,023) | | | $ | (4,313) | | | $ | (3,197) | | | $ | (9,119) | |
+| | | | | | | |
+| | | | | | | |
+Net loss per share—basic and diluted | $ | (0.03) | | | $ | (0.12) | | | $ | (0.09) | | | $ | (0.26) | |
+Weighted average common shares outstanding—basic and diluted | 34,451,624 | | | 35,820,053 | | | 35,404,060 | | | 35,697,350 | |
+
+
+
+7
+
+
+
+
+
+
+1STDIBS.COM, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(Amounts in thousands)
+(Unaudited)
+| | | | | | | | | | | |
+| Six Months Ended June 30, |
+| 2026 | | 2025 |
+Cash flows from operating activities: | | | |
+Net loss | $ | (3,197) | | | $ | (9,119) | |
+Adjustments to reconcile net loss to net cash from operating activities: | | | |
+Depreciation and amortization | 755 | | | 880 | |
+Stock-based compensation expense | 5,993 | | | 7,592 | |
+Provision for transaction losses, returns and refunds | 339 | | | 294 | |
+| | | |
+Non-cash operating lease expense | 1,936 | | | 1,777 | |
+Accretion of discounts and amortization of premiums on short-term investments, net | 14 | | | (250) | |
+Other, net | 604 | | | (65) | |
+Changes in operating assets and liabilities: | | | |
+Accounts receivable | (219) | | | (305) | |
+Prepaid expenses and other current assets | (1,034) | | | (1,261) | |
+Receivables from payment processors and seller accounts | (7,401) | | | (895) | |
+Other assets | 394 | | | (406) | |
+Accounts payable and accrued expenses | (1,103) | | | (1,680) | |
+Payables due to sellers | 745 | | | 352 | |
+Operating lease liabilities | (2,190) | | | (2,031) | |
+Other current liabilities and other liabilities | 662 | | | (122) | |
+Net cash used in operating activities | (3,702) | | | (5,239) | |
+Cash flows from investing activities: | | | |
+Maturities of short-term investments | 34,844 | | | 37,795 | |
+Sales of short-term investments | 9,006 | | | 988 | |
+Purchases of short-term investments | (20,784) | | | (32,484) | |
+| | | |
+Purchases of property and equipment | (529) | | | (449) | |
+| | | |
+Net cash provided by investing activities | 22,537 | | | 5,850 | |
+Cash flows from financing activities: | | | |
+Proceeds from exercise of stock options | 38 | | | — | |
+Payments for repurchase of common stock | (20,730) | | | (1,794) | |
+Payments for taxes related to net share settlement of stock-based compensation awards | (2,060) | | | (1,333) | |
+Net cash used in financing activities | (22,752) | | | (3,127) | |
+Effect of exchange rate changes on cash, cash equivalents, and restricted cash | (78) | | | 338 | |
+Net decrease in cash, cash equivalents, and restricted cash | (3,995) | | | (2,178) | |
+Cash, cash equivalents, and restricted cash at beginning of the period | 26,584 | | | 29,621 | |
+Cash, cash equivalents, and restricted cash at end of the period | $ | 22,589 | | | $ | 27,443 | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+
+
+
+8
+
+
+
+
+
+
+Non-GAAP Financial Measures
+Adjusted EBITDA and Adjusted EBITDA Margin
+In this press release, we provide Adjusted EBITDA, a non-GAAP financial measure that represents our net loss adjusted to exclude: (1) depreciation and amortization; (2) stock-based compensation expense; (3) other income, net; (4) provision for income taxes; (5) restructuring expenses; and (6) strategic alternative expenses. We also provide Adjusted EBITDA Margin, a non-GAAP financial measure that presents Adjusted EBITDA divided by net revenue. Below is a reconciliation of net loss, the most directly comparable GAAP financial measure, to Adjusted EBITDA.
+We have included Adjusted EBITDA and Adjusted EBITDA Margin, which are non-GAAP financial measures, because they are key measures used by our management team to help us to assess our operating performance and the operating leverage in our business. We also use these measures to analyze our financial results, establish budgets and operational goals for managing our business, and make strategic decisions. We believe that Adjusted EBITDA and Adjusted EBITDA Margin help identify underlying trends in our business that could otherwise be masked by the effect of the income and expenses that we exclude from Adjusted EBITDA and Adjusted EBITDA Margin. Accordingly, we believe that these metrics provide useful information to investors and others in understanding and evaluating our results of operations, enhances the overall understanding of our past performance and future prospects, and allows for greater transparency with respect to key financial metrics used by our management in their financial and operational decision-making. We also believe that the presentation of these non-GAAP financial measures provides an additional tool for investors to use in comparing our core business and results of operations over multiple periods with other companies in our industry, many of which present similar non-GAAP financial measures to investors, and to analyze our operating performance.
+The non-GAAP financial measures presented may not be comparable to similarly titled measures reported by other companies due to differences in the way that these measures are calculated. The non-GAAP financial measures presented should not be considered as the sole measure of our performance and should not be considered in isolation from, or as a substitute for, comparable financial measures calculated in accordance with GAAP. Further, these non-GAAP financial measures have certain limitations in that they do not include the impact of certain expenses that are reflected in our condensed consolidated statements of operations. Accordingly, these non-GAAP financial measures should be considered as supplemental in nature, and are not intended, and should not be construed, as a substitute for the related financial information calculated in accordance with GAAP. These limitations of Adjusted EBITDA and Adjusted EBITDA Margin include the following:
+• The exclusion of certain recurring, non-cash charges, such as depreciation and amortization of property and equipment. While these are non-cash charges, we may need to replace the assets being depreciated in the future and Adjusted EBITDA does not reflect cash requirements for these replacements or new capital expenditure requirements;
+• The exclusion of stock-based compensation expense, which has been a significant recurring expense and will continue to constitute a significant recurring expense for the foreseeable future, as equity awards are expected to continue to be an important component of our compensation strategy;
+• The exclusion of other income, net, which includes interest income related to our cash, cash equivalents and short-term investments and realized and unrealized gains and losses on foreign currency exchange; and
+• The exclusion of discrete restructuring expenses such as severance and benefit costs from reductions in force and reorganizations that are fundamentally different in strategic nature from ongoing initiatives. We believe exclusion of these items facilitates a more consistent comparison of operating performance over time because they are distinct from ongoing operational costs.
+9
+
+
+
+
+
+Because of these limitations, you should consider Adjusted EBITDA and Adjusted EBITDA Margin alongside other financial performance measures, including net loss and our other GAAP results.
+Free Cash Flow
+Free cash flow is a non-GAAP financial measure defined as net cash from operating activities less purchases of property and equipment. We use free cash flow as a supplemental measure of liquidity and to evaluate our ability to generate cash from operations that can be used for strategic initiatives and working capital requirements.
+We believe that free cash flow is an important financial measure for use in evaluating our financial performance. Free cash flow has limitations as it omits certain components of the consolidated statements of cash flows and does not represent the residual cash flow available for discretionary expenditures. Other companies may calculate free cash flow differently, which reduces its usefulness as a comparative measure. As a result of these limitations, free cash flow should be considered in addition to, rather than as a substitute for, net cash from operating activities as a measure of our liquidity and our other GAAP results.
+The information in the tables below sets forth the non-GAAP financial measures along with the most directly comparable GAAP financial measures.
+
+
+
+10
+
+
+
+
+
+1STDIBS.COM, INC.
+Reconciliation of Net Loss to Adjusted EBITDA
+(Amounts in thousands)
+(Unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Net loss | $ | (1,023) | | | $ | (4,313) | | | $ | (3,197) | | | $ | (9,119) | |
+Excluding: | | | | | | | |
+Depreciation and amortization | 368 | | | 423 | | | 755 | | | 880 | |
+Stock-based compensation expense | 3,002 | | | 3,542 | | | 5,993 | | | 7,592 | |
+Other income, net | (1,074) | | | (1,423) | | | (2,223) | | | (2,876) | |
+Provision for income taxes | 34 | | | 19 | | | 38 | | | 23 | |
+| | | | | | | |
+Restructuring expenses | — | | | — | | | 494 | | | — | |
+| | | | | | | |
+Adjusted EBITDA (non-GAAP) | $ | 1,307 | | | $ | (1,752) | | | $ | 1,860 | | | $ | (3,500) | |
+Divided by: | | | | | | | |
+Net revenue | $ | 23,317 | | | $ | 22,135 | | | $ | 45,705 | | | $ | 44,680 | |
+Adjusted EBITDA Margin (non-GAAP) | 5.6 | % | | (7.9) | % | | 4.1 | % | | (7.8) | % |
+
+
+
+
+11
+
+
+
+
+
+1STDIBS.COM, INC.
+Reconciliation of Net Cash From Operating Activities to Free Cash Flow
+(Amounts in thousands)
+(Unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Net loss | $ | (1,023) | | | $ | (4,313) | | | $ | (3,197) | | | $ | (9,119) | |
+Adjustments to reconcile net loss to net cash from operating activities: | | | | | | | |
+Depreciation and amortization | 368 | | | 423 | | | 755 | | | 880 | |
+Stock-based compensation expense | 3,002 | | | 3,542 | | | 5,993 | | | 7,592 | |
+Provision for transaction losses, returns and refunds | 196 | | | 259 | | | 339 | | | 294 | |
+Non-cash operating lease expense | 976 | | | 910 | | | 1,936 | | | 1,777 | |
+Accretion of discounts and amortization of premiums on short-term investments, net | (4) | | | (426) | | | 14 | | | (250) | |
+Other, net | (9) | | | (63) | | | 604 | | | (65) | |
+Changes in operating assets and liabilities: | | | | | | | |
+Accounts receivable | 21 | | | (127) | | | (219) | | | (305) | |
+Prepaid expenses and other current assets | (1,617) | | | (1,811) | | | (1,034) | | | (1,261) | |
+Receivables from payment processors and seller accounts (1)
+| (5,982) | | | 296 | | | (7,401) | | | (895) | |
+Other assets | 275 | | | (542) | | | 394 | | | (406) | |
+Accounts payable and accrued expenses | 20 | | | (1,486) | | | (1,103) | | | (1,680) | |
+Payables due to sellers | (21) | | | (849) | | | 745 | | | 352 | |
+Operating lease liabilities | (1,104) | | | (1,019) | | | (2,190) | | | (2,031) | |
+Other current liabilities and other liabilities | 141 | | | 63 | | | 662 | | | (122) | |
+Net cash used in operating activities
+| $ | (4,761) | | | $ | (5,143) | | | $ | (3,702) | | | $ | (5,239) | |
+Purchases of property and equipment | (297) | | | (130) | | | (529) | | | (449) | |
+Free cash flow (non-GAAP) | $ | (5,058) | | | $ | (5,273) | | | $ | (4,231) | | | $ | (5,688) | |
+
+(1) - As of June 30, 2026, a change to our payment processor agreement resulted in a reclassification of approximately $5.9 million from cash and cash equivalents to receivables from payment processors and seller accounts, which is recorded in other current assets, and negatively impacted free cash flow.
+12

--- a/modules/test-fixtures/earnings-filings/shop.txt
+++ b/modules/test-fixtures/earnings-filings/shop.txt
@@ -1,0 +1,341 @@
+EX-99.1
+2
+exhibit991pressreleaseq220.htm
+EX-99.1
+
+
+
+
+Document
+
+
+Shopify Delivers Big: 30%+ Growth Across
+GMV, Revenue, Gross Profit, and Free Cash Flow
+August 5, 2026 - Shopify announced today financial results for the quarter ended June 30, 2026. Shopify achieved 34% revenue growth (33% in constant currency) and 18% free cash flow margins.
+“This was a monster quarter: more than 30% growth in GMV AND revenue AND gross profit AND free cash flow,” said Harley Finkelstein, President of Shopify. “We power every kind of business, and with AI, we're expanding what's possible for all of them. No one else comes close.”
+“GMV growth accelerated on top of last year’s already strong Q2 with solid results across all merchant sizes, channels, and geographies. Alongside this momentum, we continue to drive operating leverage, which flowed through to 18% free cash flow margins. Broad-based, consistent, and compounding growth with financial discipline; that’s exactly the model that we’ve been building,” said Jeff Hoffmeister, Chief Financial Officer.
+Selected Business Performance Information (1)
+(In US $ millions, except percentages)
+| | | | | | | | | | | | | | | | |
+| Three months ended | | |
+| June 30, 2026 | | June 30, 2025 | | | | | |
+GMV | 115,567 | | 87,837 | | | | | |
+| | | | | | | | |
+MRR | 221 | | 185 | | | | | |
+| | | | | | | | |
+Revenue | 3,583 | | 2,680 | | | | | |
+| | | | | | | | |
+Gross profit | 1,708 | | 1,302 | | | | | |
+| | | | | | | | |
+Operating income | 488 | | 291 | | | | | |
+| | | | | | | | |
+Free cash flow | 654 | | 422 | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+YoY revenue growth rate | 34 | % | | 31 | % | | | | | |
+| | | | | | | | |
+Free cash flow margin | 18 | % | | 16 | % | | | | | |
+
+(1) See endnotes below for definitions of GMV and MRR and additional information on constant currency, free cash flow, and free cash flow margin, which are non-GAAP financial measures and are rec onciled to the comparable GAAP measures in the non-GAAP reconciliations at the end of this press release. Please refer to the Condensed Consolidated Statements of Cash Flows for additional information on the presentation of cash flows in 2026 and 2025.
+1
+
+
+
+
+
+2026 Outlook
+The outlook that follows supersedes all prior financial outlook statements made by Shopify, constitutes forward-looking information within the meaning of applicable securities laws, is based on a number of assumptions, and is subject to a number of risks. Actual results could vary materially as a result of numerous factors, including certain risk factors, many of which are beyond Shopify’s control. Please see "Forward-looking Statements" at the end of this press release.
+For the third quarter of 2026, we expect:
+• Revenue to grow at a low-thirties percentage rate on a year-over-year basis;
+• Gross profit dollars to grow at a mid-to-high twenties percentage rate on a year-over-year basis;
+• Operating expenses as a percentage of revenue to be 33% to 34%;
+• Stock-based compensation to be $150 million; and
+• Free cash flow margin to be in the high-teens to low-twenties.
+
+
+Quarterly Conference Call
+Shopify’s management team will hold a conference call to discuss its second-quarter results today, August 5, 2026, at 8:30 a.m. ET. The conference call will be webcast in the Investor Relations section of Shopify’s website at www.shopify.com/investors/events . An archived replay of the webcast will be available following the conclusion of the call.
+Shopify’s Form 10-Q for the quarter ended June 30, 2026, including the unaudited Condensed Consolidated Financial Statements and accompanying Notes, and Management's Discussion and Analysis, will be available on Shopify’s website at www.shopify.com and will be filed on EDGAR at www.sec.gov and on SEDAR+ at www.sedarplus.ca .
+About Shopify
+Shopify provides essential internet infrastructure for commerce. Shopify’s all-in-one platform makes it easier to start, run, and grow a business, powering sales online, in-store, and everywhere in between. Millions of businesses in 175+ countries use Shopify—from entrepreneurs to brands like Aldo, BarkBox, Carrier, Meta, SKIMS, Supreme, and Vuori.
+For more information, visit www.shopify.com .
+| | | | | | | | | | | | | | |
+CONTACT INVESTORS: | Shane Kleinstein | | CONTACT MEDIA: | Ben McConaghy |
+| Director, Investor Relations | | | Director, Communications |
+| IR@shopify.com | | | press@shopify.com |
+
+2
+
+
+
+
+
+
+
+Shopify Inc. Condensed Consolidated Statements of Operations
+(In US $ millions)
+| | | | | | | | | | | | | | | | |
+| Three months ended | | |
+| June 30, 2026 | | June 30, 2025 | | | | | |
+Revenues | | | | | | | | |
+Subscription solutions | 802 | | 656 | | | | | |
+Merchant solutions | 2,781 | | 2,024 | | | | | |
+| 3,583 | | 2,680 | | | | | |
+Cost of revenues | | | | | | | | |
+Subscription solutions | 163 | | 121 | | | | | |
+Merchant solutions | 1,712 | | 1,257 | | | | | |
+| 1,875 | | 1,378 | | | | | |
+Gross profit | 1,708 | | 1,302 | | | | | |
+Operating expenses | | | | | | | | |
+Sales and marketing | 498 | | 415 | | | | | |
+Research and development | 445 | | 394 | | | | | |
+General and administrative | 136 | | 122 | | | | | |
+Transaction and loan losses | 141 | | 80 | | | | | |
+| | | | | | | | |
+Total operating expenses | 1,220 | | 1,011 | | | | | |
+Operating income | 488 | | 291 | | | | | |
+Net other income, including taxes (2)
+| 1,014 | | 615 | | | | | |
+Net Income | 1,502 | | 906 | | | | | |
+less: equity investments, marked to market, net of taxes | 1,063 | | 568 | | | | | |
+Net income excluding the impact of equity investments (3)
+| 439 | | 338 | | | | | |
+| | | | | |
+(2) Net other income, including taxes includes interest income, gains and losses on equity and other investments, foreign exchange gains and losses, and our provision for income taxes.
+|
+(3) Net income excluding the impact of equity investments is a non-GAAP financial measure which is reconciled at the end of this press release. This measure excludes the impact of any gains or losses on our equity investments in third parties. Shopify believes this measure provides useful information to investors given that valuations of third parties in public and private markets are outside of our control, and therefore, fluctuations in those valuations are not relevant to the fundamentals of our business and have little analytical or predictive value regarding our ability to drive operational results. This measure does not have a standardized meaning under US GAAP and may not be comparable to similar measures presented by other companies. GAAP and non-GAAP diluted net income (loss) per share are available in the Financial Supplemental posted on www.shopify.com/investors .
+Note: More detailed Condensed Consolidated Statements of Operations and Comprehensive Income are available in the Quarterly Report on Form 10-Q filed concurrently with this press release with US and Canadian regulators and available on www.sec.gov and www.sedarplus.ca .
+|
+
+3
+
+
+
+
+
+
+
+Shopify Inc. Condensed Consolidated Balance Sheets
+(In US $ millions)
+| | | | | | | | | | | |
+| | | |
+| June 30, 2026 | | December 31, 2025 |
+Assets | | | |
+Current assets | | | |
+Cash and cash equivalents | 1,656 | | | 1,545 | |
+Marketable securities | 3,291 | | | 4,233 | |
+Trade and other receivables, net | 466 | | | 500 | |
+Loans and merchant cash advances, net | 2,184 | | | 1,784 | |
+Other current assets | 219 | | | 234 | |
+| 7,816 | | | 8,296 | |
+Long-term assets | | | |
+| | | |
+| | | |
+| | | |
+Long-term assets (4)
+| 195 | | | 210 | |
+Deferred tax assets | 30 | | | 33 | |
+| | | |
+Long-term investments | 525 | | | 975 | |
+Equity and other investments | 4,854 | | | 4,582 | |
+Equity method investment | 559 | | | 602 | |
+Goodwill | 491 | | | 491 | |
+| 6,654 | | | 6,893 | |
+Total assets | 14,470 | | | 15,189 | |
+Liabilities and shareholders’ equity | | | |
+Liabilities | | | |
+| | | |
+| | | |
+| | | |
+| | | |
+Accounts payable | 575 | | | 570 | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+Deferred tax liabilities | 79 | | | 55 | |
+Other liabilities (5)
+| 1,132 | | | 1,091 | |
+| 1,786 | | | 1,716 | |
+| | | |
+Shareholders’ equity | 12,684 | | | 13,473 | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+Total liabilities and shareholders’ equity | 14,470 | | | 15,189 | |
+| | | |
+(4) Long-term assets includes Property and equipment, net, Operating lease right-of-use assets, net, Intangible assets, net, and Other long-term assets.
+|
+(5) Other liabilities includes Accrued liabilities, Current and Long-term Deferred revenue, and Operating lease liabilities.
+|
+Note: More detailed Condensed Consolidated Balance Sheet and Notes to the Condensed Consolidated Financial Statements are available in the Quarterly Report on Form 10-Q filed concurrently with this press release with US and Canadian regulators and available on www.sec.gov and www.sedarplus.ca .
+|
+
+4
+
+
+
+
+
+
+
+Shopify Inc. Condensed Consolidated Statements of Cash Flows
+(In US $ millions)
+| | | | | | | | | | | | | | | | |
+| Three months ended | | |
+| June 30, 2026 | | June 30, 2025 | | | | | |
+Cash flows from operating activities | | | | | | | | |
+Net income for the period | 1,502 | | 906 | | | | | |
+Adjustments to reconcile net income to
+net cash provided by operating activities: | | | | | | | | |
+Amortization and depreciation | 7 | | 8 | | | | | |
+| | | | | | | | |
+Stock-based compensation | 128 | | 113 | | | | | |
+Impairment of right-of-use assets and leasehold improvements | — | | 10 | | | | | |
+Provision for transaction and loan losses | 94 | | 44 | | | | | |
+Deferred income tax recovery
+| 165 | | 98 | | | | | |
+Revenue related to non-cash consideration | (13) | | (12) | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Net gain on equity and other investments | (1,250) | | (682) | | | | | |
+Net loss on equity method investment
+| 22 | | 24 | | | | | |
+Unrealized foreign exchange loss (gain)
+| 4 | | (46) | | | | | |
+Changes in operating assets and liabilities | (1) | | (35) | | | | | |
+Net cash provided by operating activities | 658 | | 428 | | | | | |
+Cash flows from investing activities | | | | | | | | |
+Purchases of property and equipment | (4) | | (6) | | | | | |
+Purchases of marketable securities | (654) | | (1,464) | | | | | |
+Maturities of marketable securities | 1,450 | | 1,464 | | | | | |
+Purchases and originations of loans and merchant cash advances (6)
+| (1,584) | | (944) | | | | | |
+Repayments and sales of loans and merchant cash advances (6)
+| 1,417 | | 767 | | | | | |
+Purchases of equity and other investments | (55) | | (71) | | | | | |
+Acquisition of businesses, net of cash acquired | — | | — | | | | | |
+Other | 1 | | 2 | | | | | |
+Net cash provided by (used in) investing activities | 571 | | (252) | | | | | |
+Cash flows from financing activities | | | | | | | | |
+Proceeds from the exercise of stock options | 3 | | 44 | | | | | |
+| | | | | | | | |
+Repurchases of common stock | (1,420) | | — | | | | | |
+Net cash (used in) provided by financing activities | (1,417) | | 44 | | | | | |
+Effect of foreign exchange on cash,
+cash equivalents and restricted cash | (4) | | 13 | | | | | |
+Net (decrease) increase in cash, cash
+equivalents and restricted cash | (192) | | 233 | | | | | |
+Cash, cash equivalents and restricted cash – beginning of period | 1,848 | | 1,309 | | | | | |
+Cash, cash equivalents and restricted cash – end of period | 1,656 | | 1,542 | | | | | |
+
+(6) Starting in April 2026, the cash flows associated with merchant cash advances are presented within investing cash flows rather than operating cash flows on a basis consistent with loans, given the similar nature of the underlying lending activities. For the three months ended June 30, 2026, the changes described above resulted in a net cash use of $37 million presented in Investing activities after consideration of repayments and purchases and originations.
+
+
+
+
+
+
+5
+
+
+
+
+
+
+
+Reconciliation of Non-GAAP Financial Measures
+Free Cash Flow Reconciliation
+(In US $ millions, except percentages)
+The following table illustrates how free cash flow is calculated in this press release:
+| | | | | | | | | | | | | | | | |
+| Three months ended | | |
+| June 30, 2026 | | June 30, 2025 | | | | | |
+Net cash provided by operating
+activities (6)
+| 658 | | | 428 | | | | | | |
+less: capital expenditures (7)
+| (4) | | | (6) | | | | | | |
+Free cash flow | 654 | | | 422 | | | | | | |
+Revenue | 3,583 | | | 2,680 | | | | | | |
+Free cash flow margin | 18 | % | | 16 | % | | | | | |
+
+
+
+
+
+
+
+Net Income Excluding the Impact of Equity Investments Reconciliation
+(In US $ millions)
+The following table illustrates how Net income excluding the impact of equity investments is calculated in this press release:
+| | | | | | | | | | | | | | | | |
+| Three months ended | | |
+| June 30, 2026 | | June 30, 2025 | | | | | |
+Net Income | 1,502 | | 906 | | | | | |
+less: equity investments,
+marked to market, net of taxes | 1,063 | | 568 | | | | | |
+Net income
+excluding the impact of equity investments (3)
+| 439 | | 338 | | | | | |
+
+(7) Capital expenditures is equivalent to the amount included in “Purchases of property and equipment” on our Condensed Consolidated Statements of Cash Flows for the reported period.
+6
+
+
+
+
+
+
+
+Constant Currency Analysis
+(In US $ millions, except percentages)
+The following table converts our GMV, revenues, gross profit, and operating income using the comparative period's monthly average exchange rates. We have provided the below disclosure as we believe it presents a clear comparison of our period-to-period operating results by removing the impact of fluctuations in foreign exchange rates and to assist investors in understanding our financial and operating performance. The table below and our Condensed Consolidated Statements of Operations disclosure are supplements to our Condensed Consolidated Financial Statements, which are prepared and presented in accordance with US GAAP (excluding GMV).
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three months ended June 30, |
+| GMV | | Revenue | | Subscription solutions revenue | | Merchant solutions revenue | | Gross profit | | Operating income |
+2025 as reported | 87,837 | | 2,680 | | 656 | | 2,024 | | 1,302 | | 291 |
+2026 as reported | 115,567 | | 3,583 | | 802 | | 2,781 | | 1,708 | | 488 |
+Percentage change YoY | 32 | % | | 34 | % | | 22 | % | | 37 | % | | 31 | % | | 68 | % |
+Constant currency impact | 1,149 | | | 16 | | | 3 | | | 44 | | | 12 | | | 11 | |
+Percentage change YoY
+constant currency | 30 | % | | 33 | % | | 22 | % | | 35 | % | | 30 | % | | 64 | % |
+| | | | | | | | | | | |
+| |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+
+7
+
+
+
+
+
+
+
+Regulatory Disclosures and Forward-looking Statements
+Advisory Regarding Forward-looking Statements
+This press release contains forward-looking statements and forward-looking information (collectively, “forward-looking statements“), including statements related to Shopify’s financial outlook, such as expected revenue and expenses for the next fiscal quarter, Shopify's expectations regarding its ability to support merchants as they scale, and Shopify's expectations regarding the development of emerging technologies, including AI. These statements can be identified by words such as “will“ and “expect“ and are based on Shopify's current projections and expectations about future events and financial results. Known and unknown risks may cause actual results to differ materially from those described in the forward-looking statements. These risks include, but are not limited to, the Company’s ability to maintain expected growth and manage expenses, the impact of changes in economic conditions and consumer spending in key markets such as the United States, Europe, and globally, the impact of measures that affect international trade, including tariffs, the adoption and impact of emerging technologies such as AI, our reliance on third-party providers to deliver services, a cyberattack or security breach, and serious errors or defects in software or hardware. Other factors and risks that may cause actual results to differ materially from those set out in the forward-looking statements are set out in Shopify's Form 10-Q under the heading “Risk Factors“ and other filings made with US and Canadian securities regulators, available at www.sec.gov and www.sedarplus.ca . Undue reliance should not be placed on the forward-looking statements in this press release, which are based on information available to management on the date hereof and represent management’s beliefs regarding future events, projections, and financial trends, which, by their nature, are inherently uncertain. The forward-looking statements are provided to give additional information about management’s expectations and beliefs and may not be appropriate for other purposes. Shopify undertakes no duty to publicly update or revise any forward-looking statements, except as may be required by law.
+
+
+Endnotes:
+Gross Merchandise Volume, or GMV, represents the total dollar value of orders facilitated through the Shopify platform including certain apps and channels for which a revenue-sharing arrangement is in place in the period, net of refunds, and inclusive of shipping and handling, duty, and value-added taxes.
+Monthly Recurring Revenue , or MRR, is the aggregate value of all subscription plans, excluding variable platform fees, in effect on the last day of the period, assuming merchants maintain their subscription the following month and is used by management as a directional indicator of subscription solutions revenue going forward.
+Free cash flow and free cash flow margin are non-GAAP financial measures that are reconciled in the non-GAAP reconciliation within this press release. These non-GAAP financial measures do not have standardized meanings under US GAAP and may not be comparable to similar measures presented by other companies. Shopify believes free cash flow and free cash flow margin provide useful information to help investors and others understand our operating results and the performance of our business in the same manner as management. Shopify does not reconcile forward-looking non-GAAP free cash flow margin because certain financial information, the probable significance of which cannot be determined, is not available and cannot be reasonably estimated. Free cash flow is a non-GAAP financial measure calculated as cash flow from operations less capital expenditures.
+8

--- a/modules/test-fixtures/earnings-filings/uber.txt
+++ b/modules/test-fixtures/earnings-filings/uber.txt
@@ -1,0 +1,556 @@
+EX-99.1
+2
+uberq226earningspressrelea.htm
+EXHIBIT 99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+Uber Announces Results for Second Quarter 2026
+
+
+Gross Bookings grew 22% year-over-year on a constant currency basis; Trips grew 18% year-over-year
+GAAP Income from operations of $1.9 billion; Non-GAAP Operating Income of $2.1 billion, up 40% year-over-year
+GAAP Diluted EPS of $1.17; Non-GAAP EPS of $0.81, up 35% year-over-year
+
+
+SAN FRANCISCO – August 5, 2026 – Uber Technologies, Inc. (NYSE: UBER) today announced financial results for the quarter ended June 30, 2026.
+
+
+“Uber’s platform advantage continues to compound: record consumers and engagement, and profitable growth across our business,” said Dara Khosrowshahi, CEO. “In fact, we’ve added more first-time users over the past twelve months than in any period over the past five years. We’re investing from a position of strength, as we accelerate our cross-platform strategy at a global scale and build the world’s largest platform for autonomous vehicles.”
+“We continue to convert strong top-line growth into faster earnings and significant cash generation,” said Balaji Krishnamurthy, CFO. “Gross Bookings grew 22%, Non-GAAP EPS grew 35%, and trailing twelve-month free cash flow exceeded $10 billion for the first time in Uber’s history—giving us the flexibility to both invest for the future and pursue strategic opportunities, while continuing to reduce our share count.”
+
+
+
+
+Financial and Operational Highlights for Second Quarter 2026
+• Trips during the quarter grew 18% year-over-year (“YoY”) to 3.9 billion, driven by Monthly Active Platform Consumers (“MAPCs") growth of 16% YoY and monthly Trips per MAPC growth of 2% YoY.
+• Gross Bookings grew 24% YoY to $58.0 billion, and 22% on a constant currency basis.
+• Revenue grew 12% YoY to $14.2 billion, or 11% on a constant currency basis. Business model changes negatively impacted total revenue YoY growth by 8 percentage points on a reported and constant currency basis.
+• GAAP Income from operations grew 30% YoY to $1.9 billion.
+• GAAP Net income attributable to Uber Technologies, Inc. was $2.4 billion, which includes a $1.6 billion net benefit (pre-tax) from revaluations of Uber’s equity investments. GAAP Diluted earnings per share (“EPS”) was $1.17.
+• Adjusted EBITDA grew 33% YoY to $2.8 billion. Adjusted EBITDA margin as a percentage of Gross Bookings was 4.9%, up from 4.5% in Q2 2025.
+• Non-GAAP Operating Income grew 40% YoY to $2.1 billion. Non-GAAP Operating Income as a percentage of Gross Bookings was 3.7%, up from 3.3% in Q2 2025.
+• Non-GAAP Net Income grew 29% YoY to $1.7 billion and Non-GAAP EPS grew 35% YoY to $0.81.
+• Net cash provided by operating activities was $2.9 billion and free cash flow, defined as net cash flows from operating activities less capital expenditures, was $2.8 billion.
+• Unrestricted cash, cash equivalents, and short-term investments were $5.4 billion at the end of the second quarter.
+
+
+Outlook for Q3 2026
+For Q3 2026, we anticipate:
+• Gross Bookings of $58.25 billion to $60.25 billion, representing growth of 18% to 22% YoY on a constant-currency basis.
+◦ Our outlook assumes a roughly 1 percentage-point currency headwind to total reported YoY growth.
+• Non-GAAP EPS of $0.84 to $0.88, representing growth of 28% to 35% YoY.
+◦ Our outlook translates to Adjusted EBITDA of $2.86 billion to $2.96 billion.
+
+
+
+
+
+
+
+
+
+
+1
+
+
+
+
+
+
+
+Financial and Operational Highlights for Second Quarter 2026
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | | | |
+(In millions, except percentages and per share amounts) | | 2025 | | 2026 | | % Change | | % Change
+(Constant Currency (1) )
+|
+| | | | | | | | |
+Monthly Active Platform Consumers (“MAPCs”) | | 180 | | | 208 | | | 16 | % | | |
+Trips | | 3,268 | | | 3,867 | | | 18 | % | | |
+Gross Bookings | | $ | 46,756 | | | $ | 58,022 | | | 24 | % | | 22 | % |
+Revenue | | $ | 12,651 | | | $ | 14,191 | | | 12 | % | | 11 | % |
+GAAP Income from operations | | $ | 1,450 | | | $ | 1,890 | | | 30 | % | | |
+GAAP Net income attributable to Uber Technologies, Inc. (2)
+| | $ | 1,355 | | | $ | 2,394 | | | 77 | % | | |
+GAAP Diluted EPS | | $ | 0.63 | | | $ | 1.17 | | | 85 | % | | |
+Adjusted EBITDA (1)
+| | $ | 2,119 | | | $ | 2,819 | | | 33 | % | | |
+Non-GAAP Operating Income (1)
+| | $ | 1,534 | | | $ | 2,143 | | | 40 | % | | |
+Non-GAAP Net Income (1)
+| | $ | 1,280 | | | $ | 1,652 | | | 29 | % | | |
+Non-GAAP EPS (1)
+| | $ | 0.60 | | | $ | 0.81 | | | 35 | % | | |
+Net cash provided by operating activities
+| | $ | 2,564 | | | $ | 2,862 | | | 12 | % | | |
+Free cash flow (1)
+| | $ | 2,475 | | | $ | 2,792 | | | 13 | % | | |
+
+(1) See “Definitions of Non-GAAP Measures” and “Reconciliations of Non-GAAP Measures” sections herein for an explanation and reconciliations of non-GAAP measures used throughout this release.
+(2) Q2 2025 net income includes a $17 million net headwind (pre-tax) from revaluations of Uber’s equity investments. Q2 2026 net income includes a $1.6 billion net benefit (pre-tax) from revaluations of Uber’s equity investments.
+
+
+Results by Offering and Segment
+Gross Bookings
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | | | |
+(In millions, except percentages) | | 2025 | | 2026 | | % Change | | % Change
+(Constant Currency) |
+| | | | | | | | |
+Gross Bookings: | | | | | | | | |
+Mobility | | $ | 23,762 | | | $ | 28,988 | | | 22 | % | | 20 | % |
+Delivery | | 21,734 | | | 27,463 | | | 26 | % | | 25 | % |
+Freight | | 1,260 | | | 1,571 | | | 25 | % | | 25 | % |
+Total | | $ | 46,756 | | | $ | 58,022 | | | 24 | % | | 22 | % |
+
+
+
+Revenue
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | | | |
+(In millions, except percentages) | | 2025 | | 2026 | | % Change | | % Change
+(Constant Currency) |
+| | | | | | | | |
+Revenue: | | | | | | | | |
+Mobility
+| | $ | 7,288 | | | $ | 7,363 | | | 1 | % | | 0 | % |
+Delivery
+| | 4,102 | | | 5,245 | | | 28 | % | | 26 | % |
+Freight | | 1,261 | | | 1,583 | | | 26 | % | | 25 | % |
+Total
+| | $ | 12,651 | | | $ | 14,191 | | | 12 | % | | 11 | % |
+
+
+
+
+
+2
+
+
+
+
+
+
+
+Non-GAAP Operating Income and Segment Operating Income (Loss)
+| | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | |
+(In millions, except percentages) | | 2025 | | 2026 | | % Change |
+| | | | | | |
+Segment Operating Income (Loss): | | | | | | |
+Mobility | | $ | 1,729 | | | $ | 2,215 | | | 28 | % |
+Delivery | | 766 | | | 1,055 | | | 38 | % |
+Freight | | (26) | | | (24) | | | 8 | % |
+Corporate G&A and Platform R&D (1)
+| | (935) | | | (1,103) | | | (18) | % |
+Non-GAAP Operating Income (2)
+| | $ | 1,534 | | | $ | 2,143 | | | 40 | % |
+
+(1) Includes costs that are not directly attributable to our reportable segments. Corporate G&A also includes certain shared costs such as finance, accounting, tax, human resources, information technology and legal costs. Platform R&D also includes mapping and payment technologies and support and development of the internal technology infrastructure. Our allocation methodology is periodically evaluated and may change.
+(2) “Non-GAAP Operating Income” is a non-GAAP measure as defined by the SEC. See “Definitions of Non-GAAP Measures” and “Reconciliations of Non-GAAP Measures” sections herein for an explanation and reconciliations of non-GAAP measures used throughout this release.
+
+
+
+
+3
+
+
+
+
+
+Webcast and conference call information
+A live audio webcast of our second quarter ended June 30, 2026 earnings release call will be available at https://investor.uber.com/, along with the earnings press release and slide presentation. The call begins on August 5, 2026 at 5:00 AM (PT) / 8:00 AM (ET). This press release, including the reconciliations of certain non-GAAP measures to their nearest comparable GAAP measures, is also available on that site.
+We also provide announcements regarding our financial performance and other matters, including SEC filings, investor events, press and earnings releases, on our investor relations website (https://investor.uber.com/), and our blogs (https://uber.com/blog) and X accounts (@uber and @dkhos), as a means of disclosing material information and complying with our disclosure obligations under Regulation FD.
+About Uber
+Uber’s mission is to create opportunity through movement. We started in 2010 to solve a simple problem: how do you get access to a ride at the touch of a button? More than 79 billion trips later, we're building products to get people closer to where they want to be. By changing how people, food, and things move through cities, Uber is a platform that opens up the world to new possibilities.
+Forward-Looking Statements
+This press release contains forward-looking statements regarding our future business expectations which involve risks and uncertainties. Actual results may differ materially from the results predicted, and reported results should not be considered as an indication of future performance. Forward-looking statements include all statements that are not historical facts and can be identified by terms such as “anticipate,” “believe,” “contemplate,” “continue,” “could,” “estimate,” “expect,” “hope,” “intend,” “may,” “might,” “objective,” “ongoing,” “plan,” “potential,” “predict,” “project,” “should,” “target,” “will,” or “would” or similar expressions and the negatives of those terms. Forward-looking statements involve known and unknown risks, uncertainties and other factors that may cause our actual results, performance or achievements to be materially different from any future results, performance or achievements expressed or implied by the forward-looking statements. These risks, uncertainties and other factors relate to, among others: competition, managing our growth and corporate culture, financial performance, investments in new products or offerings, our ability to attract drivers, consumers and other partners to our platform, our brand and reputation and other legal and regulatory developments, particularly with respect to our relationships with drivers and couriers and the impact of the global economy, including rising inflation and interest rates. For additional information on other potential risks and uncertainties that could cause actual results to differ from the results predicted, please see our annual report on Form 10-K for the year ended December 31, 2025 and subsequent quarterly reports and other filings filed with the Securities and Exchange Commission from time to time. All information provided in this release and in the attachments is as of the date of this press release and any forward-looking statements contained herein are based on assumptions that we believe to be reasonable as of this date. Undue reliance should not be placed on the forward-looking statements in this press release, which are based on information available to us on the date hereof. We undertake no duty to update this information unless required by law.
+Non-GAAP Financial Measures
+To supplement our financial information, which is prepared and presented in accordance with generally accepted accounting principles in the United States of America (“GAAP”), we use the following non-GAAP financial measures: Adjusted EBITDA; Non-GAAP Operating Income; Non-GAAP Net Income; Non-GAAP EPS; Free cash flow; as well as, revenue growth rates in constant currency. The presentation of this financial information is not intended to be considered in isolation or as a substitute for, or superior to, the financial information prepared and presented in accordance with GAAP. We use these non-GAAP financial measures for financial and operational decision-making and as a means to evaluate period-to-period comparisons. We believe that these non-GAAP financial measures provide meaningful supplemental information regarding our performance by excluding certain items that may not be indicative of our recurring core business operating results.
+We believe that both management and investors benefit from referring to these non-GAAP financial measures in assessing our performance and when planning, forecasting, and analyzing future periods. These non-GAAP financial measures also facilitate management’s internal comparisons to our historical performance. We believe these non-GAAP financial measures are useful to investors both because (1) they allow for greater transparency with respect to key metrics used by management in its financial and operational decision-making and (2) they are used by our institutional investors and the analyst community to help them analyze the health of our business.
+There are a number of limitations related to the use of non-GAAP financial measures. In light of these limitations, we provide specific information regarding the GAAP amounts excluded from these non-GAAP financial measures and evaluating these non-GAAP financial measures together with their relevant financial measures in accordance with GAAP.
+
+
+
+
+4
+
+
+
+
+
+For more information on these non-GAAP financial measures, please see the sections titled “Definitions of Non-GAAP Measures” and “Reconciliations of Non-GAAP Measures” included at the end of this release. In regards to forward looking non-GAAP guidance, we are not able to reconcile the forward-looking Non-GAAP EPS and Adjusted EBITDA measures to the closest corresponding GAAP measures without unreasonable efforts because we are unable to predict the ultimate outcome of certain significant items. These items include, but are not limited to, significant legal settlements, unrealized gains and losses on equity investments, tax and regulatory reserve changes, restructuring costs and acquisition and financing related impacts.
+Contacts
+Investors and analysts: investor@uber.com
+Media: press@uber.com
+
+
+
+
+5
+
+
+
+
+
+
+UBER TECHNOLOGIES, INC.
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(In millions)
+(Unaudited)
+| | | | | | | | | | | | | | |
+| | As of December 31, 2025 | | As of June 30, 2026 |
+Assets | | | | |
+Cash and cash equivalents | | $ | 7,105 | | | $ | 4,870 | |
+Short-term investments | | 528 | | | 521 | |
+Restricted cash and cash equivalents | | 631 | | | 661 | |
+Accounts receivable, net | | 3,827 | | | 4,298 | |
+Prepaid expenses and other current assets | | 1,902 | | | 2,179 | |
+Total current assets | | 13,993 | | | 12,529 | |
+Restricted cash and cash equivalents | | 1,911 | | | 1,646 | |
+Restricted investments | | 8,874 | | | 9,486 | |
+Investments | | 9,178 | | | 8,759 | |
+Equity method investments | | 287 | | | 3,773 | |
+Property and equipment, net | | 1,897 | | | 1,809 | |
+Operating lease right-of-use assets | | 1,114 | | | 1,558 | |
+Intangible assets, net | | 1,048 | | | 1,132 | |
+Goodwill | | 8,931 | | | 9,472 | |
+Deferred tax assets | | 10,951 | | | 10,162 | |
+Other non-current assets | | 3,618 | | | 5,475 | |
+Total assets | | $ | 61,802 | | | $ | 65,801 | |
+Liabilities, redeemable non-controlling interests and equity | | | | |
+Accounts payable | | $ | 1,013 | | | $ | 1,366 | |
+Short-term insurance reserves | | 3,387 | | | 3,758 | |
+Operating lease liabilities, current | | 169 | | | 178 | |
+Short-term debt | | — | | | 1,997 | |
+Accrued and other current liabilities | | 7,751 | | | 7,572 | |
+Total current liabilities | | 12,320 | | | 14,871 | |
+Long-term insurance reserves | | 9,076 | | | 9,528 | |
+Long-term debt, net of current portion | | 10,521 | | | 10,726 | |
+Operating lease liabilities, non-current | | 1,390 | | | 1,830 | |
+Other non-current liabilities | | 412 | | | 447 | |
+Total liabilities | | 33,719 | | | 37,402 | |
+| | | | |
+Redeemable non-controlling interests | | 165 | | | 180 | |
+Equity | | | | |
+Common stock | | — | | | — | |
+Additional paid-in capital | | 38,101 | | | 35,698 | |
+Accumulated other comprehensive loss | | (432) | | | (432) | |
+Accumulated deficit | | (10,628) | | | (7,950) | |
+Total Uber Technologies, Inc. stockholders' equity | | 27,041 | | | 27,316 | |
+Non-redeemable non-controlling interests | | 877 | | | 903 | |
+Total equity | | 27,918 | | | 28,219 | |
+Total liabilities, redeemable non-controlling interests and equity | | $ | 61,802 | | | $ | 65,801 | |
+
+
+
+
+
+
+
+
+
+6
+
+
+
+
+
+UBER TECHNOLOGIES, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(In millions, except share amounts which are reflected in thousands, and per share amounts)
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, |
+| | 2025 | | 2026 | | 2025 | | 2026 |
+Revenue | | $ | 12,651 | | | $ | 14,191 | | | $ | 24,184 | | | $ | 27,394 | |
+Costs and expenses | | | | | | | | |
+Cost of revenue, exclusive of depreciation and amortization shown separately below | | 7,611 | | | 7,815 | | | 14,548 | | | 15,073 | |
+Operations and support | | 696 | | | 805 | | | 1,364 | | | 1,568 | |
+Sales and marketing | | 1,210 | | | 1,515 | | | 2,267 | | | 2,841 | |
+Research and development | | 840 | | | 1,043 | | | 1,655 | | | 1,994 | |
+General and administrative | | 669 | | | 935 | | | 1,326 | | | 1,733 | |
+Depreciation and amortization | | 175 | | | 188 | | | 346 | | | 372 | |
+Total costs and expenses | | 11,201 | | | 12,301 | | | 21,506 | | | 23,581 | |
+Income from operations | | 1,450 | | | 1,890 | | | 2,678 | | | 3,813 | |
+Interest expense | | (108) | | | (127) | | | (213) | | | (235) | |
+Interest income | | 181 | | | 172 | | | 350 | | | 347 | |
+Other income (expense), net | | (19) | | | 1,342 | | | 74 | | | (152) | |
+Income before income taxes and loss from equity method investments | | 1,504 | | | 3,277 | | | 2,889 | | | 3,773 | |
+Provision for (benefit from) income taxes | | 142 | | | 840 | | | (260) | | | 1,034 | |
+Loss from equity method investments | | (12) | | | (21) | | | (25) | | | (41) | |
+Net income including non-controlling interests | | 1,350 | | | 2,416 | | | 3,124 | | | 2,698 | |
+Less: net income (loss) attributable to non-controlling interests, net of tax | | (5) | | | 22 | | | (7) | | | 41 | |
+Net income attributable to Uber Technologies, Inc. | | $ | 1,355 | | | $ | 2,394 | | | $ | 3,131 | | | $ | 2,657 | |
+Net income per share attributable to Uber Technologies, Inc. common stockholders: | | | | | | | | |
+Basic | | $ | 0.65 | | | $ | 1.18 | | | $ | 1.50 | | | $ | 1.30 | |
+Diluted | | $ | 0.63 | | | $ | 1.17 | | | $ | 1.46 | | | $ | 1.29 | |
+Weighted-average shares used to compute net income per share attributable to common stockholders: | | | | | | | | |
+Basic | | 2,091,106 | | | 2,036,458 | | | 2,091,781 | | | 2,044,279 | |
+Diluted | | 2,125,628 | | | 2,050,225 | | | 2,124,181 | | | 2,060,763 | |
+
+
+
+
+
+7
+
+
+
+
+
+UBER TECHNOLOGIES, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(In millions)
+(Unaudited) | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, |
+| | 2025 | | 2026 | | 2025 | | 2026 |
+Cash flows from operating activities | | | | | | | | |
+Net income including non-controlling interests | | $ | 1,350 | | | $ | 2,416 | | | $ | 3,124 | | | $ | 2,698 | |
+Adjustments to reconcile net income to net cash provided by operating activities: | | | | | | | | |
+Depreciation and amortization | | 181 | | | 195 | | | 359 | | | 386 | |
+Stock-based compensation | | 475 | | | 550 | | | 910 | | | 1,023 | |
+Deferred income taxes | | 87 | | | 665 | | | (325) | | | 771 | |
+(Gains) losses on debt and equity securities, net | | 17 | | | (1,612) | | | (34) | | | (138) | |
+(Gains) losses on foreign currency transactions, net | | (101) | | | (58) | | | (152) | | | (53) | |
+Other | | 106 | | | 296 | | | 79 | | | 316 | |
+Change in assets and liabilities, net of impact of business acquisitions and disposals: | | | | | | | | |
+Accounts receivable | | (212) | | | (425) | | | (335) | | | (499) | |
+Prepaid expenses and other assets | | (251) | | | (163) | | | (748) | | | (375) | |
+Operating lease right-of-use assets | | 46 | | | 38 | | | 89 | | | 100 | |
+Accounts payable | | 125 | | | 161 | | | 131 | | | 345 | |
+Accrued insurance reserves | | 812 | | | 387 | | | 1,487 | | | 830 | |
+Accrued expenses and other liabilities | | (20) | | | 447 | | | 410 | | | (94) | |
+Operating lease liabilities | | (51) | | | (35) | | | (107) | | | (97) | |
+Net cash provided by operating activities | | 2,564 | | | 2,862 | | | 4,888 | | | 5,213 | |
+Cash flows from investing activities | | | | | | | | |
+Purchases of property and equipment | | (89) | | | (70) | | | (163) | | | (135) | |
+Purchases of non-marketable equity securities | | (12) | | | (175) | | | (191) | | | (507) | |
+Purchases of marketable securities | | (5,095) | | | (10,887) | | | (7,635) | | | (17,646) | |
+Purchases of notes receivable | | — | | | (111) | | | — | | | (298) | |
+Proceeds from maturities and sales of marketable securities | | 4,636 | | | 8,119 | | | 7,033 | | | 14,665 | |
+Acquisition of businesses, net of cash acquired | | (804) | | | (647) | | | (804) | | | (653) | |
+Purchase of total return swaps | | — | | | (1,640) | | | — | | | (1,640) | |
+Other investing activities | | (97) | | | 22 | | | (243) | | | 52 | |
+Net cash used in investing activities | | (1,461) | | | (5,389) | | | (2,003) | | | (6,162) | |
+Cash flows from financing activities | | | | | | | | |
+Proceeds from term loan, notes, and credit facility, net of issuance costs | | 1,127 | | | 3,997 | | | 1,127 | | | 3,997 | |
+Principal repayment on term loan, notes, and credit facility | | — | | | (2,000) | | | — | | | (2,000) | |
+Principal payments on finance leases | | (28) | | | (42) | | | (75) | | | (82) | |
+Proceeds from the issuance of common stock under the Employee Stock Purchase Plan | | 120 | | | 136 | | | 120 | | | 136 | |
+Repurchases of common stock | | (1,363) | | | (518) | | | (3,148) | | | (3,529) | |
+Other financing activities | | (51) | | | (33) | | | (81) | | | (73) | |
+Net cash provided by (used in) financing activities | | (195) | | | 1,540 | | | (2,057) | | | (1,551) | |
+Effect of exchange rate changes on cash and cash equivalents, and restricted cash and cash equivalents | | 159 | | | 54 | | | 229 | | | 30 | |
+Net increase (decrease) in cash and cash equivalents, and restricted cash and cash equivalents | | 1,067 | | | (933) | | | 1,057 | | | (2,470) | |
+
+
+
+
+
+8
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+Cash and cash equivalents, and restricted cash and cash equivalents | | | | | | | | |
+Beginning of period | | 8,600 | | | 8,110 | | | 8,610 | | | 9,647 | |
+End of period | | $ | 9,667 | | | $ | 7,177 | | | $ | 9,667 | | | $ | 7,177 | |
+
+
+Key Terms for Our Key Metrics
+Driver(s). The term Driver collectively refers to independent providers of ride or delivery services who use our platform to provide Mobility or Delivery services, or both.
+Gross Bookings. We define Gross Bookings as the total dollar value, including any applicable taxes, tolls, and fees, of: Mobility rides, Delivery orders (in each case without any adjustment for consumer discounts and refunds, Driver and Merchant earnings, and Driver incentives) and Freight revenue. Gross Bookings do not include tips earned by Drivers. Gross Bookings are an indication of the scale of our current platform, which ultimately impacts revenue.
+Monthly Active Platform Consumers (“MAPCs”). We define MAPCs as the number of unique consumers who completed a Mobility ride or received a Delivery order on our platform at least once in a given month, averaged over each month in the quarter. While a unique consumer can use multiple product offerings on our platform in a given month, that unique consumer is counted as only one MAPC.
+Segment Operating Income (Loss). We define each segment’s Operating Income (Loss) as segment revenue less direct costs and expenses of that segment as well as any applicable exclusions from Non-GAAP Operating Income.
+Trips. We define Trips as the number of completed consumer Mobility rides and Delivery orders in a given period. For example, an UberX Share ride with three paying consumers represents three unique Trips, whereas an UberX ride with three passengers represents one Trip. We believe that Trips are a useful metric to measure the scale and usage of our platform.
+
+Definitions of Non-GAAP Measures
+We collect and analyze operating and financial data to evaluate the health of our business and assess our performance. In addition to revenue, net income (loss), income (loss) from operations, and other results under GAAP, we use: Non-GAAP Operating Income; Non-GAAP Net Income; Non-GAAP EPS; Free cash flow; as well as, reve nue growth rates in constant currency, which are described below, to evaluate our business. Adjusted EBITDA is no longer a key measure used by management; we include a disclosure on Adjusted EBITDA to assist during the transition to our new non-GAAP measures. We have included these non-GAAP financial measures because they are key measures used by our management to evaluate our operating performance, generate future operating plans, and make strategic decisions. Accordingly, we believe that these non-GAAP financial measures provide useful information to investors and others in understanding and evaluating our operating results in the same manner as our management team and board of directors. In addition, they provide useful measures for period-to-period comparisons of our business, as they remove the effect of certain non-cash expenses, certain variable charges and other gains, losses, benefits, or charges that are unpredictable, in both magnitude and timing, and items not indicative of our ongoing operating performance. Our calculation of these non-GAAP financial measures may differ from similarly-titled non-GAAP measures, if any, reported by our peer companies. These non-GAAP financial measures should not be considered in isolation from, or as substitutes for, financial information prepared in accordance with GAAP.
+Non-GAAP Operating Income
+We define Non-GAAP Operating Income as income from operations, excluding (i) amortization of acquired intangible assets, (ii) certain legal, non-income tax, and regulatory reserve changes and settlements, (iii) goodwill and asset impairments/loss on sale of assets, (iv) acquisition, financing and divestitures related expenses, (v) restructuring and related charges, and (vi) other items not indicative of our ongoing operating performance.
+• Amortization of acquired intangible assets. Management views amortization of acquired intangible assets as items arising from pre-acquisition activities determined at the time of an acquisition. While these intangible assets are continually evaluated for impairment, amortization of acquired intangible assets is a static expense, which is not typically affected by operations during any particular period and is not reflective of ongoing operating performance. Although we exclude the amortization of acquired intangibles, management believes that it is important for investors to understand that such intangible assets were recorded as part of purchase accounting and contribute to revenue generation.
+• Legal, non-income tax, and regulatory reserve changes and settlements. Legal, non-income tax, and regulatory reserve changes and settlements are primarily related to certain significant legal proceedings or governmental investigations related to worker classification definitions, or tax agencies challenging our non-income tax positions. These matters have limited precedent, cover extended historical periods and are unpredictable in both magnitude and timing, therefore are distinct from normal, recurring legal, non-income tax and regulatory matters and related expenses incurred in our ongoing operating performance.
+Non-GAAP Net Income
+
+
+
+
+9
+
+
+
+
+
+Our Non-GAAP Net Income excludes the adjustments that are excluded from Non-GAAP Operating Income, as well as certain components below income from operations, such as certain items that are not indicative of our recurring core business operating results and certain income tax effects.
+• Other income (expense), net. Primarily includes items not indicative of our ongoing operating performance. From time to time, we may exclude other gains, losses, benefits, or charges that are unpredictable, in both magnitude and timing, and items not indicative of our ongoing operating performance. These items include, but are not limited to: foreign currency exchange gain (losses), net, and unrealized (gain) loss on debt and equity securities, net.
+• Income tax effects. Primarily include the income tax effects of the adjustments excluded from Non-GAAP Net Income and exclude other income tax benefits or expenses that are unpredictable, in both magnitude and timing, and not indicative of the tax associated with our ongoing operating performance.
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, |
+| | 2025 | | 2026 | | 2025 | | 2026 |
+GAAP effective tax rate | | 9 | % | | 26 | % | | (9) | % | | 27 | % |
+Total adjustments to GAAP provision for income taxes | | 12 | % | | (2) | % | | 31 | % | | (3) | % |
+Non-GAAP effective tax rate
+| | 21 | % | | 24 | % | | 22 | % | | 24 | % |
+
+• Adjustment to redeemable non-controlling interests. Primarily reflects changes in the carrying value of redeemable non-controlling interests that are subject to put or call arrangements not solely within our control, which are remeasured to their estimated redemption value on a quarterly basis. These adjustments are non-cash in nature and are not indicative of our ongoing operating performance.
+Non-GAAP EPS
+We define Non-GAAP EPS as Non-GAAP Net Income attributable to common stockholders divided by Non-GAAP weighted-average shares outstanding. Adjustments to GAAP diluted weighted-average shares outstanding are for any potentially dilutive outstanding securities in periods where Non-GAAP Net Income is positive, but GAAP Net income was in a loss position.
+Limitations of Non-GAAP Operating Income, Non-GAAP Net Income and Non-GAAP EPS and Non-GAAP Operating Income, Non-GAAP Net Income and Non-GAAP EPS Reconciliations
+These non-GAAP financial measures have limitations as financial measures, should be considered as supplemental in nature, and are not meant as a substitute for the related financial information prepared in accordance with GAAP. These limitations include the following:
+• These non-GAAP financial measures exclude certain recurring, non-cash charges, such as amortization of acquired intangible assets, and although these are non-cash charges, the assets being amortized may have to be replaced in the future, and Non-GAAP Operating Income and Non-GAAP Net Income do not reflect all cash capital expenditure requirements for such replacements or for new capital expenditure requirements;
+• These non-GAAP financial measures exclude certain restructuring and related charges, part of which may be settled in cash;
+• These non-GAAP financial measures exclude certain legal, non-income tax, and regulatory reserve changes and settlements that may reduce cash available to us;
+• These non-GAAP financial measures exclude other items not indicative of our ongoing operating performance; and
+• These non-GAAP financial measures do not reflect the components of other income (expense), net, which primarily includes: foreign currency exchange gains (losses), net; and unrealized gain (loss) on debt and equity securities, net.
+Adjusted EBITDA
+We define Adjusted EBITDA as net income (loss), excluding (i) income (loss) from discontinued operations, net of income taxes, (ii) net income (loss) attributable to non-controlling interests, net of tax, (iii) provision for (benefit from) income taxes, (iv) income (loss) from equity method investments, (v) interest expense, (vi) interest income, (vii) other income (expense), net, (viii) depreciation and amortization, (ix) stock-based compensation expense, (x) certain legal, non-income tax, and regulatory reserve changes and settlements, (xi) goodwill and asset impairments/loss on sale of assets, (xii) acquisition, financing and divestitures related expenses, (xiii) restructuring and related charges and (xiv) other items not indicative of our ongoing operating performance.
+• Legal, non-income tax, and regulatory reserve changes and settlements. Legal, non-income tax, and regulatory reserve changes and settlements are primarily related to certain significant legal proceedings or governmental investigations related to worker classification definitions, or tax agencies challenging our non-income tax positions. These matters have limited precedent, cover extended historical periods and are unpredictable in both magnitude and timing, therefore are distinct from
+
+
+
+
+10
+
+
+
+
+
+normal, recurring legal, non-income tax and regulatory matters and related expenses incurred in our ongoing operating performance.
+Limitations of Adjusted EBITDA and Adjusted EBITDA Reconciliation
+Adjusted EBITDA has limitations as a financial measure, should be considered as supplemental in nature, and is not meant as a substitute for the related financial information prepared in accordance with GAAP. These limitations include the following:
+• Adjusted EBITDA excludes certain recurring, non-cash charges, such as depreciation of property and equipment and amortization of intangible assets, and although these are non-cash charges, the assets being depreciated and amortized may have to be replaced in the future, and Adjusted EBITDA does not reflect all cash capital expenditure requirements for such replacements or for new capital expenditure requirements;
+• Adjusted EBITDA excludes stock-based compensation expense, which has been, and will continue to be for the foreseeable future, a significant recurring expense in our business and an important part of our compensation strategy;
+• Adjusted EBITDA excludes certain restructuring and related charges, part of which may be settled in cash;
+• Adjusted EBITDA excludes other items not indicative of our ongoing operating performance;
+• Adjusted EBITDA does not reflect period to period changes in taxes, income tax expense or the cash necessary to pay income taxes;
+• Adjusted EBITDA does not reflect the components of other income (expense), net, which primarily includes: foreign currency exchange gains (losses), net; and unrealized gain (loss) on debt and equity securities, net; and
+• Adjusted EBITDA excludes certain legal, non-income tax, and regulatory reserve changes and settlements that may reduce cash available to us.
+Constant Currency
+We compare the percent change in our current period results from the corresponding prior period using constant currency disclosure. We present constant currency growth rate information to provide a framework for assessing how our underlying revenue performed excluding the effect of foreign currency rate fluctuations. We calculate constant currency by translating our current period financial results using the corresponding prior period’s monthly exchange rates for our transacted currencies other than the U.S. dollar.
+Free Cash Flow
+We define free cash flow as net cash flows from operating activities less capital expenditures.
+
+
+
+
+
+
+
+11
+
+
+
+
+
+Reconciliations of Non-GAAP Measures
+Non-GAAP Operating Income, Non-GAAP Net Income and Non-GAAP EPS
+The following tables present reconciliations of GAAP and Non-GAAP Operating Income, GAAP and Non-GAAP Net Income and GAAP and Non-GAAP EPS:
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, |
+(In millions, except share amounts which are reflected in thousands, and per share amounts) | | 2025 | | 2026 | | 2025 | | 2026 |
+GAAP Income from operations | | $ | 1,450 | | | $ | 1,890 | | | $ | 2,678 | | | $ | 3,813 | |
+Add (deduct): | | | | | | | | |
+Amortization of acquired intangible assets | | 65 | | | 61 | | | 129 | | | 120 | |
+Legal, non-income tax, and regulatory reserve changes and settlements | | — | | | 141 | | | 28 | | | 12 | |
+Goodwill and asset impairments/loss on sale of assets | | — | | | 4 | | | — | | | 4 | |
+Acquisition, financing and divestitures related expenses | | 19 | | | 31 | | | 22 | | | 56 | |
+Loss on lease arrangement, net | | — | | | — | | | 2 | | | 5 | |
+Restructuring and related charges | | — | | | 16 | | | 1 | | | 16 | |
+Total adjustments excluded from Non-GAAP Operating Income | | 84 | | | 253 | | | 182 | | | 213 | |
+Non-GAAP Operating Income | | $ | 1,534 | | | $ | 2,143 | | | $ | 2,860 | | | $ | 4,026 | |
+| | | | | | | | |
+GAAP Net income attributable to Uber Technologies, Inc. | | 1,355 | | | 2,394 | | | 3,131 | | | 2,657 | |
+Adjustments excluded from Non-GAAP Operating Income (see above) | | 84 | | | 253 | | | 182 | | | 213 | |
+Other (income) expense, net | | 19 | | | (1,342) | | | (74) | | | 152 | |
+Income tax effects (1)
+| | (190) | | | 315 | | | (912) | | | 61 | |
+Loss from equity method investments | | 12 | | | 21 | | | 25 | | | 41 | |
+Adjustment to redeemable non-controlling interests | | — | | | 11 | | | — | | | 21 | |
+Non-GAAP Net Income | | 1,280 | | | 1,652 | | | 2,352 | | | 3,145 | |
+Assumed net loss attributable to Freight Holding contingently issuable shares | | (14) | | | — | | | (27) | | | — | |
+Non-GAAP Net Income attributable to common stockholders | | $ | 1,266 | | | $ | 1,652 | | | $ | 2,325 | | | $ | 3,145 | |
+| | | | | | | | |
+Diluted weighted-average shares outstanding
+| | 2,125,628 | | | 2,050,225 | | | 2,124,181 | | | 2,060,763 | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+GAAP Diluted EPS (2)
+| | $ | 0.63 | | | $ | 1.17 | | | $ | 1.46 | | | $ | 1.29 | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Non-GAAP EPS (2)
+| | $ | 0.60 | | | $ | 0.81 | | | $ | 1.09 | | | $ | 1.53 | |
+
+(1) Income tax effects include the impact of a stock loss and capitalized research and development expenses through Q2 2025 and the deferred U.S. tax impact related to our equity securities through Q2 2026.
+(2) Per share amounts are calculated using unrounded numbers and therefore may not recalculate.
+
+
+
+
+12
+
+
+
+
+
+Adjusted EBITDA
+The following table presents reconciliations of Adjusted EBITDA to the most directly comparable GAAP financial measure for each of the periods indicated:
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, |
+(In millions) | | 2025 | | 2026 | | 2025 | | 2026 |
+Adjusted EBITDA reconciliation: | | | | | | | | |
+Net income attributable to Uber Technologies, Inc. | | $ | 1,355 | | | $ | 2,394 | | | $ | 3,131 | | | $ | 2,657 | |
+Add (deduct): | | | | | | | | |
+Net income (loss) attributable to non-controlling interests, net of tax | | (5) | | | 22 | | | (7) | | | 41 | |
+Loss from equity method investments | | 12 | | | 21 | | | 25 | | | 41 | |
+Provision for (benefit from) income taxes | | 142 | | | 840 | | | (260) | | | 1,034 | |
+Other (income) expense, net | | 19 | | | (1,342) | | | (74) | | | 152 | |
+Interest expense | | 108 | | | 127 | | | 213 | | | 235 | |
+Interest income | | (181) | | | (172) | | | (350) | | | (347) | |
+Income from operations | | 1,450 | | | 1,890 | | | 2,678 | | | 3,813 | |
+Add (deduct): | | | | | | | | |
+Depreciation and amortization | | 175 | | | 188 | | | 346 | | | 372 | |
+Stock-based compensation expense | | 475 | | | 549 | | | 910 | | | 1,022 | |
+Legal, non-income tax, and regulatory reserve changes and settlements | | — | | | 141 | | | 28 | | | 12 | |
+Goodwill and asset impairments/loss on sale of assets, net | | — | | | 4 | | | — | | | 4 | |
+Acquisition, financing and divestitures related expenses | | 19 | | | 31 | | | 22 | | | 56 | |
+| | | | | | | | |
+Loss on lease arrangement, net | | — | | | — | | | 2 | | | 5 | |
+Restructuring and related charges | | — | | | 16 | | | 1 | | | 16 | |
+Adjusted EBITDA | | $ | 2,119 | | | $ | 2,819 | | | $ | 3,987 | | | $ | 5,300 | |
+| | | | | | | | |
+
+Free Cash Flow
+The following tables present reconciliations of free cash flow to the most directly comparable GAAP financial measure for each of the periods indicated:
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, |
+(In millions) | | 2025 | | 2026 | | 2025 | | 2026 |
+Free cash flow reconciliation: | | | | | | | | |
+Net cash provided by operating activities | | $ | 2,564 | | | $ | 2,862 | | | $ | 4,888 | | | $ | 5,213 | |
+Purchases of property and equipment | | (89) | | | (70) | | | (163) | | | (135) | |
+Free cash flow | | $ | 2,475 | | | $ | 2,792 | | | $ | 4,725 | | | $ | 5,078 | |
+
+
+
+
+
+13


### PR DESCRIPTION
## Why

Six more filings audited across three batches (DIS, CVS, UBER, SHOP, DIBS, plus PFE/ANET re-checked). The defects share a theme: **a period or a measure named in a form the parser did not recognise**, so a figure from the wrong column, period or measure got reported.

| Ticker | Posted | Correct | Cause |
|---|---|---|---|
| UBER | EPS `$0.63` | `$1.17` | prior-year-first columns; year header 20+ rows above the per-share row |
| UBER | Outlook `EPS 28% to 35% growth` | `Adj EPS $0.84 to $0.88` | growth rate read instead of the figure; wrong measure label |
| SHOP | `Q3 2026` | `Q2 2026` | guidance period ("For the third quarter of 2026, we expect") became the reporting period |
| DIS | no quarter label | `Q3 2026` | fiscal quarter stated only as "third quarter results for fiscal 2026" |
| DIS | `EPS 12% growth`, `Operating income $4.9B` | `FY2026 Adj EPS`, `Q4 Operating income` | bare "fiscal 2026" not recognised as an annual period, so the section read as single-period and every item lost its period |
| PFE | Outlook `EPS $2.8 to $3` | `Adj EPS` | Pfizer's guidance is its *adjusted* diluted EPS |
| ANET | Outlook Adj EPS missing | `$1.06 to $1.08` | non-GAAP per-share label unmatched |

CVS, DIBS and SHOP's figures were already correct. SHOP omits per-share figures **correctly** — that exhibit points to a separate supplemental.

## Root causes

Two boundary bugs and two naming gaps:

- **`non-` ends a word**, so a bare `\bgaap` also matched inside "Non-**GAAP EPS**" and reported the adjusted guidance a second time under the GAAP label. Same trap as the XBRL currency header in #1842.
- **Header scanning.** The lookback now reaches a header twenty-plus rows up, but stops at whichever header governs the row so a differently shaped table above cannot supply the layout. A header naming columns by period end ("June 30, 2026 | March 31, 2026 | …") also stops the scan — where such a table carries a year-to-date pair, those bare years otherwise look like a run starting at the wrong column, which is exactly how Opendoor's 7-column table broke mid-change.
- **The reported period outranks a written quarter** elsewhere in the document.
- **`fiscal 2026`** is recognised alongside `fiscal year 2026` / `FY2026`, for both the quarter label and the annual-period signal.

A sentence guiding on both measures still yields both — the qualified *occurrence* is passed over rather than the whole line. My first attempt skipped the line and silently dropped a GAAP figure from a sentence that guided on both; the existing Trane tests caught it.

## Verification

- **2,430 tests pass**; `audit`, `lint`, `typecheck` and `test:coverage` all clean, no thresholds altered.
- Corpus grows to **23 filings** (Uber, Shopify, 1stdibs added; each verified to parse identically as text before storing).
- **All seven fixes mutation-checked** — each confirmed to fail a test when reverted, per the rule added in #1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)