### PR TITLE
Define the caption qualifiers that keep defeating a word boundary

### DIFF
--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -3,6 +3,7 @@ import {stripReferenceMarkers} from "./earnings-results-format-selection.ts";
 import {findNumericValues, getCurrencyCodeFromText} from "./earnings-results-money.ts";
 import {type EarningsResultMetric} from "./earnings-results-metrics.ts";
 import {type EarningsOutlookMetric} from "./earnings-results-outlook.ts";
+import {hasNewTaiwanDollarSymbol} from "./earnings-results-terms.ts";
 
 export type ParsedEarningsDocument = {
   // The weighted-average diluted share count as printed, without applying a scale. Filings
@@ -66,7 +67,7 @@ export function getDocumentCurrencyCode(lines: string[]): string | undefined {
   const currencyDeclaration = headerLines
     .find(line => /\b(?:Canadian|New Taiwan|U\.S\.)\s+dollars?\b/i.test(line) ||
       /\b(?:CAD|TWD|NTD|USD|EUR|GBP|JPY)\b/.test(line) ||
-      /(?:^|[^A-Za-z])NT\s*\$/.test(line));
+      hasNewTaiwanDollarSymbol(line));
   if (undefined !== currencyDeclaration) {
     return getDominantCurrencyCode(currencyDeclaration) ??
       getCurrencyCodeFromText(currencyDeclaration);

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -6,6 +6,7 @@ import {
   isDefinitionalLine,
 } from "./earnings-results-format-selection.ts";
 import {extractOutlookMetrics} from "./earnings-results-outlook.ts";
+import {gaapTermSource} from "./earnings-results-terms.ts";
 import {
   getDocumentCurrencyCode,
   getDilutedShareMantissa,
@@ -262,7 +263,7 @@ function extractMetric(
     const isForwardLooking = isForwardLookingLine(line);
     const hasExplicitGaapEps = "gaap_eps" === definition.key &&
       false === isForwardLooking &&
-      /\bgaap\s+(?:diluted\s+)?eps\b/i.test(line);
+      explicitGaapEpsPattern.test(line);
     const hasReportedGaapEps = "gaap_eps" === definition.key &&
       false === isForwardLooking &&
       true === hasGaapNarrativeBeforeAdjustment(line, definition.patterns);
@@ -363,6 +364,10 @@ function isSkippedMetricLine(line: string, definition: MetricDefinition): boolea
 
   return true;
 }
+
+// A line naming only the non-GAAP measure must not override the adjusted skip, so this uses
+// the shared GAAP term rather than a bare \bgaap.
+const explicitGaapEpsPattern = new RegExp(String.raw`${gaapTermSource}\s+(?:diluted\s+)?eps\b`, "i");
 
 function isForwardLookingLine(line: string): boolean {
   return /\b(?:guidance|outlook|forecast)\b/i.test(line) ||

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -2,6 +2,7 @@ import {
   getPositionedQuarterValues,
   isDefinitionalLine,
 } from "./earnings-results-format-selection.ts";
+import {gaapTermSource, unitedStatesSource} from "./earnings-results-terms.ts";
 import {getMoneyScaleFromContextText} from "./earnings-results-money.ts";
 
 export type EarningsResultOutcome = "beat" | "inline" | "miss";
@@ -75,7 +76,7 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\bprofit\s+(?:\(loss\)\s+)?per\s+(?:common\s+|ordinary\s+)?(?:share|ADS)\b/i,
       /\bnet\s+loss\s+per\s+(?:common\s+|ordinary\s+)?share\b/i,
       /\bdiluted\s+eps\b/i,
-      /\bgaap\s+(?:diluted\s+)?eps\b/i,
+      new RegExp(String.raw`${gaapTermSource}\s+(?:diluted\s+)?eps\b`, "i"),
       /\b(?:reported\s+)?(?:net\s+)?earnings?\b(?:(?![.!?]\s)[^!?\n]){0,180}?(?<metricValue>-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share(?:\s*[-–—]\s*diluted)?\b/i,
       /(?<metricValue>\(?-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?(?:\s*(?:cents?|¢))?)\s+per\s+(?:fully\s+)?(?:common\s+)?diluted\s+share\b/i,
       /\beps\b/i,
@@ -92,7 +93,7 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\brevenues?\b/i,
       /\bsales\b/i,
     ],
-    skipPattern: /\bcosts?\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsystemwide\s+sales\b|\b(?:U\.S\.|U\.K\.|US|international|domestic|non-US|segment)\s+(?:commercial\s+|government\s+)?revenues?\b|\b(?:U\.S\.|US|international|worldwide|non-US)\s+(?:[A-Z][A-Za-z]+\s+){1,2}revenues?\b|\brevenues?\s+(?:in|outside)\s+the\s+U\.S\.|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\bannuali[sz]ed\s+(?:revenue\s+)?run[-\s]*rate\b|\brevenue\s+run[-\s]*rate\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b|\bnot\s+recognized\s+in\s+revenue\b|\bnon-cash\s+revenues?\b|\bsales\s+volumes?\b|\b(?:external\s+power|pipeline\s+gas|hydrocarbon|asset)\s+sales\b|\bproceeds\s+from\b|\bsales\s+of\s+pipeline\s+gas\b|\b(?:kbd|koebd|boepd|bpd|mboed|mmboe|bcfe|mmcf|mw|gw|kt)\b/i,
+    skipPattern: new RegExp(String.raw`\bcosts?\s+of\b|\bdeferred\b|\bunearned\b|\bguidance\b|\boutlook\b|\bsystemwide\s+sales\b|\b(?:${unitedStatesSource}|U\.K\.|US|international|domestic|non-US|segment)\s+(?:commercial\s+|government\s+)?revenues?\b|\b(?:${unitedStatesSource}|US|international|worldwide|non-US)\s+(?:[A-Z][A-Za-z]+\s+){1,2}revenues?\b|\brevenues?\s+(?:in|outside)\s+the\s+${unitedStatesSource}|\bsince\s+(?:launch|inception)\b|\blife-to-date\b|\bcumulative\b|\bannuali[sz]ed\s+(?:revenue\s+)?run[-\s]*rate\b|\brevenue\s+run[-\s]*rate\b|\brevenue\s+\(expense\)|\bnon[-\s]insurance\s+warranty\s+revenue\b|\bnot\s+recognized\s+in\s+revenue\b|\bnon-cash\s+revenues?\b|\bsales\s+volumes?\b|\b(?:external\s+power|pipeline\s+gas|hydrocarbon|asset)\s+sales\b|\bproceeds\s+from\b|\bsales\s+of\s+pipeline\s+gas\b|\b(?:kbd|koebd|boepd|bpd|mboed|mmboe|bcfe|mmcf|mw|gw|kt)\b`, "i"),
     valueType: "money",
   },
   {

--- a/modules/earnings-results-money.ts
+++ b/modules/earnings-results-money.ts
@@ -1,4 +1,8 @@
 import {isEmbeddedAlphaNumericValue} from "./earnings-results-format-selection.ts";
+import {
+  hasNewTaiwanDollarSymbol,
+  newTaiwanDollarPrefixSource,
+} from "./earnings-results-terms.ts";
 
 export type MoneyContext = {
   currencyCode?: string | undefined;
@@ -293,7 +297,7 @@ export function getCurrencyCodeFromText(
   // "NT$" only denotes New Taiwan dollars as a standalone symbol. Without the leading
   // boundary it also matches inside ordinary words — "we spe(nt $)883 million" turned a
   // US filer's revenue into NT$883M.
-  if (/(?:^|[^A-Za-z])NT\s*\$/.test(text) || /\b(?:TWD|NTD)\b|\bNew Taiwan dollars?\b/i.test(text)) {
+  if (true === hasNewTaiwanDollarSymbol(text) || /\b(?:TWD|NTD)\b|\bNew Taiwan dollars?\b/i.test(text)) {
     return "TWD";
   }
 
@@ -373,7 +377,7 @@ export function parseNumber(value: unknown): number | null {
   const normalizedValue = value
     .replace(/^\((.*)\)$/, "-$1")
     .replace(/^\((.*)$/, "-$1")
-    .replace(/NT\s*\$/gi, "")
+    .replace(new RegExp(newTaiwanDollarPrefixSource, "gi"), "")
     .replace(/C\s*\$/gi, "")
     .replace(/[$€£¥]/g, "")
     .replaceAll(",", "")

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -1,3 +1,4 @@
+import {gaapTermSource} from "./earnings-results-terms.ts";
 
 export type EarningsOutlookMetric = {
   key: string;
@@ -59,9 +60,7 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
     key: "eps",
     label: "EPS",
     patterns: [
-      // "non-" ends a word, so a bare \bgaap here also matches inside "Non-GAAP EPS" and
-      // reports the adjusted guidance a second time under the GAAP label.
-      /(?<!non-)\bgaap\s+(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b/i,
+      new RegExp(String.raw`${gaapTermSource}\s+(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?eps\b`, "i"),
       // Guidance for a non-GAAP per-share measure must not be posted under the GAAP label,
       // so an occurrence carrying that qualifier is passed over. One sentence often guides
       // on both measures ("Earnings per Share (EPS) is expected to be between $4.05 and

--- a/modules/earnings-results-terms.test.ts
+++ b/modules/earnings-results-terms.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, test} from "vitest";
+import {parseEarningsDocument} from "./earnings-results-format.ts";
+import {
+  gaapTermSource,
+  hasNewTaiwanDollarSymbol,
+  hasStandaloneGaapTerm,
+  newTaiwanDollarPrefixSource,
+  unitedStatesSource,
+} from "./earnings-results-terms.ts";
+
+// Each case below is wording that defeated a naive `\b` in a shipped release. They are pinned
+// so the same guard is not dropped again, whichever call site is being edited.
+describe("qualifier terms", () => {
+  describe("GAAP", () => {
+    test("does not read a non-GAAP caption as a GAAP one", () => {
+      expect(hasStandaloneGaapTerm("Non-GAAP EPS of $1.02")).toBe(false);
+      expect(hasStandaloneGaapTerm("non-GAAP diluted net income per share")).toBe(false);
+    });
+
+    test("still reads a GAAP caption", () => {
+      expect(hasStandaloneGaapTerm("GAAP EPS of $0.95")).toBe(true);
+      expect(hasStandaloneGaapTerm("GAAP and non-GAAP diluted EPS")).toBe(true);
+    });
+
+    test("composes into a larger caption pattern", () => {
+      const epsPattern = new RegExp(String.raw`${gaapTermSource}\s+(?:diluted\s+)?eps\b`, "i");
+      expect(epsPattern.test("GAAP diluted EPS")).toBe(true);
+      expect(epsPattern.test("Non-GAAP diluted EPS")).toBe(false);
+    });
+  });
+
+  describe("New Taiwan dollar", () => {
+    test("does not match inside an ordinary word", () => {
+      expect(hasNewTaiwanDollarSymbol("Since 2022, we spent $400 million")).toBe(false);
+      expect(hasNewTaiwanDollarSymbol("the amount $883 million")).toBe(false);
+    });
+
+    test("matches the symbol as a currency", () => {
+      expect(hasNewTaiwanDollarSymbol("NT$883 million")).toBe(true);
+      expect(hasNewTaiwanDollarSymbol("Revenue of NT$1.2 billion")).toBe(true);
+      expect(hasNewTaiwanDollarSymbol("(NT$ millions)")).toBe(true);
+    });
+
+    test("strips the symbol without consuming what precedes it", () => {
+      const prefixPattern = new RegExp(newTaiwanDollarPrefixSource, "gi");
+      expect("NT$883".replace(prefixPattern, "")).toBe("883");
+      expect("(NT$883)".replace(prefixPattern, "")).toBe("(883)");
+    });
+  });
+
+  describe("United States", () => {
+    const qualifierPattern = new RegExp(String.raw`revenues?\s+outside\s+the\s+${unitedStatesSource}`, "i");
+
+    test("matches where a trailing word boundary cannot", () => {
+      // A boundary after the full stop needs a word character beside it, so `\bU\.S\.\b`
+      // never matches before a space.
+      expect(qualifierPattern.test("Jardiance revenue outside the U.S. included a milestone"))
+        .toBe(true);
+      expect(/revenues?\s+outside\s+the\s+U\.S\.\b/i.test("revenue outside the U.S. included"))
+        .toBe(false);
+    });
+
+    test("does not match a longer abbreviation", () => {
+      expect(new RegExp(unitedStatesSource).test("U.S.A. operations")).toBe(false);
+    });
+  });
+
+  test("a non-GAAP per-share row is not also reported as the GAAP figure", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Reports Second Quarter 2026 Results</h1>
+          <p>(in millions, except per share amounts)</p>
+          <p>Three Months Ended June 30,</p>
+          <p>Non-GAAP EPS | $ | 1.02 | $ | 0.73</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics.map(metric => metric.key)).not.toContain("gaap_eps");
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", value: "$1.02"}),
+    ]));
+  });
+});

--- a/modules/earnings-results-terms.ts
+++ b/modules/earnings-results-terms.ts
@@ -1,0 +1,40 @@
+// Terms used to qualify a financial caption, defined once each.
+//
+// These are gathered here because the same mistake kept being rebuilt per call site: `\b`
+// needs a word character on one side of the boundary, so it behaves unexpectedly for a term
+// that begins or ends with punctuation. Each export below records the wording that defeated
+// a naive `\b`, so a future edit can see what the guard is for rather than reintroducing it.
+//
+// Pattern sources are exported as strings for composing into a larger pattern; predicates are
+// exported where a call site only asks a yes/no question.
+
+// "Non-GAAP" ends a word at the hyphen, so `\bgaap` matches inside it and a non-GAAP caption
+// reads as a GAAP one. Defeated by: "Non-GAAP EPS of $1.02", which was reported as both the
+// adjusted and the reported per-share figure.
+export const gaapTermSource = String.raw`(?<!non-)\bgaap\b`;
+
+// "NT$" opens with letters and closes with a symbol, so `\b` cannot anchor the symbol end and
+// an unanchored match lands inside ordinary words. Defeated by: "we spent $883 million", which
+// reported a US filer's revenue in New Taiwan dollars.
+const newTaiwanDollarBody = String.raw`NT\s*\$`;
+export const newTaiwanDollarSource = String.raw`(?:^|[^A-Za-z])${newTaiwanDollarBody}`;
+
+// The same term where a match must not consume the preceding character, for use in a replace.
+export const newTaiwanDollarPrefixSource = String.raw`(?:^|(?<=[^A-Za-z]))${newTaiwanDollarBody}`;
+
+// "U.S." ends in a full stop, so a trailing `\b` can never match before a space: a boundary
+// there would need a word character next to the stop. Defeated by: "Jardiance revenue outside
+// the U.S. included a sales-based milestone", where the qualifier went unseen and a single
+// product's revenue was reported as the company's.
+export const unitedStatesSource = String.raw`U\.S\.(?![A-Za-z])`;
+
+// Case-insensitive, matching how filings are read elsewhere. That is also what makes the
+// leading boundary load-bearing rather than incidental: without it, the lowercase "nt $" in
+// "we spent $400 million" matches.
+export function hasNewTaiwanDollarSymbol(text: string): boolean {
+  return new RegExp(newTaiwanDollarSource, "i").test(text);
+}
+
+export function hasStandaloneGaapTerm(text: string): boolean {
+  return new RegExp(gaapTermSource, "i").test(text);
+}


### PR DESCRIPTION
## Why

Five releases have carried a bug from the same cause: **`\b` needs a word character on one side**, so it behaves unexpectedly for a term that begins or ends with punctuation. Each was fixed where it surfaced, with the guard rebuilt from scratch each time.

| Release | Term | Defeated by |
|---|---|---|
| #1842 | currency in XBRL header | multiple `iso4217:` codes |
| #1847 | `NT$` | "we spe**nt $**400 million" → US revenue in New Taiwan dollars |
| #1852 | `\bgaap` | "Non-**GAAP** EPS" → adjusted figure under the GAAP label |
| #1858 | `\bU\.S\.\b` | "revenue outside the U.S. included" → one product reported as the company |
| **this** | `\bgaap`, twice more | see below |

## It fixes a live defect the audit had not reached

**Two GAAP patterns still had no guard at all.** A row captioned only `Non-GAAP EPS` was reported *twice* — correctly as the adjusted figure, and again as the reported one:

```
Non-GAAP EPS | $ | 1.02 | $ | 0.73
  →  adjusted_eps: $1.02
  →  gaap_eps:     $1.02     ← wrong
```

One of the two decided whether to **override** the adjusted skip ([format.ts](modules/earnings-results-format.ts) `hasExplicitGaapEps`), so the mislabelling could not be caught downstream.

## What's here

One module defining the three terms, each recording the wording that defeated a naive boundary, with every call site routed through it — five sites across `document`, `format`, `metrics`, `money` and `outlook`.

Sources are exported as strings for composing into larger caption patterns; predicates where a site only asks yes/no. `NT$` needs two forms: one for matching, one that does not consume the preceding character for use in a replace.

## One test that passed for the wrong reason

Worth flagging, since it is the failure mode this session kept hitting. My first version of the NT$ test passed — but mutation-checking showed **removing the boundary changed nothing**. The predicate compiled without the case-insensitive flag, so lowercase `nt $` never matched and the boundary was doing no work. Restoring the flag (the original behaviour) is what makes the guard load-bearing, and the test then genuinely pins it.

All four guards confirmed to **fail a test when replaced by their naive form**.

## Verification

**2,446 tests pass**; `audit`, `lint`, `typecheck`, `test:coverage` clean, no thresholds altered. The 24-filing corpus is byte-identical — this is a refactor plus one bug fix, not a behaviour change to any audited filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)