### PR TITLE
Point AGENTS.md at the existing repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
-# CLAUDE.md
+# Repository guidance
 
 Coding guidance for this repo. Extracts the rules a contributor (human or agent) needs to write code that passes CI and runs in production. README.md remains the source of truth for setup, secrets, and operations.
+
+`AGENTS.md` is a symlink to this file, so tools that look for either name read the same rules and neither can drift from the other.
 
 ## Stack
 


### PR DESCRIPTION
## Why

`CLAUDE.md` has a **Codex sandbox** section, so Codex clearly runs against this repo — but Codex reads `AGENTS.md`, which didn't exist (`.codex/` is empty). Those sessions started with none of the repo's rules, including two added recently that specifically prevent damage: the fixture corpus being append-only, and the mutation check for parsing work.

## What

`AGENTS.md` is a **symlink** to `CLAUDE.md` (git mode `120000`).

Two files stating the same rules drift, and the one nobody edits becomes the wrong one. A symlink cannot. The heading changes from `# CLAUDE.md` to `# Repository guidance` so it reads correctly under either name, with a line noting the arrangement.

Verified: `git ls-files -s` records it as a symlink, reading `AGENTS.md` resolves to the guidance, and `npm run lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)