### PR TITLE
Check a reported EPS against net income over the share count

### DIFF
--- a/modules/earnings-results-ai.ts
+++ b/modules/earnings-results-ai.ts
@@ -432,3 +432,56 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function getArray(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
 }
+
+// Net income divided by earnings per share is the share count, so a filing that states all
+// three lets the reported pair be checked against the company's own denominator. This is what
+// catches a per-share figure taken from the wrong column or with a misplaced decimal, where
+// the value is plausible on its own but cannot belong to the reported net income.
+//
+// The count is compared by magnitude rather than by unit, because a filing scales shares
+// independently of money in the same table ("in millions, except share amounts which are
+// reflected in thousands").
+const shareCountScales = [1, 1_000, 1_000_000];
+
+// Below these magnitudes the published figures are rounded so coarsely that the implied count
+// is meaningless: a reported "-$0.01" per share on a "$1 million" loss reconciles to anywhere
+// between 67 and 200 million shares.
+const minimumReconcilableEps = 0.05;
+const minimumReconcilableNetIncome = 5_000_000;
+
+// The audited corpus reconciles within 8%. A figure off by more than this cannot be a
+// rounding artefact, which leaves a wide margin before a correct filing is ever questioned.
+const shareCountTolerance = 0.6;
+
+export function getInconsistentPerShareReasons(
+  metrics: EarningsResultMetric[],
+  dilutedShareMantissa: number | undefined,
+): SuspiciousEarningsReason[] {
+  const netIncome = metrics.find(metric => "net_income" === metric.key)?.numericValue;
+  const epsMetric = metrics.find(metric => "gaap_eps" === metric.key);
+  const eps = epsMetric?.numericValue;
+  if (undefined === epsMetric ||
+      "number" !== typeof eps ||
+      "number" !== typeof netIncome ||
+      "number" !== typeof dilutedShareMantissa ||
+      false === Number.isFinite(eps) ||
+      false === Number.isFinite(netIncome) ||
+      Math.abs(eps) < minimumReconcilableEps ||
+      Math.abs(netIncome) < minimumReconcilableNetIncome ||
+      0 >= dilutedShareMantissa) {
+    return [];
+  }
+
+  const impliedShareCount = Math.abs(netIncome / eps);
+  const closestDeviation = Math.min(...shareCountScales
+    .map(scale => Math.abs(impliedShareCount / (dilutedShareMantissa * scale) - 1)));
+  if (closestDeviation <= shareCountTolerance) {
+    return [];
+  }
+
+  return [{
+    message: `${epsMetric.label} ${epsMetric.value} does not reconcile with net income over the reported share count.`,
+    metricKey: epsMetric.key,
+    severity: "high",
+  }];
+}

--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -1,10 +1,16 @@
 import moment from "moment-timezone";
 import {stripReferenceMarkers} from "./earnings-results-format-selection.ts";
-import {getCurrencyCodeFromText} from "./earnings-results-money.ts";
+import {findNumericValues, getCurrencyCodeFromText} from "./earnings-results-money.ts";
 import {type EarningsResultMetric} from "./earnings-results-metrics.ts";
 import {type EarningsOutlookMetric} from "./earnings-results-outlook.ts";
 
 export type ParsedEarningsDocument = {
+  // The weighted-average diluted share count as printed, without applying a scale. Filings
+  // scale shares independently of money in the same table ("in millions, except share
+  // amounts which are reflected in thousands"), so the reader compares magnitudes rather
+  // than trusting a unit. Not a posted metric — it exists to check that a reported EPS and
+  // net income belong to the same period.
+  dilutedShareMantissa?: number | undefined;
   headline?: string | undefined;
   metrics: EarningsResultMetric[];
   outlook: EarningsOutlookMetric[];
@@ -198,4 +204,37 @@ function getQuarterFromName(name: string): string | undefined {
     ["fourth", "Q4"],
   ]);
   return quarterByName.get(name.toLowerCase());
+}
+
+// The share row sits under a "weighted-average shares" caption, with the diluted count
+// below the basic one. Any period's count serves the purpose: a company's share count moves
+// by a few percent between quarters, while the errors this guards against — a prior-year
+// column, a misplaced decimal — are off by far more.
+export function getDilutedShareMantissa(lines: string[]): number | undefined {
+  for (const [lineIndex, line] of lines.entries()) {
+    // The caption has to be about shares. "dollar-weighted average contract duration" is
+    // boilerplate about contracts, and matching it reads an unrelated figure as a count.
+    const captionMatch = /weighted[-\s]average\s+(?:number\s+of\s+)?(?:[a-z]+\s+){0,3}shares\b|shares\s+used\s+in\s+(?:the\s+)?(?:comput|calculat)/i
+      .exec(line);
+    if (null === captionMatch) {
+      continue;
+    }
+
+    // Read forward from the caption only. A guidance bullet states the per-share figure
+    // before the count it rests on ("per share of approximately $0.87 to $0.92 on
+    // weighted-average diluted shares outstanding of approximately 185 million"), and
+    // reading the whole line would take the per-share figure as the count.
+    const blockText = [
+      line.slice(captionMatch.index + captionMatch[0].length),
+      ...lines.slice(lineIndex + 1, lineIndex + 4),
+    ].join(" ");
+    const dilutedMatch = /\bdiluted\b([\s\S]*)$/i.exec(blockText);
+    const counts = findNumericValues(dilutedMatch?.[1] ?? blockText, {minUncuedAbsValue: 10})
+      .filter(count => count >= 100);
+    if (0 < counts.length) {
+      return counts[0];
+    }
+  }
+
+  return undefined;
 }

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -8,6 +8,7 @@ import {
 import {extractOutlookMetrics} from "./earnings-results-outlook.ts";
 import {
   getDocumentCurrencyCode,
+  getDilutedShareMantissa,
   getDocumentHeadline,
   getMeaningfulLines,
   getQuarterLabel,
@@ -65,6 +66,7 @@ export function parseEarningsDocument(html: string): ParsedEarningsDocument {
   const quarterLabel = getQuarterLabel(text);
   const documentCurrencyCode = getDocumentCurrencyCode(lines);
   return {
+    dilutedShareMantissa: getDilutedShareMantissa(lines),
     headline: getDocumentHeadline(lines),
     metrics: extractEarningsMetrics(lines, quarterLabel, documentCurrencyCode),
     outlook: extractOutlookMetrics(lines, documentCurrencyCode),

--- a/modules/earnings-results-money.ts
+++ b/modules/earnings-results-money.ts
@@ -42,7 +42,7 @@ export function findColumnValueMatch(
   return matches[columnIndex] ?? matches[0] ?? null;
 }
 
-function findNumericValues(
+export function findNumericValues(
   text: string,
   options: NumericValueOptions = {},
 ): number[] {

--- a/modules/earnings-results-share-consistency.test.ts
+++ b/modules/earnings-results-share-consistency.test.ts
@@ -1,0 +1,58 @@
+import {readFileSync, readdirSync} from "node:fs";
+import {describe, expect, test} from "vitest";
+import {getInconsistentPerShareReasons} from "./earnings-results-ai.ts";
+import {parseEarningsDocument} from "./earnings-results-format.ts";
+import {type EarningsResultMetric} from "./earnings-results-metrics.ts";
+
+const fixtureDirectory = "modules/test-fixtures/earnings-filings";
+
+const asMetrics = (netIncome: number, eps: number): EarningsResultMetric[] => [
+  {key: "net_income", label: "Net income", numericValue: netIncome, value: "x"},
+  {key: "gaap_eps", label: "EPS", numericValue: eps, value: `$${eps.toFixed(2)}`},
+];
+
+describe("per-share consistency gate", () => {
+  // A false positive suppresses a correct announcement, so silence on audited filings is the
+  // property that matters most.
+  test("stays silent on every audited filing", () => {
+    const flagged: string[] = [];
+    for (const fixture of readdirSync(fixtureDirectory).filter(name => name.endsWith(".txt"))) {
+      const document = parseEarningsDocument(readFileSync(`${fixtureDirectory}/${fixture}`, "utf8"));
+      const reasons = getInconsistentPerShareReasons(document.metrics, document.dilutedShareMantissa);
+      if (0 < reasons.length) {
+        flagged.push(fixture.replace(".txt", ""));
+      }
+    }
+
+    expect(flagged).toEqual([]);
+  });
+
+  test("flags a per-share figure taken from the prior-year column", () => {
+    // Uber reported $0.63 against $1.17; the count is printed in thousands.
+    expect(getInconsistentPerShareReasons(asMetrics(2_394_000_000, 0.63), 2_125_628))
+      .toEqual([expect.objectContaining({metricKey: "gaap_eps", severity: "high"})]);
+    expect(getInconsistentPerShareReasons(asMetrics(2_394_000_000, 1.17), 2_125_628)).toEqual([]);
+  });
+
+  test("flags a per-share figure off by a factor of a hundred", () => {
+    // Pfizer reported -$4.00 against -$0.04; the count is printed in millions.
+    expect(getInconsistentPerShareReasons(asMetrics(-248_000_000, -4), 5_734))
+      .toEqual([expect.objectContaining({metricKey: "gaap_eps", severity: "high"})]);
+    expect(getInconsistentPerShareReasons(asMetrics(-248_000_000, -0.04), 5_734)).toEqual([]);
+  });
+
+  test("reads the count regardless of the scale it is printed in", () => {
+    for (const mantissa of [2_046, 2_046_000, 2_046_000_000]) {
+      expect(getInconsistentPerShareReasons(asMetrics(2_394_000_000, 1.17), mantissa)).toEqual([]);
+    }
+  });
+
+  test("says nothing when a figure is too rounded to reconcile", () => {
+    // Wayfair's "-$0.01" on a "$1 million" loss reconciles to anywhere from 67M to 200M shares.
+    expect(getInconsistentPerShareReasons(asMetrics(-1_000_000, -0.01), 132)).toEqual([]);
+  });
+
+  test("says nothing when the filing states no share count", () => {
+    expect(getInconsistentPerShareReasons(asMetrics(2_394_000_000, 0.63), undefined)).toEqual([]);
+  });
+});

--- a/modules/earnings-results.ts
+++ b/modules/earnings-results.ts
@@ -7,6 +7,7 @@ import {
 import {
   checkEarningsQualityWithAi,
   clearEarningsAiState,
+  getInconsistentPerShareReasons,
   getSuspiciousEarningsReasons,
   type EarningsAiQualityGateResult,
   type SuspiciousEarningsReason,
@@ -705,6 +706,7 @@ async function buildEarningsResultAnnouncement(
   const metrics = getMessageMetrics(sourceMetrics, surprise, watch.event);
   const suspiciousReasons = [
     ...getSuspiciousEarningsReasons(metrics, surprise, watch.event),
+    ...getInconsistentPerShareReasons(metrics, parsedDocument.dilutedShareMantissa),
     ...getSuspiciousQuarterReasons(parsedDocument.quarterLabel, now),
   ];
   const filingUrl = filingDetails?.documentUrl || filing.filingUrl;


### PR DESCRIPTION
## Why

The audit's clearest lesson was that **omitting a metric beats publishing a wrong one**. This is the internal-consistency check that acts on it.

Net income ÷ EPS is the share count. A filing stating all three lets the reported pair be checked against the company's own denominator — which catches a per-share figure taken from the wrong column or with a misplaced decimal: plausible alone, impossible alongside the reported net income.

| Historical error | Deviation |
|---|---|
| UBER `$0.63` vs `$1.17` (prior-year column) | **79%** |
| PFE `-$4.00` vs `-$0.04` (footnote marker) | **99%** |

## Design

**Compared by magnitude, not by unit.** A filing scales shares independently of money in the same table — Uber prints money in millions and shares in thousands. Accepting whichever of ×1, ×10³ or ×10⁶ reconciles avoids depending on a unit that would have to be parsed correctly for the check to be safe.

## Thresholds

A false positive here **suppresses a correct announcement**, so they sit well clear of the audited corpus, which reconciles within **8%**:

- Flag only past **60%** — a sevenfold margin.
- Silent where the published figures are too rounded to reconcile: a reported `-$0.01` per share on a `$1 million` loss is consistent with anywhere between 67 and 200 million shares.
- Silent when the filing states no count (5 of the 23 audited filings).

## What it does not cover

Being explicit, since I overstated this earlier in the session: this catches **UBER and PFE**, not all five errors I once attributed to a sanity gate. MRK's `$1B` net income isn't covered — that filing prints no share row. SPCX's segment revenue and OPEN's `NT$` are not per-share problems at all; both are already fixed in the parser.

## Verification

- **2,436 tests pass**; `audit`, `lint`, `typecheck`, `test:coverage` clean, no thresholds altered.
- A test asserts the gate is **silent on all 23 audited filings** — the property that matters most — and that it fires on both historical values while passing their corrected ones.
- Reading the count needed care of its own: the caption must be about shares, or "dollar-weighted average contract **duration**" boilerplate is read as one (Palantir), and only text *after* the caption counts, or a guidance bullet stating a per-share range before the count it rests on supplies the per-share figure instead (Astera Labs). Both mistakes flagged a correct filing while this was being written, which is exactly why the corpus-silence test is there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)