### PR TITLE
Read guidance from a revised-guidance table's updated column

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -337,8 +337,9 @@ const filingCorpus: {
   },
   {
     // Guidance sits in a prior-versus-updated table whose captions and value cells are on
-    // separate lines, so it is not reached: the recorded outlook is a raise stated in a
-    // highlights bullet, which is a change rather than a level. Documented as a known gap.
+    // separate lines. Each figure is read from the updated column; the tax rate reads from the
+    // prior one because its update is stated as "unchanged". The per-share row is labelled by
+    // its own caption, though the table as a whole is the company's non-GAAP guidance.
     company: "Eli Lilly",
     metrics: [
       ["adjusted_eps", "$8.38"],
@@ -347,7 +348,9 @@ const filingCorpus: {
       ["net_income", "$7.09B"],
     ],
     outlook: [
-      ["Q2 EPS", "$2.78"]
+      ["Revenue", "$85B to $87B"],
+      ["EPS", "$35.5 to $36.5"],
+      ["Tax rate", "18% to 19%"],
     ],
     quarterLabel: "Q2 2026",
     source: "59478/000005947826000077/q226lillysalesandearningsp.htm",

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -167,7 +167,8 @@ export function isEmbeddedAlphaNumericValue(
 export function stripReferenceMarkers(line: string): string {
   const withoutParenthesisedMarkers = line
     .replace(/\(\s*Note\s+\d{1,2}\s*\)/gi, " ")
-    .replace(/([A-Za-z]) ?\(\d{1,2}\)/g, "$1");
+    // A caption can carry more than one marker ("Earnings per Share(3)(4)").
+    .replace(/([A-Za-z])(?: ?\(\d{1,2}\))+/g, "$1");
 
   // A bare superscript trailing a label ("Profit per common share - diluted 2") is a
   // footnote too. Only strip it where the line carries no value cell of its own, so a

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -31,6 +31,10 @@ type OutlookSection = {
   heading?: string | undefined;
   lines: string[];
   mixedPeriods: boolean;
+  // A guidance table headed "Prior | Updated" restates each figure twice. Its rows are the
+  // guidance, so they are read rather than dismissed as a comparison table, and the updated
+  // column is the one that now applies.
+  revisedColumns: boolean;
 };
 
 const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:C\s*\$|[$€£¥])\s*|(?:(?:USD|CAD|EUR|GBP|JPY)\s+))?-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:(?:trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b)?\)?`;
@@ -143,9 +147,12 @@ export function extractOutlookMetrics(
     const metric = extractOutlookMetric(
       section.lines,
       definition,
-      section.mixedPeriods,
+      // Every row of a revised-guidance table covers the same period, so the rows are not
+      // asked to name it themselves — which they cannot, and which would discard them all.
+      section.mixedPeriods && false === section.revisedColumns,
       section.heading,
       documentCurrencyCode,
+      section.revisedColumns,
     );
     if (null === metric || true === seenKeys.has(metric.key)) {
       continue;
@@ -190,7 +197,15 @@ function getOutlookSection(lines: string[]): OutlookSection {
     heading,
     lines: sectionLines,
     mixedPeriods: mixedPeriods || hasMixedOutlookPeriods(sectionLines),
+    revisedColumns: sectionLines.some(line => hasRevisedColumnHeader(line)),
   };
+}
+
+// The header of a revised-guidance table, carrying only the two column captions.
+function hasRevisedColumnHeader(line: string): boolean {
+  return /\bprior\b/i.test(line) &&
+    /\bupdated\b/i.test(line) &&
+    false === /\d/.test(line);
 }
 
 function hasMixedOutlookPeriods(lines: string[]): boolean {
@@ -270,10 +285,11 @@ function extractOutlookMetric(
   includePeriodLabel: boolean,
   sectionHeading: string | undefined,
   documentCurrencyCode: string,
+  revisedColumns: boolean,
 ): EarningsOutlookMetric | null {
   let bestCandidate: OutlookMetricCandidate | null = null;
-  for (const line of lines) {
-    if (true === isNoisyOutlookLine(line)) {
+  for (const [lineIndex, line] of lines.entries()) {
+    if (false === revisedColumns && true === isNoisyOutlookLine(line)) {
       continue;
     }
 
@@ -282,11 +298,17 @@ function extractOutlookMetric(
         continue;
       }
 
+      // A guidance table can carry its caption on one line and its cells on the next
+      // ("Earnings per Share" / "| | | $35.50 to $37.00 | $35.50 to $36.50 |").
+      const valueLine = true === revisedColumns && false === /\d/.test(line)
+        ? `${line} ${lines[lineIndex + 1] ?? ""}`
+        : line;
       const value = extractOutlookValue(
-        line,
+        valueLine,
         pattern,
         definition.valueType,
         documentCurrencyCode,
+        revisedColumns,
       );
       if (null === value) {
         continue;
@@ -314,7 +336,9 @@ function extractOutlookMetric(
         metric.periodLabel = periodLabel;
       }
       const candidate = {
-        score: getOutlookMetricCandidateScore(line),
+        // Score what the value was read from: a caption joined to its cells is a table row,
+        // whereas the caption alone looks like prose.
+        score: getOutlookMetricCandidateScore(valueLine),
         metric,
       };
       if (null === bestCandidate || candidate.score > bestCandidate.score) {
@@ -354,6 +378,15 @@ function getOutlookPeriodLabel(line: string): string | undefined {
 function getOutlookMetricCandidateScore(line: string): number {
   let score = 0;
 
+  // A guidance table states the figures; the paragraph introducing it only describes them,
+  // and any amount it happens to mention belongs to that description rather than to the
+  // metric ("...guidance, reflecting the continued strong revenue performance in Q2").
+  if (2 <= (line.match(/\|/g)?.length ?? 0)) {
+    score += 30;
+  } else if (200 < line.length) {
+    score -= 20;
+  }
+
   if (/\b(?:expects?|expected|guidance|outlook|forecast|projected|targets?|targeting|anticipates?|anticipated|reaffirms?|reiterates?|maintains?|raises?|raised)\b/i.test(line)) {
     score += 20;
   }
@@ -380,10 +413,11 @@ function extractOutlookValue(
   pattern: RegExp,
   valueType: OutlookValueType,
   documentCurrencyCode: string,
+  revisedColumns = false,
 ): string | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
-  for (const rawValueText of getOutlookValueSegments(line, patternMatch)) {
+  for (const rawValueText of getOutlookValueSegments(line, patternMatch, revisedColumns)) {
     const valueText = normalizeOutlookValueText(rawValueText);
     if ("" === valueText) {
       continue;
@@ -409,9 +443,23 @@ function extractOutlookValue(
   return null;
 }
 
-function getOutlookValueSegments(line: string, patternMatch: RegExpExecArray | null): string[] {
+function getOutlookValueSegments(
+  line: string,
+  patternMatch: RegExpExecArray | null,
+  revisedColumns: boolean,
+): string[] {
   if (null === patternMatch) {
     return [line];
+  }
+
+  // Each row of a revised-guidance table holds the prior figure and then the updated one.
+  // Reading from the last cell backwards takes the figure that now applies.
+  if (true === revisedColumns) {
+    const cells = line.slice(patternMatch.index + patternMatch[0].length).split("|");
+    const populatedCells = cells.filter(cell => /\d/.test(cell)).reverse();
+    if (0 < populatedCells.length) {
+      return populatedCells;
+    }
   }
 
   const rawValueText = line.slice(patternMatch.index + patternMatch[0].length);


### PR DESCRIPTION
## Why

This closes the last known-wrong output. Lilly's outlook read:

```
Q2 EPS: $2.78
```

Which is neither a Q2 figure nor an EPS — it is **how much the full-year guidance was raised by**, taken from the paragraph introducing the guidance table because the table itself was never reached.

| | Was | Now |
|---|---|---|
| Revenue | — | **`$85B to $87B`** |
| EPS | `Q2 EPS $2.78` | **`$35.5 to $36.5`** |
| Tax rate | — | **`18% to 19%`** |

Each checked against the filing: revenue prior `$82–85B` / updated `$85–87B`; EPS prior `$35.50–$37.00` / updated `$35.50–$36.50`; tax rate `18–19%` with its update stated as "unchanged".

## What a "Prior | Updated" header now means

Detecting that header marks the section as revised guidance, which changes three things for its rows:

- **They are read at all.** Rows are otherwise dismissed as a results comparison table — right for a results table sitting inside an outlook section, wrong for the guidance itself.
- **Each figure comes from the last populated cell**, the column that now applies. The tax rate falls back to the prior column precisely because "unchanged" carries no figure.
- **A caption is joined to the cells on the line below, and the joined row is what gets scored.** Scoring the bare caption made a real table row look like prose and lose to the paragraph above it — that one cost me two debugging rounds.

Every row of such a table covers one period, named by the heading, so rows are no longer required to name a period themselves. That requirement had been silently discarding all of them, which is why the prose won.

Also strips repeated footnote markers from a single caption (`Earnings per Share(3)(4)`), which left a digit in the caption, suppressed the join, and supplied `-$3` as the figure.

## Note on what I did not do

The per-share row is labelled **EPS**, by its own caption, even though the table as a whole is the company's *non-GAAP* guidance. Relabelling it Adj EPS would match what I did for Pfizer and Disney — but this section's intro names both bases ("In addition to providing guidance for GAAP revenue, Lilly provides guidance for certain non-GAAP measures"), so a section-level "says non-GAAP" test would be guessing. The number is right; the nuance is recorded in the corpus entry rather than acted on blind.

## Verification

**2,446 tests pass**; `audit`, `lint`, `typecheck`, `test:coverage` clean, no thresholds altered. All seven changes mutation-checked. The corpus flagged the LLY change rather than absorbing it, and the expectation was updated only after re-reading the filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)