### PR TITLE
Fix currency, period and guidance selection across nine filings

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -356,6 +356,141 @@ const filingCorpus: {
     source: "59478/000005947826000077/q226lillysalesandearningsp.htm",
     ticker: "lly",
   },
+  {
+    // A "Quarter Ended | Six Months Ended" highlights table: reading past the first column
+    // group took both revenue and net income from the half-year columns.
+    company: "AppLovin",
+    metrics: [
+      ["gaap_eps", "$3.76"],
+      ["revenue", "$1.92B"],
+      ["net_income", "$1.27B"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1751008/000175100826000057/exhibit991-2q26earningspre.htm",
+    ticker: "app",
+  },
+  {
+    company: "Fastly",
+    metrics: [
+      ["adjusted_eps", "$0.15"],
+      ["gaap_eps", "-$0.10"],
+      ["revenue", "$183.3M"],
+      ["net_income", "-$15.59M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1517413/000151741326000212/ex991-fslypressrelease63026.htm",
+    ticker: "fsly",
+  },
+  {
+    company: "Dutch Bros",
+    metrics: [
+      ["gaap_eps", "$0.28"],
+      ["revenue", "$550.9M"],
+      ["net_income", "$51.6M"],
+    ],
+    outlook: [
+      ["Revenue", "$2.1B to $2.13B"],
+      ["Adj EBITDA", "$385M to $390M"],
+      ["Capex", "$350M to $370M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1866581/000186658126000131/a2026-q2_ex991.htm",
+    ticker: "bros",
+  },
+  {
+    // Guidance states its scale once above the rows, and a footnote states the size of the
+    // items the non-GAAP measures exclude rather than the measures themselves.
+    company: "Sandisk",
+    metrics: [
+      ["adjusted_eps", "$39.25"],
+      ["gaap_eps", "$43.97"],
+      ["revenue", "$8.97B"],
+      ["net_income", "$6.9B"],
+    ],
+    outlook: [
+      ["Revenue", "$10.3B to $10.8B"],
+      ["Gross margin", "83% to 84.9%"],
+      ["Operating expenses", "$574M to $614M"],
+    ],
+    quarterLabel: "Q4 2026",
+    source: "2023554/000162828026053346/sndkq4-26ex991xpressrelease.htm",
+    ticker: "sndk",
+  },
+  {
+    // "typing the call into the CAD in another jurisdiction" is Computer-Aided Dispatch in a
+    // customer quote, not a currency declaration.
+    company: "Axon Enterprise",
+    metrics: [
+      ["revenue", "$904M"],
+      ["net_income", "$29.43M"],
+    ],
+    outlook: [
+      ["Capex", "$160M to $190M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1069183/000162828026053363/axon-20260805xex991.htm",
+    ticker: "axon",
+  },
+  {
+    company: "e.l.f. Beauty",
+    metrics: [
+      ["adjusted_eps", "$1.75"],
+      ["gaap_eps", "$1.12"],
+      ["revenue", "$479.37M"],
+      ["net_income", "$66.6M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q1 2027",
+    source: "1600033/000160003326000036/q12027er-991.htm",
+    ticker: "elf",
+  },
+  {
+    // A segment results table repeats the consolidated captions, distinguished only by its
+    // heading naming the segment ("Specialties Results").
+    company: "Albemarle",
+    metrics: [
+      ["gaap_eps", "$3.52"],
+      ["revenue", "$1.74B"],
+      ["net_income", "$480M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "915913/000091591326000101/a2q26earningsreleaseex991.htm",
+    ticker: "alb",
+  },
+  {
+    // "Net Loss improved by $56.0 million year-over-year to $(41.0) million" leads with the
+    // change, so the loss itself comes second.
+    company: "Redwire",
+    metrics: [
+      ["adjusted_eps", "-$0.09"],
+      ["gaap_eps", "-$0.19"],
+      ["revenue", "$117.1M"],
+      ["net_income", "-$41.48M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1819810/000181981026000121/exhibit991redwire06302026e.htm",
+    ticker: "rdw",
+  },
+  {
+    // Reported net income with a diluted loss per share: genuine, from the if-converted
+    // treatment of the notes, and recorded so the pair is not "corrected" later.
+    company: "Beyond Meat",
+    metrics: [
+      ["gaap_eps", "-$0.06"],
+      ["revenue", "$68.8M"],
+      ["net_income", "$16.4M"],
+    ],
+    outlook: [
+      ["Revenue", "$60M to $65M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1655210/000165521026000053/ex991pressrelease-q22026ea.htm",
+    ticker: "bynd",
+  },
 ];
 
 describe("earnings result filing corpus", () => {
@@ -376,6 +511,6 @@ describe("earnings result filing corpus", () => {
   }
 
   test("covers every stored fixture", () => {
-    expect(filingCorpus).toHaveLength(24);
+    expect(filingCorpus).toHaveLength(33);
   });
 });

--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -3,7 +3,10 @@ import {stripReferenceMarkers} from "./earnings-results-format-selection.ts";
 import {findNumericValues, getCurrencyCodeFromText} from "./earnings-results-money.ts";
 import {type EarningsResultMetric} from "./earnings-results-metrics.ts";
 import {type EarningsOutlookMetric} from "./earnings-results-outlook.ts";
-import {hasNewTaiwanDollarSymbol} from "./earnings-results-terms.ts";
+import {
+  hasDeclaredIsoCode,
+  hasNewTaiwanDollarSymbol,
+} from "./earnings-results-terms.ts";
 
 export type ParsedEarningsDocument = {
   // The weighted-average diluted share count as printed, without applying a scale. Filings
@@ -66,7 +69,7 @@ export function getDocumentCurrencyCode(lines: string[]): string | undefined {
   const headerLines = lines.slice(0, 60);
   const currencyDeclaration = headerLines
     .find(line => /\b(?:Canadian|New Taiwan|U\.S\.)\s+dollars?\b/i.test(line) ||
-      /\b(?:CAD|TWD|NTD|USD|EUR|GBP|JPY)\b/.test(line) ||
+      hasDeclaredIsoCode(line, ["CAD", "TWD", "NTD", "USD", "EUR", "GBP", "JPY"]) ||
       hasNewTaiwanDollarSymbol(line));
   if (undefined !== currencyDeclaration) {
     return getDominantCurrencyCode(currencyDeclaration) ??

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -58,7 +58,7 @@ export function getMetricCandidateScore({
     score -= 60;
   }
 
-  if (/\b(?:increase|decrease|improvement|decline|change)(?:d)?\s+(?:by|of)\b/i.test(metricLine) ||
+  if (/\b(?:increase|decrease|improve|improvement|decline|worsen|change)(?:d)?\s+(?:by|of)\b/i.test(metricLine) ||
       /\b(?:rose|fell|grew|up|down)\s+by\b/i.test(metricLine)) {
     score -= 140;
   }
@@ -79,6 +79,12 @@ export function getMetricCandidateScore({
     score += 40;
   } else if ("annual" === periodScope) {
     score -= 80;
+  }
+
+  // A row under a guidance heading states guidance even where its caption does not say so,
+  // so a table of forward ranges is not read as the reported quarter.
+  if (true === isUnderGuidanceHeading(lines, lineIndex)) {
+    score -= 120;
   }
 
   if (true === hasForeignPeriodAttribution(metricLine, quarterLabel)) {
@@ -369,6 +375,28 @@ function getLineScope(line: string): PeriodScope {
 
 // "compared with earnings per share of $1.76 for the second quarter of 2025" states a
 // prior-year figure; the leading value on such a line is not the reported quarter.
+function isUnderGuidanceHeading(lines: string[], lineIndex: number): boolean {
+  for (let index = lineIndex - 1, examined = 0; index >= 0 && examined < 14; index--, examined++) {
+    const line = lines[index];
+    if (undefined === line || line.length > 130) {
+      continue;
+    }
+
+    const heading = line.replace(/^[\s•–—-]+/, "").replace(/[\s|:]+$/, "");
+    if (/\b(?:outlook|guidance)\b/i.test(heading) && 90 > heading.length) {
+      return true;
+    }
+
+    // A results or statement heading ends the guidance section above it.
+    if (/\b(?:results|statements?\s+of\s+operations|balance\s+sheets?|highlights)\b/i.test(heading) &&
+        90 > heading.length) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
 function hasForeignPeriodAttribution(
   metricLine: string,
   quarterLabel: string | undefined,

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -53,7 +53,7 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\bnon-gaap\s+(?:diluted\s+)?(?:earnings\s+per\s+share|eps)\b/i,
       // "Non-GAAP diluted net income per share" / "Non-GAAP Diluted Loss Per Share" are
       // the reconciliation-table labels for the same measure.
-      /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?(?:earnings|net\s+income|net\s+loss|loss|\(loss\))\s+per\s+(?:common\s+)?share\b/i,
+      /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?(?:earnings|net\s+income|net\s+loss|loss)(?:\s*\/?\s*\(loss(?:es)?\))?\s+per\s+(?:common\s+)?share\b/i,
       // A reconciliation table can name the measure after the caption instead of before
       // it ("Earnings per share - Non-GAAP").
       /\b(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\s*[–—-]\s*non-gaap\b/i,
@@ -333,8 +333,11 @@ export function hasMixedMonthQuarterColumns(lines: string[], lineIndex: number):
   const context = lines
     .slice(Math.max(0, lineIndex - 8), lineIndex + 1)
     .join(" ");
-  const hasMonth = /\b(?:month|january|february|march|april|may|june|july|august|september|october|november|december)\b/i.test(context);
-  return hasMonth && /\bquarter\b/i.test(context) && /\bchange\b/i.test(context);
+  // Only a monthly-and-quarterly layout puts the reported quarter in the second column
+  // group. Accepting any month name here caught an ordinary "Quarter Ended June 30 | Six
+  // Months Ended June 30" table too, and skipped its quarter columns for the half-year ones.
+  return /\bmonths?\s+and\s+quarter\b|\bquarter\s+and\s+months?\b/i.test(context) &&
+    /\bchange\b/i.test(context);
 }
 
 export function isNearTableNoteColumn(lines: string[], lineIndex: number): boolean {

--- a/modules/earnings-results-money.ts
+++ b/modules/earnings-results-money.ts
@@ -1,5 +1,6 @@
 import {isEmbeddedAlphaNumericValue} from "./earnings-results-format-selection.ts";
 import {
+  hasDeclaredIsoCode,
   hasNewTaiwanDollarSymbol,
   newTaiwanDollarPrefixSource,
 } from "./earnings-results-terms.ts";
@@ -297,27 +298,33 @@ export function getCurrencyCodeFromText(
   // "NT$" only denotes New Taiwan dollars as a standalone symbol. Without the leading
   // boundary it also matches inside ordinary words — "we spe(nt $)883 million" turned a
   // US filer's revenue into NT$883M.
-  if (true === hasNewTaiwanDollarSymbol(text) || /\b(?:TWD|NTD)\b|\bNew Taiwan dollars?\b/i.test(text)) {
+  if (true === hasNewTaiwanDollarSymbol(text) ||
+      true === hasDeclaredIsoCode(text, ["TWD", "NTD"]) ||
+      /\bNew Taiwan dollars?\b/i.test(text)) {
     return "TWD";
   }
 
-  if (/(?:^|[^A-Za-z])C\s*\$/.test(text) || /\bCAD\b|\bCanadian dollars?\b/i.test(text)) {
+  if (/(?:^|[^A-Za-z])C\s*\$/.test(text) ||
+      true === hasDeclaredIsoCode(text, ["CAD"]) ||
+      /\bCanadian dollars?\b/i.test(text)) {
     return "CAD";
   }
 
-  if (text.includes("€") || /\bEUR\b/i.test(text)) {
+  if (text.includes("€") || true === hasDeclaredIsoCode(text, ["EUR"])) {
     return "EUR";
   }
 
-  if (text.includes("£") || /\bGBP\b/i.test(text)) {
+  if (text.includes("£") || true === hasDeclaredIsoCode(text, ["GBP"])) {
     return "GBP";
   }
 
-  if (text.includes("¥") || /\bJPY\b/i.test(text)) {
+  if (text.includes("¥") || true === hasDeclaredIsoCode(text, ["JPY"])) {
     return "JPY";
   }
 
-  if (/US\s*\$|\bUSD\b|\bU\.S\. dollars?\b/i.test(text)) {
+  if (/US\s*\$/i.test(text) ||
+      true === hasDeclaredIsoCode(text, ["USD"]) ||
+      /\bU\.S\. dollars?\b/i.test(text)) {
     return "USD";
   }
 

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -1,3 +1,5 @@
+import {isDefinitionalLine} from "./earnings-results-format-selection.ts";
+import {getMoneyScaleFromContextText} from "./earnings-results-money.ts";
 import {gaapTermSource} from "./earnings-results-terms.ts";
 
 export type EarningsOutlookMetric = {
@@ -29,6 +31,9 @@ type ParsedMoneyValue = {
 
 type OutlookSection = {
   heading?: string | undefined;
+  // A guidance table states its scale once, above the rows ("(in millions, except per share
+  // amounts)"). Without it a row reading "$10,300 - $10,800" is published as $10.3K.
+  moneyUnit?: string | undefined;
   lines: string[];
   mixedPeriods: boolean;
   // A guidance table headed "Prior | Updated" restates each figure twice. Its rows are the
@@ -153,6 +158,7 @@ export function extractOutlookMetrics(
       section.heading,
       documentCurrencyCode,
       section.revisedColumns,
+      section.moneyUnit,
     );
     if (null === metric || true === seenKeys.has(metric.key)) {
       continue;
@@ -195,10 +201,28 @@ function getOutlookSection(lines: string[]): OutlookSection {
 
   return {
     heading,
+    moneyUnit: getSectionMoneyUnit(sectionLines),
     lines: sectionLines,
     mixedPeriods: mixedPeriods || hasMixedOutlookPeriods(sectionLines),
     revisedColumns: sectionLines.some(line => hasRevisedColumnHeader(line)),
   };
+}
+
+const unitByMoneyScale = new Map<number, string>([
+  [1_000, "thousand"],
+  [1_000_000, "million"],
+  [1_000_000_000, "billion"],
+]);
+
+function getSectionMoneyUnit(lines: string[]): string | undefined {
+  for (const line of lines) {
+    const scale = getMoneyScaleFromContextText(line);
+    if (null !== scale) {
+      return unitByMoneyScale.get(scale);
+    }
+  }
+
+  return undefined;
 }
 
 // The header of a revised-guidance table, carrying only the two column captions.
@@ -286,10 +310,18 @@ function extractOutlookMetric(
   sectionHeading: string | undefined,
   documentCurrencyCode: string,
   revisedColumns: boolean,
+  sectionMoneyUnit: string | undefined,
 ): EarningsOutlookMetric | null {
   let bestCandidate: OutlookMetricCandidate | null = null;
   for (const [lineIndex, line] of lines.entries()) {
     if (false === revisedColumns && true === isNoisyOutlookLine(line)) {
+      continue;
+    }
+
+    // A footnote to a guidance table states what the measure excludes, not the measure:
+    // "(1) ... guidance excludes ... totaling $59 million to $81 million" is the size of the
+    // exclusions, and reading it reports that range as the guidance itself.
+    if (true === isDefinitionalLine(line)) {
       continue;
     }
 
@@ -309,6 +341,7 @@ function extractOutlookMetric(
         definition.valueType,
         documentCurrencyCode,
         revisedColumns,
+        sectionMoneyUnit,
       );
       if (null === value) {
         continue;
@@ -414,6 +447,7 @@ function extractOutlookValue(
   valueType: OutlookValueType,
   documentCurrencyCode: string,
   revisedColumns = false,
+  sectionMoneyUnit?: string,
 ): string | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
@@ -427,14 +461,14 @@ function extractOutlookValue(
     // in the same breath ("Non-GAAP EPS of $0.84 to $0.88, representing growth of 28% to
     // 35%"). Guidance given only as growth still falls through to the growth reading.
     const value = ("eps" === valueType
-      ? getOutlookRangeValue(valueText, valueType, documentCurrencyCode)
+      ? getOutlookRangeValue(valueText, valueType, documentCurrencyCode, sectionMoneyUnit)
       : null) ??
       getGrowthOutlookValue(valueText) ??
-      getOutlookRangeValue(valueText, valueType, documentCurrencyCode) ??
+      getOutlookRangeValue(valueText, valueType, documentCurrencyCode, sectionMoneyUnit) ??
       ("eps" === valueType ? getEpsPercentOutlookValue(valueText) : null) ??
       ("text" === valueType ? getSingleOutlookValue(valueText, "money", documentCurrencyCode) : null) ??
       ("text" === valueType ? getNumericGrowthOutlookValue(valueText) : null) ??
-      getSingleOutlookValue(valueText, valueType, documentCurrencyCode);
+      getSingleOutlookValue(valueText, valueType, documentCurrencyCode, sectionMoneyUnit);
     if (null !== value) {
       return value;
     }
@@ -533,6 +567,7 @@ function getOutlookRangeValue(
   value: string,
   valueType: OutlookValueType,
   documentCurrencyCode: string,
+  sectionMoneyUnit?: string,
 ): string | null {
   // A per-share range is read before a percentage one, so guidance that states the figure
   // and its growth together ("$0.84 to $0.88, representing growth of 28% to 35%") reports
@@ -571,7 +606,9 @@ function getOutlookRangeValue(
       continue;
     }
 
-    const inferredUnit = getMoneyUnit(secondRangeValue) ?? getMoneyUnit(firstRangeValue);
+    const inferredUnit = getMoneyUnit(secondRangeValue) ??
+      getMoneyUnit(firstRangeValue) ??
+      sectionMoneyUnit;
     const inferredCurrencyCode = getCurrencyCodeFromText(secondRangeValue, documentCurrencyCode) ??
       getCurrencyCodeFromText(firstRangeValue, documentCurrencyCode) ??
       getCurrencyCodeFromText(value, documentCurrencyCode) ??
@@ -590,6 +627,7 @@ function getSingleOutlookValue(
   value: string,
   valueType: OutlookValueType,
   documentCurrencyCode: string,
+  sectionMoneyUnit?: string,
 ): string | null {
   if ("percent" === valueType) {
     const percentMatch = value.match(/-?\d+(?:\.\d+)?\s*%/);
@@ -609,7 +647,7 @@ function getSingleOutlookValue(
         continue;
       }
 
-      const moneyValue = parseMoneyWithOptionalUnit(token, undefined, inferredCurrencyCode);
+      const moneyValue = parseMoneyWithOptionalUnit(token, sectionMoneyUnit, inferredCurrencyCode);
       if (null !== moneyValue) {
         return formatMoneyCompact(moneyValue.value, moneyValue.currencyCode);
       }

--- a/modules/earnings-results-terms.ts
+++ b/modules/earnings-results-terms.ts
@@ -38,3 +38,19 @@ export function hasNewTaiwanDollarSymbol(text: string): boolean {
 export function hasStandaloneGaapTerm(text: string): boolean {
   return new RegExp(gaapTermSource, "i").test(text);
 }
+
+// A three-letter currency code is also an ordinary acronym, so on its own it says nothing
+// about the reporting currency. Defeated by: "typing the call into the CAD in another
+// jurisdiction" — Computer-Aided Dispatch in a customer quote, which reported a US filer's
+// revenue in Canadian dollars. A code counts only where it declares units or sits against an
+// amount.
+export function hasDeclaredIsoCode(text: string, codes: string[]): boolean {
+  const alternatives = codes.join("|");
+  return new RegExp(
+    String.raw`\biso4217:(?:${alternatives})\b` +
+    String.raw`|\bin\s+(?:${alternatives})\b` +
+    String.raw`|\(\s*(?:${alternatives})\b` +
+    String.raw`|\b(?:${alternatives})\s*(?:[$\d]|millions?|billions?|thousands?)`,
+    "i",
+  ).test(text);
+}

--- a/modules/test-fixtures/earnings-filings/alb.txt
+++ b/modules/test-fixtures/earnings-filings/alb.txt
@@ -1,0 +1,882 @@
+EX-99.1
+2
+a2q26earningsreleaseex991.htm
+EX-99.1
+
+
+
+
+Document
+Exhibit 99.1
+
+
+| | | | | |
+Contact: | |
+invest@albemarle.com | 1.980.308.6194 |
+
+
+
+
+
+
+Albemarle Reports Second Quarter 2026 Results
+| | |
+|
+
+
+
+CHARLOTTE, N.C. – August 5, 2026 - Albemarle Corporation (NYSE: ALB), a global leader in providing essential elements for mobility, energy, connectivity and health, today announced its results for the second quarter ended June 30, 2026.
+Second Quarter 2026 and Recent Highlights
+(Unless otherwise stated, all percentage changes represent year-over-year comparisons and do not exclude the prior-period results of Ketjen’s refining catalyst solutions business in which the company sold a 51% stake on March 2, 2026)
+• Net sales of $1.7 billion, up 31% due to higher pricing in Energy Storage (+73%) and higher pricing and volumes in Specialties (price +11%, volume +8%).
+• Net income of $480 million, or $3.52 per diluted share attributable to common shareholders.
+• Adjusted EBITDA (a) of $858 million; up 155% due primarily to higher pricing in Energy Storage, increased pricing and volumes in Specialties and ongoing cost and productivity improvements. Adjusted EBITDA expanded in both Energy Storage (+229%) and Specialties (+61%).
+• Cash from operating activities of $710 million and free cash flow of $638 million (a) . Operating cash flow conversion of 83% (a) , primarily driven by timing of an increased dividend from the Talison joint venture and non-recurring working capital benefits.
+• Delivered $100 million in year-to-date run-rate cost and productivity improvements, tracking towards the high end of our full-year target of $100 to $150 million.
+• Improving full-year 2026 outlook considerations including:
+◦ Increasing full-year Specialties net sales outlook to $1.4 to $1.6 billion and adjusted EBITDA outlook to $275 to $325 million, due to stronger-than-expected pricing and volume performance year to date.
+◦ Expect minimal impact to Energy Storage sales volume related to the fire at Talison CGP3 which occurred on June 9, in part due to better-than-planned output from the Wodgina mine.
+◦ Reducing full-year capital expenditure forecast to approximately $500 million due to ongoing capital efficiency improvements.
+(a) See Non-GAAP Reconciliations for further details.
+
+
+“Albemarle delivered another quarter of strong results, reflecting improved pricing, continued strength in Specialties, disciplined cost and productivity execution, and strong cash generation,” said Kent Masters, Chairman and CEO. “We continue to see resilient demand fundamentals across our core markets, including energy storage, electric vehicles, and semiconductors. We are advancing our highest value organic growth opportunities while maintaining a disciplined approach to capital allocation and execution.”
+
+
+Second Quarter 2026 Results | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | |
+| | |
+In millions, except per share amounts | Q2 2026 | | Q2 2025 | | $ Change | | % Change | | | |
+Net sales | $ | 1,743.3 | | | $ | 1,330.0 | | | $ | 413.3 | | | 31.1 | % | | | |
+|
+| | | | | | | | | | |
+Net income attributable to Albemarle Corporation | $ | 480.0 | | | $ | 22.9 | | | $ | 457.1 | | | 1,996.2 | % | | | |
+|
+Adjusted EBITDA (a)
+| $ | 858.1 | | | $ | 336.5 | | | $ | 521.6 | | | 155.0 | % | | | |
+|
+| | | | | | | | | | |
+Diluted income (loss) per share attributable to common shareholders | $ | 3.52 | | | $ | (0.16) | | | $ | 3.68 | | | NM | | | |
+| | | | | | | | | | |
+Non-recurring and other unusual items (a)
+| 0.22 | | | 0.27 | | | | | | | | |
+| | | | | | | | | | |
+Adjusted diluted income per share attributable to common shareholders (a)(b)
+| $ | 3.75 | | | $ | 0.11 | | | $ | 3.64 | | | NM | | | |
+
+(a) See Non-GAAP Reconciliations for further details.
+(b) Totals may not add due to rounding.
+
+
+1
+
+
+
+
+
+
+
+Net sales for the second quarter of 2026 were $1.7 billion compared to $1.3 billion for the prior-year quarter, up 31%, driven primarily by higher prices in both Energy Storage and Specialties and volume growth in Specialties. Adjusted EBITDA of $858 million increased by $522 million from the prior-year quarter, primarily due to higher net sales and ongoing cost and productivity improvements.
+
+
+Net income attributable to Albemarle of $480 million increased year over year by $457 million. The effective income tax rate for the second quarter of 2026 was 21.3% or 19.1% on an adjusted basis.
+
+
+Energy Storage Results | | | | | | | | | | | | | | | | | | | | | | | |
+In millions | Q2 2026 | | Q2 2025 | | $ Change | | % Change |
+Net Sales | $ | 1,276.7 | | | $ | 717.7 | | | $ | 559.0 | | | 77.9 | % |
+Sales Volume (kT LCE) (a)
+| 65 | | | 59 | | | 6 | | | 11.0 | % |
+Avg. Realized Price ($/kg LCE) (a)
+| $ | 19.53 | | | $ | 12.17 | | | $ | 7.36 | | | 60.5 | % |
+Adjusted EBITDA | $ | 723.5 | | | $ | 219.7 | | | $ | 503.7 | | | 229.3 | % |
+
+(a) Includes aggregated salts and spodumene sales on a lithium carbonate equivalent (LCE) basis.
+
+
+Energy Storage net sales for the second quarter of 2026 were $1.3 billion, an increase of $559 million, or 78%, due to higher pricing. Adjusted EBITDA of $723 million increased $504 million, or 229%, primarily due to higher lithium pricing partially offset by higher CORFO commissions.
+
+
+Specialties Results | | | | | | | | | | | | | | | | | | | | | | | |
+In millions | Q2 2026 | | Q2 2025 | | $ Change | | % Change |
+Net Sales | $ | 423.5 | | | $ | 351.6 | | | $ | 71.9 | | | 20.5 | % |
+Adjusted EBITDA | $ | 117.7 | | | $ | 73.0 | | | $ | 44.7 | | | 61.3 | % |
+
+
+
+Specialties net sales for the second quarter of 2026 were $423 million, an increase of $72 million, or 20%, primarily due to higher volumes (+8%) and pricing (+11%). Adjusted EBITDA of $118 million increased $45 million, or 61%, primarily due to higher volumes and favorable pricing in bromine and derivatives, along with continued productivity improvements and proactive management of cost escalations driven by the conflict in the Middle East.
+
+
+2026 Outlook Considerations
+
+
+Total Corporate Outlook Considerations
+The table below reflects expected outcomes for the total company based on recently observed lithium market price scenarios. Outlook ranges for each scenario are based on variation in sales volume and product mix. Energy Storage production volumes are expected to increase year over year. Sales volumes are expected to be in the range of 225 to 235 kilotons lithium carbonate equivalent, as increased Wodgina volumes partially offset a delay in the Talison CGP3 ramp due to a fire that occurred on June 9. All three scenarios assume flat market pricing flowing through Energy Storage’s current contract book which includes approximately 40% of salts volume (or one-third of total volumes) on long-term agreements. Scenarios also assume that spodumene pricing averages 10% of the lithium carbonate equivalent (LCE) price, while other costs are assumed to be constant.
+
+
+| | | | | | | | | | | |
+| Total Corporate FY 2026E |
+Observed market price case (a)
+| FY 2025 avg. | Q1 2026 avg. | 2021-2025 avg. |
+Average lithium market price ($/kg LCE) (a)
+| ~$10 | ~$20 | ~$30 |
+Net sales | $4.1 - $4.3 billion | $5.7 - $6.0 billion | $7.5 - $7.8 billion |
+Adjusted EBITDA (b)
+| $0.9 - $1.0 billion | $2.4 - $2.6 billion | $4.2 - $4.4 billion |
+
+
+
+(a) Price represents blend of relevant market pricing including spot and regional indices for the periods referenced.
+(b) The Company does not provide a reconciliation of forward-looking non-GAAP financial measures to the most directly comparable financial measures calculated and reported in accordance with GAAP, as the company is unable to estimate significant non-recurring or unusual items without unreasonable effort. See “Additional Information Regarding Non-GAAP Measures” for more information.
+
+
+2
+
+
+
+
+
+Energy Storage Market Price Scenarios
+| | | | | | | | | | | |
+| Energy Storage FY 2026E |
+Observed market price case (a)
+| FY 2025 avg. | Q1 2026 avg. | 2021-2025 avg. |
+Average lithium market price ($/kg LCE) (a)
+| ~$10 | ~$20 | ~$30 |
+Net sales | $2.5 - $2.6 billion | $4.0 - $4.2 billion | $5.9 - $6.1 billion |
+Adjusted EBITDA | $0.7 - $0.8 billion | $2.1 - $2.3 billion | $3.9 - $4.1 billion |
+Equity in net income of unconsolidated investments (net of tax) (b)
+| $0.2 - $0.3 billion | $0.6 - $0.7 billion | $1.0 - $1.1 billion |
+
+
+
+(a) Price represents blend of relevant market pricing including spot and regional indices for the periods referenced.
+(b) Included in adjusted EBITDA on a pre-tax basis.
+
+
+Specialties Outlook Considerations
+Specialties net sales and adjusted EBITDA outlook is improved primarily due to strong year to date performance driven by volume growth in bromine specialties and cost and productivity improvements. Our outlook continues to reflect modest volume growth in key end markets led by semiconductors, oil and gas, flame retardants and pharmaceuticals partially offset by expected softness in automotive and petrochemicals. Second-half outlook assumes stabilization in the bromine market and continued uncertainties including the situation in the Middle East. Operations at the Jordan Bromine Company (JBC) joint venture are in line with expectations as it continues to navigate geopolitical tensions in the region.
+
+
+| | | | | |
+| Segment FY 2026E |
+Specialties net sales | $1.4 - $1.6 billion |
+Specialties adjusted EBITDA | $275 - $325 million |
+
+
+
+Other Corporate Outlook Considerations
+Albemarle expects its full-year 2026 capital expenditures to be approximately $500 million, down 15% compared to 2025 due to ongoing capital efficiency improvements.
+
+
+Following the sale of a controlling stake in Ketjen’s refining catalyst solutions business, announced on March 2, 2026, the refining catalyst business earnings are now classified as equity income and included in Corporate, as are the results of the retained Performance Catalyst Solutions (PCS) business. The adjusted EBITDA and equity income contributions from these are expected to be immaterial post transaction.
+
+
+Interest and financing expense is expected to be between $120 and $140 million for 2026 following the debt reduction actions completed in the first quarter of 2026.
+| | | | | |
+| Other Corporate FY 2026E |
+Capital expenditures | ~$500 million |
+Depreciation and amortization | $660 - $680 million |
+Adjusted effective tax rate (a)
+| (50)% - 30% |
+Corporate adjusted EBITDA (incl. FX, Ketjen equity income & PCS) | ($20) - $20 million |
+Interest and financing expenses | $120 - $140 million |
+Weighted-average common shares outstanding (diluted) (b)
+| ~136 million |
+
+(a) Adjusted effective tax rate dependent on lithium market prices and geographic income mix
+(b) Diluted weighted-average common shares outstanding amount assumes the conversion of preferred stock and the net income attributable to common shareholders will not be reduced by mandatory convertible preferred stock dividends. If the reduction of mandatory convertible preferred stock dividends results in a more dilutive earnings per share, the diluted weighted-average common shares outstanding will not assume conversion of the preferred stock.
+
+
+Cash Flow and Capital Deployment
+Cash from operations of $1.1 billion in the first half of 2026 increased $518 million compared to the prior-year period. Capital expenditures of $170 million in the first six months of 2026 decreased by $132 million versus the prior-year period.
+
+
+Balance Sheet and Liquidity
+As of June 30, 2026, Albemarle had estimated liquidity of approximately $3.2 billion, including $1.6 billion of cash and cash equivalents, $1.5 billion available under our revolver and $78 million available under other credit lines. Total debt was $1.9 billion, representing a net debt to adjusted EBITDA ratio (as defined in our credit agreement) of approximately 0.5 (a) .
+(a) See Non-GAAP Reconciliations for further details.
+3
+
+
+
+
+
+Earnings Call | | | | | |
+Date: | Thurs., August 6, 2026 |
+Time: | 8:00 AM Eastern time |
+Dial-in (U.S.): | 1-800-590-8290 |
+Dial-in (International): | 1-240-690-8800 |
+Conference ID: | ALBQ2 |
+
+
+
+The company’s earnings presentation and supporting material are available on Albemarle’s website at https://investors.albemarle.com.
+
+
+About Albemarle
+Albemarle Corporation (NYSE: ALB) is a world leader in transforming essential resources into critical ingredients for mobility, energy, connectivity and health. We partner to pioneer new ways to move, power, connect and protect with people and planet in mind. A reliable and high-quality global supply of lithium and bromine allows us to deliver advanced solutions for our customers. Learn more about how the people of Albemarle are enabling a more resilient world at Albemarle.com.
+
+
+Albemarle regularly posts information to Albemarle.com, including notification of events, news, financial performance, investor presentations and webcasts, non-GAAP reconciliations, U.S. Securities and Exchange Commission filings and other information regarding the company, its businesses and the markets it serves.
+
+
+Forward-Looking Statements
+This press release contains statements concerning our expectations, anticipations and beliefs regarding the future, which constitute “forward-looking statements” within the meaning of the Private Securities Litigation Reform Act of 1995. These forward-looking statements, which are based on assumptions that we have made as of the date hereof and are subject to known and unknown risks and uncertainties, often contain words such as “ambition,” “anticipate,” “believe,” “estimate,” “expect,” “goal,” “guidance,” “intend,” “may,” “outlook,” “scenario,” “should,” “would,” and “will.” Forward-looking statements may include statements regarding: our 2026 company and segment outlooks, including expected market pricing of lithium carbonate equivalent and spodumene and other underlying assumptions and outlook consideration; plans and expectations regarding customer demand and sales; production impacts; financial flexibility and optionality; expected or actual market pricing of lithium, spodumene, bromine, and lithium specialties (“Company Products”); supply and demand for Company Products; drivers of long-term demand and growth; other underlying assumptions and outlook considerations; expected capital allocation and expenditure amounts and the corresponding impact on cash flow; expected impact of tariffs and other trade restrictions; plans and expectations regarding other mining interests, resources, reserves, projects and activities, compound annual growth rate, cost reductions, conversion network optimization, margin improvement, accounting charges, and all other information relating to matters that are not historical facts. Factors that could cause Albemarle’s actual results to differ materially from the outlook expressed or implied in any forward-looking statement include: changes in economic and business conditions; changes in trade policies and tariffs; and the financial and operating performance of customers; timing and magnitude of customer orders; fluctuations in market pricing of lithium carbonate equivalent and spodumene; potential production volume shortfalls; increased competition and pressure to renegotiate contract terms; changes in product or conversion demand; availability and cost of raw materials and energy; technological change and development; fluctuations in foreign currencies; changes in laws and government regulation; regulatory actions, proceedings, claims or litigation; cyber-security breaches, terrorist attacks, industrial accidents or natural disasters; risks related to the integration of artificial intelligence technologies into our operations; geopolitical conflicts and political unrest affecting global trade, including tensions in the Middle East; the global economy and clean energy initiatives; our ability to retain key personnel and attract new skilled personnel changes in inflation or interest rates; volatility and uncertainties in the debt and equity markets; acquisition and divestiture transactions; timing and success of projects; expected benefits and expenses from new operating structure and asset optimization activities; performance of Albemarle’s partners in joint ventures and other projects; changes in credit ratings; and the other factors detailed from time to time in the reports Albemarle files with the SEC, including those described under “Risk Factors” in Albemarle’s most recent Annual Report on Form 10-K and any subsequently filed Quarterly Reports on Form 10-Q, which are filed with the SEC and available on the investor section of Albemarle’s website (investors.albemarle.com) and on the SEC’s website at www.sec.gov. These forward-looking statements speak only as of the date of this press release. Albemarle assumes no obligation to provide any revisions to any forward-looking statements should circumstances change, except as otherwise required by securities and other applicable laws.
+
+
+
+
+
+4
+
+
+
+
+
+Albemarle Corporation and Subsidiaries
+Consolidated Statements of Income
+(In Thousands Except Per Share Amounts) (Unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+| June 30, | | June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Net sales | $ | 1,743,313 | | | $ | 1,329,992 | | | $ | 3,172,044 | | | $ | 2,406,873 | |
+Cost of goods sold | 1,153,012 | | | 1,133,116 | | | 2,080,777 | | | 2,053,698 | |
+Gross profit | 590,301 | | | 196,876 | | | 1,091,267 | | | 353,175 | |
+Selling, general and administrative expenses | 126,353 | | | 132,457 | | | 263,759 | | | 255,959 | |
+| | | | | | | |
+Restructuring charges and asset write-offs | 7,337 | | | 4,448 | | | 33,203 | | | 3,385 | |
+Research and development expenses | 3,667 | | | 12,444 | | | 12,837 | | | 26,543 | |
+Loss on sale of business | — | | | — | | | 95,018 | | | — | |
+| | | | | | | |
+Operating income | 452,944 | | | 47,527 | | | 686,450 | | | 67,288 | |
+Interest and financing expenses | (30,924) | | | (49,939) | | | (64,045) | | | (98,916) | |
+Other income (expenses), net | 19,629 | | | (6,559) | | | 73,439 | | | 3,691 | |
+Income (loss) before income taxes and equity in net income of unconsolidated investments | 441,649 | | | (8,971) | | | 695,844 | | | (27,937) | |
+Income tax expense | 94,002 | | | 34,094 | | | 115,513 | | | 30,116 | |
+Income (loss) before equity in net income of unconsolidated investments | 347,647 | | | (43,065) | | | 580,331 | | | (58,053) | |
+Equity in net income of unconsolidated investments (net of tax) | 151,564 | | | 78,258 | | | 247,857 | | | 142,544 | |
+| | | | | | | |
+| | | | | | | |
+Net income | 499,211 | | | 35,193 | | | 828,188 | | | 84,491 | |
+Net income attributable to noncontrolling interests | (19,252) | | | (12,296) | | | (29,138) | | | (20,246) | |
+Net income attributable to Albemarle Corporation | 479,959 | | | 22,897 | | | 799,050 | | | 64,245 | |
+Mandatory convertible preferred stock dividends | (41,687) | | | (41,687) | | | (83,375) | | | (83,375) | |
+Net income (loss) attributable to Albemarle Corporation common shareholders | $ | 438,272 | | | $ | (18,790) | | | $ | 715,675 | | | $ | (19,130) | |
+Basic earnings (loss) per share attributable to common shareholders | $ | 3.72 | | | $ | (0.16) | | | $ | 6.07 | | | $ | (0.16) | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+Diluted earnings (loss) per share attributable to common shareholders | $ | 3.52 | | | $ | (0.16) | | | $ | 5.87 | | | $ | (0.16) | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+Weighted-average common shares outstanding – basic | 117,961 | | | 117,665 | | | 117,907 | | | 117,634 | |
+Weighted-average common shares outstanding – diluted | 136,212 | | | 117,665 | | | 136,170 | | | 117,634 | |
+
+
+
+
+
+
+5
+
+
+
+
+
+Albemarle Corporation and Subsidiaries
+Condensed Consolidated Balance Sheets
+(In Thousands) (Unaudited)
+| | | | | | | | | | | |
+| June 30, | | December 31, |
+| 2026 | | 2025 |
+ASSETS | | | |
+Current assets: | | | |
+Cash and cash equivalents | $ | 1,631,688 | | | $ | 1,618,001 | |
+Trade accounts receivable | 603,805 | | | 593,502 | |
+Other accounts receivable | 123,870 | | | 105,110 | |
+Inventories | 1,384,563 | | | 1,179,271 | |
+Other current assets | 200,275 | | | 140,440 | |
+Current assets held for sale | — | | | 371,815 | |
+Total current assets
+| 3,944,201 | | | 4,008,139 | |
+Property, plant and equipment | 11,902,156 | | | 11,768,840 | |
+Less accumulated depreciation and amortization | 3,442,831 | | | 3,156,429 | |
+Net property, plant and equipment
+| 8,459,325 | | | 8,612,411 | |
+Investments | 1,109,241 | | | 900,926 | |
+Other assets | 707,577 | | | 647,185 | |
+Goodwill | 1,482,672 | | | 1,499,657 | |
+Other intangibles, net of amortization | 202,079 | | | 214,233 | |
+Noncurrent assets held for sale | — | | | 491,660 | |
+Total assets | $ | 15,905,095 | | | $ | 16,374,211 | |
+LIABILITIES AND EQUITY | | | |
+Current liabilities: | | | |
+Accounts payable to third parties | $ | 670,229 | | | $ | 779,160 | |
+Accounts payable to related parties | 445,421 | | | 134,369 | |
+Accrued expenses | 507,556 | | | 521,831 | |
+| | | |
+Current portion of long-term debt | 74,677 | | | 74,077 | |
+Dividends payable | 61,514 | | | 61,387 | |
+| | | |
+Income taxes payable | 131,703 | | | 35,467 | |
+Current liabilities held for sale | — | | | 191,753 | |
+Total current liabilities
+| 1,891,100 | | | 1,798,044 | |
+Long-term debt | 1,802,107 | | | 3,119,464 | |
+Postretirement benefits | 45,198 | | | 44,744 | |
+Pension benefits | 105,729 | | | 117,361 | |
+Other noncurrent liabilities | 1,158,555 | | | 1,084,892 | |
+Deferred income taxes | 368,552 | | | 368,275 | |
+Noncurrent liabilities held for sale | — | | | 59,970 | |
+Commitments and contingencies | | | |
+Equity: | | | |
+Albemarle Corporation shareholders’ equity: | | | |
+Common stock | 1,180 | | | 1,178 | |
+Mandatory convertible preferred stock | 2,235,105 | | | 2,235,105 | |
+Additional paid-in capital | 3,048,664 | | | 3,018,213 | |
+Accumulated other comprehensive loss | (243,599) | | | (334,807) | |
+Retained earnings | 5,233,819 | | | 4,613,676 | |
+Total Albemarle Corporation shareholders’ equity | 10,275,169 | | | 9,533,365 | |
+Noncontrolling interests | 258,685 | | | 248,096 | |
+Total equity | 10,533,854 | | | 9,781,461 | |
+Total liabilities and equity | $ | 15,905,095 | | | $ | 16,374,211 | |
+
+
+
+
+
+6
+
+
+
+
+
+Albemarle Corporation and Subsidiaries
+Selected Consolidated Cash Flow Data
+(In Thousands) (Unaudited)
+| | | | | | | | | | | |
+| Six Months Ended
+June 30, |
+| 2026 | | 2025 |
+Cash and cash equivalents at beginning of year | $ | 1,618,001 | | | $ | 1,192,230 | |
+Cash flows from operating activities: | | | |
+Net income | 828,188 | | | 84,491 | |
+Adjustments to reconcile net income to cash flows from operating activities: | | | |
+Depreciation and amortization | 313,606 | | | 330,485 | |
+| | | |
+| | | |
+| | | |
+| | | |
+Loss on sale of business | 95,018 | | | — | |
+Gain on sale of equity investment | (42,300) | | | — | |
+| | | |
+| | | |
+Stock-based compensation and other | 14,661 | | | 17,068 | |
+Equity in net income of unconsolidated investments (net of tax) | (247,857) | | | (142,544) | |
+Dividends received from unconsolidated investments and nonmarketable securities | 131,744 | | | 67,765 | |
+Pension and postretirement expense | 5,299 | | | 3,504 | |
+Pension and postretirement contributions | (14,298) | | | (9,934) | |
+| | | |
+Unrealized (gain) loss on investments in marketable securities | (2,792) | | | 4,984 | |
+Gain on early extinguishment of debt | (12,543) | | | — | |
+Deferred income taxes | (19,798) | | | (38,907) | |
+Working capital changes | (53,125) | | | (96,762) | |
+| | | |
+| | | |
+Noncurrent liability changes and other, net | 60,438 | | | 318,030 | |
+Net cash provided by operating activities | 1,056,241 | | | 538,180 | |
+Cash flows from investing activities: | | | |
+| | | |
+| | | |
+| | | |
+Capital expenditures | (170,407) | | | (302,252) | |
+| | | |
+Proceeds from sale of businesses, net of cash sold | 525,156 | | | — | |
+Proceeds from sale of property and equipment | — | | | 23,751 | |
+Proceeds from sale of investments | 123,270 | | | — | |
+Proceeds from sale of available for sale debt securities | — | | | 288,000 | |
+| | | |
+(Payments) proceeds from settlement of foreign currency forward contracts, net | (18,772) | | | 171,262 | |
+Sales of marketable securities, net | 1,392 | | | 2,971 | |
+| | | |
+Investments in equity investments and nonmarketable securities | (119) | | | (120) | |
+Net cash provided by investing activities | 460,520 | | | 183,612 | |
+Cash flows from financing activities: | | | |
+| | | |
+| | | |
+Repayments of long-term debt and credit agreements | (1,314,151) | | | (29,103) | |
+Proceeds from borrowings of long-term debt and credit agreements | 35,952 | | | 19,488 | |
+Other debt repayments, net | (12,309) | | | (2,427) | |
+Fees related to early extinguishment of debt | (1,686) | | | — | |
+Dividends paid to common shareholders | (95,372) | | | (95,244) | |
+Dividends paid to mandatory convertible preferred shareholders | (83,375) | | | (83,375) | |
+Dividends paid to noncontrolling interests | (37,463) | | | (18,169) | |
+| | | |
+Proceeds from exercise of stock options | 19,635 | | | 1,186 | |
+Withholding taxes paid on stock-based compensation award distributions | (4,199) | | | (2,941) | |
+| | | |
+Other | (438) | | | (55) | |
+Net cash used in financing activities | (1,493,406) | | | (210,640) | |
+Net effect of foreign exchange on cash and cash equivalents | (9,668) | | | 103,447 | |
+Increase in cash and cash equivalents | 13,687 | | | 614,599 | |
+Cash and cash equivalents at end of period | $ | 1,631,688 | | | $ | 1,806,829 | |
+
+7
+
+
+
+
+
+Albemarle Corporation and Subsidiaries
+Consolidated Summary of Segment Results
+(In Thousands) (Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+| June 30, | | June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Net sales: | | | | | | | |
+Energy Storage | $ | 1,276,684 | | | $ | 717,656 | | | $ | 2,167,849 | | | $ | 1,242,221 | |
+Specialties | 423,484 | | | 351,560 | | | 781,897 | | | 672,574 | |
+| | | | | | | |
+Total segment net sales | 1,700,168 | | | 1,069,216 | | | 2,949,746 | | | 1,914,795 | |
+| | | | | | | |
+Corporate and all other | 43,145 | | | 260,776 | | | 222,298 | | | 492,078 | |
+Total net sales | $ | 1,743,313 | | | $ | 1,329,992 | | | $ | 3,172,044 | | | $ | 2,406,873 | |
+| | | | | | | |
+Adjusted EBITDA: | | | | | | | |
+Energy Storage | $ | 723,457 | | | $ | 219,725 | | | $ | 1,274,813 | | | $ | 406,080 | |
+Specialties | 117,720 | | | 72,977 | | | 193,849 | | | 131,643 | |
+| | | | | | | |
+| | | | | | | |
+Total segment adjusted EBITDA | 841,177 | | | 292,702 | | | 1,468,662 | | | 537,723 | |
+Corporate and all other | 16,920 | | | 43,773 | | | 53,249 | | | 65,896 | |
+Total adjusted EBITDA | $ | 858,097 | | | $ | 336,475 | | | $ | 1,521,911 | | | $ | 603,619 | |
+
+
+
+See accompanying non-GAAP reconciliations below.
+
+
+Additional Information Regarding Non-GAAP Measures
+
+
+It should be noted that adjusted net income attributable to Albemarle Corporation, adjusted net income (loss) attributable to Albemarle Corporation common shareholders, adjusted diluted income (loss) per share attributable to common shareholders, non-operating pension and other post-employment benefit (“OPEB”) items per diluted share, non-recurring and other unusual items per diluted share, adjusted effective income tax rates, EBITDA, adjusted EBITDA (on a consolidated basis), EBITDA margin, adjusted EBITDA margin, operating cash flow conversion and net debt to adjusted EBITDA ratio are financial measures that are not required by, or presented in accordance with, accounting principles generally accepted in the United States, or GAAP. These non-GAAP measures should not be considered as alternatives to Net income attributable to Albemarle Corporation (“earnings”) or other comparable measures calculated and reported in accordance with GAAP. These measures are presented here to provide additional useful measurements to review the company’s operations, provide transparency to investors and enable period-to-period comparability of financial performance. The company’s chief operating decision maker uses these measures to assess the ongoing performance of the company and its segments, as well as for business and enterprise planning purposes.
+
+
+A description of other non-GAAP financial measures that Albemarle uses to evaluate its operations and financial performance, and reconciliation of these non-GAAP financial measures to the most directly comparable financial measures calculated and reported in accordance with GAAP can be found on the following pages of this press release, which is also is available on Albemarle’s website at https://investors.albemarle.com. The company does not provide a reconciliation of forward-looking non-GAAP financial measures to the most directly comparable financial measures calculated and reported in accordance with GAAP, as the company is unable to estimate significant non-recurring or unusual items without unreasonable effort. The amounts and timing of these items are uncertain and could be material to the company's results calculated in accordance with GAAP.
+
+
+8
+
+
+
+
+
+ALBEMARLE CORPORATION AND SUBSIDIARIES
+Non-GAAP Reconciliations
+(Unaudited)
+See below for a reconciliation of adjusted net income attributable to Albemarle Corporation, adjusted net income (loss) attributable to Albemarle Corporation common shareholders, EBITDA and adjusted EBITDA (on a consolidated basis), which are non-GAAP financial measures, to Net income attributable to Albemarle Corporation, the most directly comparable financial measure calculated and reported in accordance with GAAP. Adjusted net income attributable to Albemarle Corporation is defined as net income attributable to Albemarle Corporation before the non-recurring, other unusual and non-operating pension and other post-employment benefit (OPEB) items as listed below. The non-recurring and unusual items may include acquisition and integration related costs, gains or losses on sales of businesses, restructuring charges, facility divestiture charges, certain litigation and arbitration costs and charges, and other significant non-recurring items. Adjusted net income (loss) attributable to Albemarle Corporation common stockholders is defined as adjusted net income attributable to Albemarle Corporation after mandatory convertible preferred stock dividends. EBITDA is defined as net income attributable to Albemarle Corporation before interest and financing expenses, income tax expense (benefit), and depreciation and amortization. Adjusted EBITDA is defined as EBITDA plus or minus the proportionate share of Windfield Holdings income tax expense, non-recurring and other unusual items, and non-operating pension and OPEB items as listed below.
+9
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+
+
+| Three Months Ended | | Six Months Ended |
+
+
+| June 30, | | June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+In thousands, except percentages and per share amounts | $ | | % of net sales | | $ | | % of net sales | | $ | | % of net sales | | $ | | % of net sales |
+Net income attributable to Albemarle Corporation | $479,959 | | | |
+
+| $ | 22,897 | | | |
+
+| $ | 799,050 | | | |
+
+| $ | 64,245 | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+Add back: | | | | | | | | | | | | | | | |
+Non-operating pension and OPEB items (net of tax) | 626 | | | |
+
+| 169 | | | |
+
+| 1,597 | | | |
+
+| 294 | | | |
+Non-recurring and other unusual items (net of tax) | 30,555 | | | |
+
+| 31,708 | | | |
+
+| 111,945 | | | |
+
+| 10,508 | | | |
+Adjusted net income attributable to Albemarle Corporation | 511,140 | | | |
+
+| 54,774 | | | |
+
+| 912,592 | | | |
+
+| 75,047 | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+Mandatory convertible preferred stock dividends (a)
+| — | | | | | (41,687) | | | | | — | | | | | (83,375) | | | |
+Adjusted net income (loss) attributable to Albemarle Corporation common shareholders | $511,140 | | | | | $ | 13,087 | | | | | $ | 912,592 | | | | | $ | (8,328) | | | |
+
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+Adjusted diluted income (loss) per share attributable to common shareholders | $ | 3.75 | | | |
+
+| $ | 0.11 | | | |
+
+| $ | 6.70 | | | |
+
+| $ | (0.07) | | | |
+
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+Adjusted weighted-average common shares outstanding – diluted (a)
+| 136,212 | | | | | 117,691 | | | | | 136,170 | | | | | 117,634 | | | |
+
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+Net income attributable to Albemarle Corporation | $479,959 | | | 27.5 | % |
+
+| $ | 22,897 | | | 1.7 | % |
+
+| $ | 799,050 | | | 25.2 | % |
+
+| $ | 64,245 | | | 2.7 | % |
+Add back: |
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+| | | | | | | | | | | | | | | |
+Interest and financing expenses | 30,924 | | | 1.8 | % |
+
+| 49,939 | | | 3.8 | % |
+
+| 64,045 | | | 2.0 | % |
+
+| 98,916 | | | 4.1 | % |
+Income tax expense | 94,002 | | | 5.4 | % |
+
+| 34,094 | | | 2.6 | % |
+
+| 115,513 | | | 3.6 | % |
+
+| 30,116 | | | 1.3 | % |
+Depreciation and amortization | 155,801 | | | 8.9 | % |
+
+| 168,731 | | | 12.7 | % |
+
+| 313,606 | | | 9.9 | % |
+
+| 330,485 | | | 13.7 | % |
+EBITDA | 760,686 | | | 43.6 | % |
+
+| 275,661 | | | 20.7 | % |
+
+| 1,292,214 | | | 40.7 | % |
+
+| 523,762 | | | 21.8 | % |
+Proportionate share of Windfield income tax expense | 70,766 | | | 4.1 | % | | 33,150 | | | 2.5 | % | | 112,300 | | | 3.5 | % | | 58,476 | | | 2.4 | % |
+Non-operating pension and OPEB items | 854 | | | — | % |
+
+| 336 | | | — | % |
+
+| 2,201 | | | 0.1 | % |
+
+| 611 | | | — | % |
+Non-recurring and other unusual items | 25,791 | | | 1.5 | % |
+
+| 27,328 | | | 2.1 | % |
+
+| 115,196 | | | 3.6 | % |
+
+| 20,770 | | | 0.9 | % |
+Adjusted EBITDA | $858,097 | | | 49.2 | % |
+
+| $ | 336,475 | | | 25.3 | % |
+
+| $ | 1,521,911 | | | 48.0 | % |
+
+| $ | 603,619 | | | 25.1 | % |
+
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+
+|
+
+| | |
+Net sales | $ | 1,743,313 | | | |
+
+| $ | 1,329,992 | | | |
+
+| $ | 3,172,044 | | | |
+
+| $ | 2,406,873 | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+
+
+
+(a) Calculation of adjusted diluted income (loss) per share attributable to common shareholders for the three and six months ended June 30, 2026 excludes $41.7 million and $83.4 million, respectively, of mandatory convertible preferred stock dividends and includes the assumed conversion of preferred stock into the diluted shares outstanding, as this results in the more dilutive per share result.
+
+
+Non-operating pension and OPEB items, consisting of mark-to-market actuarial gains/losses, settlements/curtailments, interest cost and expected return on assets, are not allocated to Albemarle’s operating segments and are included in the Corporate and all other category. In addition, the company believes that these components of pension cost are mainly driven by market performance, and the company manages these separately from the operational performance of the company’s businesses. In accordance with GAAP, these non-operating pension and OPEB items are included in Other income (expenses), net. Non-operating pension and OPEB items were as follows (in thousands):
+
+
+10
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+| June 30, | | June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+| | | | | | | |
+| | | | | | | |
+Interest cost | $ | 8,994 | | | $ | 8,924 | | | $ | 18,035 | | | $ | 17,734 | |
+Expected return on assets | (8,140) | | | (8,588) | | | (15,834) | | | (17,123) | |
+Total | $ | 854 | | | $ | 336 | | | $ | 2,201 | | | $ | 611 | |
+
+
+
+In addition to the non-operating pension and OPEB items disclosed above, the company has identified certain other items and excluded them from Albemarle’s adjusted net income (loss) calculation for the periods presented. A listing of these items, as well as a detailed description of each follows below (per diluted share):
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+| June 30, | | June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Restructuring charges and asset write-offs (1)
+| $ | 0.05 | | | $ | 0.02 | | | $ | 0.24 | | | $ | 0.01 | |
+| | | | | | | |
+Acquisition and integration related costs (2)
+| 0.01 | | | 0.01 | | | 0.01 | | | 0.02 | |
+| | | | | | | |
+| | | | | | | |
+Loss on sale of business/equity investment, net (3)
+| — | | | — | | | 0.39 | | | — | |
+Gain on early extinguishment of debt (4)
+| — | | | — | | | (0.09) | | | — | |
+(Gain) loss in fair value of public equity securities (5)
+| (0.05) | | | — | | | (0.01) | | | 0.03 | |
+| | | | | | | |
+Other (6)
+| 0.17 | | | 0.13 | | | 0.20 | | | 0.05 | |
+Tax related items (7)
+| 0.04 | | | 0.11 | | | 0.08 | | | (0.02) | |
+Total non-recurring and other unusual items | $ | 0.22 | | | $ | 0.27 | | | $ | 0.82 | | | $ | 0.09 | |
+
+
+
+(1) In 2026, the Company announced it would place Kemerton Train 1 into care and maintenance. As a result, and in addition to other previously announced restructuring actions, the Company recorded charges of $7.3 million and $33.2 million in Restructuring charges and asset write-offs for the three and six months ended June 30, 2026, respectively. Due to the impact of valuation allowances, this resulted in total after-tax charges of $7.5 million and $33.3 million, or $0.05 and $0.24 per share, for the three and six months ended June 30, 2026, respectively. The three and six months ended June 30, 2025 included certain restructuring costs and adjustments to previously recorded costs related to restructuring actions originally entered into in 2024. As a result, the Company recorded charges of $4.4 million and $3.4 million in Restructuring charges and asset write-offs and gains (losses) of $0.1 million and ($0.1) million in Other income (expenses), net for the three and six months ended June 30, 2025, respectively. Due to the impact of valuation allowances, this resulted in total after-tax gains of $2.9 million and $0.8 million, or $0.02 and $0.01 per share, for the three and six months ended June 30, 2025, respectively.
+
+
+(2) Costs related to the acquisition, integration and divestitures for various significant projects, recorded in Selling, general and administrative expenses for the three and six months ended June 30, 2026 were $0.8 million and $1.9 million ($0.01 and $0.01 per share, with no income tax effect due to the impact of valuation allowances), respectively, and for the three and six months ended June 30, 2025 were $1.8 million and $3.2 million ($1.4 million and $2.5 million after income taxes, or $0.01 and $0.02 per share), respectively.
+
+
+(3) During the first quarter of 2026, the Company divested its controlling ownership interest in its Refining Solutions business and its full 50% ownership interest in the Eurecat joint venture. As a result of these transactions, the Company recorded a net loss of $52.7 million ($0.39 per share, with no income tax effect due to the impact of valuation allowances), representing the proceeds received less the carrying value as of the transaction dates.
+
+
+(4) During the first quarter of 2026, the Company completed a $1.3 billion debt tender and redemption, resulting in a gain on early extinguishment of debt of $12.5 million ($0.09 per share, with no income tax effect due to the impact of valuation allowances), representing the repurchase of this debt at a discount, partially offset by tender premiums and redemption fees.
+
+
+11
+
+
+
+
+
+(5) Gains resulting from the net change in fair value of investments in public equity securities, recorded in Other income (expenses), net for the three and six months ended June 30, 2026 of $6.5 million and $1.0 million ($0.05 and $0.01 per share, with no income tax effect due to the impact of valuation allowances), respectively, and for the three and six months ended June 30, 2025 gains (losses) of $0.2 million and ($4.8) million ($0.1 million and ($3.8 million) after income taxes, or less than $0.01 and $0.03 per share), respectively.
+
+
+(6) Other adjustments for the three months ended June 30, 2026 included amounts recorded in:
+• Cost of goods sold - $3.9 million of expenses related to non-routine labor and compensation related costs that are outside normal compensation arrangements.
+• Selling, general and administrative expenses - Primarily comprised of $19.0 million of expenses, mainly consulting fees, related to the Company's strategic cost savings initiative.
+• Other income (expenses), net - Primarily related to $3.4 million of charges for asset retirement obligations at a site not part of our operations and a net loss of $1.5 million primarily driven by indemnification charges related to the Eurecat S.A. joint venture sale, partially offset by a $3.9 million gain resulting from the adjustment of indemnification related to previously disposed businesses.
+After income taxes, these net losses totaled $22.8 million, or $0.17 per share.
+
+
+Other adjustments for the three months ended June 30, 2025 included amounts recorded in:
+• Selling, general and administrative expenses - $8.3 million of gains from the sale of assets not part of our production operations, partially offset by $1.8 million of severance expenses not related to a restructuring plan.
+• Other income (expenses), net - $38.0 million loss resulting from the redemption of preferred equity in a Grace subsidiary, partially offset by $10.1 million of income from PIK dividends of that preferred equity prior to redemption.
+After income taxes, these net losses totaled $15.3 million, or $0.13 per share.
+
+
+Other adjustments for the six months ended June 30, 2026 included amounts recorded in:
+• Cost of goods sold - $3.9 million of expenses related to non-routine labor and compensation related costs that are outside normal compensation arrangements.
+• Selling, general and administrative expenses - Primarily comprised of $19.0 million of expenses, mainly consulting fees, related to the Company's strategic cost savings initiative and a $3.9 million charge for a non-income tax audit of a facility no longer controlled by the Company.
+• Other income (expenses), net - Primarily related to $3.4 million of charges for asset retirement obligations at a site not part of our operations and a net loss of $1.5 million primarily driven by indemnification charges related to the Eurecat S.A. joint venture sale, partially offset by a $3.9 million gain resulting from the adjustment of indemnification related to previously disposed businesses.
+After income taxes, these net losses totaled $27.0 million, or $0.20 per share.
+
+
+Other adjustments for the six months ended June 30, 2025 included amounts recorded in:
+• Selling, general and administrative expenses - $11.4 million of gains from the sale of assets not part of our production operations, partially offset by $1.8 million of severance expenses not related to a restructuring plan and $0.6 million of expenses related to certain historical legal matters.
+• Other income (expenses), net - $38.0 million loss resulting from the redemption of preferred equity in a Grace subsidiary and $1.9 million of charges for asset retirement obligations at a site not part of our operations, partially offset by $19.8 million of income from PIK dividends of the preferred equity in a Grace subsidiary prior to redemption and a $1.9 million gain primarily resulting from the adjustment of indemnification related to previously disposed businesses.
+After income taxes, these net losses totaled $5.4 million, or $0.05 per share.
+
+
+(7) Included in Income tax expense for the three and six months ended June 30, 2026 are discrete net tax expenses of $6.0 million and $10.6 million, or $0.04 and $0.08 per share, respectively, primarily related to the impact of foreign tax reserves and foreign return to provisions.
+
+
+Included in Income tax expense for the three and six months ended June 30, 2025 are discrete net tax expenses of $12.2 million, or $0.11 per share, and benefits of $2.0 million, or $0.02 per share,
+12
+
+
+
+
+
+respectively, primarily related to the impact of foreign tax reserves and excess tax benefits realized from stock-based compensation arrangements.
+
+
+See below for a reconciliation of the adjusted effective income tax rate, the non-GAAP financial measure, to the effective income tax rate, the most directly comparable financial measure calculated and reporting in accordance with GAAP (in thousands, except percentages).
+| | | | | | | | | | | | | | | | | |
+| Income (loss) before income taxes and equity in net income of unconsolidated investments | | Income tax expense (benefit) | | Effective income tax rate |
+Three months ended June 30, 2026 | | | | | |
+As reported | $ | 441,649 | | | $ | 94,002 | | | 21.3 | % |
+Non-recurring, other unusual and non-operating pension and OPEB items | 26,691 | | | (4,490) | | | |
+As adjusted | $ | 468,340 | | | $ | 89,512 | | | 19.1 | % |
+| | | | | |
+Three months ended June 30, 2025 | | | | | |
+As reported | $ | (8,971) | | | $ | 34,094 | | | (380.0) | % |
+Non-recurring, other unusual and non-operating pension and OPEB items | 27,664 | | | (4,213) | | | |
+As adjusted | $ | 18,693 | | | $ | 29,881 | | | 159.9 | % |
+| | | | | |
+Six months ended June 30, 2026 | | | | | |
+As reported | $ | 695,844 | | | $ | 115,513 | | | 16.6 | % |
+Non-recurring, other unusual and non-operating pension and OPEB items | 104,853 | | | (8,689) | | | |
+As adjusted | $ | 800,697 | | | $ | 106,824 | | | 13.3 | % |
+| | | | | |
+Six months ended June 30, 2025 | | | | | |
+As reported | $ | (27,937) | | | $ | 30,116 | | | (107.8) | % |
+Non-recurring, other unusual and non-operating pension and OPEB items | 21,381 | | | 10,579 | | | |
+As adjusted | $ | (6,556) | | | $ | 40,695 | | | (620.7) | % |
+
+
+
+See below for the calculation of operating cash flow conversion and a reconciliation of free cash flow, a non-GAAP measure, to net cash provided by operating activities, the most directly comparable financial measure calculated and reporting in accordance with GAAP. The Company defines operating cash flow conversion as Net cash provided by operating activities from the statement of cash flows divided by adjusted EBITDA, which is a non-GAAP measure. A reconciliation of adjusted EBITDA, the non-GAAP financial measure, from net income attributable to Albemarle Corporation, the most directly comparable financial measure calculated and reporting in accordance with GAAP, is provided in the above tables (in thousands, except percentages).
+| | | | | |
+| Three Months Ended |
+| June 30, 2026 |
+Free cash flow: | |
+Net cash provided by operating activities | $ | 709,997 | |
+Less: Capital expenditures | (71,731) | |
+Free cash flow | $ | 638,266 | |
+| |
+Operating cash flow conversion: | |
+Net cash provided by operating activities | $ | 709,997 | |
+| |
+Adjusted EBITDA | $ | 858,097 | |
+| |
+Operating cash flow conversion | 83 | % |
+
+
+
+See below for the calculation of the net debt to adjusted EBITDA ratio (“Consolidated Leverage Ratio,” as defined in our credit agreement), a non-GAAP financial measure, for the twelve months ended June 30, 2026 (in thousands, except ratio).
+13
+
+
+
+
+
+| | | | | |
+| Twelve Months Ended |
+| June 30, 2026 |
+Adjusted EBITDA | $ | 2,016,285 | |
+Equity in net income of non-Windfield Holdings unconsolidated investments (net of tax) | 544 | |
+Dividends received from non-Windfield Holdings unconsolidated investments | 9,804 | |
+Consolidated Windfield-Adjusted EBITDA | $ | 2,026,633 | |
+| |
+Total Albemarle Corporation long-term debt (as reported) | $ | 1,876,784 | |
+49% Windfield Holdings debt | 718,079 | |
+Off-balance sheet obligations and other | 95,200 | |
+Consolidated Windfield-Adjusted Funded Debt | $ | 2,690,063 | |
+Less Cash | 1,631,688 | |
+Less 49% Windfield Holdings cash | 62,249 | |
+Consolidated Windfield-Adjusted Funded Net Debt | $ | 996,126 | |
+| |
+Consolidated Leverage Ratio | 0.5 |
+
+14

--- a/modules/test-fixtures/earnings-filings/app.txt
+++ b/modules/test-fixtures/earnings-filings/app.txt
@@ -1,0 +1,356 @@
+EX-99.1
+2
+exhibit991-2q26earningspre.htm
+PRESS RELEASE, DATED AUGUST 5, 2026
+
+
+
+
+Document
+Exhibit 99.1
+
+
+
+AppLovin Announces Second Quarter 2026 Financial Results
+
+
+
+PALO ALTO – August 5, 2026 – AppLovin Corporation (NASDAQ: APP) (“AppLovin”), a leading marketing platform, today announced financial results for the quarter ended June 30, 2026 and posted a financial update on its Investor Relations website located at https://investors.applovin.com .
+
+
+Second Quarter 2026 Financial Highlights:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended June 30, | | | | Six Months Ended June 30, | | |
+(In millions, except percentages) | 2026 | | 2025 | | % Change | | 2026 | | 2025 | | % Change |
+Revenue | $1,924 | | $1,259 | | 53 | % | | $3,766 | | $2,418 | | 56 | % |
+Net Income | $1,267 | | $820 | | 55 | % | | $2,472 | | $1,396 | | 77 | % |
+Net Income from Continuing Operations | $1,267 | | $772 | | 64 | % | | $2,472 | | $1,495 | | 65 | % |
+Adjusted EBITDA | $1,614 | | $1,018 | | 58 | % | | $3,171 | | $1,956 | | 62 | % |
+
+
+
+Additional Financial Highlights:
+
+
+● Net cash from operating activities was $869.0 million and Free Cash Flow was $863.3 million for the second quarter 2026.
+
+● Basic and Diluted earnings per share ("EPS") were $3.77 and $3.76, respectively, for the second quarter 2026.
+
+● During the second quarter 2026, we repurchased and withheld 1.1 million shares of our Class A common stock, for a total cost of $551.3 million 1 . At the end of 2Q 2026, we had 335 million shares of our Class A and Class B common stock outstanding.
+
+Third Quarter 2026 Financial Guidance Summary 2
+
+
+| | | | | | | | | | | |
+| 3Q26 |
+(In millions, except percentages) | Low | | High |
+Revenue | $2,055 | | $2,085 |
+Adjusted EBITDA | 1,710 | | 1,740 |
+Adjusted EBITDA Margin | 83 | % | | 83 | % |
+
+
+
+
+
+
+1 Includes repurchased shares as well as withholdings upon net share settlement of vested equity awards. Total cost includes repurchase costs, including commissions, taxes, and fees, as well as cash paid in connection with tax withholding and remittance obligations upon net share settlement.
+2 We have not provided the forward-looking GAAP equivalents for forward-looking non-GAAP metrics, specifically Adjusted EBITDA and Adjusted EBITDA margin, or a GAAP
+reconciliation as a result of the uncertainty regarding, and the potential variability of, reconciling items such as stock-based compensation expense. Accordingly, a reconciliation of
+these non-GAAP guidance metrics to their corresponding GAAP equivalents is not available without unreasonable effort. However, it is important to note that material changes to
+reconciling items could have a significant effect on future GAAP results. We have provided historical reconciliations of GAAP to non-GAAP metrics in tables at the end of this press release.
+1
+
+
+
+
+
+Webcast and Conference Call
+
+AppLovin will host a webinar today at 2:00 PM PT / 5:00 PM ET, during which management will discuss the Company’s second quarter 2026 results and provide commentary on its business performance. A question-and-answer session will follow the prepared remarks.
+
+
+The webinar may be accessed on the Company’s investor relations website or via webinar registration . A replay of the webinar will also be available under the Events & Presentations section of our Investor Relations website.
+
+About AppLovin
+AppLovin makes technologies that help businesses of every size connect to their ideal customers. The company provides end-to-end advertising solutions for businesses to reach, monetize and grow their global audiences. For more information about AppLovin, visit: www.applovin.com.
+
+
+Contacts
+| | | | | |
+Investors
+David Hsiao
+ir@applovin.com
+| Press
+Emelyne Interior
+press@applovin.com
+|
+
+
+
+Source: AppLovin Corp.
+
+
+
+
+Forward Looking Statements
+This press release contains forward-looking statements within the meaning of Section 27A of the Securities Act of 1933 and Section 21E of the Securities Exchange Act of 1934. Forward-looking statements generally relate to future events or our future financial or operating performance. In some cases, you can identify forward-looking statements because they contain words such as “may,” “will,” “should,” “expect,” “plan,” “anticipate,” “going to,” “could,” “intend,” “target,” “project,” “contemplate,” “believe,” “estimate,” “predict,” “potential,” or “continue,” or the negative of these words or other similar terms or expressions that concern our expectations, strategy, priorities, plans, or intentions. Forward-looking statements in this press release include our expected financial results and guidance. Our expectations and beliefs regarding these matters may not materialize, and actual results in future periods are subject to risks and uncertainties, including changes in our plans or assumptions, which could cause actual results to differ materially from those projected. These risks include our inability to forecast our business effectively, the macroeconomic environment, fluctuations in our results of operations, our ability to execute on our operational and financial priorities, our ability to scale our business to support new customers, the competitive advertising ecosystem, and our inability to adapt to emerging technologies and business models. The forward-looking statements contained in this press release are also subject to other risks and uncertainties, including those more fully described in our Quarterly Report on Form 10-Q for the fiscal quarter ended March 31, 2026. Additional information will also be set forth in our Quarterly Report on Form 10-Q for the quarter ended June 30, 2026. The forward-looking statements in this press release are based on information available to us as of the date hereof, and we disclaim any obligation to update any forward-looking statements, except as required by law.
+2
+
+
+
+
+
+Non-GAAP Financial Measures
+To supplement our financial information presented in accordance with generally accepted accounting principles in the United States (“GAAP”), this press release includes certain financial measures that are not prepared in accordance with GAAP, including Adjusted EBITDA, Adjusted EBITDA margin, and Free Cash Flow. A reconciliation of each such non-GAAP financial measure to the most directly comparable GAAP measure can be found below.
+We define Adjusted EBITDA for a particular period as net income adjusted for loss (income) from discontinued operations, net of income taxes, interest expense, other (income) expense, net (excluding certain recurring items), provision for income taxes, amortization, depreciation and write-offs and as further adjusted for non-operating foreign exchange gain, stock-based compensation, transaction-related expense, restructuring costs (benefits), as well as certain other items that we believe are not reflective of our core operating performance. We define Adjusted EBITDA margin as Adjusted EBITDA divided by revenue for the same period.
+
+
+We define Free Cash Flow as net cash provided by operating activities less purchases of property and equipment and principal payments on finance leases. We subtract both purchases of property and equipment and payment of finance leases in our calculation of Free Cash Flow because we believe these items represent our ongoing requirements for property and equipment to support our business, regardless of whether we utilize a finance lease to obtain such property or equipment.
+
+
+We believe that the presentation of these non-GAAP financial measures provides useful information to investors regarding our results of operations and operating performance, as they are similar to measures reported by our public competitors and are regularly used by securities analysts, institutional investors, and other interested parties in analyzing operating performance and prospects.
+
+
+Adjusted EBITDA and Adjusted EBITDA margin are key measures we use to assess our financial performance and are also used for internal planning and forecasting purposes. We believe Adjusted EBITDA and Adjusted EBITDA margin are helpful to investors, analysts, and other interested parties because they can assist in providing a more consistent and comparable overview of our operations across our historical financial periods. We use Adjusted EBITDA and Adjusted EBITDA margin in conjunction with GAAP measures as part of our overall assessment of our performance, including the preparation of our annual operating budget and quarterly forecasts, to evaluate the effectiveness of our business strategies, and to communicate with our board of directors concerning our financial performance. We use Free Cash Flow in addition to GAAP measures to help manage our business and prepare budgets and annual planning, and we believe Free Cash Flow provides useful supplemental information to help investors understand underlying trends in our business and our liquidity.
+
+
+These measures have certain limitations in that they do not include the impact of certain expenses that are reflected in our consolidated statement of operations that are necessary to run our business. Free Cash Flow reflects cash flows from both of continuing and discontinued operations. Our definitions may differ from the definitions used by other companies and therefore comparability may be limited. In addition, other companies may not publish these or similar metrics. Thus, our non-GAAP financial measures should be considered in addition to, not as substitutes for, or in isolation from, measures prepared in accordance with GAAP.
+3
+
+
+
+
+
+
+AppLovin Corporation
+Consolidated Balance Sheets
+(In thousands, except per share data)
+(Unaudited)
+
+
+
+
+| | | | | | | | | | | |
+| June 30,
+2026
+| | December 31, 2025 |
+Assets | | | |
+Current assets: | | | |
+Cash and cash equivalents | $ | 3,053,306 | | | $ | 2,487,096 | |
+Accounts receivable, net | 2,171,017 | | | 1,819,366 | |
+Prepaid expenses and other current assets | 167,993 | | | 124,330 | |
+Total current assets | 5,392,316 | | | 4,430,792 | |
+Property and equipment, net | 111,948 | | | 122,445 | |
+Goodwill | 1,518,587 | | | 1,539,986 | |
+Intangible assets, net | 355,661 | | | 396,714 | |
+Equity method investments | 289,959 | | | 287,666 | |
+Other non-current assets | 600,660 | | | 482,007 | |
+Total assets | $ | 8,269,131 | | | $ | 7,259,610 | |
+Liabilities and Stockholders’ Equity | | | |
+Current liabilities: | | | |
+Accounts payable | $ | 778,942 | | | $ | 746,977 | |
+Accrued and other current liabilities | 475,016 | | | 586,811 | |
+Total current liabilities | 1,253,958 | | | 1,333,788 | |
+Long-term debt | 3,515,072 | | | 3,512,987 | |
+Other non-current liabilities | 337,085 | | | 278,164 | |
+Total liabilities | 5,106,115 | | | 5,124,939 | |
+Stockholders’ equity: | | | |
+Preferred Stock, $0.00003 par value—100,000 shares authorized, no shares issued and outstanding as of June 30, 2026 and December 31, 2025 | — | | | — | |
+Class A, Class B, and Class C Common Stock, $0.00003 par value—1,850,000 (Class A 1,500,000, Class B 200,000, Class C 150,000) shares authorized, 335,291 (Class A 305,084, Class B 30,208, Class C nil) and 338,313 (Class A 307,955, Class B 30,358, Class C nil) shares issued and outstanding as of June 30, 2026 and December 31, 2025, respectively | 11 | | | 11 | |
+Additional paid-in capital | 575,057 | | | 446,550 | |
+Accumulated other comprehensive loss | (73,805) | | | (46,987) | |
+Retained earnings | 2,661,753 | | | 1,735,097 | |
+Total stockholders’ equity | 3,163,016 | | | 2,134,671 | |
+Total liabilities and stockholders’ equity | $ | 8,269,131 | | | $ | 7,259,610 | |
+
+
+
+4
+
+
+
+
+
+
+AppLovin Corporation
+Consolidated Statements of Operations
+(In thousands, except per share data)
+(Unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended June 30, | | | Six Months Ended June 30, |
+| 2026 | | 2025 | | | 2026 | | 2025 |
+Revenue | $ | 1,923,686 | | | $ | 1,258,754 | | | | $ | 3,766,135 | | | $ | 2,417,728 | |
+Costs and expenses: | | | | | | | | |
+Cost of revenue | 225,801 | | | 155,076 | | | | 429,433 | | | 306,756 | |
+Sales and marketing | 63,394 | | | 46,917 | | | | 124,145 | | | 106,300 | |
+Research and development | 99,901 | | | 44,032 | | | | 194,005 | | | 100,438 | |
+General and administrative | 40,313 | | | 55,047 | | | | 84,342 | | | 106,570 | |
+Total costs and expenses | 429,409 | | | 301,072 | | | | 831,925 | | | 620,064 | |
+Income from operations | 1,494,277 | | | 957,682 | | | | 2,934,210 | | | 1,797,664 | |
+Other income (expense): | | | | | | | | |
+Interest expense | (51,156) | | | (51,409) | | | | (102,315) | | | (104,297) | |
+Other income (expense), net
+| 62,405 | | | (22,269) | | | | 105,039 | | | (14,757) | |
+Total other income (expense), net
+| 11,249 | | | (73,678) | | | | 2,724 | | | (119,054) | |
+Income before income taxes | 1,505,526 | | | 884,004 | | | | 2,936,934 | | | 1,678,610 | |
+Provision for income taxes | 238,988 | | | 112,148 | | | | 464,783 | | | 183,216 | |
+Net income from continuing operations | 1,266,538 | | | 771,856 | | | | 2,472,151 | | | 1,495,394 | |
+Income (loss) from discontinued operations, net of income taxes
+| — | | | 47,675 | | | | — | | | (99,444) | |
+Net income | 1,266,538 | | | 819,531 | | | | 2,472,151 | | | 1,395,950 | |
+| | | | | | | | |
+Net income (loss) per share attributed to Class A and Class B common stockholders - Basic: | | | | | | | | |
+Continuing operations | $ | 3.77 | | | $ | 2.28 | | | | $ | 7.34 | | | $ | 4.41 | |
+Discontinued operations | — | | | 0.14 | | | | — | | | (0.30) | |
+Basic net income per share | $ | 3.77 | | | $ | 2.42 | | | | $ | 7.34 | | | $ | 4.11 | |
+| | | | | | | | |
+Net income (loss) per share attributed to Class A and Class B common stockholders - Diluted: | | | | | | | | |
+Continuing operations | $ | 3.76 | | | $ | 2.26 | | | | $ | 7.32 | | | $ | 4.35 | |
+Discontinued operations | — | | | 0.13 | | | | — | | | (0.29) | |
+Diluted net income per share | $ | 3.76 | | | $ | 2.39 | | | | $ | 7.32 | | | $ | 4.06 | |
+| | | | | | | | |
+Weighted-average common shares used to compute net income (loss) per share attributable to Class A and Class B common stockholders:
+| | | | | | | | |
+Basic | 335,800 | | | 338,617 | | | | 336,595 | | | 339,224 | |
+Diluted | 337,031 | | | 342,194 | | | | 337,875 | | | 343,529 | |
+
+
+
+
+
+5
+
+
+
+
+
+
+AppLovin Corporation
+Consolidated Statements of Cash Flows
+(In thousands)
+(Unaudited)
+
+
+| | | | | | | | | | | |
+| Six Months Ended June 30, |
+| 2026 | | 2025 |
+Operating Activities | | | |
+Net income | $ | 2,472,151 | | | $ | 1,395,950 | |
+Adjustments to reconcile net income to net cash provided by operating activities:
+| | | |
+Amortization, depreciation and write-offs | 66,228 | | | 126,940 | |
+Goodwill impairment | — | | | 188,943 | |
+Stock-based compensation, excluding cash-settled awards | 168,981 | | | 97,026 | |
+Gain on divestiture, net of transaction costs | — | | | (106,229) | |
+Other | (42,130) | | | 41,617 | |
+Changes in operating assets and liabilities: | | | |
+Accounts receivable | (352,557) | | | (291,551) | |
+Prepaid expenses and other assets | (56,890) | | | 20,691 | |
+Accounts payable | 29,617 | | | 39,040 | |
+Accrued and other liabilities | (124,967) | | | 91,511 | |
+Net cash provided by operating activities | 2,160,433 | | | 1,603,938 | |
+Investing Activities | | | |
+Proceeds from divestiture, net of cash divested | — | | | 424,702 | |
+Purchase of non-marketable equity securities | — | | | (18,678) | |
+Other investing activities | (7,688) | | | (27,140) | |
+Net cash provided by (used in) investing activities | (7,688) | | | 378,884 | |
+Financing Activities | | | |
+Repurchases of common stock
+| (1,532,952) | | | (1,272,429) | |
+Payment of withholding taxes related to net share settlement
+| (46,451) | | | (256,650) | |
+Principal repayments of debt | — | | | (200,000) | |
+Payments of licensed asset obligation | — | | | (13,532) | |
+Proceeds from issuance of debt | — | | | 200,000 | |
+Other financing activities | (3,248) | | | 3,017 | |
+Net cash used in financing activities | (1,582,651) | | | (1,539,594) | |
+Effect of foreign exchange rate on cash and cash equivalents | (3,884) | | | 7,969 | |
+Net increase in cash and cash equivalents, including cash from discontinued operations | 566,210 | | | 451,197 | |
+Less: net decrease in cash from discontinued operations
+| — | | | (44,381) | |
+Net increase in cash and cash equivalents | 566,210 | | | 495,578 | |
+Cash and cash equivalents at beginning of the period | 2,487,096 | | | 697,030 | |
+Cash and cash equivalents at end of the period | $ | 3,053,306 | | | $ | 1,192,608 | |
+| | | |
+Supplemental disclosure of cash flow information: | | | |
+Cash paid for interest | $ | 99,653 | | | $ | 99,553 | |
+Cash paid for income taxes, net of refunds | $ | 639,820 | | | $ | 100,621 | |
+
+6
+
+
+
+
+
+
+AppLovin Corporation
+Reconciliation of Net Cash Provided By Operating Activities to Free Cash Flow
+(In thousands)
+
+
+The following table provides a reconciliation of net cash provided by operating activities to Free Cash Flow for the periods presented:
+
+
+| | | | | | | | | | | | | | | | |
+| Quarter Ended June 30, | | | |
+| 2026 | | 2025 | | | | | |
+Net cash provided by operating activities | 869,040 | | | 772,226 | | | | | | |
+Less: | | | | | | | | |
+Purchase of property and equipment | (1,427) | | | (42) | | | | | | |
+Principal payments of finance leases
+| (4,296) | | | (4,121) | | | | | | |
+Free Cash Flow | $ | 863,317 | | | $ | 768,063 | | | | | | |
+Net cash provided by (used in) investing activities | $ | (2,441) | | | $ | 401,548 | | | | | | |
+Net cash used in financing activities | $ | (570,419) | | | $ | (537,377) | | | | | | |
+
+7
+
+
+
+
+
+
+AppLovin Corporation
+Reconciliation of Net Income to Adjusted EBITDA
+(In thousands, except percentages)
+
+
+The following table provides our Adjusted EBITDA and Adjusted EBITDA Margin and a reconciliation of Net Income to Adjusted EBITDA for the periods presented:
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Quarter Ended
+June 30, | | | Six Months Ended
+June 30, |
+| 2026 | | 2025 | | | 2026 | | 2025 |
+Revenue | $ | 1,923,686 | | $ | 1,258,754 | | | $ | 3,766,135 | | | $ | 2,417,728 | |
+Net income
+| 1,266,538 | | 819,531 | | | 2,472,151 | | | 1,395,950 | |
+Net margin
+| 66% | | 65% | | | 66% | | 58% |
+Loss (income) from discontinued operations, net of income taxes | — | | | (47,675) | | | | — | | | 99,444 | |
+Net income from continuing operations
+| 1,266,538 | | | 771,856 | | | | 2,472,151 | | | 1,495,394 | |
+Net margin from continuing operations
+| 66% | | 61% | | | 66% | | 62% |
+Adjusted as follows: | | | | | | | | |
+Interest expense | 51,156 | | | 51,409 | | | | 102,315 | | | 104,297 | |
+Other (income) expense, net | (59,863) | | | 12,798 | | | | (101,223) | | | 4,154 | |
+Provision for income taxes | 238,988 | | | 112,148 | | | | 464,783 | | | 183,216 | |
+Amortization, depreciation and write-offs | 32,563 | | | 31,064 | | | | 66,228 | | | 63,010 | |
+Non-operating foreign exchange gain | (2,364) | | | (1,210) | | | | (3,630) | | | (1,530) | |
+Stock-based compensation | 85,783 | | | 34,552 | | | | 169,252 | | | 93,667 | |
+Transaction-related expense | 59 | | | 5,097 | | | | 10 | | | 9,680 | |
+Restructuring costs | 963 | | | 633 | | | | 856 | | | 4,231 | |
+Adjusted EBITDA | $ | 1,613,823 | | | $ | 1,018,347 | | $ | 1,018,347 | | | $ | 3,170,742 | | | $ | 1,956,119 | |
+Adjusted EBITDA margin
+| 84% | | 81% | | | 84% | | 81% |
+
+
+
+8

--- a/modules/test-fixtures/earnings-filings/axon.txt
+++ b/modules/test-fixtures/earnings-filings/axon.txt
@@ -1,0 +1,792 @@
+EX-99.1
+2
+axon-20260805xex991.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+CONTACT:
+Investor Relations
+Axon Enterprise, Inc.
+IR@axon.com
+Axon reports Q2 2026 revenue of $904 million, up 35% year over year
+
+
+• Annual recurring revenue grows 39% to $1.6 billion; net revenue retention reaches 126%
+• Software & Services revenue grows 36% year over year to $398 million; AI Era revenue grows nearly 700%
+• Platform Solutions revenue grows 123% year over year to $150 million; Dedrone revenue surpasses $100 million
+• Reports net income of $29 million, non-GAAP net income of $155 million and Adjusted EBITDA of $242 million
+• Raises full-year revenue growth outlook to 32% to 34% ; maintains Adjusted EBITDA margin outlook at 25.5%
+Fellow shareholders,
+
+
+Axon delivered another record quarter, with revenue increasing 35% year over year to $904 million — our 10th consecutive quarter of revenue growth above 30%. Demand remained robust among both new and existing customers, supporting our vision to build the operating system for public safety and advancing our mission to protect life.
+
+
+Growth was broad-based across both segments. Software & Services revenue increased 36% year over year to $398 million, driven by new users and increased adoption of premium software offerings, including the AI Era Plan. Connected Devices revenue increased 35% year over year to $507 million, driven by Dedrone, TASER 10 and Axon Body 4. This performance reflects continued adoption across the Axon Ecosystem as customers connect more devices, data and workflows.
+
+
+Forward indicators were equally strong, with future contracted bookings growing 41% year over year to $15.1 billion. Notable wins included two nine-figure agreements with major U.S. cities, including the largest individual TASER order in our history, two eight-figure agreements with major state corrections customers and our first full-scope Axon 911 customer agreement. Momentum was also particularly strong in newer markets, with international and enterprise bookings each approximately tripling year over year. As we expand across these markets, where contract durations are often shorter than in state and local public safety, we are beginning to share new contract bookings on a five-year normalized basis to provide a more comparable view of underlying demand across end markets. On that basis, new contract bookings grew more than 30% year over year.
+
+
+Axon’s strategy is rooted in a relentless focus on delivering better outcomes for our customers and the communities they serve, supported by disciplined investment and execution. Alongside our growth, we delivered a net income margin of 3.3%, an Adjusted EBITDA margin of 26.8% and positive operating cash flow. We now expect 2026 revenue growth of 32% to 34%, up from 30% to 32% previously, and continue to expect an Adjusted EBITDA margin of approximately 25.5%.
+
+
+The examples below show the Axon Ecosystem in action—from citywide deployments and a global event to enterprise environments—and provide context for the financial performance and outlook that follow.
+
+
+
+
+
+
+
+
+
+Select Highlights
+The Axon Ecosystem
+Axon is building the largest connected network in public safety, bringing together sensors, customer-controlled data, AI-powered intelligence and response tools across the full mission chain. Fixed, body-worn and in-car cameras, drones and 911 systems create signals from the field. At the center, Axon Evidence and our broader cloud suite form the largest data repository in public safety, preserving and connecting video, audio and operational information across real-time operations, reporting, records and justice workflows.
+
+
+The relationship works in both directions, and the advantage compounds with each additional connection and data point. Each connected device enriches the data platform with additional signal and context, while the data and intelligence in the platform make every device, workflow and response more useful. AI and real-time operations help surface relevant information, automate routine tasks and accelerate decision-making, while keeping people at the center of critical decisions. TASER devices, Drone as First Responder (DFR), communications and training then help people act on that intelligence. As customers add devices, users and workflows, the network becomes more useful, more intelligent and more valuable. At the center of it all is our mission to Protect Life.
+
+
+“ I’m going to add multiple pieces of technology that need to work together — so I look at systems and how they’ll function. ” — Sheriff Michael Adkinson, Walton County, Florida
+
+
+The Network in Action
+The capabilities of the Axon network come together in different configurations for each customer and mission. Across deployments, the network follows a consistent operating arc:
+• Sense: Connected sensors identify an incident and add context.
+• Respond: Real-time awareness, training and response tools help coordinate the right response and shape what happens in the moment.
+• Resolve: Data moves through evidence, records and justice workflows to close the case and improve the next response.
+
+
+Because customers already rely on Axon across many of these workflows, they have a direct path to expand from one operational need into a comprehensive network. Today, over 80% of Axon customers deploy at least one integrated solution spanning hardware and software, while over 40% subscribe to at least one premium solution beyond our core TASER, body camera and evidence management products. The broadest deployments connect operations end to end across all three functions. Brookhaven Police Department provides one recent example of the measurable impact this model can deliver.
+
+
+Sense
+With DFR coverage across 96% of the city, Brookhaven achieved a 53-second average drone response time, providing rapid visibility into incidents as they unfolded.
+
+
+Respond
+By connecting DFR with Axon Respond, Fusus and field cameras, Brookhaven cleared 10% of calls without dispatching an officer .
+
+
+Resolve
+Brookhaven reported a 77% shoplifting clearance rate in 2025 and a 22% reduction in detective caseloads over two years . According to the department, no DFR-assisted cases had proceeded to trial, with defendants instead accepting plea agreements.
+
+
+Across the full deployment, Brookhaven also reported a 12% reduction in total index crime and a 45% reduction in burglaries in 2025.
+
+
+“ Our response time is under 60 seconds. So while you’re still typing the call into the CAD in another jurisdiction, we’ve already got the drone on the scene of the call. That’s DFR. ” — Captain Abrem Ayana, Brookhaven Police Department
+
+
+
+
+
+
+
+
+
+
+
+World Cup 2026
+The same foundation can scale beyond one city to increasingly complex missions. The 2026 World Cup demonstrated the network’s extensibility. Across U.S. host cities, agencies built on existing Axon deployments to support a mission of significantly greater scale and complexity, spanning stadiums, fan zones, transit corridors and surrounding communities.
+
+
+The World Cup deployment highlights:
+• Dedrone supported all 11 U.S. World Cup stadiums
+• More than 50 additional sites were supported, including fan zones, team facilities and other key venues
+• Multiple agencies, jurisdictions and data sources were connected through shared operating pictures
+
+
+“For FIFA, our security strategy is total visibility. Axon’s Ecosystem—from our new First Responder Drones in the air to our real-time intelligence center on the ground—means we aren’t just responding to incidents; we are seeing them unfold before officers even arrive. This technology allows us to de-escalate situations faster, track threats across a crowded city, and ensure that while the world is watching Dallas, everyone inside and outside the stadium stays safe.” — Daniel C. Comeaux, Chief of Police, Dallas
+
+
+The strategic significance extends beyond the event itself. The same real-time operations, DFR, counter-drone, ALPR and communications capabilities remain in place after the tournament, supporting routine patrol, severe weather response, retail crime intelligence and other daily needs.
+
+
+Axon Body Mini Launches for Enterprise
+In June, Axon Body Mini became generally available across the United States, Canada, the United Kingdom, the European Union, Australia and New Zealand. Purpose-built for frontline enterprise workers, Body Mini combines panic activation, livestreaming, two-way voice and Axon Assistant to provide immediate access to support.
+
+
+Early deployment activity demonstrates how workers are using the device when that support matters most:
+• 300+ cameras trialed across eight retail and healthcare organizations
+• 6,400+ recordings captured during early deployments
+• 620+ panic activations connecting workers with supervisor support
+• 420+ livestreams providing real-time visibility into unfolding situations
+
+
+Cosentino’s Food Stores provides another enterprise example, showing how an initial body-camera deployment can expand into a system for de-escalation, employee protection and incident management. Across 31 grocery locations, body-worn cameras, Axon Auto-Transcribe, Axon Evidence and retail crime intelligence workflows helped reduce physical confrontations, strengthen employee confidence and improve incident documentation, coaching and training.
+
+
+Together, these examples show how integrated deployments can deepen adoption among existing customers, extend Axon into new markets and strengthen the durability of our growth. Our financial results that follow reflect this momentum.
+
+
+Q2 2026 Summary Results
+Quarterly revenue of $904 million grew 35% year over year, driven by Software & Services revenue of $398 million, up 36% year over year, and Connected Devices revenue of $507 million, up 35% year over year.
+Total company gross margin of 60.4% was flat year over year and up 130 basis points sequentially. Excluding non-GAAP adjustments, adjusted gross margin of 62.9% decreased 40 basis points year over year and increased 130 basis points sequentially. Gross margin performance reflected a higher mix of professional services revenue and scaling new product offerings, partially offset by global tariff refunds received in the quarter.
+Operating income of $47 million increased $48 million year over year, driven by higher revenue and global tariff refunds, partially offset by increased investment to drive future growth.
+• COGS of $358 million, or 39.6% of revenue, included $11 million in stock-based compensation expense.
+
+
+
+
+
+
+
+
+
+• SG&A expense of $291 million, or 32.2% of revenue, included $71 million in stock-based compensation expense.
+• R&D expense of $209 million, or 23.1% of revenue, included $62 million in stock-based compensation expense.
+Net income of $29 million (3.3% net income margin), or $0.36 per diluted share, decreased from $36 million (5.4% net income margin) year over year. Non-GAAP net income of $155 million (17.2% non-GAAP net income margin), or $1.88 per diluted share, decreased from $179 million (26.7% non-GAAP net income margin), or $2.18 per diluted share. The year-over-year decreases in net income and non-GAAP net income primarily reflect a large tax benefit recognized in the prior year; pre-tax income increased year over year.
+Adjusted EBITDA of $242 million (26.8% Adjusted EBITDA margin) increased over 40% year over year, driven by higher revenue and global tariff refunds.
+Operating cash flow improved to $20 million from an outflow of $92 million in the prior year and drove free cash outflow of $1 million, a meaningful year-over-year improvement, primarily driven by higher EBITDA, partially offset by continued inventory investment to support customer demand and timing of customer billing and collections.
+As of June 30, 2026, Axon had $685 million in cash, cash equivalents and short-term investments and outstanding senior notes with a principal amount of $1.8 billion, resulting in a net debt position of $1.1 billion, up $46 million sequentially. Total cash received from tariff refunds was $47 million, including $18 million in expenses realized in 2025, and the remaining associated with amounts primarily classified as inventory and property and equipment, net, for which the majority would have been expensed in the current year.
+
+
+Detailed definitions of our non-GAAP financial measures and caution on the use of non-GAAP measures are included later in this letter .
+Financial commentary by segment
+Software & Services
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | CHANGE
+|
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | QoQ | | YoY |
+| (in thousands) | | | | |
+Revenue | $ | 397,836 | | $ | 354,524 | | $ | 292,178 | | 12.2 | % | | 36.2 | % |
+Gross margin | 71.3 | % | | 72.4 | % | | 75.6 | % | | (110) bp | | (430) bp |
+Adjusted gross margin | 75.1 | % | | 75.8 | % | | 78.9 | % | | (70) bp | | (380) bp |
+
+• Software & Services revenue grew 36% year over year, primarily driven by new users and increased adoption of premium software solutions by existing customers, including Axon Fusus, the AI Era Plan and Axon 911.
+• Software & Services gross margin of 71.3% decreased from 75.6% year over year. Excluding non-GAAP adjustments, adjusted gross margin of 75.1% decreased from 78.9%. The decrease in gross margin and adjusted gross margin was primarily driven by a higher mix of professional services revenue and scaling new product offerings. Software-only gross margin continued to exceed 80%.
+
+
+Connected Devices
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | CHANGE
+|
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | QoQ | | YoY |
+| (in thousands) | | | | |
+Revenue | $ | 506,553 | | $ | 452,821 | | $ | 376,360 | | 11.9 | % | | 34.6 | % |
+Gross margin | 51.9 | % | | 48.7 | % | | 48.6 | % | | 320 | bp | | 330 | bp |
+Adjusted gross margin | 53.4 | % | | 50.4 | % | | 51.1 | % | | 300 | bp | | 230 | bp |
+
+
+
+
+
+
+
+
+
+
+• Connected Devices revenue grew 35% year over year, primarily driven by Dedrone, TASER 10 and Axon Body 4.
+• Connected Devices gross margin increased to 51.9% from 48.6% a year ago and 48.7% in the prior quarter. Excluding non-GAAP adjustments, adjusted gross margin increased to 53.4% from 51.1% a year ago and 50.4% in the prior quarter. The improvement was primarily driven by global tariff refunds, partially offset by a higher revenue mix from Dedrone.
+
+
+Forward-Looking Operating Metrics
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| 30 JUN 2026 | | 31 MAR 2026 | | 31 DEC 2025 | | 30 SEP 2025 | | 30 JUN 2025 |
+| |
+Annual recurring revenue ($ millions) (1)
+| $ | 1,639 | | | $ | 1,493 | | | $ | 1,347 | | | $ | 1,252 | | | $ | 1,183 | |
+Net revenue retention (1)
+| 126 | % | | 125 | % | | 125 | % | | 124 | % | | 124 | % |
+Future contracted bookings ($ billions) (1)
+| $ | 15.1 | | | $ | 14.3 | | | $ | 14.4 | | | $ | 11.4 | | | $ | 10.7 | |
+
+____________________________________________________________________
+(1) Refer to “Statistical Definitions” below.
+• Annual recurring revenue grew 39% year over year to $1.6 billion, reflecting growing demand for premium software offerings, including our newer Axon 911 and AI Era solutions.
+• Net revenue retention reached 126% in the quarter, reflecting our ability to deliver additional value to customers over time with de minimis at trition. We drive adoption of our cloud software solutions through integrated subscription plans that include a variety of premium software options. This Software-as-a-Service (SaaS) metric excludes the hardware portion of customer subscriptions and is normalized to account for phased customer deployments throughout the year.
+• Future contracted bookings grew 41% year over year to $15.1 billion. T his operational metric tracks total unfulfilled contracted bookings for products and services, including remaining performance obligations as well as contracts with certain ter mination or other clauses that are not otherwise included in remaining performance obligations. We expect to fulfill between 20% and 25% of this balance over the next 12 months and generally expect the remainder to be fulfilled over the following ten years.
+2026 Outlook
+The following forward-looking statements reflect Axon’s expectations as of August 5, 2026 and are subject to risks and uncertainties. Please refer to “ Forward-Looking Statements ” below for additional information.
+
+
+• 2026 Revenue: Axon expects full-year 2026 revenue growth in a range of 32% to 34%, an increase from 30% to 32% previously. Our increased revenue guidance is supported by our continued execution against $15.1 billion in Future Contracted Bookings, and an expanding pipeline that supports our expectation for greater than 30% growth in five-year normalized bookings year over year for 2026.
+
+
+• 2026 Adjusted EBITDA: Axon expects full-year 2026 Adjusted EBITDA margin of 25.5%.
+
+
+◦ We provide Adjusted EBITDA guidance, rather than net income guidance, due to the inherent difficulty of forecasting certain types of expenses and gains such as income tax expenses and gains or losses on marketable securities and strategic investments, which affect net income but not Adjusted EBITDA. We are unable to reasonably estimate the impact of such expenses, which could be material, on net income. Accordingly, we do not provide a reconciliation of projected net income to projected Adjusted EBITDA.
+
+
+
+
+
+
+
+
+
+
+
+• 2026 Stock-based compensation: Axon expects full-year 2026 stock-based compensation expense to be approximately $590 million to $620 million, in line with prior guidance.
+
+
+◦ Full-year 2026 stock-based compensation expense includes approximately $280 million related to the broad-based Employee XSP and the CEO Performance Award, primarily within SG&A and R&D. These performance-based incentive programs are tied to stock price, operational, and time-based requirements.
+
+
+• 2026 CapEx: Axon expects 2026 CapEx to be in the range of $160 million to $190 million. Our 2026 capital expenditure plans include long-term R&D investment projects, continued capacity expansion, global facility build-outs and new product development costs. Expected capital expenditures do not include costs related to investments in a new headquarters.
+Quarterly conference call and webcast
+We will host our Q2 2026 earnings conference call webinar on Wednesday, August 5 at 2:00 p.m. PT / 5:00 p.m. ET
+
+
+The webcast will be available via a link on Axon's investor relations website at https://investor.axon.com or can be accessed directly via https://axon.zoom.us/j/92722647497 .
+Statistical Definitions
+Annual recurring revenue: Annual recurring revenue is a performance indicator that management believes provides more visibility into the growth of our revenue generated by our highest margin, recurring services. Annual recurring revenue should be viewed independently of revenue and deferred revenue because it is an operating measure and is not intended to be combined with or to replace GAAP revenue or deferred revenue, as they can be impacted by contract start and end dates and renewal rates. Annual recurring revenue is not intended to be a replacement or forecast of revenue or deferred revenue. We calculate annual recurring revenue as monthly recurring license, integration, warranty and storage revenue, annualized.
+
+
+Net revenue retention: Dollar-based net revenue retention is an important metric to measure our ability to retain and expand our relationships with existing customers. We calculate it as the software, camera and TASER warranty subscription and support revenue from a base set of agency customers from which we generated Axon Cloud subscription and warranty revenue in the last month of a quarter divided by the software and camera warranty subscription and support revenue from the year-ago month of that same customer base. This calculation includes high-margin warranty revenue but purposely excludes the lower-margin hardware subscription component of the customer contracts, as it is meant to be a SaaS metric that we use to monitor the health of the recurring revenue business we are building. This calculation also excludes the implied monthly revenue contribution of customers that were added since the year-ago quarter, and therefore excludes the benefit of new customer acquisition. The metric includes customers, if any, that terminated during the annual period, and therefore, this metric is inclusive of customer churn. This metric is downwardly adjusted to account for the effect of phased deployments — meaning that, for the year-ago period, we consider the total contractually obligated implied monthly revenue amount, rather than monthly revenue amounts that might have been in actuality smaller on a GAAP basis due to the customer not having yet fully deployed their Axon solution. For more information relative to our revenue recognition policies, please reference our filings with the Securities and Exchange Commission (SEC).
+
+
+
+
+
+
+
+
+
+
+
+Future contracted bookings: This operational metric tracks our total unfulfilled contracted bookings, including remaining performance obligations, in addition to contracts with certain termination or other clauses that exclude them from remaining performance obligations. Total future contracted bookings for products and services represent total orders that the Company has received and not yet performed. Beginning in Q3 2025, we have updated future contracted bookings to include cumulative gross bookings, including amounts associated with third-party agent arrangements, where we may only recognize the net portion expected to be paid on behalf of our customers as revenue. The impact of this change in historical periods was determined to be immaterial, so historical amounts have not been recast. The amounts associated with third-party agent arrangements not recognized will be eliminated from future contracted bookings upon fulfillment. This operational metric is subject to change based on future events, including terminations for convenience, the execution of optional periods or other contract modifications or cancellations. This operational metric may be unique to the Company, as it may be different from similarly titled operational metrics used by other companies. As such, the presentation of this operational metric may not enhance the comparability of the Company’s results to the results of other companies.
+
+
+Bookings: This operational metric represents total product and service orders the Company received during the period, including customer contracts with certain termination or cancellation clauses, optional periods or other clauses, as well as customer orders associated with third-party agent arrangements. To facilitate comparison across end markets with varying contract durations, the Company also presents five-year normalized bookings, which adjusts the value of new contract bookings to reflect a standardized five-year contract duration. The Company is beginning to provide this metric as growth in newer end markets, including international and enterprise, increases the mix of contracts with shorter durations than those often signed in state and local public safety. Management believes five-year normalized bookings provides a comparable view of underlying demand across end markets and periods.
+
+
+
+
+
+
+
+
+
+Supplementary Non-GAAP Measures
+To supplement the Company's financial results presented in accordance with GAAP, we present the non-GAAP financial measures of EBITDA, Adjusted EBITDA, Adjusted EBITDA margin, adjusted gross margin, non-GAAP net income, non-GAAP diluted earnings per share, free cash flow and adjusted free cash flow. The Company's management uses these non-GAAP financial measures in evaluating the Company's performance in comparison to prior periods. We believe that both management and investors benefit from referring to these non-GAAP financial measures in assessing the Company's performance, and when planning and forecasting our future periods. A reconciliation of GAAP to the non-GAAP financial measures is presented below.
+Beginning in the quarterly period ended March 31, 2026, we updated the calculation of Adjusted EBITDA to exclude all components of other income (loss), net — primarily resulting in incremental adjustments for foreign currency exchange gains and losses, net and fees incurred related to our Credit Agreement, as we do not consider these adjustments to be representative of our core operating results. For all comparable prior periods presented, our adjustment for other income (loss), net does not include the above incremental items, as the impact of this change on historical periods was determined to be de minimis. Accordingly, other income (loss), net for all comparable prior periods has not been recast and solely reflects adjustment for the impacts of net realized and unrealized gains on strategic investments and marketable securities, net realized gains on previously held minority interests acquired in business combinations and debt inducement expense.
+Furthermore, beginning in the quarterly period ended March 31, 2026, we updated the calculation of non-GAAP Net Income and non-GAAP Diluted Earnings per Share to exclude amortization expense incurred related to acquired intangible assets. Management's estimates and assumptions form the basis for determining allocation amounts, which are subject to amortization. Since the portion of the purchase price assigned to intangible assets along with the corresponding amortization period can differ considerably from one acquisition to another, we do not consider this activity to be representative of our core ongoing operations. For all comparable prior periods presented, non-GAAP Net Income and non-GAAP Diluted Earnings per Share have been recast, including the respective income tax effects.
+Furthermore, beginning in the quarterly period ended June 30, 2026, we updated the calculation of Adjusted EBITDA and Adjusted Gross Margin to exclude additional jurisdiction-specific compensation-related taxes incurred as a direct result of Employee XSP vesting events. This update expands upon our existing adjustment, which was historically limited to payroll taxes related to Employee XSP vesting events. For all comparable prior periods presented, our adjustment does not include any incremental jurisdiction-specific compensation-related taxes, as the impact of this change on historical periods was determined to be de minimis. Accordingly, compensation taxes related to Employee XSP vesting for all comparable prior periods has not been recast and solely reflects adjustment for payroll taxes incurred.
+
+
+• EBITDA (most comparable GAAP measure: Net income) – Earnings before interest expense, investment interest income, income taxes, depreciation and amortization.
+
+
+• Adjusted EBITDA (most comparable GAAP measure: Net income) – Earnings before interest expense; investment interest income; income taxes; depreciation; amortization; all components of other income (loss), net, which is primarily comprised of fair value adjustments and income or losses related to strategic investments and marketable securities, debt inducement expense associated with the early repurchase of a portion of our 2027 Notes, foreign currency exchange gains and losses, net, and fees incurred related to our Credit Agreement; noncash stock-based compensation expense; transaction and integration costs related to strategic investments and acquisitions, including the change in fair value of contingent consideration arrangements; non-recurring severance costs, including employee cash payments, equity, and related benefits; costs (or subsequent recoveries of prior costs) related to certain legal or regulatory matters we consider outside of our core operating activities; mark-to-market adjustments on our non-qualified deferred compensation liabilities; compensation taxes related to Employee XSP vesting; and inventory step-up amortization related to acquisitions.
+
+
+• Adjusted EBITDA margin (most comparable GAAP measure: Net income margin) – Adjusted EBITDA as a percentage of net sales.
+
+
+
+
+
+
+
+
+
+
+
+• Adjusted gross margin (most comparable GAAP measure: Gross margin) – Gross margin before noncash stock-based compensation expense; compensation taxes related to Employee XSP vesting; amortization of acquired intangible assets; non-recurring severance costs, including employee cash payments, equity, and related benefits; and inventory step-up amortization related to acquisitions.
+
+
+• Non-GAAP net income (most comparable GAAP measure: Net income) – Net income excluding fair value adjustments and income or losses related to strategic investments and marketable securities; the costs of noncash stock-based compensation expense; amortization of acquired intangible assets; transaction and integration costs related to strategic investments and acquisitions, including the change in fair value of contingent consideration arrangements; compensation taxes related to Employee XSP vesting; costs (or subsequent recoveries of prior costs) related to certain legal or regulatory matters we consider outside of our core operating activities; non-recurring severance costs, including employee cash payments, equity, and related benefits; debt inducement expense associated with the early repurchase of a portion of our 2027 Notes; and inventory step-up amortization related to acquisitions. The Company tax-effects non-GAAP adjustments using the blended statutory federal and state tax rates for each period presented.
+
+
+• Non-GAAP diluted earnings per share (most comparable GAAP measure: Earnings per share) – Measure of the Company's non-GAAP net income divided by the weighted average number of diluted common shares outstanding during the period presented.
+
+
+• Free cash flow (most comparable GAAP measure: Cash flow from operating activities) – Cash flows provided by operating activities minus purchases of property and equipment.
+
+
+• Adjusted free cash flow (most comparable GAAP measure: Cash flow from operating activities) – Free cash flow, excluding the net impact of investments in our new Scottsdale, Arizona campus and bond premium amortization.
+◦ We believe that free cash flow and adjusted free cash flow excluding the impact of bond premium amortization and net campus investment are non-GAAP measures that are useful to investors and management to evaluate the Company’s ability to generate cash. These non-GAAP measures can also be used to evaluate the Company’s ability to generate cash flow from operations and the impact that this cash flow has on the Company’s liquidity.
+Caution on Use of Non-GAAP Measures
+Although these non-GAAP financial measures are not consistent with GAAP, management believes investors will benefit by referring to these non-GAAP financial measures when assessing the Company's operating results, as well as when forecasting and analyzing future periods. However, management recognizes that:
+• these non-GAAP financial measures are limited in their usefulness and should be considered only as a supplement to the Company's GAAP financial measures;
+• these non-GAAP financial measures should not be considered in isolation from, or as a substitute for, the Company's GAAP financial measures;
+• these non-GAAP financial measures should not be considered to be superior to the Company's GAAP financial measures; and
+• these non-GAAP financial measures were not prepared in accordance with GAAP or under a comprehensive set of rules or principles proposed by a third party.
+Further, these non-GAAP financial measures may be unique to the Company, as they may be different from similarly titled non-GAAP financial measures used by other companies. As such, this presentation of non-GAAP financial measures may not enhance the comparability of the Company's results to the results of other companies.
+
+
+
+
+
+
+
+
+
+About Axon
+Axon (Nasdaq: AXON) is the global leader in public safety technology, relentlessly innovating to protect more lives in more places. Founder-led since 1993, Axon began with a mission to reimagine conflict in law enforcement and has grown into a global company serving everyone who takes on the responsibility of public safety, enterprise security, and national security — from first responders and governments to companies, frontline workers, and communities. Our trusted network connects TASER energy devices, cameras and sensors including body-worn, fixed and in-car cameras, drones and robotics, digital evidence and records management, real-time operations, immersive training, productivity tools, and AI-driven capabilities and insights. Designed to work seamlessly together, these solutions create a connected picture of safety that helps protect people and places with greater speed, clarity, and accountability.
+Non-Axon trademarks are property of their respective owners.
+Axon, Axon 911, Axon Assistant, AI Era Plan, Axon Body, Axon Body Mini, Axon Ecosystem, Axon Evidence, Axon Fusus, Axon Auto-Transcribe, Dedrone, TASER, TASER 10, the Filled Bolt within Circle Logo and the Delta Logo are trademarks of Axon Enterprise, Inc., some of which are registered in the United States and other countries. For more information, visit www.axon.com/legal. All rights reserved.
+Forward-looking Statements
+Forward-looking statements in this letter include, without limitation, statements regarding: proposed products and services and related development efforts and activities; expectations about the market for our current and future products and services, including statements related to our user base and customer profiles; strategies and trends relating to subscription plan programs and revenues; our expectations about the future implementation of new strategies related to artificial intelligence; the timing and realization of future contracted revenue; the fulfillment of bookings; the timing of product shipment and delivery; strategies and trends, including the amounts and benefits of R&D investments; the sufficiency of our liquidity and financial resources; expectations about customer behavior; statements concerning projections, predictions, expectations, estimates or forecasts as to our business, financial and operational results and future economic performance, including our outlook for 2026 full-year revenue, stock-based compensation expense, Adjusted EBITDA, Adjusted EBITDA margin, and capital expenditures; statements of management’s strategies, goals and objectives and other similar expressions; as well as the ultimate resolution of financial statement items requiring critical accounting estimates, including those set forth in our Annual Report on Form 10‑K for the year ended December 31, 2025 and our Quarterly Report on Form 10-Q for the quarter ended June 30, 2026. Such statements give our current expectations or forecasts of future events; they do not relate strictly to historical or current facts. Words such as “may,” “will,” “should,” “could,” “would,” “predict,” “potential,” “continue,” “expect,” “anticipate,” “future,” “intend,” “plan,” “believe,” “estimate,” and similar expressions, as well as statements in future tense, identify forward-looking statements. However, not all forward-looking statements contain these identifying words.
+
+
+
+
+
+
+
+
+
+
+
+We cannot guarantee that any forward-looking statement will be realized, although we believe we have been prudent in our plans and assumptions. Achievement of future results is subject to risks, uncertainties and potentially inaccurate assumptions. The following important factors could cause actual results to differ materially from those in the forward-looking statements: our exposure to cancellations of government contracts due to non-appropriation clauses, exercise of a cancellation clause or non-exercise of contractually optional periods; the ability of law enforcement agencies to obtain funding, including based on tax revenues; our ability to design, introduce and sell new products, services or features; our ability to defend against litigation and protect our intellectual property, and the resulting costs of this activity; our ability to win bids through the open bidding process for governmental agencies; our ability to manage our supply chain and avoid production delays, shortages and impacts to expected gross margins; the impacts of inflation, macroeconomic conditions and global events; the impact of catastrophic events or public health emergencies; the impact of stock-based compensation expense, impairment expense and income tax expense on our financial results; customer purchase behavior, including adoption of our software as a service delivery model; negative media publicity or sentiment regarding our products; the impact of various factors on projected gross margins; defects in, or misuse of, our products; changes in the costs of product components and labor; loss of customer data, a breach of security or an extended outage, including by our third-party cloud-based storage providers; exposure to international operational risks; delayed cash collections and possible credit losses due to our subscription model; changes in government regulations in the United States and in foreign markets, especially related to the classification of our products by the United States Bureau of Alcohol, Tobacco, Firearms and Explosives; our ability to integrate acquired businesses; the impact of declines in the fair values or impairment of our investments, including our strategic investments; our ability to attract and retain key personnel; litigation or inquiries and related time and costs; and counterparty risks relating to cash balances held in excess of federally insured limits. Many events beyond our control may determine whether results we anticipate will be achieved. Should known or unknown risks or uncertainties materialize, or should underlying assumptions prove inaccurate, actual results could differ materially from past results and those anticipated, estimated or projected. You should bear this in mind as you consider forward-looking statements. These factors are intended as cautionary statements for investors within the meaning of Section 21E of the Securities Exchange Act of 1934, as amended, and Section 27A of the Securities Act of 1933, as amended. Readers can find them under the heading “Risk Factors” in our Annual and Quarterly Reports, and investors should refer to them. You should understand that it is not possible to predict or identify all such factors. Consequently, you should not consider any such list to be a complete set of all potential risks or uncertainties.
+
+Except as required by law, we undertake no obligation to publicly update forward-looking statements, whether as a result of new information, future events or otherwise. You are advised, however, to consult any further disclosures we make on related subjects in our Form 8-K, 10‑Q and 10‑K reports to the SEC. Our filings with the SEC may be accessed at the SEC’s website at www.sec.gov.
+
+
+
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+CONSOLIDATED STATEMENTS OF OPERATIONS
+(in thousands, except per share data)
+(unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+Net sales from products | $ | 506,553 | | | $ | 452,821 | | | $ | 376,360 | | | $ | 959,374 | | $ | 717,256 |
+Net sales from services | 397,836 | | | 354,524 | | | 292,178 | | | 752,360 | | 554,915 |
+Net sales | 904,389 | | | 807,345 | | | 668,538 | | | 1,711,734 | | 1,272,171 |
+Cost of product sales | 243,861 | | | 232,156 | | | 193,507 | | | 476,017 | | 363,688 |
+Cost of service sales | 114,081 | | | 97,903 | | | 71,288 | | | 211,984 | | 139,001 |
+Cost of sales | 357,942 | | | 330,059 | | | 264,795 | | | 688,001 | | 502,689 |
+Gross margin | 546,447 | | | 477,286 | | | 403,743 | | | 1,023,733 | | 769,482 |
+Operating expenses: | | | | | | | | | |
+Selling, general and administrative | 290,982 | | | 259,093 | | | 242,212 | | | 550,075 | | 465,721 |
+Research and development | 208,687 | | | 188,950 | | | 162,567 | | | 397,637 | | 313,590 |
+Total operating expenses | 499,669 | | | 448,043 | | | 404,779 | | | 947,712 | | 779,311 |
+Income (loss) from operations
+| 46,778 | | | 29,243 | | | (1,036) | | | 76,021 | | (9,829) |
+Interest income | 6,815 | | | 10,611 | | | 23,253 | | | 17,426 | | 33,857 |
+Interest expense | (28,101) | | | (28,643) | | | (28,686) | | | (56,744) | | | (36,507) | |
+Other income (loss), net | 7,192 | | | 189,010 | | | (32,414) | | | 196,202 | | | 81,987 | |
+Income (loss) before provision for income taxes | 32,684 | | | 200,221 | | | (38,883) | | | 232,905 | | | 69,508 | |
+Provision for (benefit from) income taxes | 3,257 | | | 30,909 | | | (75,000) | | | 34,166 | | | (54,589) | |
+Net income | $ | 29,427 | | | $ | 169,312 | | | $ | 36,117 | | | $ | 198,739 | | $ | 124,097 |
+Net income per common and common equivalent shares: | | | | | | | | | |
+Basic | $ | 0.37 | | | $ | 2.11 | | | $ | 0.46 | | | $ | 2.47 | | $ | 1.60 |
+Diluted | $ | 0.36 | | | $ | 2.05 | | | $ | 0.44 | | | $ | 2.41 | | $ | 1.52 |
+Weighted average number of common and common equivalent shares outstanding: | | | | | | | | | |
+Basic | 80,573 | | | 80,150 | | | 77,999 | | | 80,363 | | 77,448 |
+Diluted | 82,541 | | | 82,478 | | | 82,062 | | | 82,518 | | 81,782 |
+
+
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+SALES BY PRODUCT AND SERVICE
+(in thousands)
+(unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | THREE MONTHS ENDED | | THREE MONTHS ENDED
+|
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 |
+| Connected Devices | | Software & Services | | Total | | Connected Devices | | Software & Services | | Total | | Connected Devices | | Software & Services | | Total |
+TASER (1)
+| $ | 261,321 | | | $ | — | | | $ | 261,321 | | | $ | 232,853 | | | $ | — | | | $ | 232,853 | | | $ | 216,234 | | | $ | — | | | $ | 216,234 | |
+Personal Sensors (2)
+| 95,392 | | | — | | | 95,392 | | | 108,751 | | | — | | | 108,751 | | | 92,819 | | | — | | | 92,819 | |
+Platform Solutions (3)
+| 149,840 | | | — | | | 149,840 | | | 111,217 | | | — | | | 111,217 | | | 67,307 | | | — | | | 67,307 | |
+Software & Services | — | | | 397,836 | | | 397,836 | | | — | | | 354,524 | | | 354,524 | | | — | | | 292,178 | | | 292,178 | |
+Total | $ | 506,553 | | | $ | 397,836 | | | $ | 904,389 | | | $ | 452,821 | | | $ | 354,524 | | | $ | 807,345 | | | $ | 376,360 | | | $ | 292,178 | | | $ | 668,538 | |
+
+____________________________________________________________________________________
+(1) 'TASER' includes TASER handles, cartridges and related extended warranties.
+(2) 'Personal Sensors' primarily includes body cameras and accessories, signal sidearm, and related extended warranties.
+(3) 'Platform Solutions' primarily includes fleet in-car video, interview room, fixed cameras, drones and counter-drone equipment, virtual reality training hardware, and related extended warranties.
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| SIX MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 30 JUN 2025 |
+| Connected Devices | | Software & Services | | Total | | Connected Devices | | Software & Services | | Total |
+TASER (1)
+| $ | 494,174 | | | $ | — | | | $ | 494,174 | | | $ | 411,729 | | | $ | — | | | $ | 411,729 | |
+Personal Sensors (2)
+| 204,143 | | | — | | | 204,143 | | | 181,224 | | | — | | | 181,224 | |
+Platform Solutions (3)
+| 261,057 | | | — | | | 261,057 | | | 124,303 | | | — | | | 124,303 | |
+Software & Services | — | | | 752,360 | | | 752,360 | | | — | | | 554,915 | | | 554,915 | |
+Total | $ | 959,374 | | | $ | 752,360 | | | $ | 1,711,734 | | | $ | 717,256 | | | $ | 554,915 | | | $ | 1,272,171 | |
+
+____________________________________________________________________________________
+(1) 'TASER' includes TASER handles, cartridges and related extended warranties.
+(2) 'Personal Sensors' primarily includes body cameras and accessories, signal sidearm, and related extended warranties.
+(3) 'Platform Solutions' primarily includes fleet in-car video, interview room, fixed cameras, drones and counter-drone equipment, virtual reality training hardware, and related extended warranties.
+
+
+
+
+
+
+
+
+
+
+
+
+SALES BY GEOGRAPHY
+(in thousands)
+(unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | THREE MONTHS ENDED | | THREE MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 |
+United States | $ | 742,307 | | | 82 | % | | $ | 646,527 | | | 80 | % | | $ | 537,373 | | | 80 | % |
+Other countries | 162,082 | | | 18 | | | 160,818 | | | 20 | | | 131,165 | | | 20 | |
+Total | $ | 904,389 | | | 100 | % | | $ | 807,345 | | | 100 | % | | $ | 668,538 | | | 100 | % |
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| SIX MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 30 JUN 2025 |
+United States | $ | 1,388,834 | | | 81 | % | | $ | 1,066,756 | | | 84 | % |
+Other countries | 322,900 | | | 19 | | | 205,415 | | | 16 | |
+Total | $ | 1,711,734 | | | 100 | % | | $ | 1,272,171 | | | 100 | % |
+
+
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES
+(in thousands)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+EBITDA and Adjusted EBITDA: | | | | | | | | | |
+Net income | $ | 29,427 | | $ | 169,312 | | $ | 36,117 | | $ | 198,739 | | $ | 124,097 |
+Depreciation and amortization | 31,615 | | 29,346 | | 19,324 | | 60,961 | | 38,519 |
+Interest expense | 28,101 | | 28,643 | | 28,686 | | 56,744 | | 36,507 |
+Investment interest income | (6,815) | | (10,611) | | (23,253) | | (17,426) | | (33,857) |
+Provision for (benefit from) income taxes | 3,257 | | 30,909 | | (75,000) | | 34,166 | | (54,589) |
+EBITDA | $ | 85,585 | | $ | 247,599 | | $ | (14,126) | | $ | 333,184 | | $ | 110,677 |
+| | | | | | | | | |
+Non-GAAP adjustments: | | | | | | | | | |
+Other (income) loss, net | $ | (7,192) | | $ | (189,010) | | $ | 32,167 | | $ | (196,202) | | $ | (83,088) |
+Stock-based compensation expense | 144,320 | | 133,685 | | 139,244 | | 278,005 | | 279,483 |
+Transaction costs related to strategic investments and acquisitions | 4,560 | | 6,488 | | 2,230 | | 11,048 | | 4,957 |
+Compensation taxes related to Employee XSP vesting | 9,417 | | 115 | | 9,782 | | 9,532 | | 9,782 |
+Litigation and regulatory costs | 1,886 | | 1,334 | | 774 | | 3,220 | | 2,823 |
+Severance costs (1)
+| 681 | | 2,049 | | — | | 2,730 | | — |
+Non-qualified deferred compensation liability adjustments | 2,767 | | (630) | | 1,561 | | 2,137 | | 1,561 |
+Inventory step-up amortization | — | | — | | — | | — | | 607 |
+Adjusted EBITDA | $ | 242,024 | | $ | 201,630 | | $ | 171,632 | | $ | 443,654 | | $ | 326,802 |
+Net income as a percentage of net sales | 3.3 | % | | 21.0 | % | | 5.4 | % | | 11.6 | % | | 9.8 | % |
+Adjusted EBITDA as a percentage of net sales | 26.8 | % | | 25.0 | % | | 25.7 | % | | 25.9 | % | | 25.7 | % |
+| | | | | | | | | |
+Stock-based compensation expense: | | | | | | | | | |
+Cost of product and service sales | $ | 11,341 | | $ | 10,709 | | $ | 12,561 | | $ | 22,050 | | $ | 25,448 |
+Selling, general and administrative expenses | 70,988 | | 66,519 | | 72,187 | | 137,507 | | 143,534 |
+Research and development expenses | 61,667 | | 57,473 | | 54,496 | | 119,140 | | 110,501 |
+Total stock-based compensation expense | 143,996 | | 134,701 | | 139,244 | | 278,697 | | 279,483 |
+Severance costs (2)
+| (324) | | 1,016 | | — | | 692 | | — |
+Total stock-based compensation expense, excluding non-recurring severance costs | $ | 144,320 | | $ | 133,685 | | $ | 139,244 | | $ | 278,005 | | $ | 279,483 |
+
+____________________________________________________________________________________
+(1) For the six months ended June 30, 2026, non-recurring severance costs of $2.7 million consisted of stock-based compensation, cash payments and employee benefits.
+
+
+(2) For the six months ended June 30, 2026, stock-based compensation expense included $0.7 million of non-recurring severance costs. The majority of these costs were recorded in selling, general and administrative expenses.
+
+
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES - continued
+(in thousands)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+Non-GAAP net income: | | | | | | | | | |
+GAAP net income | $ | 29,427 | | $ | 169,312 | | $ | 36,117 | | $ | 198,739 | | $ | 124,097 |
+Non-GAAP adjustments: | | | | | | | | | |
+(Income) or losses from investments and marketable securities, net | (6,784) | | (191,089) | | 32,167 | | (197,873) | | (111,754) |
+Stock-based compensation expense | 144,320 | | 133,685 | | 139,244 | | 278,005 | | 279,483 |
+Amortization of acquired intangible assets | 13,445 | | 11,500 | | 6,746 | | 24,945 | | 13,309 |
+Transaction costs related to strategic investments and acquisitions | 4,560 | | 6,488 | | 2,230 | | 11,048 | | 4,957 |
+Compensation taxes related to Employee XSP vesting | 9,417 | | 115 | | 9,782 | | 9,532 | | 9,782 |
+Litigation and regulatory costs | 1,886 | | 1,334 | | 774 | | 3,220 | | 2,823 |
+Severance costs (1)
+| 681 | | 2,049 | | — | | 2,730 | | — |
+Debt inducement expense | — | | — | | — | | — | | 28,666 |
+Inventory step-up amortization | — | | — | | — | | — | | 607 |
+Income tax effects | (41,475) | | (453) | | (48,275) | | (41,928) | | (53,359) |
+Non-GAAP net income | $ | 155,477 | | $ | 132,941 | | $ | 178,785 | | $ | 288,418 | | $ | 298,611 |
+Non-GAAP net income as a percentage of net sales | 17.2 | % | | 16.5 | % | | 26.7 | % | | 16.8 | % | | 23.5 | % |
+| | | | | | | | | |
+Diluted income per common share | | | | | | | | | |
+GAAP | $ | 0.36 | | $ | 2.05 | | $ | 0.44 | | $ | 2.41 | | $ | 1.52 |
+Non-GAAP | $ | 1.88 | | $ | 1.61 | | $ | 2.18 | | $ | 3.50 | | $ | 3.65 |
+| | | | | | | | | |
+Weighted average number of diluted common and common equivalent shares outstanding | 82,541 | | 82,478 | | 82,062 | | 82,518 | | 81,782 |
+
+____________________________________________________________________________________
+(1) For the three and six months ended June 30, 2026, non-recurring severance costs of $0.7 million and $2.7 million, respectively, consisted of stock-based compensation, cash payments and employee benefits.
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES - continued
+(in thousands)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+Net sales | $ | 904,389 | | | $ | 807,345 | | | $ | 668,538 | | | $ | 1,711,734 | | | $ | 1,272,171 | |
+Cost of sales | (357,942) | | | (330,059) | | | (264,795) | | | (688,001) | | | (502,689) | |
+Gross margin | 546,447 | | | 477,286 | | | 403,743 | | | 1,023,733 | | | 769,482 | |
+Stock-based compensation expense | 11,341 | | | 10,503 | | | 12,561 | | | 21,844 | | | 25,448 | |
+Amortization of acquired intangible assets | 10,301 | | | 8,966 | | | 5,186 | | | 19,267 | | | 10,149 | |
+Compensation taxes related to Employee XSP vesting | 1,059 | | | — | | | 1,488 | | | 1,059 | | | 1,488 | |
+Severance costs | (25) | | | 166 | | | — | | | 141 | | | — | |
+Inventory step-up amortization | — | | | — | | | — | | | — | | | 607 | |
+Adjusted gross margin | $ | 569,123 | | | $ | 496,921 | | | $ | 422,978 | | | $ | 1,066,044 | | | $ | 807,174 | |
+Gross margin | 60.4 | % | | 59.1 | % | | 60.4 | % | | 59.8 | % | | 60.5 | % |
+Adjusted gross margin | 62.9 | % | | 61.6 | % | | 63.3 | % | | 62.3 | % | | 63.4 | % |
+
+Software & Services
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+Net sales | $ | 397,836 | | | $ | 354,524 | | | $ | 292,178 | | | $ | 752,360 | | | $ | 554,915 | |
+Cost of sales | (114,081) | | | (97,903) | | | (71,288) | | | (211,984) | | | (139,001) | |
+Gross margin | 283,755 | | | 256,621 | | | 220,890 | | | 540,376 | | | 415,914 | |
+Stock-based compensation expense | 5,825 | | | 4,728 | | | 4,978 | | | 10,553 | | | 10,389 | |
+Amortization of acquired intangible assets | 8,572 | | | 7,236 | | | 3,853 | | | 15,808 | | | 7,479 | |
+Compensation taxes related to Employee XSP vesting | 633 | | | — | | | 854 | | | 633 | | | 854 | |
+Severance costs | — | | | 20 | | | — | | | 20 | | | — | |
+Adjusted gross margin | $ | 298,785 | | | $ | 268,605 | | | $ | 230,575 | | | $ | 567,390 | | | $ | 434,636 | |
+Gross margin | 71.3 | % | | 72.4 | % | | 75.6 | % | | 71.8 | % | | 75.0 | % |
+Adjusted gross margin | 75.1 | % | | 75.8 | % | | 78.9 | % | | 75.4 | % | | 78.3 | % |
+
+
+
+
+
+
+
+
+
+
+Connected Devices
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+Net sales | $ | 506,553 | | | $ | 452,821 | | | $ | 376,360 | | | $ | 959,374 | | | $ | 717,256 | |
+Cost of sales | (243,861) | | | (232,156) | | | (193,507) | | | (476,017) | | | (363,688) | |
+Gross margin | 262,692 | | | 220,665 | | | 182,853 | | | 483,357 | | | 353,568 | |
+Stock-based compensation expense | 5,516 | | | 5,775 | | | 7,583 | | | 11,291 | | | 15,059 | |
+Amortization of acquired intangible assets | 1,729 | | | 1,730 | | | 1,333 | | | 3,459 | | | 2,670 | |
+Compensation taxes related to Employee XSP vesting | 426 | | | — | | | 634 | | | 426 | | | 634 | |
+Severance costs | (25) | | | 146 | | | — | | | 121 | | | — | |
+Inventory step-up amortization | — | | | — | | | — | | | — | | | 607 | |
+Adjusted gross margin | $ | 270,338 | | | $ | 228,316 | | | $ | 192,403 | | | $ | 498,654 | | | $ | 372,538 | |
+Gross margin | 51.9 | % | | 48.7 | % | | 48.6 | % | | 50.4 | % | | 49.3 | % |
+Adjusted gross margin | 53.4 | % | | 50.4 | % | | 51.1 | % | | 52.0 | % | | 51.9 | % |
+
+
+
+
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+CONSOLIDATED BALANCE SHEETS
+(in thousands)
+| | | | | | | | | | | |
+| 30 JUN 2026 | | 31 DEC 2025 |
+| (Unaudited) | | |
+ASSETS | | | |
+Current Assets: | | | |
+Cash and cash equivalents | $ | 597,704 | | | $ | 1,201,147 | |
+Short-term investments | 75,703 | | | 505,417 | |
+Marketable securities | 19,126 | | | 27,213 | |
+Accounts and notes receivable, net of allowance
+| 768,637 | | | 777,486 | |
+Contract assets, net | 750,950 | | | 582,630 | |
+Inventory | 486,556 | | | 341,811 | |
+Prepaid expenses | 190,682 | | | 149,800 | |
+Other current assets | 115,347 | | | 127,548 | |
+Total current assets | 3,004,705 | | | 3,713,052 | |
+| | | |
+Property and equipment, net | 341,507 | | | 330,979 | |
+Deferred tax assets, net | 345,500 | | | 359,803 | |
+Intangible assets, net | 281,583 | | | 196,972 | |
+Goodwill | 1,898,827 | | | 1,370,189 | |
+Long-term notes receivable, net | 1,597 | | | 6,066 | |
+Long-term contract assets, net | 296,458 | | | 178,249 | |
+Strategic investments | 853,842 | | | 416,833 | |
+Other long-term assets | 457,138 | | | 428,170 | |
+Total assets | $ | 7,481,157 | | | $ | 7,000,313 | |
+| | | |
+LIABILITIES AND STOCKHOLDERS’ EQUITY | | | |
+Current Liabilities: | | | |
+Accounts payable | $ | 269,957 | | | $ | 139,086 | |
+Accrued liabilities | 423,932 | | | 510,538 | |
+Current portion of deferred revenue | 670,740 | | | 714,708 | |
+Current portion of notes payable, net | — | | | 80,552 | |
+Customer deposits | 16,477 | | | 16,156 | |
+Other current liabilities | 17,131 | | | 9,107 | |
+Total current liabilities | 1,398,237 | | | 1,470,147 | |
+| | | |
+Deferred revenue, net of current portion | 385,659 | | | 359,902 | |
+Liability for unrecognized tax benefits | 26,587 | | | 24,376 | |
+Long-term deferred compensation | 33,094 | | | 23,675 | |
+Long-term lease liabilities | 101,658 | | | 98,942 | |
+Long-term notes payable, net | 1,731,817 | | | 1,730,170 | |
+Other long-term liabilities | 129,568 | | | 50,443 | |
+Total liabilities | 3,806,620 | | | 3,757,655 | |
+| | | |
+Stockholders’ Equity: | | | |
+Common stock | 1 | | | 1 | |
+Additional paid-in capital | 2,735,708 | | | 2,475,035 | |
+Treasury stock | (180,164) | | | (157,242) | |
+Retained earnings | 1,135,409 | | | 936,670 | |
+Accumulated other comprehensive loss | (16,417) | | | (11,806) | |
+Total stockholders’ equity | 3,674,537 | | | 3,242,658 | |
+Total liabilities and stockholders’ equity | $ | 7,481,157 | | | $ | 7,000,313 | |
+
+
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(in thousands)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+| (Unaudited) | | (Unaudited) | | (Unaudited) | | (Unaudited) | | (Unaudited) |
+Cash flows from operating activities: | | | | | | | | | |
+Net income | $ | 29,427 | | | $ | 169,312 | | | $ | 36,117 | | | $ | 198,739 | | | $ | 124,097 | |
+Adjustments to reconcile net income to net cash (used in) provided by operating activities: | | | | | | | | | |
+Stock-based compensation | 143,996 | | | 134,701 | | | 139,244 | | | 278,697 | | | 279,483 | |
+Gain on strategic investments and marketable securities, net | (6,783) | | | (191,090) | | | 32,167 | | | (197,873) | | | (111,754) | |
+Debt inducement expense | — | | | — | | | — | | | — | | | 28,666 | |
+Depreciation and amortization | 32,463 | | | 30,361 | | | 17,157 | | | 62,824 | | | 36,610 | |
+Provision for bad debts and inventory | 662 | | | 1,968 | | | 2,454 | | | 2,630 | | | 6,254 | |
+Deferred income taxes | (6,564) | | | 18,020 | | | (21,297) | | | 11,456 | | | (70,065) | |
+Other noncash items | 6,771 | | | 11,695 | | | 9,763 | | | 18,466 | | | 19,278 | |
+Change in assets and liabilities: | | | | | | | | | |
+Receivables and contract assets | (305,834) | | | 48,915 | | | (139,268) | | | (256,919) | | | (212,833) | |
+Inventory | (80,386) | | | (64,713) | | | (31,112) | | | (145,099) | | | (48,098) | |
+Deferred revenue | 4,961 | | | (40,295) | | | (84,648) | | | (35,334) | | | (51,143) | |
+Accounts payable, accrued and other liabilities | 256,578 | | | (151,047) | | | 12,564 | | | 105,531 | | | 21,175 | |
+Prepaid expenses and other assets | (55,214) | | | 656 | | | (64,845) | | | (54,558) | | | (87,580) | |
+Net cash provided by (used in) operating activities | 20,077 | | | (31,517) | | | (91,704) | | | (11,440) | | | (65,910) | |
+Cash flows from investing activities: | | | | | | | | | |
+Purchases of investments | (10,892) | | | (291,952) | | | (714,693) | | | (302,844) | | | (1,793,862) | |
+Business combinations, net of cash acquired | (1,912) | | | (549,681) | | | (3,809) | | | (551,593) | | | (3,809) | |
+Proceeds from call, maturity, and sale of investments | 185,000 | | | 249,345 | | | 354,843 | | | 434,345 | | | 756,654 | |
+Purchases of property and equipment | (21,049) | | | (23,125) | | | (22,953) | | | (44,174) | | | (47,815) | |
+Other, net | 28 | | | (1,524) | | | 80 | | | (1,496) | | | 83 | |
+Net cash provided by (used in) investing activities | 151,175 | | | (616,937) | | | (386,532) | | | (465,762) | | | (1,088,749) | |
+Cash flows from financing activities: | | | | | | | | | |
+Net proceeds from equity offering | 100,477 | | | — | | | 183,960 | | | 100,477 | | | 183,960 | |
+Principal payments for conversion and redemption of convertible debt | — | | | (81,110) | | | — | | | (81,110) | | | (407,453) | |
+Income and payroll tax payments for net-settled stock awards | (129,982) | | | (10,210) | | | (187,800) | | | (140,192) | | | (192,835) | |
+Payments to third parties for debt issuance, amendment, conversion and redemption activity | — | | | (964) | | | (525) | | | (964) | | | (24,735) | |
+Proceeds from issuance of notes | — | | | — | | | — | | | — | | | 1,750,000 | |
+Other, net | (825) | | | (4) | | | — | | | (829) | | | (76) | |
+Net cash (used in) provided by financing activities | (30,330) | | | (92,288) | | | (4,365) | | | (122,618) | | | 1,308,861 | |
+Effect of exchange rate changes on cash and cash equivalents | (2,454) | | | (1,495) | | | 5,305 | | | (3,949) | | | 6,497 | |
+Net change in cash and cash equivalents | 138,468 | | | (742,237) | | | (477,296) | | | (603,769) | | | 160,699 | |
+Cash and cash equivalents and restricted cash, beginning of period | 471,156 | | | 1,213,393 | | | 1,104,758 | | | 1,213,393 | | | 466,763 | |
+Cash and cash equivalents and restricted cash, end of period | $ | 609,624 | | | $ | 471,156 | | | $ | 627,462 | | | $ | 609,624 | | | $ | 627,462 | |
+
+
+
+
+
+
+
+
+
+
+
+AXON ENTERPRISE, INC.
+SELECTED CASH FLOW INFORMATION
+(in thousands)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| THREE MONTHS ENDED | | SIX MONTHS ENDED |
+| 30 JUN 2026 | | 31 MAR 2026 | | 30 JUN 2025 | | 30 JUN 2026 | | 30 JUN 2025 |
+Net cash provided by (used in) operating activities | $ | 20,077 | | | $ | (31,517) | | | $ | (91,704) | | | $ | (11,440) | | | $ | (65,910) | |
+Purchases of property and equipment | (21,049) | | | (23,125) | | | (22,953) | | | (44,174) | | | (47,815) | |
+Free cash flow, a non-GAAP measure | (972) | | | (54,642) | | | (114,657) | | | (55,614) | | | (113,725) | |
+Bond premium amortization | — | | | 366 | | | 3,289 | | | 366 | | | 4,549 | |
+Net campus investment | 262 | | | 152 | | | 653 | | | 414 | | | 1,169 | |
+Adjusted free cash flow, a non-GAAP measure | $ | (710) | | | $ | (54,124) | | | $ | (110,715) | | | $ | (54,834) | | | $ | (108,007) | |
+
+
+AXON ENTERPRISE, INC.
+SUPPLEMENTAL TABLES
+(in thousands)
+| | | | | | | | | | | |
+| 30 JUN 2026 | | 31 DEC 2025 |
+Cash and cash equivalents | $ | 597,704 | | | $ | 1,201,147 | |
+Restricted cash | 11,920 | | | 12,246 | |
+Short-term investments | 75,703 | | | 505,417 | |
+Cash, cash equivalents, restricted cash and investments, net | 685,327 | | | 1,718,810 | |
+Current portion of notes payable, principal amount | — | | | (81,110) | |
+Long-term notes payable, principal amount | (1,750,000) | | | (1,750,000) | |
+Total cash, cash equivalents, restricted cash and investments, net of notes payable | $ | (1,064,673) | | | $ | (112,300) | |

--- a/modules/test-fixtures/earnings-filings/bros.txt
+++ b/modules/test-fixtures/earnings-filings/bros.txt
@@ -1,0 +1,657 @@
+EX-99.1
+2
+a2026-q2_ex991.htm
+EX-99.1
+
+
+
+
+Document
+Exhibit 99.1
+
+
+
+Dutch Bros Inc. Reports Second Quarter 2026 Financial Results
+Achieves 32% Revenue Growth Year-Over-Year
+Delivers 8.3% Company-Operated and 5.8% Systemwide Same Shop Sales Growth
+Raises 2026 Guidance on Total Revenues, System Same Shop Sales Growth, and Adjusted EBITDA
+TEMPE, Ariz. - August 5, 2026 - Dutch Bros Inc. (NYSE: BROS; “Dutch Bros” or the “Company”), one of the fastest-growing brands in the U.S. quick service beverage industry, today reported financial results for the second quarter ended June 30, 2026.
+
+Second Quarter 2026 Highlights
+• Opened 48 new shops, 44 of which were company-operated.
+• Total revenues grew 32.5% to $550.9 million as compared to $415.8 million in the same period of 2025.
+• Company-operated same shop sales 1 increased 8.3% and company-operated same shop transactions increased 3.4% relative to the same period of 2025. Systemwide same shop sales 1 increased 5.8% and systemwide same shop transactions increased 1.7% relative to the same period in 2025.
+• Net income was $51.6 million as compared to $38.4 million in the same period of 2025.
+• Adjusted EBITDA 2 grew 27.8% to $113.7 million as compared to $89.0 million in the same period of 2025.
+
+Christine Barone, Chief Executive Officer and President of Dutch Bros, said, “Our second quarter performance reflects the strength of the Dutch Bros brand, powered by our differentiated people-led culture and our compelling value proposition that continues to resonate with customers. The success of our strategy was evident in the second quarter as we delivered our thirteenth consecutive quarter of positive same shop sales growth and our eighth consecutive quarter of same shop transaction growth. We also maintained exceptionally strong development momentum, while AUVs climbed to record levels. This performance is the result of years of foundational investments across the business, giving us tremendous confidence in our ability to continue growing Dutch Bros for the long-term.”
+
+
+Josh Guenser, Chief Financial Officer of Dutch Bros, concluded, “Based on the performance so far this year and the recent acquisition from one of our Phoenix franchisees, we are increasing our full-year guidance on Total Revenues, Systemwide Same Shop Sales Growth and Adjusted EBITDA. We enter the second half of the year from a position of strength, with a focused plan, strong visibility into our growth initiatives, and a clear path to turning the significant whitespace ahead of us into durable growth.”
+
+
+Dutch Bros Inc. | Earnings Release | 1
+
+
+
+
+
+
+2026 Guidance 3
+• Total revenues are now projected to be between approximately $2.1 billion and $2.13 billion.
+• Same shop sales 1 growth is now estimated to be in the range of 5% to 6%.
+• Adjusted EBITDA 4 is now estimated to be between $385 million and $390 million.
+• Capital expenditures are now estimated to be between $350 million and $370 million.
+The item below remains unchanged.
+• Total system shop openings are estimated to be at least 185.
+
+_________________
+1 Same shop sales is defined in the section “Select Financial Metrics”.
+2 This is a non-GAAP financial measure. Reconciliation of U.S. GAAP to non-GAAP results is provided in the section “Non-GAAP Financial Measures”.
+3 Excludes any impact from the Salad and Go TM transaction announced on August 5, 2026.
+4 We have not reconciled guidance for Adjusted EBITDA to the corresponding U.S. GAAP financial measure because we do not provide guidance for the various reconciling items. We are unable to provide guidance for these reconciling items because we cannot determine their probable significance, as certain items are outside of our control and cannot be reasonably predicted due to the fact that these items could vary significantly from period to period. Accordingly, reconciliation to the corresponding U.S. GAAP financial measure is not available without unreasonable effort.
+
+
+Dutch Bros Inc. | Earnings Release | 2
+
+
+
+
+
+
+Conference Call and Webcast Today
+Christine Barone, Chief Executive Officer and President, and Joshua Guenser, Chief Financial Officer, will host a conference call and webcast today at 5:00 p.m. Eastern Time (ET) to discuss financial results for the second quarter ended June 30, 2026.
+Event : Second Quarter 2026 Conference Call and Webcast
+Date : Wednesday, August 5, 2026
+Time : 5:00 p.m. ET
+Dial In : 1-201-493-6779
+Webcast : https://investors.dutchbros.com under “Events & Presentations”.
+The webcast will be archived shortly after the conference call has concluded. We will also publish earnings presentation slides related to these financial results on our website https://investors.dutchbros.com under “Events & Presentations”.
+
+About Dutch Bros Inc.
+Dutch Bros Inc. (NYSE: BROS) is a fun-loving, mind-blowing drive-thru specialty beverage leader dedicated to making a massive difference, one cup at a time. It was founded in Grants Pass, Oregon, in 1992 and now shares its vibrant culture and fully customizable drinks at 1,225 locations as of June 30, 2026. Dutch Bros serves a wide variety of unique, handcrafted beverages such as its exclusive Dutch Bros Rebel ® energy drink, Myst Energy Refresher TM , specialty coffee, nitrogen-infused cold brew, tea, lemonade, soda and more.
+Dutch Bros is wholeheartedly focused on radiating kindness and sharing the Dutch Luv ® . In addition to its mission of speed, quality and service, the Dutch Bros Foundation ® is passionate about giving back to the communities it serves. Through local giving and annual nation-wide initiatives, the Dutch Bros Foundation makes impactful contributions to causes across the country.
+To learn more about Dutch Bros, visit www.dutchbros.com, follow Dutch Bros on Instagram, Facebook, X, and TikTok, and download the Dutch Bros app to earn points and score rewards!
+Dutch Bros , our Windmill logo ( ), Dutch Bros Rebel, and our other registered and common law trade names, trademarks and service marks are the property of Dutch Bros Inc. All other trademarks, trade names and service marks appearing in this press release are the property of their respective owners. Solely for convenience, the trademarks and trade names in this press release may be referred to without the ® and ™ symbols, but such references should not be construed as any indicator that their respective owners will not assert their rights thereto.
+
+
+Dutch Bros Inc. | Earnings Release | 3
+
+
+
+
+
+
+Forward-Looking Statements
+In addition to historical information, this press release contains a number of “forward-looking statements” as defined in the Private Securities Litigation Reform Act of 1995. Forward-looking statements include, without limitation, statements regarding Dutch Bros’ growth trajectory, and Dutch Bros’ potential or assumed future results of operations, including updated guidance for 2026, new shop openings, estimated capital expenditures, business strategies, and potential sales and revenue growth. These statements are based on Dutch Bros’ current expectations and beliefs, as well as a number of assumptions concerning future events. When used in this press release, the words “intend,” “may,” “target,” “estimates,” “predict,” “project,” “expect,” “should,” “guidance,” and variations of these words or similar expressions (or the negative versions of such words or expressions) are intended to identify forward-looking statements. Such forward-looking statements are subject to known and unknown risks, uncertainties, assumptions and other important factors, many of which are outside Dutch Bros’ control that could cause actual results to differ materially from the results discussed in the forward-looking statements, including those related to past growth being indicative of future results, whether Dutch Bros’ foundational investments result in continued growth for Dutch Bros, including increases in customer engagement and sales, the success of Dutch Bros’ food offering sales translating to sales of food offerings in other markets, changes in consumer preference due to new information or regulations regarding additives, diet and health or otherwise, acquisitions or partnerships not ultimately strengthening Dutch Bros’ competitive position, or achieving the intended goals of such acquisition or partnership, any problems that may arise in successfully integrating acquired businesses or assets, which may result in Dutch Bros not operating as effectively and efficiently as expected or divert management from their primary responsibilities, general economic conditions, changes in general consumer discretionary spending, including due to higher gas prices, inflation or lack of consumer confidence, commodity inflation, the ability to navigate evolving macroeconomic conditions, the effects of disruption between the U.S. and its trading partners due to military conflicts, tariffs or other policies, disruptions in our supply chain, increased labor costs, ability to hire and retain employees, the availability of suitable new shop sites and our ability to negotiate acceptable agreements regarding the new shop sites, and other risks, including those described in our Annual Report on Form 10-K for the year ended December 31, 2025 filed with the SEC on February 13, 2026, our Quarterly Report on Form 10-Q for the quarter ended March 31, 2026 filed with the SEC on May 6, 2026, and in our future reports to be filed with the SEC, including our Quarterly Report on Form 10-Q for the quarter ended June 30, 2026. Forward-looking statements contained in this press release are made as of this date, and Dutch Bros undertakes no duty to update such information except as required under applicable law.
+
+
+
+
+
+Dutch Bros Inc. | Earnings Release | 4
+
+
+
+
+
+
+
+
+DUTCH BROS INC.
+Condensed Consolidated Statements of Operations
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+(in thousands, except per share amounts; unaudited) | | 2026 | | 2025 | | 2026 | | 2025 |
+Revenues | | | | | | | | |
+Company-operated shops | | $ | 510,031 | | | $ | 380,500 | | | $ | 939,088 | | | $ | 706,921 | |
+Franchising and other | | 40,820 | | | 35,313 | | | 76,175 | | | 64,044 | |
+Total revenues | | 550,851 | | | 415,813 | | | 1,015,263 | | | 770,965 | |
+| | | | | | | | |
+Costs and Expenses | | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Cost of sales | | 399,795 | | | 295,769 | | | 756,731 | | | 560,928 | |
+Selling, general and administrative | | 80,651 | | | 65,385 | | | 153,827 | | | 124,306 | |
+Total costs and expenses | | 480,446 | | | 361,154 | | | 910,558 | | | 685,234 | |
+| | | | | | | | |
+Income from operations
+| | 70,405 | | | 54,659 | | | 104,705 | | | 85,731 | |
+| | | | | | | | |
+Other expense | | | | | | | | |
+Interest expense, net | | (7,038) | | | (7,076) | | | (14,258) | | | (14,191) | |
+Other income (expense), net | | 861 | | | (1,983) | | | 786 | | | (2,001) | |
+Total other expense | | (6,177) | | | (9,059) | | | (13,472) | | | (16,192) | |
+| | | | | | | | |
+Income before income taxes | | 64,228 | | | 45,600 | | | 91,233 | | | 69,539 | |
+Income tax expense | | 12,623 | | | 7,243 | | | 15,964 | | | 8,702 | |
+Net income | | $ | 51,605 | | | $ | 38,357 | | | $ | 75,269 | | | $ | 60,837 | |
+| | | | | | | | |
+Less: Net income attributable to non-controlling interests | | 14,195 | | | 12,733 | | | 21,762 | | | 19,860 | |
+Net income attributable to Dutch Bros Inc. | | $ | 37,410 | | | $ | 25,624 | | | $ | 53,507 | | | $ | 40,977 | |
+Net income per share of Class A common stock:
+| | | | | | | | |
+Basic | | $ | 0.28 | | | $ | 0.20 | | | $ | 0.41 | | | $ | 0.33 | |
+Diluted | | $ | 0.28 | | | $ | 0.20 | | | $ | 0.41 | | | $ | 0.33 | |
+Weighted-average shares of Class A common stock outstanding: | | | | | | | | |
+Basic | | 134,494 | | | 126,390 | | | 130,837 | | | 123,615 | |
+Diluted | | 134,765 | | | 126,830 | | | 131,263 | | | 124,178 | |
+
+
+
+
+
+Dutch Bros Inc. | Earnings Release | 5
+
+
+
+
+
+
+DUTCH BROS INC.
+Company-Operated Shops Results
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+(dollars in thousands; unaudited) | | $ | | % | | $ | | % | | $ | | % | | $ | | % |
+Company-operated shops revenue | | 510,031 | | | 100.0 | | | 380,500 | | | 100.0 | | | 939,088 | | | 100.0 | | | 706,921 | | | 100.0 | |
+| | | | | | | | | | | | | | | | |
+Beverage, food and packaging costs | | 133,108 | | | 26.1 | | | 96,468 | | | 25.3 | | | 245,430 | | | 26.1 | | | 177,847 | | | 25.2 | |
+Labor costs | | 129,460 | | | 25.4 | | | 101,270 | | | 26.6 | | | 241,765 | | | 25.8 | | | 190,709 | | | 27.0 | |
+Occupancy and other costs | | 83,085 | | | 16.3 | | | 59,984 | | | 15.8 | | | 159,870 | | | 17.0 | | | 113,911 | | | 16.1 | |
+Pre-opening costs | | 8,408 | | | 1.6 | | | 4,542 | | | 1.2 | | | 14,749 | | | 1.6 | | | 10,153 | | | 1.4 | |
+Depreciation and amortization | | 32,669 | | | 6.4 | | | 25,684 | | | 6.8 | | | 68,191 | | | 7.2 | | | 50,251 | | | 7.1 | |
+Company-operated shops costs and expenses | | 386,730 | | | 75.8 | | | 287,948 | | | 75.7 | | | 730,005 | | | 77.7 | | | 542,871 | | | 76.8 | |
+Company-operated shops gross profit | | 123,301 | | | 24.2 | | | 92,552 | | | 24.3 | | | 209,083 | | | 22.3 | | | 164,050 | | | 23.2 | |
+Company-operated shops contribution 1
+| | 155,970 | | | 30.6 | | | 118,236 | | | 31.1 | | | 277,274 | | | 29.5 | | | 214,301 | | | 30.3 | |
+
+_________________
+1 Reconciliation of GAAP to non-GAAP results is provided in the section “Non-GAAP Financial Measures”.
+
+DUTCH BROS INC.
+Summary Cash Flows Data
+| | | | | | | | | | | | | | |
+| | Six Months Ended
+June 30, |
+(in thousands; unaudited) | | 2026 | | 2025 |
+Net cash provided by operating activities | | $ | 196,933 | | | $ | 126,781 | |
+Net cash used in investing activities | | (149,048) | | | (99,731) | |
+Net cash used in financing activities | | (48,665) | | | (65,989) | |
+Net decrease in cash and cash equivalents | | $ | (780) | | | $ | (38,939) | |
+Cash and cash equivalents at beginning of period | | 269,404 | | | 293,354 | |
+Cash and cash equivalents at end of period | | $ | 268,624 | | | $ | 254,415 | |
+
+
+
+Dutch Bros Inc. | Earnings Release | 6
+
+
+
+
+
+
+DUTCH BROS INC.
+Condensed Consolidated Balance Sheets
+| | | | | | | | | | | | | | |
+| | |
+(in thousands; unaudited) | | June 30,
+2026 | | December 31,
+2025 |
+Assets
+| | | | |
+Current assets: | | | | |
+Cash and cash equivalents | | $ | 268,624 | | | $ | 269,404 | |
+Accounts receivable, net | | 18,871 | | | 18,387 | |
+Inventories, net | | 41,253 | | | 48,917 | |
+Prepaid expenses and other current assets | | 23,745 | | | 20,670 | |
+Total current assets | | 352,493 | | | 357,378 | |
+Property and equipment, net | | 905,241 | | | 824,502 | |
+Lease right-of-use assets, net | | 984,000 | | | 855,339 | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+Deferred income tax assets, net | | 1,111,070 | | | 946,571 | |
+Other long-term assets | | 23,885 | | | 25,524 | |
+Total assets | | $ | 3,376,689 | | | $ | 3,009,314 | |
+Liabilities and Equity
+| | | | |
+Current liabilities: | | | | |
+Accounts payable | | $ | 44,319 | | | $ | 37,625 | |
+| | | | |
+Other current liabilities
+| | 123,394 | | | 99,173 | |
+| | | | |
+Deferred revenue | | 47,160 | | | 55,658 | |
+| | | | |
+Current portion of tax receivable agreements liability | | 686 | | | 7,696 | |
+Current portion of lease liabilities | | 41,639 | | | 36,466 | |
+| | | | |
+| | | | |
+Current portion of long-term debt | | 3,883 | | | 3,881 | |
+Total current liabilities | | 261,081 | | | 240,499 | |
+Deferred revenue, net of current portion | | 6,524 | | | 8,918 | |
+Lease liabilities, net of current portion | | 967,206 | | | 852,380 | |
+| | | | |
+| | | | |
+| | | | |
+Long-term debt, net of current portion | | 194,600 | | | 196,295 | |
+Tax receivable agreements liability, net of current portion
+| | 972,264 | | | 813,353 | |
+| | | | |
+Total liabilities | | 2,401,675 | | | 2,111,445 | |
+Equity: | | | | |
+| | | | |
+Common stock | | 1 | | | 1 | |
+Additional paid in capital | | 644,589 | | | 581,261 | |
+Accumulated other comprehensive income | | 47 | | | 48 | |
+Retained earnings
+| | 153,015 | | | 99,508 | |
+Total stockholders' equity attributable to Dutch Bros Inc. | | 797,652 | | | 680,818 | |
+Non-controlling interests | | 177,362 | | | 217,051 | |
+Total equity | | 975,014 | | | 897,869 | |
+Total liabilities and equity | | $ | 3,376,689 | | | $ | 3,009,314 | |
+
+
+
+
+
+Dutch Bros Inc. | Earnings Release | 7
+
+
+
+
+
+
+DUTCH BROS INC.
+Select Financial Metrics
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+(dollars in thousands; unaudited) | | 2026 | | 2025 | | 2026 | | 2025 |
+Shop count, beginning of period | | | | | | | | |
+Company-operated | | 844 | | | 695 | | | 811 | | | 670 | |
+Franchised | | 333 | | | 317 | | | 325 | | | 312 | |
+
+| | 1,177 | | | 1,012 | | | 1,136 | | | 982 | |
+| | | | | | | | |
+Company-operated new openings | | 44 | | | 30 | | | 77 | | | 55 | |
+Franchised new openings | | 4 | | | 1 | | | 12 | | | 6 | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Shop count, end of period | | | | | | | | |
+Company-operated | | 888 | | | 725 | | | 888 | | | 725 | |
+Franchised | | 337 | | | 318 | | | 337 | | | 318 | |
+Total shop count | | 1,225 | | | 1,043 | | | 1,225 | | | 1,043 | |
+| | | | | | | | |
+Systemwide AUV 1
+| | N/A | | N/A | | $ | 2,193 | | | $ | 2,053 | |
+Company-operated shops AUV 1
+| | N/A | | N/A | | $ | 2,164 | | | $ | 1,982 | |
+| | | | | | | | |
+Systemwide same shop sales 1, 2
+| | 5.8 | % | | 6.1 | % | | 6.9 | % | | 5.3 | % |
+Ticket | | 4.1 | % | | 2.4 | % | | 3.6 | % | | 3.0 | % |
+Transactions | | 1.7 | % | | 3.7 | % | | 3.3 | % | | 2.3 | % |
+Company-operated same shop sales 1
+| | 8.3 | % | | 7.8 | % | | 9.3 | % | | 7.2 | % |
+Ticket | | 4.9 | % | | 1.9 | % | | 4.3 | % | | 2.6 | % |
+Transactions | | 3.4 | % | | 5.9 | % | | 5.0 | % | | 4.6 | % |
+| | | | | | | | |
+Systemwide sales 2
+| | $ | 703,320 | | | $ | 571,273 | | | $ | 1,312,919 | | | $ | 1,060,945 | |
+Company-operated operating weeks 3
+| | 11,189 | | | 9,184 | | | 21,682 | | | 17,921 | |
+Franchising and other operating weeks 3
+| | 4,353 | | | 4,119 | | | 8,583 | | | 8,130 | |
+Dutch Rewards transactions as a percentage of total transactions 4
+| | 73 | % | | 72 | % | | 74 | % | | 72 | % |
+| | | | | | | | |
+
+
+
+Dutch Bros Inc. | Earnings Release | 8
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+(dollars in thousands; unaudited) | | $ | | % | | $ | | % | | $ | | % | | $ | | % |
+Company-operated shops revenues | | 510,031 | | | 100.0 | | | 380,500 | | | 100.0 | | | 939,088 | | | 100.0 | | | 706,921 | | | 100.0 | |
+Company-operated shops gross profit | | 123,301 | | | 24.2 | | | 92,552 | | | 24.3 | | | 209,083 | | | 22.3 | | | 164,050 | | | 23.2 | |
+Company-operated shops contribution 5
+| | 155,970 | | | 30.6 | | | 118,236 | | | 31.1 | | | 277,274 | | | 29.5 | | | 214,301 | | | 30.3 | |
+Selling, general, and administrative expenses | | 80,651 | | | 14.6 | | | 65,385 | | | 15.7 | | | 153,827 | | | 15.2 | | | 124,306 | | | 16.1 | |
+Adjusted selling, general, and administrative expenses 5
+| | 72,491 | | | 13.2 | | | 58,709 | | | 14.1 | | | 138,003 | | | 13.6 | | | 112,206 | | | 14.6 | |
+Net income | | 51,605 | | | 9.4 | | | 38,357 | | | 9.2 | | | 75,269 | | | 7.4 | | | 60,837 | | | 7.9 | |
+Adjusted EBITDA 5
+| | 113,714 | | | 20.6 | | | 89,003 | | | 21.4 | | | 193,087 | | | 19.0 | | | 151,909 | | | 19.7 | |
+
+___________
+1 In 2026, AUVs are determined based on the net sales for any trailing twelve-month period for systemwide and company-operated shops, and same shop sales represent the percentage change in year-over-year sales, for the comparable shop base, that have been open at least 15 complete months as of the first day of the quarterly reporting period. Prior to 2026, AUVs were determined based on shops that had been open a minimum of 15 months, and same shop base was defined as shops open for 15 complete months or longer as of the first day of the reporting period. Prior period numbers have not been adjusted to conform to the new definition as the changes did not have a material impact. AUVs are calculated by dividing the systemwide and company-operated shops net sales by the total number of systemwide and company-operated shops, respectively. Management uses these metrics as an indicator of shop growth, expectations of mature locations, and future expansion strategy. The number of shops included in the systemwide and company-operated comparable bases for the respective periods are presented in the following table.
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, | | |
+| | 2026 | | 2025 | | 2026 | | 2025 | | |
+Systemwide shop base | | 982 | | | 831 | | | 982 | | | 794 | | | |
+Company-operated shop base | | 670 | | | 542 | | | 670 | | | 510 | | | |
+
+2 Systemwide sales and systemwide same shop sales are operating measures that include sales at company-operated shops and sales at franchised shops during the comparable periods presented. Franchise sales represent sales at all franchise shops and are revenues to our franchisees. We do not record franchise sales as revenues; however, our royalty revenues and advertising fund contributions are calculated based on a percentage of franchise sales. As these metrics include sales reported to us by our non-consolidated franchise partners, these metrics should be considered as a supplement to, not a substitute for, our results as reported under U.S. GAAP. Management uses these metrics as indicators of our system’s overall financial health, growth and future expansion prospects.
+3 Company-operated and franchise shops operating weeks are calculated based on the number of operating days for the shop base and dividing by 7. Our shop base is defined as shops opened as of the end date of the periods presented. The operating weeks calculations reflect re-acquired franchises. Management uses these metrics as indicators of our system’s overall financial health, growth and future expansion prospects.
+4 Dutch Rewards is our digitally-based rewards program available exclusively through the Dutch Rewards app. Management uses this metric as an indicator of customer loyalty adoption of our Dutch Rewards app and future promotional plans.
+5 Reconciliation of U.S. GAAP to non-GAAP results is provided in the section “Non-GAAP Financial Measures”.
+
+
+Dutch Bros Inc. | Earnings Release | 9
+
+
+
+
+
+
+Non-GAAP Financial Measures
+In addition to disclosing financial results in accordance with U.S. GAAP, this press release contains references to the non-GAAP financial measures below. We believe these non-GAAP financial measures provide investors with useful supplemental information about our operating performance, enable comparison of financial trends and results between periods where certain items may vary independent of business performance, and allow for greater transparency with respect to key metrics used by management in operating our business and measuring our performance.
+Our non-GAAP financial measures reflect adjustments based on one or more of the following items, as well as the related income tax effects where applicable. Income tax effects have been calculated based on the combined total non-GAAP adjustments using our total effective tax rate. These non-GAAP financial measures should not be considered a substitute for, or superior to, financial measures calculated in accordance with U.S. GAAP, and the financial results calculated in accordance with U.S. GAAP and reconciliations from these results should be carefully evaluated.
+
+Company-operated shops contribution (in dollars and as a percentage of revenue)
+Definition and/or calculation
+Company-operated shops segment gross profit, before company-operated shops depreciation and amortization.
+Usefulness to management and investors
+This non-GAAP measure is used by our management in making performance decisions without the impact of non-cash depreciation and amortization charges. This is a standard metric used across our industry by investors.
+
+EBITDA, Adjusted EBITDA (in dollars and as a percentage of revenue)
+EBITDA — definition and/or calculation
+Net income before interest expense (net of interest income), income tax expense, and depreciation and amortization expense.
+Adjusted EBITDA — definition and/or calculation
+Defined as EBITDA (as defined above), excluding equity-based compensation, expenses associated with credit facility refinancing, acquisition-related costs, TRA remeasurements, and organization realignment and restructurings costs.
+Usefulness to management and investors
+These non-GAAP measures are supplemental operating performance measures we believe facilitate comparisons to historical performance and competitors’ operating results. We believe these non-GAAP measures presented provide investors with a supplemental view of our operating performance that facilitates analysis and comparisons of our ongoing business operations because they exclude items that may not be indicative of our ongoing operating performance.
+
+Adjusted selling, general, and administrative (in dollars and as a percentage of revenue)
+Definition and/or calculation
+Selling, general, and administrative expenses, excluding depreciation and amortization, equity-based compensation, acquisition-related costs, and organization realignment and restructurings costs.
+Usefulness to management and investors
+This non-GAAP measure is used as a supplemental measure of operating performance that we believe is useful to evaluate our performance period over period and relative to our competitors. We believe the non-GAAP measure presented provides investors with a supplemental view of our operating performance that facilitates analysis and comparisons of our ongoing business operations because it excludes items that may not be indicative of our ongoing operating performance.
+
+
+Dutch Bros Inc. | Earnings Release | 10
+
+
+
+
+
+
+Adjusted net income
+Definition and/or calculation
+Net income, excluding equity-based compensation, expenses associated with credit facility refinancing, acquisition-related costs, TRA remeasurements, organization realignment and restructurings costs, and income tax effects of items excluded from net income.
+Usefulness to management and investors
+This non-GAAP measure is used as a supplemental measure of operating performance that we believe is useful to evaluate our performance period over period and relative to our competitors. We believe this measure facilitates a better comparison with other companies that have different organizational and tax structures, as well as comparisons period over period.
+
+Adjusted fully exchanged weighted-average shares of diluted common stock outstanding
+Definition and/or calculation
+Weighted-average shares of Class A common stock outstanding - basic with addition of dilutive impacts of restricted stock units, as well as the assumed exchange of all of the Dutch Bros OpCo Class A common units not held by Dutch Bros Inc. for Dutch Bros Inc. Class A common stock.
+Usefulness to management and investors
+This non-GAAP measure is used as a supplemental measure of operating performance that we believe is useful to evaluate our performance period over period and relative to our competitors. By adding in the assumed exchange of all of the outstanding Dutch Bros OpCo Class A common units not held by Dutch Bros Inc. for Dutch Bros Inc. Class A common stock, we believe this measure facilitates a better comparison with other companies that have different organizational and tax structures, as well as comparisons period over period.
+
+Adjusted net income per fully exchanged share of diluted common stock
+Definition and/or calculation
+Net income per share of Class A common stock - diluted, excluding per share impacts of equity-based compensation, expenses associated with credit facility refinancing, acquisition-related costs, TRA remeasurements, organization realignment and restructurings costs, income tax effects of items excluded from net income, and removal of per share impacts of controlling and non-controlling interests.
+Usefulness to management and investors
+This non-GAAP measure is used as a supplemental measure of operating performance that we believe is useful to evaluate our performance period over period and relative to our competitors. By assuming the full exchange of all of the outstanding Dutch Bros OpCo Class A common units not held by Dutch Bros Inc. for Dutch Bros Inc. Class A common stock and related net income adjustments, we believe this measure facilitates a better comparison with other companies that have different organizational and tax structures, as well as comparisons period over period.
+
+Non-GAAP adjustments
+Below are the definitions of the non-GAAP adjustments that are used in the calculation of our non-GAAP measures, as described above.
+Equity-based compensation
+Non-cash expenses related to the grant and vesting of stock awards, including restricted stock units and performance restricted stock units in Dutch Bros Inc. to certain eligible employees.
+
+
+Dutch Bros Inc. | Earnings Release | 11
+
+
+
+
+
+Expenses associated with 2022 credit facility refinancing
+Costs incurred as a result of refinancing our credit facility in May 2025, including write-off of unamortized loan costs related to the amendment and restatement of our 2022 Credit Facility, and intermediary fees and other costs related to our 2025 Credit Facility.
+Acquisition-related costs
+Costs incurred in connection with our purchase of the franchise rights and assets from a franchisee.
+TRAs remeasurements
+(Gain) loss impacts related to adjustments of our TRAs liabilities.
+Organization realignment and restructurings
+Fees and costs incurred in connection with our comprehensive initiatives to develop and implement a long-term strategy involving changes to our organizational structure to support our growth.
+Dilutive effects of restricted stock awards and units
+Addition of incremental shares of restricted stock units calculated under the treasury stock method, when they are dilutive for the calculation of weighted-average shares on a non-GAAP basis.
+Assumed exchange of weighted-average LLC interests for shares of Class A common stock
+Weighted-average of all outstanding Dutch Bros OpCo Class A common units not held by Dutch Bros Inc. that are assumed to be exchanged for Dutch Bros Inc. Class A common stock.
+
+
+
+Supplemental Reconciliations of U.S. GAAP Actuals to Non-GAAP Actuals
+Following are the reconciliations of the most comparable GAAP financial measure to non-GAAP financial measure. These non-GAAP financial measures should not be considered a substitute for, or superior to, financial measures calculated in accordance with U.S. GAAP, and the reconciliations from U.S. GAAP to Non-GAAP measures should be carefully evaluated. Please refer to "Non-GAAP Financial Measures" in this press release for a detailed explanation of the adjustments made to the comparable U.S. GAAP measures, the ways management uses the non-GAAP measures, and the reasons why management believes the non-GAAP measures provide useful information for investors.
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, | | | | |
+| | 2026 | | 2025 | | 2026 | | 2025 | | |
+(dollars in thousands; unaudited)
+| | $ | | % | | $ | | % | | $ | | % | | $ | | % | | | | |
+Company-operated shops gross profit | | 123,301 | | | 24.2 | | | 92,552 | | | 24.3 | | | 209,083 | | | 22.3 | | | 164,050 | | | 23.2 | | | | | |
+Depreciation and amortization | | 32,669 | | | 6.4 | | | 25,684 | | | 6.8 | | | 68,191 | | | 7.2 | | | 50,251 | | | 7.1 | | | | | |
+Company-operated shops contribution | | 155,970 | | | 30.6 | | | 118,236 | | | 31.1 | | | 277,274 | | | 29.5 | | | 214,301 | | | 30.3 | | | | | |
+
+
+
+
+
+Dutch Bros Inc. | Earnings Release | 12
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, | | | | |
+| | 2026 | | 2025 | | 2026 | | 2025 | | |
+(dollars in thousands; unaudited)
+| | $ | | % | | $ | | % | | $ | | % | | $ | | % | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+Net income | | 51,605 | | | 9.4 | | | 38,357 | | | 9.2 | | | 75,269 | | | 7.4 | | | 60,837 | | | 7.9 | | | | | |
+Depreciation and amortization | | 35,481 | | | 6.4 | | | 27,893 | | | 6.7 | | | 73,736 | | | 7.3 | | | 54,323 | | | 7.0 | | | | | |
+Interest expense, net | | 7,038 | | | 1.3 | | | 7,076 | | | 1.8 | | | 14,258 | | | 1.4 | | | 14,191 | | | 1.9 | | | | | |
+Income tax expense | | 12,623 | | | 2.3 | | | 7,243 | | | 1.7 | | | 15,964 | | | 1.6 | | | 8,702 | | | 1.1 | | | | | |
+EBITDA | | 106,747 | | | 19.4 | | | 80,569 | | | 19.4 | | | 179,227 | | | 17.7 | | | 138,053 | | | 17.9 | | | | | |
+Equity-based compensation | | 6,879 | | | 1.2 | | | 4,671 | | | 1.1 | | | 12,157 | | | 1.2 | | | 8,865 | | | 1.1 | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+Expenses associated with 2022 credit facility refinancing | | — | | | — | | | 2,000 | | | 0.5 | | | — | | | — | | | 2,000 | | | 0.3 | | | | | |
+Acquisition-related costs | | 309 | | | 0.1 | | | — | | | — | |
+| 309 | | | — | | | — | | | — | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+TRAs remeasurements | | (437) | | | (0.1) | | | — | | | — | | | (437) | | | — | | | — | | | — | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | |
+Organization realignment and restructurings | | 216 | | | — | | | 1,763 | | | 0.4 | | | 1,831 | | | 0.1 | | | 2,991 | | | 0.4 | | | | | |
+Adjusted EBITDA | | 113,714 | | | 20.6 | | | 89,003 | | | 21.4 | | | 193,087 | | | 19.0 | | | 151,909 | | | 19.7 | | | | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+(dollars in thousands; unaudited)
+| | $ | | % | | $ | | % | | $ | | % | | $ | | % |
+Selling, general, and administrative | | 80,651 | | | 14.6 | | | 65,385 | | | 15.7 | | | 153,827 | | | 15.2 | | | 124,306 | | | 16.1 | |
+Depreciation and amortization | | (1,656) | | | (0.3) | | | (817) | | | (0.2) | | | (3,086) | | | (0.3) | | | (1,219) | | | (0.2) | |
+Equity-based compensation | | (5,979) | | | (1.0) | | | (4,096) | | | (1.0) | | | (10,598) | | | (1.2) | | | (7,890) | | | (0.9) | |
+Acquisition-related costs | | (309) | | | (0.1) | | | — | | | — | |
+| (309) | | | — | | | — | | | — | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | |
+Organization realignment and restructurings | | (216) | | | — | | | (1,763) | | | (0.4) | | | (1,831) | | | (0.1) | | | (2,991) | | | (0.4) | |
+Adjusted selling, general, and administrative | | 72,491 | | | 13.2 | | | 58,709 | | | 14.1 | | | 138,003 | | | 13.6 | | | 112,206 | | | 14.6 | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, | | |
+(in thousands; unaudited)
+| | 2026 | | 2025 | | 2026 | | 2025 | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Net income | | $ | 51,605 | | | $ | 38,357 | | | $ | 75,269 | | | $ | 60,837 | | | |
+Equity-based compensation | | 6,879 | | | 4,671 | | | 12,157 | | | 8,865 | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Expenses associated with 2022 credit facility refinancing | | — | | | 2,000 | | | — | | | 2,000 | | | |
+Acquisition-related costs | | 309 | | | — | | | 309 | | | — | | | |
+TRAs remeasurements | | (437) | | | — | | | (437) | | | — | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Organization realignment and restructuring | | 216 | | | 1,763 | | | 1,831 | | | 2,991 | | | |
+Income tax effects | | (232) | | | (1,280) | | | (2,225) | | | (4,381) | | | |
+Adjusted net income | | $ | 58,340 | | | $ | 45,511 | | | $ | 86,904 | | | $ | 70,312 | | | |
+
+
+
+Dutch Bros Inc. | Earnings Release | 13
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Six Months Ended June 30, | | |
+(in thousands, except per share amounts; unaudited) | | 2026 | | 2025 | | 2026 | | 2025 | | |
+Weighted-average shares of Class A common stock outstanding - basic | | 134,494 | | | 126,390 | | | 130,837 | | | 123,615 | | | |
+Dilutive effects of restricted stock units | | 271 | | | 440 | | | 426 | | | 563 | | | |
+Weighted-average shares of Class A common stock outstanding - diluted | | 134,765 | | | 126,830 | | | 131,263 | | | 124,178 | | | |
+| | | | | | | | | | |
+Assumed exchange of weighted-average Dutch Bros OpCo Class A common units for shares of Dutch Bros Inc. Class A common stock | | 43,248 | | | 51,086 | | | 46,844 | | | 53,766 | | | |
+Adjusted fully exchanged weighted-average shares of common stock outstanding - diluted | | 178,013 | | | 177,916 | | | 178,107 | | | 177,944 | | | |
+| | | | | | | | | | |
+Net income per share of Class A common stock - diluted | | $ | 0.28 | | | $ | 0.20 | | | $ | 0.41 | | | $ | 0.33 | | | |
+Controlling and non-controlling interest adjustments | | 0.01 | | | 0.02 | | | 0.01 | | | 0.01 | | | |
+Equity-based compensation | | 0.04 | | | 0.03 | | | 0.07 | | | 0.05 | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Expenses associated with 2022 credit facility refinancing | | — | | | 0.01 | | | — | | | 0.01 | | | |
+Acquisition-related costs | | — | | | — | | | — | | | — | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+TRAs remeasurements | | — | | | — | | | — | | | — | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Organization realignment and restructurings | | — | | | 0.01 | | | 0.01 | | | 0.02 | | | |
+Income tax effects | | — | | | (0.01) | | | (0.01) | | | (0.02) | | | |
+| | | | | | | | | | |
+Adjusted net income per fully exchanged share of diluted common stock | | $ | 0.33 | | | $ | 0.26 | | | $ | 0.49 | | | $ | 0.40 | | | |
+
+
+
+Dutch Bros Inc. | Earnings Release | 14
+
+
+
+
+
+
+| | |
+For Investor Relations inquiries:
+|
+Neil Patel, CFA
+|
+(480) 447-2282
+|
+neil.patel@dutchbros.com
+|
+|
+For Media Relations inquiries:
+|
+Erin Gray
+|
+(480) 382-7228
+|
+erin.gray@dutchbros.com
+|
+
+
+
+Dutch Bros Inc. | Earnings Release | 15

--- a/modules/test-fixtures/earnings-filings/bynd.txt
+++ b/modules/test-fixtures/earnings-filings/bynd.txt
@@ -1,0 +1,974 @@
+EX-99.1
+2
+ex991pressrelease-q22026ea.htm
+EX-99.1 BEYOND MEAT EARNINGS RELEASE DATED AUGUST 5, 2026
+
+
+
+
+Document
+
+
+
+
+
+Exhibit 99.1
+
+For immediate release
+Beyond Meat ® Reports Second Quarter 2026 Financial Results
+
+
+EL SEGUNDO, Calif. — August 5, 2026 (GLOBE NEWSWIRE) —Beyond Meat, Inc. (NASDAQ: BYND), otherwise known as Beyond The Plant Protein Company TM (the “Company” or “Beyond Meat”), today reported financial results for its second quarter ended June 27, 2026.
+
+
+Second Quarter 2026 Financial Highlights 1
+
+
+• Net revenues were $68.8 million, a decrease of 8.2% year-over-year.
+• Gross profit was $5.9 million, or gross margin of 8.5%, compared to gross profit of $7.9 million, or gross margin of 10.6%, in the year-ago period.
+◦ Gross profit and gross margin included $ 1.6 million in expenses related to the cessation of the Company’s operational activities in China, compared to $1.7 million in the year-ago period.
+• Loss from operations was $30.8 million, or operating margin of -44.8%, compared to loss from operations of $37.5 million, or operating margin of -50.0%, in the year-ago period.
+◦ Loss from operations included the following charges recorded in operating expenses: $4.7 million in incremental share-based compensation expense related to the Company’s convertible debt exchange; $0.5 million in certain non-routine SG&A expenses; $0.4 million in amortization of costs related to a partial lease termination of a portion of the Company’s campus headquarters building in El Segundo, California (the “Campus Headquarters”); and a credit of $ 11.0 million reflecting the settlement of arbitration proceedings related to a previously-disclosed contractual dispute with a former co-manufacturer, compared to an expense of $2.5 million in the year-ago period.
+• Net income was $16.4 million, compared to net loss of $(31.8) million in the year-ago period. Net inco me per share available to common stockholders - basic was $0.03, compared to net
+
+1 This release includes references to non-GAAP financial measures. Refer to “Non-GAAP Financial Measures” later in this release for the definitions of the non-GAAP financial measures presented and a reconciliation of these measures to their closest comparable GAAP measures.
+
+
+
+
+
+
+
+
+
+
+
+loss per share available to common stockholders - basic of $(0.42) in the year-ago period. Net loss per share available to common stockholders - diluted was $(0.06), compared to net loss per share available to common stockholders - diluted of $(0.42) in the year-ago period. The increase in net income was primarily driven by a $57.7 million non-cash gain on debt extinguishment in connection with conversions of a portion of the Company’s 2030 Notes.
+• Adjusted EBITDA was a loss of $27.7 million, or -40.2% of net revenues, compared to an Adjusted EBITDA loss of $24.7 million, or -33.0% of net revenues, in the year-ago period.
+
+
+Beyond Meat President and CEO Ethan Brown commented, “Our second quarter results represent directional progress, with net revenues, gross margin and operating expenses all sequentially improving, and our top line comfortably exceeding the high end of our guidance.”
+
+
+Brown continued, “We continue to work to stabilize our plant-based meat business, with highlights including growth in international retail and the U.S. retail debut of Beyond Steak Filet, and to build upon this core as we reposition around Beyond The Plant Protein Company TM to pursue faster-growing adjacent categories. The exciting launch of Beyond Immerse represents the first output of this expanded aperture, and we expect more to come as we execute our plan to deliver the superpowers of plants to a broadening group of consumers.”
+
+
+Second Quarter 2026
+
+
+Net revenues decreased 8.2% to $68.8 million in the second quarter of 2026, compared to $75.0 million in the year-ago period. The decrease in net revenues was primarily driven by a 9.5% decrease in volume of products sold, partially offset by a 1.3% increase in net revenue per pound. The decrease in volume of products sold was primarily driven by lower sales of burger and chicken products to Quick Service Restaurant (“QSR”) customers in the international foodservice channel, and by weak category demand and reduced points of distribution in the U.S. foodservice and retail channels. The increase in net revenue per pound was primarily driven by changes in product sales mix and favorable changes in foreign currency exchange rates, partially offset by higher trade discounts.
+
+
+U.S. retail channel net revenues decreased 9.9% to $29.6 million in the second quarter of 2026, compared to $32.9 million in the year-ago period. The decrease in U.S. retail channel net revenues was primarily driven by a 5.7% decrease in volume of products sold and a 4.5% decrease in net revenue per pound. The decrease in volume of products sold was primarily driven by weak category demand and reduced points of distribution within certain channels. The decrease in net revenue per pound was
+
+
+
+
+
+
+
+
+
+
+
+primarily driven by higher trade discounts and lower price realization on certain of the Company’s products, partially offset by changes in product sales mix.
+
+
+U.S. foodservice channel net revenues decreased 27.6% to $8.0 million in the second quarter of 2026, compared to $11.1 million in the year-ago period. The decrease in U.S. foodservice channel net revenues was primarily driven by a 27.4% decrease in volume of products sold and a 0.2% decrease in net revenue per pound. The decrease in volume of products sold was primarily driven by weak category demand and reduced points of distribution. The decrease in net revenue per pound was primarily driven by lower price realization on certain of the Company’s products and higher trade discounts, partially offset by changes in product sales mix.
+
+
+International retail channel net revenues increased 16.5% to $18.5 million in the second quarter of 2026, compared to $15.9 million in the year-ago period. The increase in international retail channel net revenues was primarily driven by an 8.2% increase in volume of products sold and a 7.7% increase in net revenue per pound. The increase in volume of products sold was primarily driven by higher sales of burger products and chicken products in European markets and the U.K., and increased sales of ground beef products in Canada. The increase in net revenue per pound was primarily driven by price increases of certain of the Company’s products and favorable changes in foreign currency exchange rates, partially offset by higher trade discounts.
+
+
+International foodservice channel net revenues decreased 16.0% to $12.7 million in the second quarter of 2026, compared to $15.1 million in the year-ago period. The decrease in international foodservice channel net revenues was primarily driven by a 20.4% decrease in volume of products sold, partially offset by a 5.5% increase in net revenue per pound. The decrease in volume of products sold was primarily driven by lower sales of burger and chicken products to certain QSR customers. The increase in net revenue per pound was primarily driven by favorable changes in foreign currency exchange rates and lower trade discounts.
+
+
+Net revenues by channel (unaudited):
+
+
+The following table presents the Company's net revenues by channel for the respective periods presented (in thousands, except for percentages):
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended | | Change | | Six Months Ended
+| | Change |
+| | June 27, 2026 | | June 28, 2025 | | Amount | | % | | June 27, 2026 | | June 28, 2025 | | Amount | | % |
+U.S.: | | | | | | | | | | | | | | | | |
+Retail | | $ | 29,637 | | | $ | 32,909 | | | $ | (3,272) | | | (9.9) | % | | $ | 56,191 | | | $ | 64,269 | | | $ | (8,078) | | | (12.6) | % |
+Foodservice | | 8,005 | | | 11,055 | | | (3,050) | | | (27.6) | % | | 14,624 | | | 20,468 | | | (5,844) | | | (28.6) | % |
+U.S. net revenues | | 37,642 | | | 43,964 | | | (6,322) | | | (14.4) | % | | 70,815 | | | 84,737 | | | (13,922) | | | (16.4) | % |
+International: | | | | | | | | | | | | | | | | |
+Retail | | 18,479 | | | 15,867 | | | 2,612 | | | 16.5 | % | | 32,188 | | | 28,549 | | | 3,639 | | | 12.7 | % |
+Foodservice | | 12,711 | | | 15,127 | | | (2,416) | | | (16.0) | % | | 24,036 | | | 30,403 | | | (6,367) | | | (20.9) | % |
+International net revenues | | 31,190 | | | 30,994 | | | 196 | | | 0.6 | % | | 56,224 | | | 58,952 | | | (2,728) | | | (4.6) | % |
+Net revenues | | $ | 68,832 | | | $ | 74,958 | | | $ | (6,126) | | | (8.2) | % | | $ | 127,039 | | | $ | 143,689 | | | $ | (16,650) | | | (11.6) | % |
+| | | | | | | | | | | | | | | | |
+
+
+
+Volume of products sold by channel (unaudited):
+
+
+The following table presents consolidated volume of the Company’s products sold in pounds for the respective periods presented (in thousands, except for percentages):
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended | | Change | | Six Months Ended
+| | Change |
+| | June 27, 2026 | | June 28, 2025 | | Amount | | % | | June 27, 2026 | | June 28, 2025 | | Amount | | % |
+U.S.: | | | | | | | | | | | | | | | | |
+Retail | | 5,785 | | | 6,136 | | | (351) | | | (5.7) | % | | 10,684 | | | 11,877 | | | (1,193) | | | (10.0) | % |
+Foodservice | | 1,313 | | | 1,809 | | | (496) | | | (27.4) | % | | 2,389 | | | 3,387 | | | (998) | | | (29.5) | % |
+International: | | | | | | | | | | | | | | | | |
+Retail | | 3,689 | | | 3,410 | | | 279 | | | 8.2 | % | | 6,361 | | | 6,074 | | | 287 | | | 4.7 | % |
+Foodservice | | 3,691 | | | 4,635 | | | (944) | | | (20.4) | % | | 6,875 | | | 9,359 | | | (2,484) | | | (26.5) | % |
+Volume of products sold | | 14,478 | | | 15,990 | | | (1,512) | | | (9.5) | % | | 26,309 | | | 30,697 | | | (4,388) | | | (14.3) | % |
+| | | | | | | | | | | | | | | | |
+
+
+
+Gross profit in the second quarter of 2026 was $5.9 million, or gross margin of 8.5%, compared to gross profit of $7.9 million, or gross margin of 10.6%, in the year-ago period. Gross profit and gross margin in the second quarter of 2026 included $1.6 million in expenses related to the cessation of the Company’s operational activities in China, compared to $1.7 million in the year-ago period. Additionally, gross profit and gross margin in the second quarter of 2026 were negatively impacted by a 3.8% increase in cost of goods sold per pound, partially offset by a 1.3% increase in net revenue per pound. The increase in cost of goods sold per pound primarily reflected increased materials costs and higher manufacturing expenses, including depreciation, which included $1.6 million in expenses related to the cessation of our operational activities in China, partially offset by lower inventory provision.
+
+
+
+
+
+
+
+
+
+
+
+Operating expenses were $36.7 million in the second quarter of 2026, compared to $45.4 million in the year-ago period. Operating expenses in the second quarter of 2026 included $4.7 million in incremental share-based compensation expense related to the Company’s convertible debt exchange, $0.5 million in certain non-routine SG&A expenses, $0.4 million in amortization of costs related to a partial lease termination of a portion of the Company’s Campus Headquarters, and a credit of $ 11.0 million reflecting the settlement of arbitration proceedings related to a previously-disclosed contractual dispute with a former co-manufacturer, compared to an expense of $2.5 million in the year-ago period.
+
+
+Loss from operations in the second quarter of 2026 was $30.8 million, compared to $37.5 million in the year-ago period. The reduction in loss from operations was driven by the decrease in operating expenses, partially offset by the decrease in gross profit.
+
+
+The following table summarizes certain charges recorded in the Company’s condensed consolidated statement of operations for the second quarter of 2026 (unaudited):
+| | | | | | | | | | | | | | | | | |
+(in thousands) | | | | Three Months Ended June 27, 2026 |
+| | | | | |
+Charges recorded in cost of goods sold | | | |
+Expenses related to cessation of operational activities in China | | $ | 1,560 | |
+Total charges recorded in cost of goods sold | | | 1,560 | |
+| | | | | |
+Charges recorded in operating expenses | | | |
+Incremental non-cash share-based compensation expense | | 4,747 | |
+Certain non-routine SG&A expenses | | | 467 | |
+Amortization of costs related to partial lease termination | | 387 | |
+Settlement related to contractual dispute with former co-manufacturer | (11,000) | |
+Total charges recorded in operating expenses | | (5,399) | |
+Total | | | | | $ | (3,839) | |
+
+
+
+Total other income, net, was $47.2 million in the second quarter of 2026, compared to $5.7 million in the year-ago period. The increase in total other income, net, was primarily due to $57.7 million in non-cash gain on debt extinguishment in connection with conversions of a portion of the Company’s 2030 Notes, partially offset by a $4.6 million increase in interest expense and a $3.8 million non-cash loss from the remeasurement of derivative liability.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Net income was $16.4 million in the second quarter of 2026, compared to net loss of $(31.8) million in the year-ago period. Net income per share available to common stockholders - basic was $0.03, compared to net loss per share available to common stockholders - basic of $(0.42) in the year-ago period. Net loss per share available to common stockholders - diluted was $(0.06), compared to net loss per share available to common stockholders - diluted of $(0.42) in the year-ago period. The increase in net income in the second quarter of 2026 was primarily driven by the increase in total other income, net, and the decrease in loss from operations.
+
+
+Adjusted EBITDA was a loss of $27.7 million, or -40.2% of net revenues, in the second quarter of 2026, compared to an Adjusted EBITDA loss of $24.7 million, or -33.0% of net revenues, in the year-ago period.
+
+
+Balance Sheet and Cash Flow Highlights
+
+
+The Company’s cash and cash equivalents balance, including restricted cash, was $186.1 million and total outstanding carrying value of debt, net of debt discount, was $323.8 million as of June 27, 2026, which included the total undiscounted future cash flows of the 2030 Notes recorded at the completion of the Company’s convertible debt exchange. Net cash used in operating activities was $23.2 million in the six months ended June 27, 2026, compared to $58.0 million in the year-ago period. Capital expenditures totaled $4.0 million in the six months ended June 27, 2026, compared to $6.4 million in the year-ago period. Net cash used in investing activities was $2.3 million in the six months ended June 27, 2026, compared to $6.1 million in the year-ago period. Net cash used in financing activities was $6.6 million in the six months ended June 27, 2026, compared to net cash provided by financing activities of $32.3 million in the year-ago period.
+
+
+Third Quarter 2026 Outlook
+
+
+The Company continues to experience an elevated level of uncertainty and volatility within its operating environment, which has, and may continue to have, unforeseen impacts on the Company’s actual realized results. In light of this uncertainty, the Company is limiting its outlook to the following:
+• In the third quarter of 2026, net revenues are expected to be approximately $60 million to $65 million.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Conference Call and Webcast
+
+
+The Company will host a conference call to discuss these results at 5:00 p.m. Eastern, 2:00 p.m. Pacific on Wednesday, August 5, 2026. Investors interested in participating in the live call can dial 412-902-4255. There will also be a simultaneous, live webcast available on the Investors section of the Company’s website at www.beyondmeat.com. The webcast will also be archived.
+
+
+About Beyond Meat
+
+
+Beyond Meat, Inc. (NASDAQ: BYND), otherwise known as Beyond The Plant Protein Company TM , is a plant protein company offering a portfolio of plant-based products made from simple ingredients without GMOs, no added hormones or antibiotics, and 0 mg of cholesterol per serving. Founded in 2009, Beyond Meat’s core products are designed to have the same taste and texture as animal-based meat while being better for people and the planet. Beyond Meat’s brand promise, Eat What You Love®, represents a strong belief that there is a better way to feed our future and that the positive choices we all make, no matter how small, can have a great impact on our personal health and the health of our planet. By shifting from animal-based protein to plant-based protein, we can positively impact four growing global issues: human health, climate change, constraints on natural resources and animal welfare. Visit www.BeyondMeat.com and follow @BeyondMeat on Facebook, Instagram, Threads and LinkedIn.
+
+
+Forward-Looking Statements
+
+
+Certain statements in this release constitute “forward-looking statements" within the meaning of the federal securities laws, including statements related to the Company’s expectations with respect to its third quarter 2026 outlook, its strategic repositioning and expansion into adjacent product categories, and efforts towards sustainable growth and improved financial performance.
+
+
+Forward-looking statements are based on management's current opinions, expectations, beliefs, plans, objectives, assumptions and projections regarding financial performance, prospects, future events and future results, including ongoing uncertainty related to macroeconomic issues, including high inflation and interest rates, prolonged, weakening demand in the plant-based meat category, ongoing concerns about the likelihood of a recession and increased competition, among other matters, and involve known and unknown risks that are difficult to predict. In some cases, you can identify forward-looking statements by the use of words such as “may,” “could,” “expect,” “intend,” “plan,” “seek,” “anticipate,” “believe,” “estimate,” “project,” “predict,” “outlook,” “potential,” “continue,” “likely,” “will,” “would” and variations of these terms and similar expressions, or the negative of these terms or similar expressions.
+
+
+
+
+
+
+
+
+
+
+
+These forward-looking statements are only predictions, not historical fact, and involve certain risks and uncertainties, as well as assumptions. Forward-looking statements should not be read as a guarantee of future performance or results, and will not necessarily be accurate indications of the times at, or by which or whether, such performance or results will be achieved. Actual results, levels of activity, performance, achievements and events could differ materially from those stated, anticipated or implied by such forward-looking statements. While Beyond Meat believes that its assumptions are reasonable, it is very difficult to predict the impact of known factors and, of course, it is impossible to anticipate all factors that could affect actual results. There are many risks and uncertainties that could cause actual results to differ materially from forward-looking statements made herein including, but not limited to: a further decrease in demand, and the underlying factors negatively impacting demand, in the plant-based meat category, including the exacerbation of weakness in the category by macroeconomic trends; the success of our marketing initiatives and the ability to maintain and grow our brand awareness, maintain, protect and enhance our brand, or rebrand altogether, attract and retain new customers and maintain and grow our market share, particularly while we are seeking to reduce our operating expenses; the success of our strategic repositioning to "Beyond The Plant Protein Company," including risks related to brand dilution or confusion, the failure to achieve meaningful consumer acceptance of an expanded portfolio of plant-based protein offerings across multiple categories and adjacencies, and the diversion of management time and financial resources from our existing business or other priorities; changes in the retail landscape, including our ability to maintain and expand our distribution footprint, the timing, success and level of trade and promotion discounts, our ability to maintain and grow market share and increase household penetration, repeat purchases, buying rates (amount spent per buyer) and purchase frequency, our ability to maintain and increase sales velocity of our products, and the timing and success of our efforts to expand distribution channels, such as our direct-to-consumer (DTC) channel, and planned new products or recently launched products; our ability to successfully innovate and commercialize new plant-based protein products, including in adjacent categories outside of our core, meat analog offerings, such as our Beyond Immerse functional beverage line of sparkling plant-based protein drinks, and consumer acceptance of such new products; the sufficiency of our cash and cash equivalents to meet our liquidity needs, including estimates of our expenses, future revenues, capital expenditures and capital requirements; our ability to obtain additional equity and/or debt financing, the terms of any such financing, and our ability to continue to bolster our balance sheet, particularly because we no longer satisfy the eligibility requirements for use of a registration statement on Form S-3 and, as a result, are unable to access our ATM Program; risks associated with our indebtedness, leverage and liquidity relating to our significant debt, including our ability to repay, refinance, equitize (in the case of our 0% Convertible Senior Notes due 2027 (the “2027 Notes”) that remain outstanding) and otherwise satisfy our obligations under each of the Loan and Security Agreement, the 2027 Notes that remain outstanding and our 7.00% Convertible Senior Secured Second Lien PIK Toggle Notes due 2030 (the “2030 Notes” and, together with the 2027 Notes,
+
+
+
+
+
+
+
+
+
+
+
+the “Notes”) issued in the exchange offer related to the 2027 Notes, which was completed on October 30, 2025 (the “Exchange Offer”), and our ability to comply with the covenants in the Loan and Security Agreement and respective indentures governing the Notes; our ability to raise the funds necessary to repurchase the Notes for cash, under certain circumstances, or to pay any cash amounts due under the Notes; the impact of the Exchange Offer on future availability of our pre-change net operating loss carryforwards and other tax attributes to offset our future net taxable income; the annual limitations on utilization of any remaining operating loss and tax credit carryforwards due to ownership change limitations provided by the Internal Revenue Code and similar state tax provisions, and the outcomes of any related audits or examinations; the significant dilution to our stockholders that resulted from the Exchange Offer and the additional dilution that resulted and will continue to result if we continue to exchange any portion of our outstanding Notes for equity, issue shares of our common stock with respect to the 2030 Notes (including any 2030 Notes issued as payment-in-kind interest on such 2030 Notes), including in connection with conversions of the 2030 Notes at our option or at the option of holders, upon equitization of the 2030 Notes, as payment of accrued interest in the form of common stock or in payment of certain make-whole payments on the 2030 Notes, in each case pursuant to the terms of the 2030 Notes, or if the lenders under the Loan and Security Agreement exercise their related warrants to purchase shares of our common stock or if the holders of the Big Geyser, Inc. warrants exercise their related warrants to purchase shares of our common stock; provisions in the respective indentures governing the Notes and in the Loan and Security Agreement delaying or preventing an otherwise beneficial takeover of us; and any adverse impact on our reported financial condition and results from the accounting methods for the Notes; our ability to remediate the existing material weaknesses in our internal control over financial reporting and maintain effective internal control over financial reporting and disclosure controls and procedures; risks and uncertainties related to failures to maintain effective internal control over financial reporting, and related to the identification of errors in our previously issued financial statements, such as those disclosed and corrected in this release, and a potential need to restate financial statements in such instances; market price fluctuations in the price of our common stock, whether due to dilution, adverse business or financial performance or the perception of such adverse performance, failure to meet the Nasdaq continued listing requirement for minimum bid price or other Nasdaq listing requirements and the potential delisting of our common stock, or market and trading dynamics unrelated to our underlying business, operating and financial performance or prospects or macro or industry fundamentals which may not coincide in timing with the disclosure of news or developments by or affecting us, could cause the market price of our common stock to fluctuate dramatically or decline rapidly, regardless of any developments in our business or financial results; the impact of general economic conditions in the U.S. and international markets on us, our customers, our suppliers, our vendors and consumers, including concerns related to inflation, geopolitical and economic uncertainty and instability, a potential recession, the shutdown of the federal government including regulatory agencies, tariffs and trade wars, and the effects of those conditions on
+
+
+
+
+
+
+
+
+
+
+
+consumer spending; the impact of adverse and uncertain political conditions in the U.S. and international markets, such as greater restrictions on free trade through significant increases in tariffs on raw materials, ingredients, finished goods and other products and supplies imported into the United States and increased uncertainty surrounding international trade policy and regulations, trade wars, including through the implementation of retaliatory tariffs or related counter-measures, and the negative effects of anti-American sentiment, the conflict in the Middle East (including with Iran), as well as the impact of inflation and high interest rates on consumer behavior, including higher food, grocery, raw materials, transportation, energy, labor and fuel costs; risks and uncertainties related to identifying and executing our current and future cost-reduction initiatives, cost structure improvements, workforce reductions, executive leadership changes and other organizational changes, including realignment of reporting structures, and the timing and success of continuing to reduce operating expenses and achieving our profitability, cash flow and financial performance objectives; our ability to streamline operations and improve cost efficiencies, which could result in the contraction of our business and the continued implementation of significant cost cutting measures such as further downsizing, consolidating or exiting certain operations, including product lines, domestically and/or abroad; the timing and success of narrowing our commercial focus to certain anticipated growth opportunities; accelerating activities that prioritize gross margin expansion and cash generation, including as part of our review of our global operations initiated in 2023 (“Global Operations Review”); changes to our pricing architecture; cash-accretive inventory reduction initiatives; and further cost-reduction initiatives; our ability to successfully execute our Global Operations Review and any resulting strategic plans, including the exit or discontinuation of select product lines; the impact of non-cash charges such as provision for excess and obsolete inventory and potential additional impairment charges, write-offs, disposals and accelerated depreciation of fixed assets, and losses on sale and write-down of fixed assets and assets held for sale; further optimization of our manufacturing capacity and real estate footprint; workforce reductions; and the cessation of our operational activities in China in 2025; our ability to successfully execute the Transformation Office initiatives including, among other things, positioning the business for a more fundamental resizing of operating expenses, driving margin recovery, including through targeted investments in our facilities and supply chain cost reductions, reducing inventory and associated carrying costs through SKU rationalization and the discontinuation of certain product lines, and preserving cash and monetizing non-strategic or idle assets; our ability to meet our obligations under leases for our corporate offices, manufacturing facilities and warehouses, including matters relating to our Campus Headquarters including, without limitation, the ability to meet our obligations under our Campus Headquarters lease, as amended from time to time (the “Campus Lease”), the impact of workforce reductions or other cost-reduction initiatives on our space demands, the impact of the surrender of a portion of the existing premises, the impact of the sublease of a portion of the existing premises, other efforts to develop, repurpose or consolidate our use of our leased premises, and the timing and success of surrendering, subleasing, assigning or otherwise transferring, developing or
+
+
+
+
+
+
+
+
+
+
+
+repurposing the remaining used or excess leased space or negotiating additional partial lease terminations and/or subleases or other dispositions of our Campus Headquarters on terms advantageous to us or at all, including any additional impairment charges that may result, the amount of which could be material to our consolidated financial statements; reduced consumer confidence and changes in consumer spending, including spending to purchase our products, and negative trends in consumer purchasing patterns due to levels of consumers’ disposable income, credit availability and debt levels, and economic conditions, including due to potential recessionary and inflationary pressures, and geopolitical instability and wars; our inability to properly manage and ultimately sell our inventory in a timely manner, which has in the past and could in the future require us to sell our products through liquidation channels at lower prices, write-down or write-off excess or obsolete inventory, or increase inventory provision; ongoing and persistent declines in demand in the plant-based meat category and for our products, or strategic decisions that result in changes to our product portfolio, including the potential discontinuation of certain product lines through initiatives stemming from our transformation office and program or other strategic measures, which may require us to write-down or write-off excess or obsolete inventories; impairment charges, including due to any future changes in estimates, judgments or assumptions, failure to achieve forecasted operating results, due to weakness in the economic environment, demand for our products or other factors, changes in market conditions and declines in our publicly-quoted stock price and market capitalization, failure to sublease, assign or otherwise transfer any excess space or negotiate additional partial lease terminations and/or subleases or other dispositions of our Campus Headquarters or other facilities on terms advantageous to us or at all, and the cessation of our operational activities in China in 2025; our ability to accurately predict consumer taste preferences, trends and demand and successfully innovate, introduce and commercialize new products, including in new geographic markets; the effects of competitive activity from our market competitors, including through consolidation in the plant-based food industry or vertical consolidation of diversified food businesses with existing plant-based food businesses, and new market entrants, which may include companies with substantially greater financial resources than us; our ability to protect our brand against misinformation about our products and the plant-based meat category, real or perceived quality or health issues with our products, marketing campaigns aimed at generating negative publicity regarding our products and the plant-based meat category, including regarding the nutritional value of our products, and other issues that could adversely affect our brand and reputation; disruption to, and the impact of uncertainty in, our domestic and international supply chain, including labor shortages and disruption, shipping delays and disruption, the impact of tariffs on raw materials, ingredients, finished goods and other products and supplies imported into the U.S., and the impact of cyber incidents at suppliers and vendors; the impact of uncertainty as a result of doing business internationally, including as a result of the cessation of our operational activities in China in 2025; the volatility of or inability to access the capital markets, including due to macroeconomic factors, geopolitical tensions, trade policy uncertainty (including tariffs and retaliatory trade measures), or the
+
+
+
+
+
+
+
+
+
+
+
+outbreak or escalation of hostilities or war—for example, the ongoing war between Russia and Ukraine and the conflict in the Middle East (including with Iran), and their impacts on the surrounding areas and global economy; changes in the foodservice landscape, including the timing, success and level of marketing and other financial incentives to assist in the promotion of our products, our ability to maintain and grow market share and attract and retain new foodservice customers or retain existing foodservice customers, and our ability to introduce and sustain offering of our products on menus; the timing and success of distribution expansion and new product introductions, including the success of our DTC channel, and the timing and success of planned new products or recently launched products in increasing revenues and market share, including the success of our distribution partnership with Big Geyser for Beyond Immerse; our ability to differentiate and continuously create innovative products, respond to competitive innovation and achieve speed-to-market, including the timing and success of planned new products or recently launched products; the timing and success of strategic Quick Service Restaurant (“QSR”) partnership launches and limited time offerings resulting in permanent menu items and our ability to attract and retain QSR and other strategic customers; the outcomes of, and costs related to, legal or administrative proceedings, including any settlements, appeals from initial decisions or other developments in such proceedings, or new legal or administrative proceedings filed against us; foreign currency exchange rate fluctuations; the effectiveness of our business systems and processes; our estimates of the size of our market opportunities and ability to accurately forecast market conditions; our ability to effectively optimize our manufacturing and production capacity, and real estate footprint, including consolidating manufacturing facilities and production lines, exiting co-manufacturing arrangements or entering into new arrangements under terms that are ultimately beneficial to us and effectively managing capacity for specific products with shifts in demand; risks associated with underutilization of capacity which have in the past and could in the future give rise to increased cost of goods sold per pound, underutilization fees, termination fees and other costs to exit certain supply chain arrangements and product lines, and/or the write-down or write-off of certain equipment and other fixed assets and impairment charges, all of which could negatively impact gross margin, driving less leverage on fixed costs and delaying the speed at which cost savings initiatives positively impact our financial results; our ability to accurately forecast our future results of operations and financial goals or targets, including as a result of fluctuations in demand for our products and in the plant-based meat category generally, increased competition, the impact and success of launching new products and new channels, and the impact of broader macroeconomic conditions and market uncertainty; our ability to accurately forecast demand for our products and manage our inventory, including the impact of customer orders ahead of holidays and the timing of customer promotions, shelf reset activities, and price increases as a result of tariffs or otherwise; customer and distributor changes and buying patterns, such as reductions in targeted inventory levels; and supply chain and labor disruptions, including due to the impact of cyber incidents at suppliers and vendors; our operational effectiveness and ability to fulfill orders in full and on time; variations in product selling prices and costs, the timing and success of
+
+
+
+
+
+
+
+
+
+
+
+changes to our pricing architecture, our ability to pass on price increases in full or at all, including due to the impact of tariffs and macroeconomic conditions, and the mix of products sold; our ability to successfully enter new geographic markets, manage our international business and comply with any applicable laws and regulations, including risks associated with doing business in foreign countries, and our ability to comply with the U.S. Foreign Corrupt Practices Act or other anti-corruption laws; the effects of global outbreaks of pandemics, epidemics or other public health crises, or fear of such crises; our ability to attract, maintain and effectively expand our relationships with key strategic foodservice partners; our ability to attract and retain our suppliers, distributors, vendors, co-manufacturers and customers; our ability to procure sufficient high-quality raw materials at competitive prices to manufacture our products; the availability of pea and other proteins and avocado oil that meet our standards; our ability to diversify the protein sources and avocado oil sources used for our products; our ability to successfully execute our strategic initiatives; the volatility associated with ingredient, packaging, transportation and other input costs, including due to the impact of tariffs and rising energy and fuel costs; our ability to keep pace with technological changes impacting the development of our products and implementation of our business needs; significant disruption in, or breach in security of our or our suppliers’ or vendors’ information technology systems, including any inability to detect or timely report any cybersecurity incidents, and resultant interruptions in service and any related impact on our reputation, including data privacy, and any potential impact on our supply chain, including on customer demand, order fulfillment and lost sales, and the resulting timing and/or amount of net revenues recognized; the ability of our transportation providers to ship and deliver our products in a timely and cost-effective manner; senior management and key personnel changes, the attraction, training and retention of qualified employees and key personnel, and our ability to maintain our company culture; risks related to use of a professional employer organization to administer human resources, payroll and employee benefits functions for certain of our international employees, and use of certain third party service providers for the performance of several business operations including payroll, human capital, supply chain optimization, financial reporting and accounting, and certain other management services; the impact of potential workplace hazards; the effects of natural or man-made catastrophic or severe weather events, including events brought on by climate change, particularly involving our or any of our co-manufacturers’ manufacturing facilities, our suppliers’ facilities or any other vital aspects of our supply chain; accounting estimates based on judgment and assumptions that may differ from actual results; changes in laws and government regulation, and their enforcement, affecting our business, including the U.S. Food and Drug Administration (“FDA”) and the U.S. Federal Trade Commission governmental regulation, and state, local and foreign regulation; new or pending legislation, or changes in laws, regulations or policies of governmental agencies or regulators, both in the U.S. and abroad, affecting plant-based meat, the labeling, packaging or naming of our products, including requirements regarding nutrient content claims, our brand name or logo, or the definition of “ultraprocessed” foods or ingredients; the failure of acquisitions and other investments to be efficiently
+
+
+
+
+
+
+
+
+
+
+
+integrated and produce the results we anticipate; risks inherent in investment in real estate; adverse developments affecting the financial services industry, including the potential failure of financial institutions with which we have deposits or other business relationships; the financial condition of, and our relationships with our suppliers, vendors, co-manufacturers, distributors, retailers and foodservice customers, and their future decisions regarding their relationships with us; our ability and the ability of our suppliers, vendors and co-manufacturers to comply with food safety, environmental or other laws or regulations and the impact of any non-compliance on our operations, brand reputation and ability to fulfill orders in full and on time; seasonality, including increased levels of grilling activity and higher levels of purchasing by customers ahead of holidays, customer shelf reset activity and the timing of product restocking by our retail customers; the impact of increased scrutiny from a variety of stakeholders, institutional investors and governmental bodies on environmental, social and governance (“ESG”) practices; our suppliers’ and our co-manufacturers’ ability to protect our proprietary technology, intellectual property and trade secrets adequately; the impact of changes in tax laws; and the risks discussed in Part I, Item 1A, Risk Factors, included in our Annual Report on Form 10-K for the fiscal year ended December 31, 2025 filed with the Securities and Exchange Commission (the “SEC”) on April 9, 2026, the Company’s Quarterly Report on Form 10-Q for the fiscal quarter ended June 27, 2026 to be filed with the SEC, and those discussed in other documents we file from time to time with the SEC. All forward-looking statements attributable to us or persons acting on our behalf are expressly qualified in their entirety by the cautionary statements set forth above. Such forward-looking statements are made only as of the date of this release. Beyond Meat undertakes no obligation to publicly update or revise any forward-looking statement because of new information, future events, changes in assumptions or otherwise, except to the extent required by applicable laws. If the Company does update one or more forward-looking statements, no inference should be made that it will make additional updates with respect to those or other forward-looking statements.
+
+
+Non-GAAP Financial Measures
+
+
+The Company refers to certain financial measures that are not recognized under U.S. generally accepted accounting principles (GAAP) in this press release, including: Adjusted loss from operations, Adjusted operating margin, Adjusted net loss, Adjusted net loss per diluted common share, Adjusted EBITDA and Adjusted EBITDA as a % of net revenues. See “Non-GAAP Financial Measures” below for additional information and reconciliations of such non-GAAP financial measures.
+
+
+
+
+
+
+
+
+
+
+
+Availability of Information on Beyond Meat’s Website and Social Media Channels
+Investors and others should note that Beyond Meat routinely announces material information to investors and the marketplace using SEC filings, press releases, public conference calls, webcasts and the Beyond Meat Investor Relations website. The Company also intends to use certain social media channels as a means of disclosing information about it and its products to consumers, and its customers, investors and the public (e.g., @BeyondMeat on Facebook, Instagram, Threads and LinkedIn. The information posted on social media channels is not incorporated by reference in this press release or in any other report or document we file with the SEC. While not all of the information that the Company posts to the Beyond Meat Investor Relations website or to social media accounts is of a material nature, some information could be deemed to be material. Accordingly, the Company encourages investors, the media and others interested in Beyond Meat to review the information that it shares at the “Investors” link located at the bottom of the Company’s webpage at https://investors.beyondmeat.com/investor-relations and to sign up for and regularly follow the Company’s social media accounts. Users may automatically receive email alerts and other information about the Company when enrolling an email address by visiting “Request Email Alerts” in the “Investors” section of Beyond Meat’s website at https://investors.beyondmeat.com/investor-relations.
+
+
+Contacts
+
+
+Media:
+Shira Zackai
+shira.zackai@beyondmeat.com
+
+
+Investors:
+Raphael Gross
+beyondmeat@icrinc.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+Correction of Previously Issued Interim Unaudited Condensed Consolidated Financial Statements
+
+
+During the fourth quarter and full year 2025 financial close procedures, the Company identified errors in its previously issued interim unaudited condensed consolidated financial statements for the first three quarters of 2025 relating to (i) inventory valuation and (ii) debt issuance costs. The Company determined that the errors identified were immaterial to its previously issued interim unaudited condensed consolidated financial statements for the three and six months ended June 28, 2025 and has corrected these errors prospectively in the interim unaudited condensed consolidated financial statements for the three and six months ended June 28, 2025 in accordance with Accounting Standards Codification 250, “Accounting Changes and Error Corrections.”
+
+
+As a result, the comparative financial information for the three and six months ended June 28, 2025 included in the unaudited condensed consolidated financial statements and related non-GAAP reconciliations presented herein reflects these corrections and may differ from amounts previously reported in the Company’s Quarterly Report on Form 10-Q for the fiscal quarter ended June 28, 2025.
+
+
+To assist investors in reconciling amounts previously reported to the “as corrected” amounts presented herein, the Company has included the following tables that summarize the affected line items and totals. Readers should review these tables together with the discussion above, the unaudited condensed consolidated financial statements included herein, and the additional detail in the Company’s Quarterly Report on Form 10 ‑ Q for the quarter ended June 27, 2026, when filed with the SEC.
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+Condensed Consolidated Statement of Operations (unaudited) | | | | |
+
+
+| | Three Months Ended June 28, 2025
+|
+| | As Previously Reported | | Inventory Valuation | | Debt Issuance Costs | | As Corrected |
+Cost of goods sold | | $ | 66,367 | | | $ | 671 | | | $ | — | | | $ | 67,038 | |
+Gross profit | | 8,591 | | | (671) | | | — | | | 7,920 | |
+Selling, general and administrative expenses | | 37,696 | | | — | | | 1,932 | | | 39,628 | |
+Total operating expenses | | 43,503 | | | — | | | 1,932 | | | 45,435 | |
+Loss from operations | | (34,912) | | | (671) | | | (1,932) | | | (37,515) | |
+Loss before taxes | | (29,183) | | | (671) | | | (1,932) | | | (31,786) | |
+Net loss | | (29,242) | | | (671) | | | (1,932) | | | (31,845) | |
+Net loss per share available to common stockholders—basic and diluted | | $ | (0.38) | | | $ | (0.01) | | | $ | (0.03) | | | $ | (0.42) | |
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+Condensed Consolidated Statement of Operations (unaudited) | | | | |
+
+
+| | Six Months Ended June 28, 2025
+|
+| | As Previously Reported | | Inventory Valuation | | Debt Issuance Costs | | As Corrected |
+Cost of goods sold | | $ | 136,163 | | | $ | 6,531 | | | $ | — | | | $ | 142,694 | |
+Gross profit | | 7,526 | | | (6,531) | | | — | | | 995 | |
+Selling, general and administrative expenses | | 85,368 | | | — | | | 4,242 | | | 89,610 | |
+Total operating expenses | | 98,637 | | | — | | | 4,242 | | | 102,879 | |
+Loss from operations | | (91,111) | | | (6,531) | | | (4,242) | | | (101,884) | |
+Loss before taxes | | (82,088) | | | (6,531) | | | (4,242) | | | (92,861) | |
+Net loss | | (82,158) | | | (6,531) | | | (4,242) | | | (92,931) | |
+Net loss per share available to common stockholders—basic and diluted | | $ | (1.08) | | | $ | (0.08) | | | $ | (0.06) | | | $ | (1.22) | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+
+
+|
+Condensed Consolidated Statement of Comprehensive Loss (unaudited) | | | | | |
+| | Three Months Ended June 28, 2025 |
+| | As Previously Reported | | Inventory Valuation | | Debt Issuance Costs | | As Corrected |
+Net loss | | $(29,242) | | $(671) | | $(1,932) | | $(31,845) |
+Comprehensive loss | | $(31,710) | | $(671) | | $(1,932) | | $(34,313) |
+| | | | | | | | |
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+
+
+| | | | | | |
+Condensed Consolidated Statement of Comprehensive Loss (unaudited) | | | | | |
+| | Six Months Ended June 28, 2025 |
+| | As Previously Reported | | Inventory Valuation | | Debt Issuance Costs | | As Corrected |
+Net loss | | $(82,158) | | $(6,531) | | $(4,242) | | $(92,931) |
+Comprehensive loss | | $(85,666) | | $(6,531) | | $(4,242) | | $(96,439) |
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | |
+Condensed Consolidated Cash flows (unaudited) | | | | | | | | |
+
+
+| | Six Months Ended June 28, 2025
+|
+| | As Previously Reported | | Inventory Valuation | | Debt Issuance Costs | | As Corrected |
+Net loss | | $ | (82,158) | | | $ | (6,531) | | | $ | (4,242) | | | $ | (92,931) | |
+Inventories | | 4,709 | | | 6,531 | | | — | | | 11,240 | |
+Prepaid expenses and other current assets | | (8,473) | | | — | | | 5,623 | | | (2,850) | |
+Net cash used in operating activities | | (59,355) | | | — | | | 1,381 | | | (57,974) | |
+| | | | | | | | |
+Debt issuance costs | | (5,117) | | | — | | | (1,381) | | | (6,498) | |
+Net cash provided by financing activities | | $ | 33,640 | | | $ | — | | | $ | (1,381) | | | $ | 32,259 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+BEYOND MEAT, INC. AND SUBSIDIARIES
+Condensed Consolidated Statements of Operations
+(In thousands, except share and per share data)
+(unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | |
+| | Three Months Ended | | Six Months Ended |
+| | June 27, 2026 | | June 28, 2025 | | June 27, 2026 | | June 28, 2025 |
+Net revenues | | $ | 68,832 | | | $ | 74,958 | | | $ | 127,038 | | | $ | 143,689 | |
+Cost of goods sold | | 62,959 | | | 67,038 | | | 119,180 | | | 142,694 | |
+Gross profit
+| | 5,873 | | | 7,920 | | | 7,858 | | | 995 | |
+Operating expenses: | | | | | | | | |
+Research and development expenses | | 4,189 | | | 5,807 | | | 9,409 | | | 13,269 | |
+Selling, general and administrative expenses | | 32,490 | | | 39,628 | | | 70,359 | | | 89,610 | |
+| | | | | | | | |
+Total operating expenses | | 36,679 | | | 45,435 | | | 79,768 | | | 102,879 | |
+Loss from operations
+| | (30,806) | | | (37,515) | | | (71,910) | | | (101,884) | |
+Other income (expense), net: | | | | | | | | |
+Interest expense | | (6,571) | | | (2,002) | | | (13,303) | | | (3,026) | |
+Remeasurement of delayed draw term loan warrant liability | | (76) | | | — | | | 1,224 | | | — | |
+Remeasurement of derivative liability | | (3,838) | | | — | | | 8,053 | | | — | |
+Gain on debt extinguishment | | 57,729 | | | — | | | 63,789 | | | — | |
+Other (expense) income, net | | (18) | | | 7,731 | | | 101 | | | 12,049 | |
+Total other income, net
+| | 47,226 | | | 5,729 | | | 59,864 | | | 9,023 | |
+Income (loss) before taxes
+| | 16,420 | | | (31,786) | | | (12,046) | | | (92,861) | |
+Income tax expense | | — | | | — | | | — | | | — | |
+Equity in losses of unconsolidated joint venture | | 16 | | | 59 | | | 32 | | | 70 | |
+Net income (loss)
+| | $ | 16,404 | | | $ | (31,845) | | | $ | (12,078) | | | $ | (92,931) | |
+| | | | | | | | |
+| | | | | | | | |
+Net income (loss) per share attributable to common stockholders:
+| | | | | | | | |
+Basic | | $ | 0.03 | | | $ | (0.42) | | | $ | (0.03) | | | $ | (1.22) | |
+Diluted | | (0.06) | | | (0.42) | | | (0.03) | | | (1.22) | |
+Weighted average common shares outstanding | | | | | | | | |
+Basic | | 501,304,934 | | | 76,491,594 | | | 476,742,903 | | | 76,348,524 | |
+| | | | | | | | |
+Diluted | | 591,868,891 | | | 76,491,594 | | | 476,742,903 | | | 76,348,524 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | |
+BEYOND MEAT, INC. AND SUBSIDIARIES |
+Condensed Consolidated Balance Sheets |
+(In thousands, except share and per share data) |
+(unaudited) |
+| | June 27, 2026 | | December 31, 2025 |
+|
+Assets | | | | |
+Current assets: | | | | |
+Cash and cash equivalents | | $ | 171,369 | | | $ | 203,890 | |
+Restricted cash, current | | 5,516 | | | 4,350 | |
+Accounts receivable, net | | 25,725 | | | 26,060 | |
+Inventory | | 63,127 | | | 84,032 | |
+Prepaid expenses and other current assets | | 21,168 | | | 13,758 | |
+Assets held for sale | | 8,744 | | | 9,394 | |
+Total current assets | | 295,649 | | | 341,484 | |
+Restricted cash, non-current | | 9,250 | | | 9,291 | |
+Property, plant, and equipment, net | | 201,672 | | | 213,262 | |
+Operating lease right-of-use assets | | 4,613 | | | 5,661 | |
+Prepaid lease costs, non-current | | 42,503 | | | 40,931 | |
+Other non-current assets, net | | 4,675 | | | 2,595 | |
+Investment in unconsolidated joint venture | | 1,491 | | | 1,523 | |
+Total assets | | $ | 559,853 | | | $ | 614,747 | |
+Liabilities and stockholders’ deficit | | | | |
+Current liabilities: | | | | |
+Accounts payable | | $ | 25,015 | | | $ | 20,525 | |
+2027 Notes | | 29,459 | | | — | |
+| | | | |
+Current portion of operating lease liabilities | | 2,162 | | | 2,132 | |
+Accrued expenses and other current liabilities | | 12,709 | | | 8,975 | |
+Accrued litigation expenses | | 38,900 | | | 38,900 | |
+| | | | |
+| | | | |
+Short-term finance lease liabilities | | 3,998 | | | 4,385 | |
+| | | | |
+Total current liabilities | | 112,243 | | | 74,917 | |
+Long-term liabilities: | | | | |
+2027 Notes | | — | | | 29,459 | |
+2030 Notes, net | | 208,705 | | | 308,404 | |
+Delayed draw term loans, net | | 85,632 | | | 77,877 | |
+Delayed draw term loan warrants at fair value | | 3,843 | | | 5,066 | |
+| | | | |
+Operating lease liabilities, net of current portion | | 3,058 | | | 4,059 | |
+Finance lease liabilities | | 74,799 | | | 76,590 | |
+2030 Notes Embedded Derivative liability at fair value | | 14,596 | | | 39,152 | |
+Other long-term liabilities | | 220 | | | 220 | |
+Total long-term liabilities | | 390,853 | | | 540,827 | |
+(continued on next page) |
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | |
+BEYOND MEAT, INC. AND SUBSIDIARIES |
+Condensed Consolidated Balance Sheets |
+(In thousands, except share and per share data) |
+(unaudited) |
+| | June 27, 2026 | | December 31, 2025 |
+|
+Commitments and contingencies | | | | |
+Stockholders’ deficit: | | | | |
+Preferred stock, par value $0.0001 per share — 500,000 shares authorized, none issued and outstanding
+| | — | | | — | |
+Common stock, par value $0.0001 per share — 3,000,000,000 shares authorized; 515,793,219 shares and 453,688,312 shares issued and outstanding at June 27, 2026 and December 31, 2025, respectively
+| | 52 | | | 45 | |
+Additional paid-in-capital | | 1,096,070 | | | 1,029,308 | |
+| | | | |
+Accumulated deficit | | (1,034,585) | | | (1,022,507) | |
+Accumulated other comprehensive loss | | (4,780) | | | (7,843) | |
+Total stockholders’ equity (deficit) | | 56,757 | | | (997) | |
+Total liabilities and stockholders' equity (deficit) | | $ | 559,853 | | | $ | 614,747 | |
+|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | |
+BEYOND MEAT, INC. AND SUBSIDIARIES
+|
+Condensed Consolidated Statements of Cash Flows
+|
+(In thousands)
+|
+(unaudited) |
+| | Six Months Ended |
+| | June 27, 2026 | | June 28, 2025 |
+Cash flows from operating activities: | | | | |
+Net loss
+| | $ | (12,078) | | | $ | (92,931) | |
+Adjustments to reconcile net loss to net cash used in operating activities: | | | | |
+Depreciation and amortization | | 13,549 | | | 15,682 | |
+Non-cash lease expense | | 985 | | | 2,889 | |
+| | | | |
+Share-based compensation expense | | 13,919 | | | 10,157 | |
+| | | | |
+Amortization of debt issuance costs and debt discount | | 3,652 | | | 1,970 | |
+Loss on sale and write-down of fixed assets | | 162 | | | 223 | |
+| | | | |
+Equity in losses of unconsolidated joint venture | | 32 | | | 70 | |
+| | | | |
+Remeasurement of delayed draw term loan warrant liability | | (1,224) | | | — | |
+Remeasurement of derivative liability | | (8,053) | | | — | |
+Gain on debt extinguishment | | (63,789) | | | — | |
+Unrealized losses (gains) on foreign currency transactions | | 3,093 | | | (11,161) | |
+Paid-in-kind interest | | 6,315 | | | — | |
+| | | | |
+| | | | |
+Net change in operating assets and liabilities: | | | | |
+Accounts receivable | | 168 | | | (9,291) | |
+Inventories | | 20,580 | | | 11,240 | |
+Prepaid expenses and other current assets | | (8,540) | | | (2,850) | |
+Accounts payable | | 5,140 | | | 25,710 | |
+Accrued expenses and other current liabilities | | 4,006 | | | (3,638) | |
+Prepaid lease costs, non-current | | (155) | | | (3,888) | |
+Operating lease liabilities | | (918) | | | (2,156) | |
+| | | | |
+| | | | |
+Net cash used in operating activities
+| | (23,156) | | | (57,974) | |
+| | | | |
+Cash flows from investing activities: | | | | |
+Purchases of property, plant and equipment | | (4,015) | | | (6,423) | |
+| | | | |
+Proceeds from sales of fixed assets | | 1,924 | | | 348 | |
+| | | | |
+| | | | |
+| | | | |
+Payments of security deposits | | (204) | | | — | |
+Net cash used in investing activities
+| | (2,295) | | | (6,075) | |
+(continued on the next page) |
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | |
+BEYOND MEAT, INC. AND SUBSIDIARIES
+|
+Condensed Consolidated Statements of Cash Flows
+|
+(In thousands)
+|
+(unaudited) |
+| | Six Months Ended |
+| | June 27, 2026 | | June 28, 2025 |
+Cash flows from financing activities: | | | | |
+| | | | |
+Proceeds from delayed draw term loan | | $ | — | | | $ | 40,000 | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+Payments of debt issuance costs | | — | | | (6,498) | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+Principal payments under finance lease obligations | | (3,594) | | | (937) | |
+| | | | |
+| | | | |
+| | | | |
+Payments of minimum withholding taxes on net share settlement of equity awards | | (3,019) | | | (312) | |
+| | | | |
+| | | | |
+Net cash (used in) provided by financing activities
+| | (6,613) | | | 32,259 | |
+Effect of foreign currency exchange rate changes on cash | | 668 | | | 3,505 | |
+Net decrease in cash, cash equivalents and restricted cash
+| | (31,396) | | | (28,285) | |
+Cash, cash equivalents and restricted cash at the beginning of the period | | 217,531 | | | 145,554 | |
+Cash, cash equivalents and restricted cash at the end of the period | | $ | 186,135 | | | $ | 117,269 | |
+| | | | |
+Supplemental disclosures of cash flow information: | | | | |
+| | | | |
+| | | | |
+| | | | |
+Non-cash investing and financing activities: | | | | |
+| | | | |
+Conversion of 2030 Notes by issuance of common stock | | $ | 54,627 | | | $ | — | |
+Issuance of delayed draw term loan warrants | | $ | — | | | $ | 20,143 | |
+Non-cash additions to property, plant and equipment | | $ | 161 | | | $ | 1,345 | |
+| | | | |
+Operating lease right-of-use assets obtained in exchange for lease liabilities | | $ | 83 | | | $ | 2,082 | |
+Reclassification of pre-paid lease costs to finance lease right-of-use assets | | $ | — | | | $ | 19,929 | |
+| | | | |
+Non-cash additions to finance leases | | $ | — | | | $ | 10,091 | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Non-GAAP Financial Measures
+
+
+Beyond Meat uses the non-GAAP financial measures set forth below in assessing its operating performance and in its financial communications. Management believes these non-GAAP financial measures provide useful additional information to investors about current trends in the Company's operations and are useful for period-over-period comparisons of operations. In addition, management uses these non-GAAP financial measures to assess operating performance and for business planning purposes. Management also believes these measures are widely used by investors, securities analysts, rating agencies and other parties in evaluating companies in the Company’s industry as a measure of its operational performance. These non-GAAP financial measures should not be considered in isolation or as substitutes for the comparable GAAP measures. In addition, these non-GAAP financial measures may not be computed in the same manner as similarly titled measures used by other companies.
+
+
+“Adjusted loss from operations” is defined as loss from operations adjusted to exclude, when applicable, costs attributable to special items, which are those items deemed not to be reflective of the Company’s ongoing normal business activities.
+
+
+“Adjusted operating margin” is defined as Adjusted loss from operations divided by net revenues.
+
+
+“Adjusted net loss” is defined as net loss adjusted to exclude, when applicable, costs attributable to special items, which are those items deemed not to be reflective of the Company’s normal business activities.
+
+
+“Adjusted net loss per diluted common share” is defined as Adjusted net loss divided by the number of diluted common shares outstanding.
+
+
+The Company considers Adjusted loss from operations, Adjusted operating margin, Adjusted net loss and Adjusted net loss per diluted common share to be useful indicators of operating performance because excluding special items allows for period-over-period comparisons of its ongoing operations. Adjusted net loss per diluted common share is a performance measure and should not be used as a measure of liquidity.
+
+
+“Adjusted EBITDA” is defined as net income (loss) adjusted to exclude, when applicable, income tax expense (benefit), interest expense, depreciation and amortization expense, share-based compensation expense, non-cash charges related to the cessation of our operational activities in China, costs related to a partial lease termination of a portion of the Campus Headquarters, settlement related to dispute with former co-manufacturer, remeasurement of delayed draw term loan warrant liability,
+
+
+
+
+
+
+
+
+
+
+
+remeasurement of derivative liability, and Other, net, including interest income, gain on debt extinguishment, foreign currency transaction gains and losses, and the reclassification of cumulative foreign currency translation losses from accumulated other comprehensive loss to Other (expense) income, net upon the cessation of our operational activities in China.
+
+
+“Adjusted EBITDA as a % of net revenues” is defined as Adjusted EBITDA divided by net revenues.
+
+
+Our definition of Adjusted EBITDA has been updated from the definition used in our 2025 10-K to reflect the following changes: (i) we removed the adjustments for restructuring expenses, non-cash loss from impairment of long-lived assets and gain on debt restructuring, net of exchange fees, as these items related to transactions completed in 2025 and are not expected to recur in 2026; (ii) we removed litigation-related accruals as there were no such accruals in the three and six months ended June 27, 2026 and June 28, 2025; (iii) we removed accrued litigation settlement costs, as the class action settlement was finalized in 2025; (iv) we added settlement related to dispute with former co-manufacturer; and (v) we added gain on debt extinguishment to Other, net, to reflect gains arising from conversions of the 2030 Notes, in the three and six months ended June 27, 2026, and reclassification of cumulative foreign currency translation losses from accumulated other comprehensive loss to Other (expense) income, net upon the cessation of our operational activities in China. These definitional changes had no impact on previously reported Adjusted EBITDA for the comparative period presented, as there were no restructuring expenses, impairment charges, gain on debt restructuring, litigation-related accruals, accrued litigation settlement costs or gain on debt extinguishment in the three and six months ended June 28, 2025.
+
+
+There are a number of limitations related to the use of Adjusted EBITDA and Adjusted EBITDA as a % of net revenues rather than their most directly comparable GAAP measures. Some of these limitations are:
+• Adjusted EBITDA excludes depreciation and amortization expense and, although these are non-cash expenses, the assets being depreciated may have to be replaced in the future increasing our cash requirements;
+• Adjusted EBITDA does not reflect interest expense, or the cash required to service our debt, which reduces cash available to us;
+• Adjusted EBITDA does not reflect income tax payments that reduce cash available to us;
+• Adjusted EBITDA does not reflect share-based compensation expense and therefore does not include all of our compensation costs;
+• Adjusted EBITDA excludes the SG&A decrease related to our settlement we received in a legal matter;
+
+
+
+
+
+
+
+
+
+
+
+• Adjusted EBITDA does not reflect non-cash charges and reclassification of cumulative foreign currency translation losses from accumulated other comprehensive loss to earnings, related to the cessation of our operational activities in China;
+• Adjusted EBITDA does not reflect certain cash costs related to a partial lease termination of a portion of the Campus Headquarters, which reduces cash available to us;
+• Adjusted EBITDA does not reflect the non-cash impact of the gain on debt extinguishment;
+• Adjusted EBITDA does not reflect the non-cash impact of the remeasurement of delayed draw term loan warrant liability;
+• Adjusted EBITDA does not reflect the non-cash impact of the remeasurement of derivative liability;
+• Adjusted EBITDA does not reflect Other, net, including interest income, gain on debt extinguishment and foreign currency transaction gains and losses, that may increase or decrease cash available to us; and
+• other companies, including companies in our industry, may calculate Adjusted EBITDA differently, which reduces its usefulness as a comparative measure.
+
+
+The following tables present the reconciliation of Adjusted loss from operations, Adjusted operating margin, Adjusted net loss and Adjusted net loss per common share to their most comparable GAAP measures, loss from operations, loss from operations as a % of net revenues, net income (loss) and net income (loss) per share available to common stockholders—basic, each as reported (unaudited):
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+(in thousands) | June 27, 2026 | | June 28, 2025 | | June 27, 2026 | | June 28, 2025 |
+Loss from operations, as reported
+| $ | (30,806) | | | $ | (37,515) | | | $ | (71,910) | | $ | (101,884) |
+Non-cash charges related to the cessation of operational activities in China | 1,560 | | | 1,739 | | | 2,106 | | 3,822 |
+Costs related to partial lease termination | 387 | | | 499 | | | 773 | | 499 |
+Settlement related to dispute with former co- manufacturer | (11,000) | | | — | | | (11,000) | | — |
+| | | | | | | |
+Adjusted loss from operations
+| $ | (39,859) | | $ | (35,277) | | $ | (80,031) | | $ | (97,563) |
+Loss from operations as a % of net revenues | (44.8) | % | | (50.0) | % | | (56.6) | % | | (70.9) | % |
+Adjusted operating margin | (57.9) | % | | (47.1) | % | | (63.0) | % | | (67.9) | % |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+| | Six Months Ended
+|
+(in thousands)
+| June 27, 2026 | | June 28, 2025 | | June 27, 2026 | | June 28, 2025 |
+Net income (loss), as reported
+| $ | 16,404 | | | $ | (31,845) | | | $ | (12,078) | | | $ | (92,931) | |
+Non-cash charges related to the cessation of operational activities in China
+| 1,560 | | | 1,739 | | | 2,106 | | | 3,822 | |
+Costs related to partial lease termination
+| 387 | | | 499 | | | 773 | | | 499 | |
+Remeasurement of delayed draw term loan warrant liability | 76 | | | — | | | (1,224) | | | — | |
+Remeasurement of derivative liability | 3,838 | | | — | | | (8,053) | | | — | |
+Gain on debt extinguishment | (57,729) | | | — | | | (63,789) | | | — | |
+Settlement related to dispute with former co- manufacturer | (11,000) | | | — | | | (11,000) | | | — | |
+| | | | | | | |
+Adjusted net loss
+| $ | (46,464) | | | $ | (29,607) | | | $ | (93,265) | | | $ | (88,610) | |
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+| | Six Months Ended
+|
+(in thousands, except share and per share amounts)
+| June 27, 2026 | | June 28, 2025 | | June 27, 2026 | | June 28, 2025 |
+Numerator:
+| | | | | | | |
+Net income (loss), as reported
+| $ | 16,404 | | | $ | (31,845) | | | $ | (12,078) | | | $ | (92,931) | |
+Non-cash charges related to the cessation of operational activities in China
+| 1,560 | | | 1,739 | | | 2,106 | | | 3,822 | |
+Costs related to partial lease termination
+| 387 | | | 499 | | | 773 | | | 499 | |
+Remeasurement of delayed draw term loan warrant liability | 76 | | | — | | | (1,224) | | | — | |
+Remeasurement of derivative liability | 3,838 | | | — | | | (8,053) | | | — | |
+Gain on debt extinguishment | (57,729) | | | — | | | (63,789) | | | — | |
+Settlement related to dispute with former co- manufacturer | $ | (11,000) | | | $ | — | | | $ | (11,000) | | | $ | — | |
+| | | | | | | |
+Adjusted net loss used in computing Adjusted net loss per common share
+| $ | (46,464) | | | $ | (29,607) | | | $ | (93,265) | | | $ | (88,610) | |
+Denominator:
+| | | | | | | |
+Net income (loss) per share available to common stockholders — basic
+| $ | 0.03 | | | $ | (0.42) | | | $ | (0.03) | | | $ | (1.22) | |
+Weighted average common shares outstanding — basic | 501,304,934 | | | 76,491,594 | | | 476,742,903 | | | 76,348,524 | |
+Weighted average shares used in computing Adjusted net loss per common share
+| 501,304,934 | | | 76,491,594 | | | 476,742,903 | | | 76,348,524 | |
+Adjusted net loss per common share
+| $ | (0.09) | | | $ | (0.39) | | | $ | (0.20) | | | $ | (1.16) | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+The following table presents the reconciliation of Adjusted EBITDA to its most comparable GAAP measure, net income (loss), as reported, for the respective periods presented (unaudited) (in thousands, except for percentages):
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended | | Six Months Ended
+|
+| | June 27, 2026 | | June 28, 2025 | | June 27, 2026 | | June 28, 2025 |
+Net income (loss), as reported
+| | $ | 16,404 | | | $ | (31,845) | | | $ | (12,078) | | | $ | (92,931) | |
+Income tax expense | | — | | | — | | | — | | | — | |
+Interest expense | | 6,571 | | | 2,002 | | | 13,303 | | | 3,026 | |
+Depreciation and amortization expense (1)(2)
+| | 5,167 | | | 6,530 | | | 11,443 | | | 12,476 | |
+Share-based compensation expense | | 7,398 | | | 4,304 | | | 13,919 | | | 10,157 | |
+Non-cash charges related to the cessation of operational activities in China (3)
+| | 1,560 | | | 1,739 | | | 2,106 | | | 3,822 | |
+Costs related to partial lease termination, net of amounts included in depreciation and amortization expense | | — | | | 275 | | | — | | | 275 | |
+Remeasurement of delayed draw term loan warrant liability | | 76 | | | — | | | (1,224) | | | — | |
+Remeasurement of derivative liability | | 3,838 | | | — | | | (8,053) | | | — | |
+Gain on debt extinguishment | | (57,729) | | | — | | | (63,789) | | | — | |
+Settlement related to dispute with former co-manufacturer | | (11,000) | | | — | | | (11,000) | | | — | |
+Other, net (4)(5)
+| | 18 | | | (7,731) | | | (101) | | | (12,049) | |
+Adjusted EBITDA | | $ | (27,697) | | | $ | (24,726) | | | $ | (55,474) | | | $ | (75,224) | |
+Net loss as a % of net revenues | | 23.8 | % | | (42.5) | % | | (9.5) | % | | (64.7) | % |
+Adjusted EBITDA as a % of net revenues | | (40.2) | % | | (33.0) | % | | (43.7) | % | | (52.4) | % |
+_____________
+| | | | | |
+(1) | Excludes $1.6 million and $1.7 million in accelerated depreciation and other non-cash charges related to the reassessment of useful lives of certain assets resulting from the cessation of our operational activities in China in the three months ended June 27, 2026, and June 28, 2025, respectively, and $2.1 million and $3.8 million in the six months ended June 27, 2026, and June 28, 2025, respectively.
+|
+(2) | Includes $0.4 million and $0.8 million in amortization of lease termination costs apportioned for the three and six months ended June 27, 2026, respectively, and $0.3 million incurred in the three and six months ended June 28, 2025.
+|
+(3) | Includes $1.6 million and $1.7 million in accelerated depreciation and other non-cash charges related to the reassessment of useful lives of certain assets resulting from the cessation of our operational activities in China in the three months ended June 27, 2026, and June 28, 2025, respectively, and $2.1 million and $3.2 million, respectively, and $0 and $0.6 million in inventory and asset write-offs related to the cessation of operational activities in China in the six months ended June 27, 2026, and June 28, 2025, respectively.
+|
+(4) | Includes $(1.8) million and $7.5 million in net realized and unrealized foreign currency transaction (losses) gains in the three months ended June 27, 2026 and June 28, 2025, respectively and $(3.1) million and $11.0 million in net realized and unrealized foreign currency transaction (losses) gains in the six months ended June 27, 2026 and June 28, 2025, respectively.
+|
+(5) | Includes $1.5 million and $0.5 million in interest income in the three months ended June 27, 2026 and June 28, 2025, respectively, and $3.0 million and $1.4 million in interest income in the six months ended June 27, 2026 and June 28, 2025, respectively.
+|

--- a/modules/test-fixtures/earnings-filings/elf.txt
+++ b/modules/test-fixtures/earnings-filings/elf.txt
@@ -1,0 +1,359 @@
+EX-99.1
+2
+q12027er-991.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+
+
+e.l.f. Beauty Announces First Quarter Fiscal 2027 Results
+– Delivered 36% Net Sales Growth –
+– Raises Fiscal 2027 Outlook –
+OAKLAND, California; August 5, 2026 — e.l.f. Beauty (NYSE: ELF) today announced results for the three months ended June 30, 2026.
+“I’m proud of the e.l.f. Beauty team for achieving another quarter of industry-leading results,” said Tarang Amin, e.l.f. Beauty’s Chairman and Chief Executive Officer. “In Q1, we delivered 36% net sales growth, marking our 30th consecutive quarter – over seven continuous years – of net sales growth. This consistent, category-leading growth is a testament to the strength of our team, strategy, and portfolio of brands. With the momentum we’re seeing, we’re raising our fiscal 2027 outlook to 18 to 20 percent net sales growth from 12 to 14 percent previously.”
+
+
+Three Months Ended June 30, 2026 Results
+For the three months ended June 30, 2026, compared to the three months ended June 30, 2025:
+• Net sales increased 36% to $479.4 million, driven by strong performance in both our retailer and e-commerce channels, in the US and internationally.
+• Gross margin increased approximately 1,400 basis points to 83%, including approximately 1,050 basis points benefit from IEEPA tariff refunds, with the remaining increase primarily driven by benefits from pricing and lower year-over-year tariff rates.
+• Selling, general and administrative (“SG&A”) expenses increased $84.5 million to $280.3 million. Adjusted SG&A (SG&A excluding the items identified in the reconciliation table below) increased $83.4 million to $260.7 million. The increase in SG&A is primarily related to increases in marketing, merchandising and distribution costs, compensation and benefits, and depreciation and amortization.
+• Change in fair value of contingent consideration related to the acquisition of rhode (the “rhode Acquisition”). The Company recorded a fair value adjustment of $16.1 million for the three months ended June 30, 2026, driven by the outperformance of rhode's revenue results relative to the earnout thresholds set forth in the merger agreement entered into in connection with the rhode Acquisition.
+• Other (expense) income, net changed by $5.4 million year over year from $5.0 million in income to $0.3 million of expense, primarily driven by a decrease in foreign currency gains for the period attributable to currency rate fluctuation.
+• Net income was $66.6 million on a GAAP basis. Adjusted net income (net income excluding the items identified in the reconciliation table below) was $104.6 million.
+• Diluted earnings per share was $1.12 per share on a GAAP basis. Adjusted diluted earnings per share (diluted earnings per share calculated with adjusted net income excluding the items identified in the reconciliation table below) were $1.75.
+• Adjusted EBITDA (EBITDA excluding the items identified in the reconciliation table below) was $168.2 million, or 35% of net sales, up 93% year over year.
+Liquidity
+As of June 30, 2026, the Company had $344.2 million in cash and cash equivalents, and $834.2 million of total debt, as compared to $170.0 million in cash and cash equivalents and $256.7 million of total debt outstanding as of June 30, 2025.
+
+
+
+
+
+
+
+
+
+Updated Fiscal 2027 Outlook
+
+
+The Company is providing the following updated outlook for fiscal 2027. The updated outlook for fiscal 2027 reflects an expected 18-20% year-over-year increase in net sales, as compared to an expected 12-14% increase previously. | | | | | | | | | | | | | | | | | |
+| | | Previous Fiscal 2027 Outlook | | Updated Fiscal 2027 Outlook | | |
+Net sales | | | $1,835-1,865 million | | $1,938-1,968 million | | |
+Adjusted EBITDA | | | $379-385 million | | $401-407 million | | |
+Adjusted effective tax rate | | | 25-26% | | 25-26% | | |
+Adjusted net income | | | $198-201 million | | $212-215 million | | |
+Adjusted diluted earnings per share | | | $3.27-3.32 | | $3.50-3.55 | | |
+Weighted average diluted shares outstanding | | | 60.5 million | | 60.5 million | | |
+
+Webcast Details
+The Company will hold a webcast to discuss the results from its first quarter fiscal 2027 today, August 5, 2026, at 4:30 p.m. Eastern Time. The webcast will be broadcast live at https://investor.elfbeauty.com/stock-and-financial/events-and-presentations. For those unable to listen to the live broadcast, an archived version will be available at the same location.
+
+
+About e.l.f. Beauty
+e.l.f. Beauty (NYSE: ELF) is a different kind of company that disrupts norms, shapes culture and connects communities, through positivity, inclusivity and accessibility. The mission is clear: to make the best of beauty accessible to every eye, lip and face. e.l.f. Beauty and its brands, e.l.f. Cosmetics, e.l.f. SKIN, e.l.f. Hair, rhode, Naturium and Well People, are led by purpose and driven by results. e.l.f. Beauty offers e.l.f. clean and vegan products, all double-certified by PETA and Leaping Bunny as cruelty free, and proudly stands as the first beauty company with Fair Trade Certified™ facilities. With a kind heart at the center of e.l.f.’s ethos, the company donates 2% of net profits to organizations that make positive impacts.
+Learn more at https://www.elfbeauty.com/
+
+
+Note Regarding non-GAAP Financial Measures
+
+
+This press release includes references to non-GAAP measures, including adjusted EBITDA, adjusted SG&A, adjusted net income and adjusted diluted earnings per share. The Company presents these non-GAAP measures because its management uses them as supplemental measures in assessing its operating performance, and believes they are helpful to investors, securities analysts and other interested parties in evaluating the Company’s performance. The non-GAAP measures included in this press release are not measurements of financial performance under GAAP and they should not be considered as alternatives to or substitutes for measures of performance derived in accordance with GAAP. In addition, these non-GAAP measures should not be construed as an inference that the Company’s future results will be unaffected by unusual or non-recurring items. These non-GAAP measures have limitations as analytical tools, and you should not consider such measures either in isolation or as substitutes for analyzing the Company’s results as reported under GAAP. The Company’s definitions and calculations of these non-GAAP measures are not necessarily comparable to other similarly titled measures used by other companies due to different methods of calculation.
+Adjusted EBITDA excludes expense or income related to stock-based compensation, change in fair value of contingent consideration and other non-cash and non-recurring items. Such other non-cash or non-recurring items include amortization of internal-use software costs related to cloud applications, acquisition related costs and ERP implementation costs.
+Adjusted SG&A excludes expense related to stock-based compensation and other non-recurring items. Such other non-recurring items include other non-recurring ERP implementation costs and acquisition related costs.
+Adjusted effective tax rate is the tax rate when excluding the pre-tax impact of expense or income related to stock-based compensation, other non-cash and non-recurring items, amortization of acquired intangible assets, as well as the related tax impact for these items, calculated utilizing the statutory rate for where the impact was incurred.
+Adjusted net income excludes expense related to stock-based compensation, change in fair value of contingent consideration, other non-recurring items, amortization of acquired intangible assets and the tax impact of the foregoing adjustments. Such other non-recurring items include other non-recurring ERP implementation costs and acquisition related costs.
+
+
+
+
+
+
+
+Forward-looking Statements
+
+
+This press release contains forward-looking statements within the meaning of the federal securities laws, including those statements relating to the Company’s outlook for Fiscal 2027 under “Updated Fiscal 2027 Outlook” above and those statements that with the momentum we’re seeing, we’re raising our fiscal 2027 outlook to 18 to 20 percent net sales growth from 12 to 14 percent previously. Although the Company believes that the expectations reflected in the forward-looking statements are reasonable, actual results and the timing of selected events may differ materially from those expectations. Factors that could cause actual results to differ materially from those in the forward looking statements include, among other things, the risks and uncertainties that are described in the Company's most recent Annual Report on Form 10-K, as updated from time to time in the Company's SEC filings, as well as the Company’s ability to effectively compete with other beauty companies; the Company’s ability to successfully introduce new products; the Company’s ability to attract new retail customers and/or expand business with its existing retail customers; the Company’s ability to optimize shelf space at its key retail customers; the loss of any of the Company’s key retail customers or if the general business performance of its key retail customers declines; disruptions to the Company’s business resulting from acquisitions or investments, such as the Company’s acquisition of rhode; and the Company’s ability to effectively manage its SG&A and other expenses. Potential investors are urged to consider these factors carefully in evaluating the forward-looking statements. These forward-looking statements speak only as of the date hereof. Except as required by law, the Company assumes no obligation to update or revise these forward-looking statements for any reason, even if new information becomes available in the future.
+
+
+| | | | | | | | | | | | | | |
+Investors: | | Media: |
+KC Katten
+| | Sam Critchell |
+VP, Corporate Development & Investor Relations
+kkatten@elfbeauty.com
+| | VP, Corporate Communications
+scritchell@elfbeauty.com
+|
+
+
+
+
+
+
+
+
+
+e.l.f. Beauty, Inc. and subsidiaries
+Condensed consolidated statements of operations
+(unaudited)
+(in thousands, except share and per share data)
+
+| | | | | | | | | | | | | | | | | | |
+| | | | Three months ended June 30, |
+| | | | | | 2026 | | 2025 |
+Net sales | | | | | | $ | 479,373 | | | $ | 353,739 | |
+Cost of sales | | | | | | 80,533 | | | 109,198 | |
+Gross profit | | | | | | 398,840 | | | 244,541 | |
+Selling, general and administrative expenses | | | | | | 280,319 | | | 195,832 | |
+Change in fair value of contingent consideration | | | | | | 16,080 | | | — | |
+| | | | | | | | |
+Operating income | | | | | | 102,441 | | | 48,709 | |
+Other (expense) income, net | | | | | | (331) | | | 5,037 | |
+| | | | | | | | |
+Interest expense, net | | | | | | (7,808) | | | (2,632) | |
+| | | | | | | | |
+Income before provision for income taxes | | | | | | 94,302 | | | 51,114 | |
+Income tax provision | | | | | | (27,703) | | | (17,803) | |
+Net income | | | | | | $ | 66,599 | | | $ | 33,311 | |
+| | | | | | | | |
+Net income per share: | | | | | | | | |
+Basic | | | | | | $ | 1.13 | | | $ | 0.59 | |
+Diluted | | | | | | $ | 1.12 | | | $ | 0.58 | |
+Weighted average shares outstanding: | | | | | | | | |
+Basic | | | | | | 59,144,587 | | | 56,328,483 | |
+Diluted | | | | | | 59,727,575 | | | 57,675,035 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+e.l.f. Beauty, Inc. and subsidiaries
+Condensed consolidated balance sheets
+(unaudited)
+(in thousands, except share and per share data)
+
+| | | | | | | | | | | | | | | | | | | | |
+| | June 30, 2026 | | March 31, 2026 | | June 30, 2025 |
+Assets | | | | | | |
+Current assets: | | | | | | |
+Cash and cash equivalents | | $ | 344,241 | | | $ | 289,685 | | | $ | 170,029 | |
+Accounts receivable, net | | 174,529 | | | 174,644 | | | 173,352 | |
+Inventory, net | | 246,814 | | | 220,246 | | | 170,379 | |
+Prepaid expenses and other current assets | | 94,257 | | | 104,792 | | | 88,766 | |
+Total current assets | | 859,841 | | | 789,367 | | | 602,526 | |
+Property and equipment, net | | 39,692 | | | 41,496 | | | 39,182 | |
+Intangible assets, net | | 541,976 | | | 553,110 | | | 203,348 | |
+Goodwill | | 853,475 | | | 853,475 | | | 340,582 | |
+Other assets | | 165,665 | | | 156,710 | | | 129,258 | |
+Total assets | | $ | 2,460,649 | | | $ | 2,394,158 | | | $ | 1,314,896 | |
+| | | | | | |
+Liabilities and stockholders' equity | | | | | | |
+Current liabilities: | | | | | | |
+Current portion of long-term debt | | $ | 30,000 | | | $ | 30,000 | | | $ | — | |
+Current portion of contingent consideration | | 28,240 | | | 26,227 | | | — | |
+Accounts payable | | 95,918 | | | 97,467 | | | 74,603 | |
+Accrued expenses and other current liabilities | | 183,498 | | | 182,470 | | | 110,136 | |
+Total current liabilities | | 337,656 | | | 336,164 | | | 184,739 | |
+Long-term debt | | 801,996 | | | 809,348 | | | 256,676 | |
+Long-term contingent consideration | | 52,589 | | | 38,522 | | | — | |
+Deferred tax liabilities | | 6,208 | | | 6,197 | | | 17,009 | |
+Long-term operating lease obligations | | 89,659 | | | 69,928 | | | 50,351 | |
+Other long-term liabilities | | 3,651 | | | 3,469 | | | 1,269 | |
+Total liabilities | | 1,291,759 | | | 1,263,628 | | | 510,044 | |
+| | | | | | |
+Stockholders' equity: | | | | | | |
+| | | | | | |
+Common stock, par value of $0.01 per share; 250,000,000 shares authorized as of June 30, 2026, March 31, 2026 and June 30, 2025; 58,936,996, 59,089,708 and 56,734,903 shares issued and outstanding as of June 30, 2026, March 31, 2026 and June 30, 2025, respectively
+| | 589 | | | 590 | | | 566 | |
+Additional paid-in capital | | 1,256,706 | | | 1,284,987 | | | 952,015 | |
+Accumulated other comprehensive income | | 925 | | | 882 | | | 1,207 | |
+Accumulated deficit | | (89,330) | | | (155,929) | | | (148,936) | |
+Total stockholders' equity | | 1,168,890 | | | 1,130,530 | | | 804,852 | |
+Total liabilities and stockholders' equity | | $ | 2,460,649 | | | $ | 2,394,158 | | | $ | 1,314,896 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+e.l.f. Beauty, Inc. and subsidiaries
+Condensed consolidated statements of cash flows
+(unaudited)
+(in thousands)
+| | | | | | | | | | | | | | |
+| | Three months ended June 30, |
+| | 2026 | | 2025 |
+Cash flows from operating activities: | | | | |
+Net income | | $ | 66,599 | | | $ | 33,311 | |
+Adjustments to reconcile net income to net cash provided by operating activities: | | | | |
+Depreciation and amortization | | 26,101 | | | 13,192 | |
+Non-cash lease expense | | 3,196 | | | 2,843 | |
+Stock-based compensation expense | | 19,677 | | | 9,868 | |
+Amortization of debt issuance costs and discount on debt | | 473 | | | 134 | |
+Deferred income taxes | | 1,782 | | | 14,216 | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+Change in fair value of contingent consideration | | 16,080 | | | — | |
+Other, net | | 2 | | | 911 | |
+Changes in operating assets and liabilities: | | | | |
+Accounts receivable | | 198 | | | (46,170) | |
+Inventory | | (26,524) | | | 18,684 | |
+Prepaid expenses and other assets | | 8,202 | | | (16,332) | |
+Accounts payable and accrued expenses | | (2,429) | | | (1,542) | |
+Other liabilities | | (1,692) | | | (1,882) | |
+Net cash provided by operating activities | | 111,665 | | | 27,233 | |
+| | | | |
+Cash flows from investing activities: | | | | |
+| | | | |
+Purchase of property and equipment | | (1,431) | | | (7,095) | |
+| | | | |
+Other, net | | (240) | | | (464) | |
+Net cash used in investing activities | | (1,671) | | | (7,559) | |
+| | | | |
+Cash flows from financing activities: | | | | |
+| | | | |
+| | | | |
+| | | | |
+Repayment of long-term debt | | (7,500) | | | — | |
+| | | | |
+Repurchase of common stock | | (49,982) | | | — | |
+Cash received from issuance of common stock | | 2,022 | | | 121 | |
+| | | | |
+| | | | |
+| | | | |
+| | | | |
+Net cash (used in) provided by financing activities | | (55,460) | | | 121 | |
+| | | | |
+Effect of exchange rate changes on cash and cash equivalents | | 22 | | | 1,542 | |
+| | | | |
+Net increase in cash and cash equivalents | | 54,556 | | | 21,337 | |
+Cash and cash equivalents - beginning of period | | 289,685 | | | 148,692 | |
+Cash and cash equivalents - end of period | | $ | 344,241 | | | $ | 170,029 | |
+
+
+
+
+
+
+
+
+
+e.l.f. Beauty, Inc. and subsidiaries
+Reconciliation of GAAP net income to non-GAAP adjusted EBITDA
+(unaudited)
+(in thousands)
+
+
+| | | | | | | | | | | | | | | | | | |
+| | | | Three months ended June 30, |
+| | | | | | 2026 | | 2025 |
+Net income | | | | | | $ | 66,599 | | | $ | 33,311 | |
+Interest expense, net | | | | | | 7,808 | | | 2,632 | |
+Income tax provision | | | | | | 27,703 | | | 17,803 | |
+Depreciation and amortization | | | | | | 26,101 | | | 13,192 | |
+EBITDA | | | | | | $ | 128,211 | | | $ | 66,938 | |
+Stock-based compensation | | | | | | 19,677 | | | 9,868 | |
+Change in fair value of contingent consideration (a) | | | | | | 16,080 | | | — | |
+| | | | | | | | |
+| | | | | | | | |
+Other non-cash and non-recurring items (b) | | | | | | 4,232 | | | 10,257 | |
+Adjusted EBITDA | | | | | | $ | 168,200 | | | $ | 87,063 | |
+
+
+
+(a) Represents increase in fair value of contingent consideration related to rhode Acquisition.
+(b) Represents other non-cash or non-recurring items, which include amortization of internal-use software costs related to cloud applications, acquisition related costs and ERP implementation costs.
+
+
+
+
+
+
+
+
+
+
+e.l.f. Beauty, Inc. and subsidiaries
+Reconciliation of GAAP SG&A to non-GAAP adjusted SG&A
+(unaudited)
+(in thousands)
+
+
+| | | | | | | | | | | | | | | | | | |
+| | | | Three months ended June 30, |
+| | | | | | 2026 | | 2025 |
+Selling, general and administrative expenses | | | | | | $ | 280,319 | | | $ | 195,832 | |
+Stock-based compensation | | | | | | (19,678) | | | (9,879) | |
+Other non-recurring items (a) | | | | | | 23 | | | (8,643) | |
+Adjusted selling, general and administrative expenses | | | | | | $ | 260,664 | | | $ | 177,310 | |
+
+
+(a) Represents other non-recurring ERP implementation costs and acquisition related costs.
+
+
+
+
+
+
+
+
+e.l.f. Beauty, Inc. and subsidiaries
+Reconciliation of GAAP net income to non-GAAP adjusted net income
+(unaudited)
+(in thousands, except share and per share data)
+
+| | | | | | | | | | | | | | | | | | |
+| | | | Three months ended June 30, |
+| | | | | | 2026 | | 2025 |
+Net income | | | | | | $ | 66,599 | | | $ | 33,311 | |
+Stock-based compensation | | | | | | 19,677 | | | 9,868 | |
+Change in fair value of contingent consideration (a) | | | | | | 16,080 | | | — | |
+Other non-recurring items (b) | | | | | | (142) | | | 8,643 | |
+| | | | | | | | |
+Amortization of acquired intangible assets (c) | | | | | | 11,133 | | | 4,349 | |
+Tax Impact (d) | | | | | | (8,792) | | | (4,846) | |
+Adjusted net income | | | | | | $ | 104,555 | | | $ | 51,325 | |
+| | | | | | | | |
+Weighted average number of shares outstanding – diluted | | | | | | 59,727,575 | | | 57,675,035 | |
+Adjusted diluted earnings per share | | | | | | $ | 1.75 | | | $ | 0.89 | |
+
+
+
+(a) Represents increase in fair value of contingent consideration related to rhode Acquisition.
+(b) Represents other non-recurring ERP implementation costs and acquisition related costs.
+(c) Represents amortization expense of acquired intangible assets consisting of customer relationships and trademarks.
+(d) Represents the tax impact of the above adjustments.

--- a/modules/test-fixtures/earnings-filings/fsly.txt
+++ b/modules/test-fixtures/earnings-filings/fsly.txt
@@ -1,0 +1,562 @@
+EX-99.1
+2
+ex991-fslypressrelease63026.htm
+EX-99.1
+
+
+
+
+Document
+
+
+Exhibit 99.1
+
+Fastly Announces Second Quarter 2026 Financial Results
+
+
+Record second quarter revenue of $183.3 million grew 23% year-over-year
+Record second quarter gross margin of 63.3% and record non-GAAP gross margin of 65.8%
+LTM NRR of 117% reaches highest level in over three years
+
+
+SAN FRANCISCO — August 5, 2026 — Fastly, Inc. (NASDAQ: FSLY), a leader in global edge cloud platforms, today announced financial results for its second quarter ended June 30, 2026.
+"Record second quarter results reflect strong execution and the deep trust customers place in our technology and our teams," said Kip Compton, CEO of Fastly. "Our platform strategy is driving business momentum, giving us the confidence to raise our full-year outlook."
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+($ in thousands, except per share data) (unaudited) | | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Revenue | | $ | 183,317 | | | $ | 148,709 | | | $ | 356,338 | | | $ | 293,183 | |
+Gross margin | | | | | | | | |
+GAAP gross margin | | 63.3 | % | | 54.5 | % | | 62.9 | % | | 53.9 | % |
+Non-GAAP gross margin (1)
+| | 65.8 | % | | 59.0 | % | | 65.5 | % | | 58.2 | % |
+Operating loss | | | | | | | | |
+GAAP operating loss | | $ | (14,433) | | | $ | (36,943) | | | $ | (38,328) | | | $ | (75,122) | |
+Non-GAAP operating income (loss) (1)
+| | $ | 26,993 | | | $ | (4,594) | | | $ | 46,136 | | | $ | (10,439) | |
+Net income (loss) per share | | | | | | | | |
+GAAP net loss per common share — basic and diluted | | $ | (0.10) | | | $ | (0.26) | | | $ | (0.23) | | | $ | (0.53) | |
+Non-GAAP net income (loss) per common share — basic (1)
+| | $ | 0.17 | | | $ | (0.03) | | | $ | 0.32 | | | $ | (0.08) | |
+Non-GAAP net income (loss) per common share — diluted (1)
+| | $ | 0.15 | | | $ | (0.03) | | | $ | 0.28 | | | $ | (0.08) | |
+
+For a reconciliation of non-GAAP financial measures to their corresponding GAAP measures, please refer to the reconciliation table at the end of this press release.
+Second Quarter 2026 Financial Summary
+• Total revenue of $183.3 million, representing 23% year-over-year growth. Network Services revenue of $133.9 million, representing 17% year-over-year growth. Security revenue of $41.7 million, representing 43% year-over-year growth. Other revenue of $7.7 million, representing 69% year-over-year growth. Network Services revenue includes solutions designed to improve performance of websites, apps, APIs, and digital media. Security revenue includes products designed to protect websites, apps, APIs, and users. Other revenue includes Compute and Observability solutions.
+• Generated $39.3 million of operating cash flow compared to $25.8 million of operating cash flow in the second quarter of 2025. Generated $3.6 million of positive free cash flow compared to $10.9 million in the second quarter of 2025.
+• GAAP gross margin of 63.3%, compared to 54.5% in the second quarter of 2025. Non-GAAP gross margin 1 of 65.8%, compared to 59.0% in the second quarter of 2025.
+• GAAP net loss of $15.6 million, compared to $37.5 million in the second quarter of 2025. Non-GAAP net income 1 of $26.2 million, compared to non-GAAP net loss 1 of $5.0 million in the second quarter of 2025.
+• GAAP net loss per basic and diluted share of $0.10, compared to $0.26 in the second quarter of 2025. Non-GAAP net income per basic share 1 of $0.17, c ompared to non-GAAP net loss per basic share 1 of $0.03 in the second quarter of 2025. Non-GAAP net income per diluted share 1 of $0.15, compared to non-GAAP net loss per diluted share 1 of $0.03 in the second quarter of 2025.
+Key Metrics
+• Remaining Performance Obligations (RPO) 2 were $341 million, up 38% from $247 million in the second quarter of 2025.
+• Fastly's top ten customers accounted for 37% of revenue in the second quarter of 2026 compared to 31% in the second quarter of 2025.
+
+
+
+
+
+
+
+
+
+
+
+• Last 12-month net retention rate (LTM NRR) 3 increased to 117% in the second quarter from 113% in the first quarter of 2026.
+Second Quarter Business and Product Highlights
+• Announced new research showing how rapidly growing AI traffic is reshaping the internet, growing 6.5x faster than human traffic this year, and why organizations need new strategies to manage machine traffic.
+• Released a joint announcement with LALIGA on the collaboration of anti-piracy solutions that are designed to address illegal streaming of live sports and help rights holders prevent lost revenue.
+• Announced a new partnership with Skyfire, enabling trusted commerce at the edge so enterprises can now securely identify, verify, and transact with AI agents in real time and at global scale, without re-architecting existing infrastructure.
+• Released C++ SDK for Fastly Compute, enabling enterprises to secure, scale, and accelerate their C++ AI workloads, gaming features, and other low-latency applications.
+
+
+Third Quarter and Full Year 2026 Guidance
+| | | | | | | | | | | | | | |
+| | Q3 2026 | | Full Year 2026 |
+Total Revenue (millions) | | $184.0 - $190.0 | | $732.0 - $746.0 |
+Non-GAAP Operating Income (millions)
+| | $20.0 - $24.0 | | $88.0 - $96.0 |
+Non-GAAP Net Income per share (4)(5)
+| | $0.11 - $0.13 | | $0.50 - $0.54 |
+
+A reconciliation of non-GAAP guidance measures to corresponding GAAP measures is not available on a forward-looking basis without unreasonable effort due to the uncertainty of expenses that may be incurred in the future and cannot be reasonably determined or predicted at this time, although it is important to note that these factors could be material to Fastly’s future GAAP financial results.
+Conference Call Information
+Fastly will host an investor conference call to discuss its results at 1:30 p.m. PT / 4:30 p.m. ET on Wednesday, August 5, 2026.
+To access the conference call, please pre-register and dial-in using this link at least 15 minutes prior to the 1:30 p.m. PT start time. Registrants will receive an email confirmation with dial-in details.
+A live webcast of the event can be accessed using this link. A replay of the webcast will be available on https://investors.fastly.com starting approximately two hours after the event and archived on the site for one quarter.
+
+
+About Fastly, Inc.
+Fastly’s powerful and programmable edge cloud platform helps the world’s top brands deliver online experiences that are fast, safe, and engaging through edge compute, delivery, security, and observability offerings that improve site performance, enhance security, and empower innovation at global scale. Compared to other providers, Fastly’s powerful, high-performance, and modern platform architecture empowers developers to deliver secure websites and apps with rapid time-to-market and demonstrated, industry-leading cost savings. Organizations around the world trust Fastly to help them upgrade the internet experience, including Reddit, Universal Music Group, and SeatGeek. Learn more about Fastly at https://www.fastly.com, and follow us @fastly.
+
+
+
+Forward-Looking Statements
+This press release contains “forward-looking” statements that are based on our beliefs and assumptions and on information currently available to us. Forward-looking statements may involve known and unknown risks, uncertainties, and other factors that may cause our actual results, performance, or achievements to be materially different from those expressed or implied by the forward-looking statements. These statements include, but are not limited to, statements regarding our future financial and operating performance and shareholder returns, including our outlook and guidance and ability to maintain and strengthen our liquidity position; our ability to acquire new customers, expand cross-sell opportunities, and grow market share; our ability to enrich our revenue mix with platform enhancements; the performance of our existing and new platform enhancements; our ability to accelerate global growth; our partnerships and collaborations; the performance, capabilities, and expectations regarding customer experiences with Fastly Compute, including its C++ SDK, Bot Management and DDoS Protection, and Next-Gen WAF; and Fastly's strategies, platform, and business plans. Except as required by law, we assume no
+
+
+
+
+
+
+
+
+
+
+
+obligation to update these forward-looking statements publicly or to update the reasons actual results could differ materially from those anticipated in the forward-looking statements, even if new information becomes available in the future. Important factors that could cause our actual results to differ materially are detailed from time to time in the reports Fastly files with the Securities and Exchange Commission (“SEC”), including those more fully described in Fastly’s Annual Report on Form 10-K for the year ended December 31, 2025 . Additional information will also be set forth in Fastly’s Quarterly Report on Form 10-Q for the quarter ended June 30, 2026, and other filings and reports that Fastly may file from time to time with the SEC . Copies of reports filed with the SEC are posted on Fastly’s website and are available from Fastly without charge.
+Use of Non-GAAP Financial Measures
+To supplement our condensed consolidated financial statements, which are prepared and presented in accordance with accounting principles generally accepted in the United States ( “ GAAP ” ), the Company uses the following non-GAAP measures of financial performance: non-GAAP gross profit, non-GAAP gross margin, non-GAAP operating income (loss), non-GAAP net income (loss), non-GAAP basic and diluted net income (loss) per common share, non-GAAP research and development, non-GAAP sales and marketing, non-GAAP general and administrative, free cash flow and adjusted EBITDA. The presentation of this additional financial information is not intended to be considered in isolation from, as a substitute for, or superior to, the financial information prepared and presented in accordance with GAAP. These non-GAAP measures have limitations in that they do not reflect all of the amounts associated with our results of operations as determined in accordance with GAAP. In addition, these non-GAAP financial measures may be different from the non-GAAP financial measures used by other companies. These non-GAAP measures should only be used to evaluate our results of operations in conjunction with the corresponding GAAP measures. Management compensates for these limitations by reconciling these non-GAAP financial measures to the most comparable GAAP financial measures within our earnings releases.
+Non-GAAP gross profit, non-GAAP gross margin, non-GAAP operating income (loss), non-GAAP net income (loss) and non-GAAP basic and diluted net income (loss) per common share, non-GAAP research and development, non-GAAP sales and marketing, and non-GAAP general and administrative differ from GAAP in that they exclude stock-based compensation expense and related employer payroll taxes, amortization of capitalized stock-based compensation - cost of revenue , amortization of acquired intangible assets, executive transition costs, and amortization of debt discount and issuance costs.
+Adjusted EBITDA : excludes stock-based compensation expense and related employer payroll taxes, amortization of capitalized stock-based compensation - cost of revenue, gain on modification of lease, depreciation and other amortization expenses, amortization of acquired intangible assets, impairment expense, executive transition costs, interest income, interest expense, including amortization of debt discount and issuance costs, other expense (income), net, and income taxes.
+Amortization of Acquired Intangible Assets : consists of non-cash charges that can be affected by the timing and magnitude of asset purchases and acquisitions. Management considers its operating results without this activity when evaluating its ongoing non-GAAP performance and its adjusted EBITDA performance because these charges are non-cash expenses that can be affected by the timing and magnitude of asset purchases and acquisitions and may not be reflective of our core business, ongoing operating results, or future outlook .
+Amortization of Debt Discount and Issuance Costs : consists primarily of amortization expense related to our debt obligations. Management considers its operating results without this activity when evaluating its ongoing non-GAAP net income (loss) performance and its adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results or future outlook. These are included in our total interest expense.
+Capital Expenditures : consists of cash used for purchases of property and equipment, net of proceeds from sale of property and equipment, capitalized internal-use software and payments on finance lease obligations, as reflected in our statement of cash flows.
+Depreciation a nd Other Amortization Expense : consists of non-cash charges that can be affected by the timing and magnitude of asset purchases. Management considers its operating results without this activity when evaluating its ongoing adjusted EBITDA performance because these charges are non-cash expenses that can be affected by the timing and magnitude of asset purchases and may not be reflective of our core business, ongoing operating results, or future outlook.
+Executive Transition Costs : consists of one-time cash charges recognized with respect to changes in our executive’s employment status. Management considers its operating results without this activity when evaluating its ongoing non-GAAP net income (loss) performance and its adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results, or future outlook.
+Free Cash Flow : calculated as net cash used in operating activities less purchases of property and equipment, net of proceeds from sale of property and equipment, and capitalized internal-use software costs. Management specifically identifies adjusting items in the reconciliation of GAAP to non-GAAP financial measures. Management considers non-GAAP free cash flow to be a profitability and liquidity measure that provides useful information to management and investors about the amount of cash generated by the business that can possibly be used for investing in Fastly's business and strengthening its balance sheet, but it is not intended to represent the residual cash flow available for discretionary expenditures. The
+
+
+
+
+
+
+
+
+
+
+
+presentation of non-GAAP free cash flow is also not meant to be considered in isolation or as an alternative to cash flows from operating activities as a measure of liquidity.
+Gain on Modification of Lease : consists of a one-time non-cash charge recognized with respect to the modification of our leases. Management considers its operating results without this activity when evaluating its ongoing non-GAAP net income (loss) performance and its adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results, or future outlook.
+Impairment Expense: consists of charges related to our long-lived assets. Management considers its operating results without this activity when evaluating its ongoing non-GAAP net income (loss) performance and its adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results or future outlook.
+Income Taxes : consists primarily of expenses recognized related to state and foreign income taxes. Management considers its operating results without this activity when evaluating its ongoing adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results or future outlook.
+Interest Expense : consists primarily of interest expense related to our debt instruments, including amortization of debt discount and issuance costs. Management considers its operating results without this activity when evaluating its ongoing non-GAAP net income (loss) performance and its adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results or future outlook.
+Interest Income : consists primarily of interest income related to our marketable securities. Management considers its operating results without this activity when evaluating its ongoing non-GAAP net income (loss) performance and its adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results or future outlook.
+Other (Expense) Income, Net : consists primarily of foreign currency transaction gains and losses. Management considers its operating results without this activity when evaluating its ongoing adjusted EBITDA performance because it is not believed by management to be reflective of our core business, ongoing operating results or future outlook.
+Stock-Based Compensation Expense and Related Employer Payroll Taxes : consists of expenses for stock options, restricted stock units, performance awards and other shares issued under our equity incentive plans or our Employee Stock Purchase Plan ("ESPP"), as applicable, and the related employer payroll taxes. Although stock-based compensation and its related employer payroll taxes are expenses for the Company, management considers its operating results without this activity when evaluating its ongoing non-GAAP net income (loss) performance and its adjusted EBITDA performance, primarily because they are expenses not believed by management to be reflective of our core business, ongoing operating results, or future outlook. In addition, the value of some stock-based instruments is determined using formulas that incorporate variables, such as market volatility, that are beyond our control.
+Amortization of Capitalized Stock-Based Compensation - Cost of Revenue : in order to reflect the performance of our core business, ongoing operating results, or future outlook, and to be consistent with the way many investors evaluate our performance and compare our operating results to peer companies, similar to stock-based compensation, management considers it appropriate to exclude amortization of capitalized stock-based compensation from our non-GAAP financial measures.
+Management believes these non-GAAP financial measures and adjusted EBITDA serve as useful metrics for our management and investors because they enable a better understanding of the long-term performance of our core business and facilitate comparisons of our operating results over multiple periods and to those of peer companies, and when taken together with the corresponding GAAP financial measures and our reconciliations, enhance investors' overall understanding of our current financial performance.
+In the financial tables below, the Company provides a reconciliation of the most comparable GAAP financial measure to the historical non-GAAP financial measures used in this press release.
+Key Metrics
+1 Beginning with the quarter ended March 31, 2026, we are excluding stock-based compensation related employer payroll taxes from our non-GAAP gross margin, non-GAAP operating income (loss), non-GAAP net income (loss) per common share — basic and non-GAAP net income (loss) per common share — diluted, because we consider our operating results without this activity when evaluating our ongoing non-GAAP net income (loss) performance and our adjusted EBITDA performance. We did not recast the presentation for all prior periods presented due to the immaterial amount of such payroll taxes.
+2 Remaining Performance Obligations include future committed revenue for periods within current contracts with customers, as well as deferred revenue arising from consideration invoiced for which the related performance obligations have not been satisfied. During the third quarter of 2025, we identified an error in RPO calculations from certain contracts with a termination-for-convenience clause. We recast the presentation of RPO for all prior periods presented to reflect the correction of this error.
+
+
+
+
+
+
+
+
+
+
+
+3 We calculate LTM Net Retention Rate by dividing the total customer revenue for the prior twelve-month period (“prior 12-month period”) ending at the beginning of the last twelve-month period (“LTM period”) minus revenue contraction due to billing decreases or customer churn, plus revenue expansion due to billing increases during the LTM period from the same customers by the total prior 12-month period revenue. We believe the LTM Net Retention Rate is supplemental as it removes some of the volatility that is inherent in a usage-based business model.
+4 Non-GAAP net income per share is calculated as Non-GAAP net income divided by weighted average diluted shares for 2026.
+5 Assumes weighted average diluted shares outstanding of 181.4 million in Q3 2026 and 180.3 million for the full year 2026.
+
+
+
+
+
+
+
+
+
+
+
+
+Condensed Consolidated Statements of Operations
+(unaudited, in thousands, except per share amounts)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Revenue | | $ | 183,317 | | | $ | 148,709 | | | $ | 356,338 | | | $ | 293,183 | |
+Cost of revenue (1)
+| | 67,366 | | | 67,593 | | | 132,206 | | | 135,269 | |
+Gross profit | | 115,951 | | | 81,116 | | | 224,132 | | | 157,914 | |
+Operating expenses: | | | | | | | | |
+Research and development (1)
+| | 42,071 | | | 42,221 | | | 84,043 | | | 79,650 | |
+Sales and marketing (1)
+| | 56,735 | | | 51,100 | | | 111,849 | | | 100,413 | |
+General and administrative (1)
+| | 31,578 | | | 24,323 | | | 66,568 | | | 52,558 | |
+Impairment expense | | — | | | 415 | | | — | | | 415 | |
+Total operating expenses | | 130,384 | | | 118,059 | | | 262,460 | | | 233,036 | |
+Loss from operations | | (14,433) | | | (36,943) | | | (38,328) | | | (75,122) | |
+Interest income | | 2,842 | | | 3,084 | | | 5,769 | | | 6,059 | |
+Interest expense | | (3,348) | | | (3,164) | | | (6,654) | | | (6,337) | |
+Other (expense) income, net | | (400) | | | 39 | | | (780) | | | (41) | |
+Loss before income taxes | | (15,339) | | | (36,984) | | | (39,993) | | | (75,441) | |
+Income tax expense (benefit) | | 252 | | | 557 | | | (3,878) | | | 1,248 | |
+Net loss | | $ | (15,591) | | | $ | (37,541) | | | $ | (36,115) | | | $ | (76,689) | |
+Net loss per share attributable to common stockholders, basic and diluted | | $ | (0.10) | | | $ | (0.26) | | | $ | (0.23) | | | $ | (0.53) | |
+Weighted-average shares used in computing net loss per share attributable to common stockholders, basic and diluted | | 157,596 | | | 145,780 | | | 155,598 | | | 144,539 | |
+
+__________
+(1) Includes stock-based compensation expense as follows:
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Cost of revenue | | $ | 2,757 | | | $ | 2,573 | | | $ | 5,293 | | | $ | 4,512 | |
+Research and development | | 11,902 | | | 11,755 | | | 21,932 | | | 20,648 | |
+Sales and marketing | | 10,344 | | | 8,176 | | | 19,697 | | | 14,869 | |
+General and administrative | | 10,169 | | | 3,831 | | | 23,231 | | | 11,888 | |
+Total | | $ | 35,172 | | | $ | 26,335 | | | $ | 70,153 | | | $ | 51,917 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reconciliation of GAAP to Non-GAAP Financial Measures
+(unaudited, in thousands, except per share data)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Gross profit | | | | | | | | |
+GAAP gross profit | | $ | 115,951 | | | $ | 81,116 | | | $ | 224,132 | | | $ | 157,914 | |
+Stock-based compensation expense and related employer payroll taxes (1)
+| | 3,026 | | | 2,573 | | | 5,773 | | | 4,512 | |
+Amortization of capitalized stock-based compensation - Cost of revenue
+| | 1,694 | | | 1,581 | | | 3,383 | | | 3,222 | |
+Amortization of acquired intangible assets | | — | | | 2,475 | | | — | | | 4,950 | |
+Non-GAAP gross profit | | $ | 120,671 | | | $ | 87,745 | | | $ | 233,288 | | | $ | 170,598 | |
+GAAP gross margin | | 63.3 | % | | 54.5 | % | | 62.9 | % | | 53.9 | % |
+Non-GAAP gross margin | | 65.8 | % | | 59.0 | % | | 65.5 | % | | 58.2 | % |
+Research and development | | | | | | | | |
+GAAP research and development | | $ | 42,071 | | | $ | 42,221 | | | $ | 84,043 | | | $ | 79,650 | |
+Stock-based compensation expense and related employer payroll taxes (1)
+| | (12,967) | | | (11,755) | | | (24,355) | | | (20,648) | |
+Non-GAAP research and development | | $ | 29,104 | | | $ | 30,466 | | | $ | 59,688 | | | $ | 59,002 | |
+Sales and marketing | | | | | | | | |
+GAAP sales and marketing | | $ | 56,735 | | | $ | 51,100 | | | $ | 111,849 | | | $ | 100,413 | |
+Stock-based compensation expense and related employer payroll taxes (1)
+| | (10,869) | | | (8,176) | | | (21,009) | | | (14,869) | |
+Amortization of acquired intangible assets | | (2,160) | | | (2,279) | | | (4,319) | | | (4,580) | |
+Executive transition costs | | — | | | — | | | (262) | | | — | |
+Non-GAAP sales and marketing | | $ | 43,706 | | | $ | 40,645 | | | $ | 86,259 | | | $ | 80,964 | |
+General and administrative | | | | | | | | |
+GAAP general and administrative | | $ | 31,578 | | | $ | 24,323 | | | $ | 66,568 | | | $ | 52,558 | |
+Stock-based compensation expense and related employer payroll taxes (1)
+| | (10,710) | | | (3,831) | | | (24,302) | | | (11,888) | |
+Executive transition costs | | — | | | — | | | (1,061) | | | (335) | |
+Gain on modification of lease | | — | | | 736 | | | — | | | 736 | |
+Non-GAAP general and administrative | | $ | 20,868 | | | $ | 21,228 | | | $ | 41,205 | | | $ | 41,071 | |
+Operating income (loss) | | | | | | | | |
+GAAP operating loss | | $ | (14,433) | | | $ | (36,943) | | | $ | (38,328) | | | $ | (75,122) | |
+Stock-based compensation expense and related employer payroll taxes (1)
+| | 37,572 | | | 26,335 | | | 75,439 | | | 51,917 | |
+Amortization of capitalized stock-based compensation - Cost of revenue
+| | 1,694 | | | 1,581 | | | 3,383 | | | 3,222 | |
+Executive transition costs | | — | | | — | | | 1,323 | | | 335 | |
+Gain on modification of lease | | — | | | (736) | | | — | | | (736) | |
+Amortization of acquired intangible assets | | 2,160 | | | 4,754 | | | 4,319 | | | 9,530 | |
+Impairment expense | | — | | | 415 | | | — | | | 415 | |
+Non-GAAP operating income (loss) | | $ | 26,993 | | | $ | (4,594) | | | $ | 46,136 | | | $ | (10,439) | |
+Net income (loss) | | | | | | | | |
+GAAP net loss | | $ | (15,591) | | | $ | (37,541) | | | $ | (36,115) | | | $ | (76,689) | |
+Stock-based compensation expense and related employer payroll taxes (1)
+| | 37,572 | | | 26,335 | | | 75,439 | | | 51,917 | |
+Amortization of capitalized stock-based compensation - Cost of revenue
+| | 1,694 | | | 1,581 | | | 3,383 | | | 3,222 | |
+Executive transition costs | | — | | | — | | | 1,323 | | | 335 | |
+Gain on modification of lease | | — | | | (736) | | | — | | | (736) | |
+Amortization of acquired intangible assets | | 2,160 | | | 4,754 | | | 4,319 | | | 9,530 | |
+Impairment expense | | — | | | 415 | | | — | | | 415 | |
+Amortization of debt discount and issuance costs | | 366 | | | 217 | | | 767 | | | 434 | |
+Non-GAAP net income (loss) | | $ | 26,201 | | | $ | (4,975) | | | $ | 49,116 | | | $ | (11,572) | |
+Non-GAAP net income (loss) per common share — basic | | $ | 0.17 | | | $ | (0.03) | | | $ | 0.32 | | | $ | (0.08) | |
+Non-GAAP net income (loss) per common share — diluted | | $ | 0.15 | | | $ | (0.03) | | | $ | 0.28 | | | $ | (0.08) | |
+Weighted average basic common shares | | 157,596 | | | 145,780 | | | 155,598 | | | 144,539 | |
+Weighted average diluted common shares | | 180,304 | | | 145,780 | | | 178,410 | | | 144,539 | |
+
+
+
+
+
+
+
+
+
+
+
+
+(1) Similar to stock-based compensation, we believe it is also appropriate to exclude employer payroll taxes related to stock-based compensation from our non-GAAP financial measures in order to reflect the performance of our core business and to be consistent with the way many investors evaluate our performance and compare our operating results to peer companies. In order to continue to improve the usefulness of our non-GAAP financial measures to the investors, starting with the quarter ended March 31, 2026, we are excluding stock-based compensation related employer payroll taxes from our non-GAAP financial measures. We did not recast the presentation for all prior periods presented due to the immaterial amount of such payroll taxes. Refer to Non-GAAP Financial Measures definition for further details.
+Reconciliation of GAAP to Non-GAAP Financial Measures (continued)
+(unaudited, in thousands, except per share data)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Reconciliation of GAAP to Non-GAAP diluted shares | | | | | | | | |
+GAAP diluted shares | | 157,596 | | | 145,780 | | | 155,598 | | | 144,539 | |
+Other dilutive equity awards | | 22,708 | | | — | | | 22,812 | | | — | |
+Non-GAAP diluted shares | | 180,304 | | | 145,780 | | | 178,410 | | | 144,539 | |
+Non-GAAP diluted net income (loss) per share | | $ | 0.15 | | | $ | (0.03) | | | $ | 0.28 | | | $ | (0.08) | |
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Adjusted EBITDA | | | | | | | | |
+GAAP net loss | | $ | (15,591) | | | $ | (37,541) | | | $ | (36,115) | | | $ | (76,689) | |
+Stock-based compensation expense and related employer payroll taxes (1)
+| | 37,572 | | | 26,335 | | | 75,439 | | | 51,917 | |
+Amortization of capitalized stock-based compensation - Cost of revenue | | 1,694 | | | 1,581 | | | 3,383 | | | 3,222 | |
+Gain on modification of lease | | — | | | (736) | | | — | | | (736) | |
+Depreciation and other amortization | | 11,129 | | | 13,505 | | | 21,449 | | | 27,155 | |
+Amortization of acquired intangible assets | | 2,160 | | | 4,754 | | | 4,319 | | | 9,530 | |
+Amortization of debt discount and issuance costs | | 366 | | | 217 | | | 767 | | | 434 | |
+Impairment expense | | — | | | 415 | | | — | | | 415 | |
+Executive transition costs | | — | | | — | | | 1,323 | | | 335 | |
+Interest income | | (2,842) | | | (3,084) | | | (5,769) | | | (6,059) | |
+Interest expense | | 2,982 | | | 2,947 | | | 5,887 | | | 5,903 | |
+Other expense (income), net | | 400 | | | (39) | | | 780 | | | 41 | |
+Income tax expense (benefit) | | 252 | | | 557 | | | (3,878) | | | 1,248 | |
+Adjusted EBITDA | | $ | 38,122 | | | $ | 8,911 | | | $ | 67,585 | | | $ | 16,716 | |
+
+
+
+
+
+(1) Similar to stock-based compensation, we believe it is also appropriate to exclude employer payroll taxes related to stock-based compensation from our non-GAAP financial measures in order to reflect the performance of our core business and to be consistent with the way many investors evaluate our performance and compare our operating results to peer companies. In order to continue to improve the usefulness of our non-GAAP financial measures to the investors, starting with the quarter ended March 31, 2026, we are excluding stock-based compensation related employer payroll taxes from our non-GAAP financial measures. We did not recast the presentation for all prior periods presented due to the immaterial amount of such payroll taxes. Refer to Non-GAAP Financial Measures definition for further details.
+
+
+
+
+
+
+
+
+
+
+
+
+Condensed Consolidated Balance Sheets
+(unaudited, in thousands)
+| | | | | | | | | | | | | | |
+| | As of
+June 30, 2026 | | As of
+December 31, 2025 |
+ASSETS | | | | |
+Current assets: | | | | |
+Cash and cash equivalents | | $ | 89,798 | | | $ | 180,563 | |
+Marketable securities
+| | 247,700 | | | 181,196 | |
+Accounts receivable, net of allowance for credit losses | | 114,216 | | | 118,029 | |
+Prepaid expenses and other current assets | | 27,333 | | | 26,921 | |
+Total current assets | | 479,047 | | | 506,709 | |
+Property and equipment, net | | 220,354 | | | 186,785 | |
+Operating lease right-of-use assets, net | | 58,213 | | | 52,067 | |
+Goodwill | | 670,356 | | | 670,356 | |
+Intangible assets, net | | 21,232 | | | 25,771 | |
+Other assets | | 54,441 | | | 57,789 | |
+Total assets | | $ | 1,503,643 | | | $ | 1,499,477 | |
+LIABILITIES AND STOCKHOLDERS’ EQUITY | | | | |
+Current liabilities: | | | | |
+Accounts payable | | $ | 20,124 | | | $ | 17,612 | |
+Accrued expenses | | 52,937 | | | 70,669 | |
+Long-term debt, current | | — | | | 38,557 | |
+Operating lease liabilities, current | | 30,100 | | | 24,427 | |
+Deferred revenue
+| | 34,266 | | | 35,234 | |
+Other current liabilities | | 5,096 | | | 7,499 | |
+Total current liabilities | | 142,523 | | | 193,998 | |
+Long-term debt, net
+| | 323,958 | | | 323,282 | |
+Operating lease liabilities, non-current | | 44,234 | | | 43,921 | |
+Other long-term liabilities | | 2,111 | | | 8,698 | |
+Total liabilities | | 512,826 | | | 569,899 | |
+Stockholders’ equity: | | | | |
+Common stock | | 3 | | | 3 | |
+Additional paid-in capital | | 2,141,909 | | | 2,044,103 | |
+Accumulated other comprehensive loss | | (493) | | | (41) | |
+Accumulated deficit | | (1,150,602) | | | (1,114,487) | |
+Total stockholders’ equity | | 990,817 | | | 929,578 | |
+Total liabilities and stockholders’ equity | | $ | 1,503,643 | | | $ | 1,499,477 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Condensed Consolidated Statements of Cash Flows
+(unaudited, in thousands) | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Cash flows from operating activities: | | | | | | | | |
+Net loss | | $ | (15,591) | | | $ | (37,541) | | | $ | (36,115) | | | $ | (76,689) | |
+Adjustments to reconcile net loss to net cash provided by operating activities:
+| | | | | | | | |
+Depreciation expense | | 12,720 | | | 14,962 | | | 24,612 | | | 30,129 | |
+Amortization of intangible assets | | 2,262 | | | 4,878 | | | 4,539 | | | 9,778 | |
+Non-cash lease expense | | 6,887 | | | 5,694 | | | 13,085 | | | 11,349 | |
+Amortization of debt discount and issuance costs | | 366 | | | 217 | | | 767 | | | 434 | |
+Amortization of deferred contract costs | | 4,733 | | | 4,847 | | | 9,491 | | | 9,697 | |
+Stock-based compensation | | 35,172 | | | 26,335 | | | 70,153 | | | 51,917 | |
+Deferred income taxes | | (23) | | | 327 | | | (4,353) | | | 749 | |
+Provision for credit losses | | 1,014 | | | 1,048 | | | 2,532 | | | 1,994 | |
+(Gain) loss on disposals of property and equipment | | (9) | | | (43) | | | 267 | | | (43) | |
+Accretion of discounts and amortization of premiums, net | | (1,019) | | | (1,356) | | | (1,817) | | | (1,982) | |
+Impairment expense | | — | | | 415 | | | — | | | 415 | |
+Non-cash interest expense | | 969 | | | 969 | | | 969 | | | 969 | |
+Other adjustments | | (57) | | | (84) | | | (275) | | | 292 | |
+Changes in operating assets and liabilities: | | | | | | | | |
+Accounts receivable, net | | 14,807 | | | 669 | | | 1,281 | | | (3,324) | |
+Prepaid expenses and other current assets | | 2,227 | | | 121 | | | (412) | | | 2,337 | |
+Other assets | | (3,195) | | | (6,076) | | | (1,845) | | | (8,171) | |
+Accounts payable | | 1,497 | | | 3,446 | | | 8,309 | | | 6,021 | |
+Accrued expenses | | (2,651) | | | 1,577 | | | 872 | | | (1,806) | |
+Operating lease liabilities | | (7,114) | | | (2,332) | | | (12,923) | | | (7,888) | |
+Other liabilities | | (13,661) | | | 7,725 | | | (10,937) | | | 16,908 | |
+Net cash provided by operating activities | | 39,334 | | | 25,798 | | | 68,200 | | | 43,086 | |
+Cash flows from investing activities: | | | | | | | | |
+Purchases of marketable securities | | (87,262) | | | (93,440) | | | (266,602) | | | (272,926) | |
+Maturities of marketable securities | | 24,329 | | | 37,836 | | | 201,472 | | | 45,805 | |
+Purchases of property and equipment | | (31,623) | | | (9,852) | | | (52,644) | | | (12,457) | |
+Proceeds from sale of property and equipment | | 10 | | | 44 | | | 10 | | | 44 | |
+Capitalized internal-use software | | (4,148) | | | (4,542) | | | (7,884) | | | (9,305) | |
+Net cash used in investing activities | | (98,694) | | | (69,954) | | | (125,648) | | | (248,839) | |
+Cash flows from financing activities: | | | | | | | | |
+Repayment of convertible senior notes | | — | | | — | | | (38,593) | | | — | |
+Payments of other debt issuance costs | | — | | | — | | | (502) | | | — | |
+Repayments of finance lease liabilities | | — | | | (537) | | | — | | | (2,248) | |
+Proceeds from exercise of vested stock options | | 92 | | | 279 | | | 1,135 | | | 687 | |
+Proceeds from employee stock purchase plan | | 2,397 | | | 1,240 | | | 4,676 | | | 3,371 | |
+Net cash provided by (used in) financing activities | | 2,489 | | | 982 | | | (33,284) | | | 1,810 | |
+Effects of exchange rate changes on cash and cash equivalents | | (1) | | | 177 | | | (33) | | | 255 | |
+Net decrease in cash and cash equivalents | | (56,872) | | | (42,997) | | | (90,765) | | | (203,688) | |
+Cash and cash equivalents at beginning of period | | 146,670 | | | 125,484 | | | 180,563 | | | 286,175 | |
+Cash and cash equivalents at end of period | | $ | 89,798 | | | $ | 82,487 | | | $ | 89,798 | | | $ | 82,487 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Free Cash Flow
+( unaudited, in thousands) | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended
+June 30, | | Six months ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Net cash provided by operating activities | | $ | 39,334 | | | $ | 25,798 | | | $ | 68,200 | | | $ | 43,086 | |
+Capital expenditures (1)
+| | (35,761) | | | (14,887) | | | (60,518) | | | (23,966) | |
+Free Cash Flow | | $ | 3,573 | | | $ | 10,911 | | | $ | 7,682 | | | $ | 19,120 | |
+
+__________
+(1) Capital expenditures are defined as cash used for purchases of property and equipment, net of proceeds from sale of property and equipment, capitalized internal-use software and payments on finance lease obligations, as reflected in our statement of cash flows.
+
+
+
+
+
+
+
+
+Contacts
+Investor Contact
+Vernon Essi, Jr.
+ir@fastly.com
+
+
+Media Contact
+Stacey Hurwitz
+press@fastly.com
+
+
+Source: Fastly, Inc.

--- a/modules/test-fixtures/earnings-filings/rdw.txt
+++ b/modules/test-fixtures/earnings-filings/rdw.txt
@@ -1,0 +1,802 @@
+EX-99.1
+2
+exhibit991redwire06302026e.htm
+EX-99.1
+
+
+
+
+Document
+
+
+Exhibit 99.1
+
+
+
+
+| | | | | | | | |
+8226 Philips Highway, Suite 101 | | Investor Relations Contact: |
+Jacksonville, FL 32256 USA | | investorrelations@redwirespace.com |
+
+
+
+Redwire Corporation Reports Second Quarter 2026 Financial Results, Achieves Record Revenue, Gross Margins, and Contracted Backlog
+JACKSONVILLE, Fla. / August 5, 2026 Redwire Corporation (NYSE:RDW, “Redwire” or the “Company”), a global leader in space and defense technology solutions, today announced results for its second quarter ended June 30, 2026.
+“With new record highs for both revenue of $117.1 million and gross margin of 27.8%, Redwire’s second quarter of 2026 was defined by successful execution,” said Peter Cannito, Chairman, Chief Executive Officer, and President of Redwire. “With a record Backlog 1 of $542.1 million and a strengthened balance sheet to enable strategic investments, Redwire is scaling to meet the strong demand we see for our mission critical space and defense tech offerings.”
+
+
+Second Quarter 2026 Highlights
+• Announced key follow-on awards for Stalker Block 30 from both the Marine Corps Portfolio Acquisition Executive Robotic Autonomous Systems and the 1st Aviation Brigade, U.S. Army Aviation Center of Excellence.
+• Awarded contracts to deliver Penguin uncrewed aerial systems across the globe, including a multi-year contract valued at high eight-figures from an undisclosed NATO country and a contract from Taiwan Color Optics, Inc. for the Taiwan Coast Guard.
+• Delivered nearly 200 Octopus ISR payloads year-to-date, a more than 15% increase year-over-year, and announced two new Octopus products, the Octopus E140 MWIR and E180 HD MWIR.
+• Completed on-orbit operations for pharmaceutical drug development investigations in partnership with researchers at Aspera Biomedicines, Bristol Myers Squibb, Rowan University, and Purdue University, marking more than 50 PIL-BOXes flown since the inaugural mission in November 2023.
+• Subsequent to the end of the second quarter of 2026, held a grand opening in Georgetown, Indiana and announced a facility expansion in Huntsville, Alabama, bringing new capabilities and additional capacity online to support growth.
+• Revenues increased 89.6% year-over-year to $117.1 million for the second quarter of 2026.
+• Year-over-year improvement in gross margins to 27.8% for the second quarter of 2026 compared to (30.9)% for the second quarter of 2025.
+• Net Loss improved by $56.0 million year-over-year to $(41.0) million for the second quarter of 2026.
+• Adjusted EBITDA 2 increased by $24.2 million year-over-year to $(3.2) million for the second quarter of 2026, inclusive of $12.5 million in Research and Development expense.
+
+1 Backlog is a key business measure. Please refer to “Key Performance Indicators” and the tables included in this press release for additional information.
+2 Adjusted EBITDA is not a measure of results under generally accepted accounting principles in the United States. Please refer to “Non-GAAP Financial Information” and the reconciliation tables included in this press release for details regarding this Non-GAAP measure.
+
+
+Page 1
+
+
+
+
+
+
+
+• Achieved Book-to-Bill 3 ratio of 1.42 for the second quarter of 2026 with a meaningful year-over-year increase on a last twelve months basis to 1.52 as of the second quarter of 2026.
+• Ended second quarter 2026 with total liquidity 4 of $607.8 million, a 366.9% increase over the end of 2025.
+
+
+2026 Forecast
+• For the full year ended December 31, 2026, Redwire reaffirms that it is forecasting revenues of $450 million to $500 million.
+
+
+“Consistent with our expectations, during the second quarter of 2026, Redwire expanded gross margins to 27.8%, and achieved sequential and year-over-year improvement in Adjusted EBITDA 5 to $(3.2) million, while investing $12.5 million in Research and Development,” said Chris Edmunds, Chief Financial Officer of Redwire. “During the quarter we reduced the aggregate amount of our term loans from $90.0 million to $50.0 million and ended the quarter with record total liquidity 4 of $607.8 million. With $214.0 million of recorded revenue during the first half of 2026 and Backlog 3 providing significant visibility for the back half of the year, we are again pleased to reaffirm our 2026 revenue forecast.”
+
+
+Webcast and Investor Call
+Management will conduct a conference call starting at 9:00 a.m. ET on Thursday, August 6, 2026 to review financial results for the second quarter ended June 30, 2026. This release is available in the investor section of Redwire’s website at RDW.com.
+
+
+Redwire will live stream a presentation with slides during the call. Please use the following link to follow along with the live stream: https://event.choruscall.com/mediaframe/webcast.html?webcastid=ITIRLOWy. The dial-in number for the live call is 877-485-3108 (toll free) or 201-689-8264 (toll), and the conference ID is 13761352.
+
+
+A telephone replay of the call will be available for two weeks following the event by dialing 877-660-6853 (toll-free) or 201-612-7415 (toll) and entering the access code 13761352. The webcast replay and accompanying investor presentation will be available on August 6, 2026 in the investor section of Redwire’s website at RDW.com.
+
+
+Any replay, rebroadcast, transcript or other reproduction or transmission of this conference call, other than the replay accessible by calling the number and website above, has not been authorized by Redwire and is strictly prohibited. Investors should be aware that any unauthorized reproduction of this conference call may not be an accurate reflection of its contents.
+
+
+About Redwire Corporation
+Redwire Corporation (NYSE:RDW) is an integrated space and defense tech company focused on advanced technologies. We are building the future of aerospace infrastructure, autonomous systems and multi-domain operations leveraging digital engineering and AI automation. Redwire’s approximately 1,400 employees located throughout North America and Europe are committed to delivering innovative space and airborne platforms transforming the future of multi-domain operations. For more information, please visit RDW.com.
+
+
+Use of Projections
+The financial outlook and projections, estimates and targets in this press release are forward-looking statements that are based on assumptions that are inherently subject to significant uncertainty and contingencies, many of which are beyond Redwire’s control. Redwire’s independent auditors have not audited, reviewed, compiled or performed any procedures with respect to the financial projections for purposes of inclusion in this press release, and, accordingly, they did not express an opinion or provide any other form of assurance with respect thereto for the purposes of this press release. While all financial projections, estimates and targets are necessarily speculative, Redwire believes that the preparation of prospective financial information involves increasingly higher levels of uncertainty the further out the projection, estimate
+
+3 Book-to-Bill and Backlog are key business measures. Please refer to “Key Performance Indicators” and the tables included in this press release for additional information.
+4 Total liquidity of $607.8 million as of June 30, 2026 is comprised of $557.0 million in cash and cash equivalents, $50.0 million in available borrowings from our existing credit facilities, and $0.8 million in restricted cash.
+5 Adjusted EBITDA is not a measure of results under generally accepted accounting principles in the United States. Please refer to “Non-GAAP Financial Information” and the reconciliation tables included in this press release for details regarding this Non-GAAP measure.
+
+
+
+
+Page 2
+
+
+
+
+
+
+
+or target extends from the date of preparation. The assumptions and estimates underlying the projected, expected or target results for the Company are inherently uncertain and are subject to a wide variety of significant business, economic and competitive risks and uncertainties that could cause actual results to differ materially from those contained in the financial projections, estimates and targets. The inclusion of financial projections, estimates and targets in this press release should not be regarded as an indication that Redwire, or its representatives, considered or consider the financial projections, estimates or targets to be a reliable prediction of future events. Further, inclusion of the prospective financial information in this press release should not be regarded as a representation by any person that the results contained in the prospective financial information will be achieved.
+
+
+Cautionary Statement Regarding Forward-Looking Statements
+Readers are cautioned that the statements contained in this press release regarding expectations of our performance or other matters that may affect our business, results of operations, or financial condition are “forward-looking statements” as defined by the “safe harbor” provisions in the Private Securities Litigation Reform Act of 1995. Such statements are made in reliance on the safe harbor provisions of Section 27A of the Securities Act of 1933, as amended, and Section 21E of the Securities Exchange Act of 1934, as amended. All statements, other than statements of historical fact, included or incorporated in this press release, including statements regarding our strategy, financial projections, including the prospective financial information provided in this press release, financial position, funding for continued operations, cash reserves, liquidity, projected costs, plans, projects, awards and contracts, and objectives of management, among others, are forward-looking statements. Words such as “expect,” “anticipate,” “should,” “believe,” “target,” “continued,” “project,” “plan,” “opportunity,” “estimate,” “potential,” “predict,” “demonstrates,” “may,” “will,” “could,” “intend,” “shall,” “possible,” “forecast,” “trends,” “contemplate,” “would,” “approximately,” “likely,” “outlook,” “schedule,” “pipeline,” and variations of these terms or the negative of these terms and similar expressions are intended to identify these forward-looking statements, but the absence of these words does not mean that a statement is not forward-looking. These forward-looking statements are not guarantees of future performance, conditions or results. Forward-looking statements are subject to a number of risks and uncertainties, many of which involve factors or circumstances that are beyond our control.
+
+
+These factors and circumstances include, but are not limited to (1) risks associated with economic uncertainty, including high inflation, market volatility, and the potential worsening of macro-economic conditions; (2) geopolitical and macroeconomic events; (3) tariffs impacting demand for our products; (4) the failure of financial institutions or transactional counterparties; (5) our evolving industry, limited operating history since our acquisition of Redwire Defense Tech Intermediate Holdings, LLC and its subsidiaries (f/k/a Edge Autonomy Intermediate Holdings, LLC) (“Edge Autonomy”) and history of losses makes it difficult to evaluate our future prospects and the risks and challenges we may encounter; (6) the inability to successfully integrate recently completed and future acquisitions, including the recent acquisition of Edge Autonomy, or successfully select, execute or integrate future acquisitions into the business and realize the anticipated benefits or do so within the expected timeframe; (7) the development and continued refinement of many of Redwire’s proprietary technologies, products and service offerings; (8) competition with new or existing companies; (9) a limited number of customers make up a high percentage of our revenue; (10) potential litigation arising from time to time; (11) natural disasters, geopolitical conflicts, or other natural or man-made catastrophic events; (12) adverse publicity stemming from any incident or perceived risk involving Redwire or our competitors; (13) incurring significant risks and uncertainties not covered by insurance or indemnity; (14) failure to respond to industry cycles in terms of our cost structure, manufacturing capacity, and/or personnel needs; (15) customers unwillingness to adopt our core offerings; (16) delays in the development, design, engineering and manufacturing of our core offerings; (17) unsatisfactory performance of our core offerings; (18) impacts to our cash flows caused by our mix of fixed-price, cost-plus and time-and-material type contracts; (19) incurrence of expenditures prior to final receipt of a contract; (20) failure of new offerings and technologies to materialize; (21) the inability to convert orders in backlog into revenue; (22) the inability to properly manage the use of artificial intelligence in our business; (23) reliance on third-party launch vehicles to launch our spacecraft and customer payloads; (24) risk of an accident on launch or during a journey into space; (25) Redwire’s inability to meet expected financial results; (26) unfavorable changes in the proportion of cost-plus-fee or fixed-price contracts in our total contract mix and the resulting impact on our margins and operating results; (27) shorter lives than anticipated for our systems, products, technologies, services and related equipment; (28) cyber-attacks and other security threats and disruptions; (29) risks resulting from broader geographic operations; (30) impairment of goodwill; (31) inability to use net operating loss carryforwards and certain other tax attributes; (32) requirements of the National Industrial Security Program Operating Manual for our facility security clearance, which is a prerequisite to performing on classified contracts for the U.S. government; (33) changes to the U.S. government’s budget deficit and the national debt,
+
+
+
+
+Page 3
+
+
+
+
+
+
+
+as well as any inability of the U.S. government to complete its budget process for any government fiscal year, and any resulting government shutdowns; (34) dependence on U.S. government contracts; (35) disputes with our subcontractors or the inability of our subcontractors to perform, or of our key suppliers to timely deliver components, parts or services, resulting in our core offerings being produced or delivered in an untimely or unsatisfactory manner; (36) the potential application of U.S. foreign investment regulations to investments in us, which may impose conditions on or limit certain investors' ability to purchase our common stock, potentially making our common stock less attractive to investors; (37) Redwire is subject to stringent U.S. economic sanctions, and trade control laws and regulations, as well as risks related to doing business in other countries; (38) the wide variety of extensive and evolving government laws and regulations to which our business is subject, and the potential material adverse effect of any failure to comply with such laws and regulations; (39) the potential impact on our reputation and ability to do business resulting from improper conduct of our employees, agents or business partners; (40) failure to comply with federal, state and foreign laws and regulations relating to privacy, data protection and consumer protection, or the expansion of current or enactment of new laws or regulations relating to privacy, data protection and consumer protection, and the resulting adverse effect on our business and financial condition; (41) changes in tax laws or regulations and the resulting increase in tax uncertainty and adverse effect on our results of operations and effective tax rate; (42) failure to adequately protect our intellectual property rights; (43) potential violations of third-party proprietary rights by our technology; (44) failure to obtain necessary additional funding; (45) the possibility of sales of a substantial amount of our common stock by our current stockholders; (46) the inability to remain in compliance with the continued listing requirements of the New York Stock Exchange; (47) the issuance of additional common stock or other equity securities and the resulting dilution of our shareholders' ownership interests; (48) volatility in the trading price of our common stock; (49) our existing material weaknesses and the identification of material weaknesses of other deficiencies or failure to maintain effective internal controls over financial reporting and (50) other risks and uncertainties described in our most recent Annual Report on Form 10-K and Quarterly Reports on Form 10-Q and those indicated from time to time in other documents filed or to be filed with the Securities and Exchange Commission by Redwire. The forward-looking statements contained in this press release are based on our current expectations and beliefs concerning future developments and their potential effects on us. If underlying assumptions to forward-looking statements prove inaccurate, or if known or unknown risks or uncertainties materialize, actual results could vary materially from those anticipated, estimated, or projected. The forward-looking statements contained in this press release are made as of the date of this press release, and Redwire disclaims any intention or obligation, other than imposed by law, to update or revise any forward-looking statements, whether as a result of new information, future events, or otherwise. Persons reading this press release are cautioned not to place undue reliance on forward-looking statements.
+
+
+Non-GAAP Financial Information
+This press release contains financial measures that have not been prepared in accordance with United States Generally Accepted Accounting Principles (“U.S. GAAP”). These financial measures include Adjusted EBITDA, Adjusted Gross Profit, Adjusted Gross Margin, Segment Adjusted EBITDA, Adjusted EPS and Free Cash Flow.
+
+
+Non-GAAP financial measures are used to supplement the financial information presented on a U.S. GAAP basis and should not be considered in isolation or as a substitute for the relevant U.S. GAAP measures and should be read in conjunction with information presented on a U.S. GAAP basis. Because not all companies use identical calculations, our presentation of Non-GAAP measures may not be comparable to other similarly titled measures of other companies. We encourage investors and stockholders to review our financial statements and publicly-filed reports in their entirety and not to rely on any single financial measure.
+
+
+Adjusted EBITDA is defined as net income (loss) adjusted for interest expense, net, income tax expense (benefit), depreciation and amortization, impairment expense, transaction expenses, acquisition integration costs, acquisition earnout costs, purchase accounting fair value adjustment related to deferred revenue and inventory, severance costs, capital market and advisory fees, disposal of long-lived assets, litigation-related expenses, equity-based compensation, committed equity facility transaction costs, debt financing costs and extinguishment losses, gains on sale of joint ventures, net of costs incurred, and warrant liability change in fair value adjustment.
+
+
+Adjusted Gross Profit is defined as revenues less cost of sales as computed in accordance with U.S. GAAP, excluding adjustments resulting from the application of purchase accounting included in cost of sales and Adjusted Gross Margin is defined as Adjusted Gross Profit as a percentage of revenue. Management believes these non-GAAP measures provide investors meaningful insight into results from ongoing operations as the calculation of these measures excludes the impact of certain non-recurring charges. Management believes that by using Adjusted Gross Margin in conjunction with GAAP
+
+
+
+
+Page 4
+
+
+
+
+
+
+
+Gross Margin, investors will get a more complete view of what management considers to be the Company’s core operating performance and allow for comparison of this measure when compared to those of prior periods.
+
+
+Segment Adjusted EBITDA is defined as income (loss) before taxes, excluding, depreciation and amortization, impairment expense, transaction expenses, acquisition integration costs, acquisition earnout costs, purchase accounting fair value adjustment related to deferred revenue and inventory, severance costs, disposal of long-lived assets, equity-based compensation and gains on sale of joint ventures, net of costs incurred. Segment Adjusted EBITDA also excludes intra- and inter-segment sales and costs and corporate pushdown costs.
+
+
+Adjusted EPS is defined as U.S. GAAP diluted earnings per share (the most directly comparable U.S. GAAP measure) before transaction expenses, acquisition integration costs, purchase accounting fair value adjustment related to deferred revenue and inventory, litigation expenses, equity-based compensation, debt financing costs and extinguishment losses and changes in fair value of private warrants, adjusted to assume the Company’s Convertible Preferred Stock does not exist. Adjusted EPS is a useful measure because it eliminates the impact of infrequent or non-recurring items that do not relate to operational performance and provides additional information to investors about certain material non-cash items that we do not expect to continue at the same level in the future.
+
+
+Free Cash Flow is computed as net cash provided by (used in) operating activities less capital expenditures.
+
+
+We use Adjusted EBITDA, Adjusted Gross Profit, Adjusted Gross Margin, Segment Adjusted EBITDA, and Adjusted EPS to evaluate our operating performance, generate future operating plans, and make strategic decisions, including those relating to operating expenses and the allocation of internal resources. We use Free Cash Flow as an indicator of liquidity to evaluate our period-over-period operating cash generation that will be used to service our debt, and can be used to invest in future growth through new business development activities and/or acquisitions, among other uses. Free Cash Flow does not represent the total increase or decrease in our cash balance, and it should not be inferred that the entire amount of Free Cash Flow is available for discretionary expenditures, since we have mandatory debt service requirements and other non-discretionary expenditures that are not deducted from this measure.
+
+
+Key Performance Indicators
+Management uses Key Performance Indicators (“KPIs”) to assess the financial performance of the Company, monitor relevant trends and support financial, operational and strategic decision-making. Management frequently monitors and evaluates KPIs against internal targets, core business objectives as well as industry peers and may, on occasion, change the mix or calculation of KPIs to better align with the business, its operating environment, standard industry metrics or other considerations. If the Company changes the method by which it calculates or presents a KPI, prior period disclosures are recast to conform to current presentation.
+
+
+
+
+
+
+Page 5
+
+
+
+
+
+
+
+
+REDWIRE CORPORATION
+CONDENSED CONSOLIDATED BALANCE SHEETS
+Unaudited
+(In thousands of U.S. dollars, except share data)
+| | |
+|
+
+| | | | | | | | | | | |
+| June 30, 2026 | | December 31, 2025 |
+| | | |
+Current assets:
+| | | |
+Cash, cash equivalents and restricted cash
+| $ | 557,718 | | | $ | 95,183 | |
+Accounts receivable, net
+| 27,495 | | | 37,251 | |
+Contract assets
+| 72,045 | | | 44,019 | |
+Inventory, net
+| 85,364 | | | 55,847 | |
+| | | |
+| | | |
+| | | |
+Prepaid expenses and other current assets
+| 18,538 | | | 20,512 | |
+Total current assets
+| 761,160 | | | 252,812 | |
+Property, plant and equipment, net of accumulated depreciation of $20,013 and $14,558 | 56,092 | | | 49,199 | |
+Right-of-use assets | 34,390 | | | 31,741 | |
+Intangible assets, net of accumulated amortization of $62,817 and $46,192
+| 319,104 | | | 336,153 | |
+Goodwill
+| 772,170 | | | 779,114 | |
+| | | |
+| | | |
+Other non-current assets
+| 428 | | | 118 | |
+Total assets
+| $ | 1,943,344 | | | $ | 1,449,137 | |
+| | | |
+Liabilities, Convertible Preferred Stock and Equity (Deficit)
+| | | |
+Current liabilities:
+| | | |
+Accounts payable
+| $ | 54,158 | | | $ | 32,295 | |
+Notes payable to sellers
+| 3,171 | | | 2,171 | |
+Short-term debt, including current portion of long-term debt
+| 4,500 | | | 5,162 | |
+Short-term operating lease liabilities | 4,545 | | | 4,088 | |
+Short-term finance lease liabilities | 611 | | | 595 | |
+Accrued expenses
+| 29,715 | | | 32,034 | |
+Deferred revenue
+| 84,970 | | | 60,119 | |
+Other current liabilities
+| 12,568 | | | 19,150 | |
+Total current liabilities
+| 194,238 | | | 155,614 | |
+Long-term debt, net
+| 43,561 | | | 80,036 | |
+Long-term operating lease liabilities | 32,698 | | | 30,471 | |
+Long-term finance lease liabilities | 1,189 | | | 1,276 | |
+Warrant liabilities | 692 | | | 4,213 | |
+Deferred tax liabilities
+| 39,885 | | | 38,358 | |
+Other non-current liabilities
+| 1,224 | | | 2,119 | |
+Total liabilities
+| $ | 313,487 | | | $ | 312,087 | |
+| | | |
+| | | |
+|
+| | | |
+| | | |
+| | | |
+| | | |
+Convertible preferred stock, $0.0001 par value, 125,292.00 shares authorized; issued and outstanding: 2026—none and 2025—46,505.13. Liquidation preference: 2026—none and 2025—$118,434
+| $ | — | | | $ | 77,034 | |
+| | | |
+Shareholders’ Equity (Deficit):
+| | | |
+Preferred stock, $0.0001 par value, 99,874,708 shares authorized; none issued and outstanding
+| — | | | — | |
+Common stock, $0.0001 par value, 500,000,000 shares authorized; issued and outstanding 2026—249,221,102 and 2025—191,915,804
+| 25 | | | 19 | |
+Treasury stock, at cost: 2026—1,036,294 shares and 2025—1,036,294 shares
+| (7,342) | | | (7,342) | |
+Additional paid-in capital
+| 2,377,689 | | | 1,678,799 | |
+Accumulated deficit
+| (739,235) | | | (621,762) | |
+Accumulated other comprehensive income (loss)
+| (1,280) | | | 10,302 | |
+Total shareholders’ equity (deficit) | 1,629,857 | | | 1,060,016 | |
+| | | |
+| | | |
+Total liabilities, convertible preferred stock and equity (deficit)
+| $ | 1,943,344 | | | $ | 1,449,137 | |
+
+
+
+
+
+Page 6
+
+
+
+
+
+
+
+
+REDWIRE CORPORATION
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS AND COMPREHENSIVE INCOME (LOSS)
+Unaudited
+(In thousands of U.S. dollars, except share and per share data)
+| | |
+|
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | |
+| Three Months Ended | | Six Months Ended | | | |
+| June 30, 2026 | | June 30, 2025 | | June 30, 2026 | | June 30, 2025 | | | |
+Revenues
+| $ | 117,074 | | | $ | 61,760 | | | $ | 214,046 | | | $ | 123,155 | | | | |
+Cost of sales
+| 84,530 | | | 80,824 | | | 155,694 | | | 133,178 | | | | |
+Gross profit
+| 32,544 | | | (19,064) | | | 58,352 | | | (10,023) | | | | |
+Operating expenses:
+| | | | | | | | | | |
+Selling, general and administrative expenses
+| 42,076 | | | 54,464 | | | 124,963 | | | 73,210 | | | | |
+| | | | | | | | | | |
+Transaction expenses
+| 11 | | | 16,643 | | | 51 | | | 20,442 | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Research and development
+| 12,547 | | | 1,720 | | | 25,129 | | | 2,533 | | | | |
+Operating income (loss)
+| (22,090) | | | (91,891) | | | (91,791) | | | (106,208) | | | | |
+Interest expense, net
+| 796 | | | 23,755 | | | 3,263 | | | 27,349 | | | | |
+Loss on extinguishment of debt | 1,186 | | | — | | | 3,731 | | | — | | | | |
+Other (income) expense, net
+| 15,037 | | | 13,937 | | | 16,185 | | | (844) | | | | |
+Income (loss) before income taxes
+| (39,109) | | | (129,583) | | | (114,970) | | | (132,713) | | | | |
+Income tax expense (benefit)
+| 1,862 | | | (32,604) | | | 2,503 | | | (32,786) | | | | |
+Net income (loss)
+| (40,971) | | | (96,979) | | | (117,473) | | | (99,927) | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Less: dividends on Convertible Preferred Stock | 504 | | | 29,739 | | | 2,016 | | | 33,179 | | | | |
+Net income (loss) available to common shareholders | $ | (41,475) | | | $ | (126,718) | | | $ | (119,489) | | | $ | (133,106) | | | | |
+| | | | | | | | | | |
+Net income (loss) per common share: | | | | | | | | | | |
+Basic and diluted
+| $ | (0.19) | | | $ | (1.41) | | | $ | (0.58) | | | $ | (1.66) | | | | |
+Weighted-average shares outstanding: | | | | | | | | | | |
+Basic and diluted
+| 220,466,669 | | | 89,554,940 | | | 207,143,490 | | | 80,424,270 | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+| | | | | | | | | | |
+Comprehensive income (loss):
+| | | | | | | | | | |
+Net income (loss) | $ | (40,971) | | | $ | (96,979) | | | $ | (117,473) | | | $ | (99,927) | | | | |
+Foreign currency translation gain (loss), net of tax
+| (5,157) | | | 10,174 | | | (11,582) | | | 11,009 | | | | |
+Total other comprehensive income (loss), net of tax
+| (5,157) | | | 10,174 | | | (11,582) | | | 11,009 | | | | |
+Total comprehensive income (loss)
+| $ | (46,128) | | | $ | (86,805) | | | $ | (129,055) | | | $ | (88,918) | | | | |
+| | | | | | | | | | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Page 7
+
+
+
+
+
+
+
+
+REDWIRE CORPORATION
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+Unaudited
+(In thousands of U.S. dollars)
+| | |
+|
+| | | | | | | | | | | | | | |
+| Six Months Ended | | | |
+| June 30, 2026 | | June 30, 2025 | | | |
+Cash flows from operating activities: | | | | | | |
+| | | | | | |
+| | | | | | |
+Net income (loss) | $ | (117,473) | | | $ | (99,927) | | | | |
+Adjustments to reconcile net income (loss) to net cash provided by (used in) operating activities: | | | | | | |
+Depreciation and amortization expense | 22,710 | | | 8,106 | | | | |
+Amortization of debt issuance costs and discount | 657 | | | 642 | | | | |
+| | | | | | |
+Equity-based compensation expense | 50,635 | | | 35,598 | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+Loss on extinguishment of debt | 3,731 | | | — | | | | |
+| | | | | | |
+(Gain) loss on change in fair value of warrants | 14,787 | | | 2,692 | | | | |
+Deferred provision (benefit) for income taxes | 2,485 | | | (32,069) | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+Other | 1,961 | | | (3,677) | | | | |
+Changes in assets and liabilities: | | | | | | |
+(Increase) decrease in accounts receivable | 9,553 | | | (3,468) | | | | |
+(Increase) decrease in contract assets | (28,388) | | | (5,724) | | | | |
+(Increase) decrease in inventory | (30,170) | | | 1,449 | | | | |
+| | | | | | |
+(Increase) decrease in prepaid expenses and other assets | 68 | | | (3,024) | | | | |
+Increase (decrease) in accounts payable and accrued expenses | 19,358 | | | (5,586) | | | | |
+Increase (decrease) in deferred revenue | 25,344 | | | (28,433) | | | | |
+Increase (decrease) in operating lease liabilities | (427) | | | (55) | | | | |
+Increase (decrease) in other liabilities | (7,433) | | | 732 | | | | |
+Increase (decrease) in notes payable to sellers | 1,000 | | | — | | | | |
+Net cash provided by (used in) operating activities | (31,602) | | | (132,744) | | | | |
+| | | | | | |
+Cash flows from investing activities: | | | | | | |
+Acquisition of businesses, net of cash acquired | — | | | (151,791) | | | | |
+| | | | | | |
+Purchases of property, plant and equipment | (13,287) | | | (4,752) | | | | |
+Purchase of intangible assets | (3,154) | | | (5,186) | | | | |
+| | | | | | |
+| | | | | | |
+Net cash provided by (used in) investing activities | (16,441) | | | (161,729) | | | | |
+| | | | | | |
+Cash flows from financing activities: | | | | | | |
+Proceeds received from debt | 89,728 | | | 190,327 | | | | |
+Repayments of debt | (129,537) | | | (125,876) | | | | |
+Payment of debt issuance fees | (1,914) | | | (105) | | | | |
+Repayment of finance leases | (294) | | | (227) | | | | |
+Proceeds from (repayment of) third-party advances | — | | | (7,820) | | | | |
+Proceeds from issuance of common stock | 566,243 | | | 328,684 | | | | |
+Payment of equity issuance costs | (13,881) | | | — | | | | |
+| | | | | | |
+Proceeds from common stock issued for options exercise | 4,155 | | | — | | | | |
+Shares repurchased for settlement of employee tax withholdings on share-based awards | — | | | (8) | | | | |
+| | | | | | |
+Convertible preferred stock dividend | (3,039) | | | — | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+Repurchase of convertible preferred stock | — | | | (61,486) | | | | |
+Net cash provided by (used in) financing activities | 511,461 | | | 323,489 | | | | |
+Effect of foreign currency rate changes on cash, cash equivalents and restricted cash | (883) | | | 472 | | | | |
+Net increase (decrease) in cash, cash equivalents and restricted cash | 462,535 | | | 29,488 | | | | |
+Cash, cash equivalents and restricted cash at beginning of period | 95,183 | | | 49,071 | | | | |
+Cash, cash equivalents and restricted cash at end of period | $ | 557,718 | | | $ | 78,559 | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+| | | | | | |
+
+
+
+Page 8
+
+
+
+
+
+
+
+
+REDWIRE CORPORATION
+Reportable Segment Results
+Unaudited
+(In thousands of U.S. dollars)
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+| June 30, 2026 | | June 30, 2025 | | June 30, 2026 | | June 30, 2025 |
+Revenues
+| | | | | | | |
+Space
+| $ | 55,192 | | | $ | 56,682 | | | $ | 107,859 | | | $ | 108,815 | |
+Defense Tech
+| 61,882 | | | 5,078 | | | 106,187 | | | 14,340 | |
+Total revenues
+| $ | 117,074 | | | $ | 61,760 | | | $ | 214,046 | | | $ | 123,155 | |
+| | | | | | | |
+Segment Adjusted EBITDA
+| | | | | | | |
+Space
+| $ | (4,203) | | | $ | 1,040 | | | $ | (5,732) | | | $ | 8,484 | |
+Defense Tech
+| 14,083 | | | (15,041) | | | 19,481 | | | (12,614) | |
+Total Segment Adjusted EBITDA
+| $ | 9,880 | | | $ | (14,001) | | | $ | 13,749 | | | $ | (4,130) | |
+Reconciliation of Segment Adjusted EBITDA to consolidated net income (loss):
+| | | | | | | |
+Interest expense, net | (796) | | | (23,755) | | | (3,263) | | | (27,349) | |
+Depreciation and amortization expense | (11,460) | | | (5,060) | | | (22,710) | | | (8,106) | |
+Severance costs
+| (294) | | | (1,999) | | | (556) | | | (2,176) | |
+Equity-based compensation expense | (3,900) | | | (32,686) | | | (50,635) | | | (35,598) | |
+Transaction expenses
+| (11) | | | (16,643) | | | (51) | | | (20,442) | |
+All other corporate charges (1)
+| (30,800) | | | (32,459) | | | (46,626) | | | (31,932) | |
+| | | | | | | |
+Debt financing costs and extinguishment losses
+| (1,260) | | | (105) | | | (4,185) | | | (105) | |
+| | | | | | | |
+Purchase accounting fair value adjustment related to inventory
+| — | | | (2,418) | | | — | | | (2,418) | |
+Acquisition integration cost | (259) | | | (457) | | | (484) | | | (457) | |
+Disposal of long-lived assets
+| (209) | | | — | | | (209) | | | — | |
+Income (loss) before income taxes
+| $ | (39,109) | | | $ | (129,583) | | | $ | (114,970) | | | $ | (132,713) | |
+
+(1) All other corporate charges mainly consists of corporate overhead costs maintained at the corporate level, including gains and losses related to financial instruments measured at fair value. These expenses include costs relating to treasury, accounting, consulting, advisory, legal, tax and audit, insurance, financial reporting services and various administrative expenses related to the corporate headquarters.
+Page 9
+
+
+
+
+
+
+
+
+REDWIRE CORPORATION
+Supplemental Non-GAAP Information
+Unaudited
+
+
+Adjusted EBITDA
+The following table presents the reconciliations of Adjusted EBITDA to net income (loss), computed in accordance with U.S. GAAP.
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+(in thousands) | June 30, 2026 | | June 30, 2025 | | June 30, 2026 | | June 30, 2025 |
+Net income (loss) | $ | (40,971) | | | $ | (96,979) | | | $ | (117,473) | | | $ | (99,927) | |
+Interest expense, net | 796 | | | 23,755 | | | 3,263 | | | 27,349 | |
+Income tax expense (benefit) | 1,862 | | | (32,604) | | | 2,503 | | | (32,786) | |
+Depreciation and amortization | 11,460 | | | 5,060 | | | 22,710 | | | 8,106 | |
+| | | | | | | |
+Transaction expenses (i) | 11 | | | 16,643 | | | 51 | | | 20,442 | |
+Acquisition integration costs (i) | 259 | | | 457 | | | 484 | | | 457 | |
+| | | | | | | |
+Purchase accounting fair value adjustment related to inventory (ii) | — | | | 2,418 | | | — | | | 2,418 | |
+| | | | | | | |
+Severance costs (iii) | 294 | | | 1,999 | | | 556 | | | 2,176 | |
+Capital market and advisory fees (iv) | 2,742 | | | 2,740 | | | 4,757 | | | 3,708 | |
+Disposal of long-lived assets (v) | 209 | | | — | | | 209 | | | — | |
+Litigation-related expenses (vi) | 477 | | | — | | | 903 | | | — | |
+Equity-based compensation (vii) | 3,900 | | | 32,686 | | | 50,635 | | | 35,598 | |
+| | | | | | | |
+Debt financing costs and extinguishment loss (viii) | 1,260 | | | 105 | | | 4,185 | | | 105 | |
+| | | | | | | |
+Warrant liability change in fair value adjustment (ix) | 14,469 | | | 16,326 | | | 14,787 | | | 2,692 | |
+Adjusted EBITDA | $ | (3,232) | | | $ | (27,394) | | | $ | (12,430) | | | $ | (29,662) | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+
+i. Redwire incurred acquisition costs including due diligence, integration costs and additional expenses related to pre-acquisition activity.
+ii. Redwire adjusted inventory related to the application of purchase accounting for the Edge Autonomy acquisition and recognized expense for the amount of the fair value adjustment included in cost of sales for the inventory sold after the acquisition date.
+iii. Redwire incurred severance costs related to separation agreements entered into with former employees.
+iv. Redwire incurred capital market and advisory fees related to advisors assisting with the implementation of internal controls over financial reporting, including material weakness remediation efforts, and the internalization of corporate services, including, but not limited to, implementing enhanced enterprise resource planning systems across U.S. and foreign operations.
+v. Redwire incurred a loss on the disposal of long-lived assets.
+vi. Redwire incurred expenses related to settlements of legal matters.
+vii. Redwire incurred expenses related to equity-based compensation under Redwire’s equity-based compensation plan and Edge Autonomy’s incentive units.
+viii. Redwire incurred expenses related to debt financing agreements, including amendment related fees paid to third parties that are expensed in accordance with U.S. GAAP and losses on debt extinguishments.
+ix. Redwire adjusted the private warrant liability to reflect changes in fair value recognized as a gain or loss during the respective periods.
+Page 10
+
+
+
+
+
+
+
+REDWIRE CORPORATION
+Supplemental Non-GAAP Information
+Unaudited
+
+
+Adjusted Gross Profit and Margin
+The following table presents the reconciliation of Adjusted Gross Profit to Gross Profit, computed in accordance with U.S. GAAP, and the calculation of Adjusted Gross Margin.
+| | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended | | |
+(in thousands) | June 30, 2026 | | June 30, 2025 | | June 30, 2026 | | June 30, 2025 | | | | |
+Gross Profit
+| $ | 32,544 | | | $ | (19,064) | | | $ | 58,352 | | | $ | (10,023) | | | | | |
+Purchase accounting adjustments (1)
+| — | | | 2,418 | | | — | | | 2,418 | | | | | |
+Adjusted Gross Profit
+| $ | 32,544 | | | $ | (16,646) | | | $ | 58,352 | | | $ | (7,605) | | | | | |
+Adjusted Gross Margin
+| 27.8 | % | | (27.0) | % | | 27.3 | % | | (6.2) | % | | | | |
+
+(1) Relates to the application of purchase accounting for the Edge Autonomy acquisition and represents the amount of the fair value adjustment recognized in cost of sales for the inventory sold after the acquisition date.
+
+
+Free Cash Flow
+The following table presents the reconciliation of Free Cash Flow to Net cash provided by (used in) operating activities, computed in accordance with U.S. GAAP.
+| | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended | | |
+(in thousands) | June 30, 2026 | | June 30, 2025 | | June 30, 2026 | | June 30, 2025 | | | | |
+Net cash provided by (used in) operating activities | $ | (24,936) | | | $ | (87,663) | | | $ | (31,602) | | | $ | (132,744) | | | | | |
+Less: Capital expenditures | (10,405) | | | (5,883) | | | (16,441) | | | (9,938) | | | | | |
+Free Cash Flow | $ | (35,341) | | | $ | (93,546) | | | $ | (48,043) | | | $ | (142,682) | | | | | |
+
+
+
+Adjusted EPS
+The table below presents a reconciliation of Adjusted EPS to diluted EPS, computed in accordance with U.S. GAAP for the following periods:
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Six Months Ended |
+| June 30, 2026 | | June 30, 2025 | | June 30, 2026 | | June 30, 2025 | | |
+Diluted EPS
+| $ | (0.19) | | | $ | (1.41) | | | $ | (0.58) | | | $ | (1.66) | | | |
+Dividends on convertible preferred stock
+| — | | | 0.33 | | | 0.01 | | | 0.41 | | | |
+| | | | | | | | | |
+Transaction expenses (i) | — | | | 0.19 | | | — | | | 0.25 | | | |
+Acquisition integration costs (i) | — | | | 0.01 | | | — | | | 0.01 | | | |
+| | | | | | | | | |
+Purchase accounting fair value adjustment (ii) | — | | | 0.03 | | | — | | | 0.03 | | | |
+Litigation-related expenses (iii)
+| — | | | — | | | — | | | — | | | |
+Equity-based compensation (iv)
+| 0.02 | | | 0.36 | | | 0.24 | | | 0.44 | | | |
+| | | | | | | | | |
+Debt financing costs and extinguishment losses (v)
+| 0.01 | | | — | | | 0.02 | | | — | | | |
+| | | | | | | | | |
+Warrant liability change in fair value adjustment (vi)
+| 0.07 | | | 0.18 | | | 0.07 | | | 0.03 | | | |
+Adjusted EPS | $ | (0.09) | | | $ | (0.31) | | | $ | (0.24) | | | $ | (0.49) | | | |
+
+i. Redwire incurred acquisition costs including due diligence, integration costs and additional expenses related to pre-acquisition activity.
+ii. Redwire adjusted inventory related to the application of purchase accounting for the Edge Autonomy acquisition and recognized expense for the amount of the fair value adjustment included in cost of sales for the inventory sold after the acquisition date.
+iii. Redwire incurred expenses related to settlements of legal matters.
+iv. Redwire incurred expenses related to equity-based compensation under Redwire’s equity-based compensation plan and Edge Autonomy’s incentive units.
+Page 11
+
+
+
+
+
+
+
+v. Redwire incurred expenses related to debt financing agreements, including amendment related fees paid to third parties that are expensed in accordance with U.S. GAAP, and losses on debt extinguishments.
+vi. Redwire adjusted the private warrant liability to reflect changes in fair value recognized as a gain or loss during the respective periods.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Page 12
+
+
+
+
+
+
+
+
+REDWIRE CORPORATION
+KEY PERFORMANCE INDICATORS
+Unaudited
+
+
+Book-to-Bill
+Our book-to-bill ratio was as follows for the periods presented:
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | |
+| Three Months Ended | | Last Twelve Months Ended
+| | | |
+(in thousands, except ratio) | June 30, 2026 | | June 30, 2025 | | June 30, 2026 | | June 30, 2025 | | | |
+Contracts awarded
+| | | | | | | | | | |
+Space
+| $ | 20,648 | | | $ | 9,537 | | | $ | 309,733 | | | $ | 138,789 | | | | |
+Defense Tech
+| 145,139 | | | 81,026 | | | 337,255 | | | 88,269 | | | | |
+Total contracts awarded
+| $ | 165,787 | | | $ | 90,563 | | | $ | 646,988 | | | $ | 227,058 | | | | |
+Revenues
+| | | | | | | | | | |
+Space
+| $ | 55,192 | | | $ | 56,682 | | | $ | 208,871 | | | $ | 220,304 | | | | |
+Defense Tech
+| 61,882 | | | 5,078 | | | 217,401 | | | 41,049 | | | | |
+Total revenues
+| $ | 117,074 | | | $ | 61,760 | | | $ | 426,272 | | | $ | 261,353 | | | | |
+Book-to-bill ratio
+| | | | | | | | | | |
+Space
+| 0.37 | | 0.17 | | 1.48 | | 0.63 | | | |
+Defense Tech
+| 2.35 | | 15.96 | | 1.55 | | 2.15 | | | |
+Total book-to-bill ratio
+| 1.42 | | 1.47 | | 1.52 | | 0.87 | | | |
+
+Book-to-bill is the ratio of total contracts awarded to revenues recorded in the same period. The contracts awarded balance includes firm contract orders, including time-and-material contracts, awarded during the period and does not include unexercised contract options or potential orders under indefinite delivery/indefinite quantity contracts. Although the contracts awarded balance reflects firm contract orders, terminations, amendments, or contract cancellations may occur which could result in a reduction to the contracts awarded balance.
+
+
+We view book-to-bill as an indicator of future revenue growth potential. To drive future revenue growth, our goal is for the level of contracts awarded in a given period to exceed the revenue recorded, thus yielding a book-to-bill ratio greater than 1.0.
+
+
+Our book-to-bill ratio was 1.42 for the three months ended June 30, 2026, as compared to 1.47 for the three months ended June 30, 2025. For the three months ended June 30, 2026 none of the contracts awarded balance relates to acquired contract value. For the three months ended June 30, 2025, the contracts awarded includes $73.7 million of acquired contract value from the Edge Autonomy acquisition.
+
+
+Our book-to-bill ratio was 1.52 for the Last Twelve Months (“LTM”) ended June 30, 2026, as compared to 0.87 for the LTM ended June 30, 2025. For the LTM ended June 30, 2026 none of the contracts awarded balance relates to acquired contract value. For the LTM ended June 30, 2025, contracts awarded includes $73.7 million of acquired contract value from the Edge Autonomy acquisition, which was completed in the second quarter of 2025 and included in the Defense Tech segment, and $21.9 million of acquired contract value from the Hera Systems acquisition, which was completed in the third quarter of 2024, and included in the Space segment.
+
+
+Page 13
+
+
+
+
+
+
+
+Backlog
+The following table presents our contracted backlog as of June 30, 2026 and December 31, 2025, and related activity for the six months ended June 30, 2026 as compared to the year ended December 31, 2025.
+| | | | | | | | | | | | | |
+| | | |
+(in thousands) | June 30, 2026 | | December 31, 2025 | | |
+Organic backlog, beginning balance | $ | 411,246 | | | $ | 296,652 | | | |
+Organic additions during the period | 352,316 | | | 441,478 | | | |
+Organic revenue recognized during the period | (214,046) | | | (335,381) | | | |
+Foreign currency translation | (7,389) | | | 8,497 | | | |
+Organic backlog, ending balance | 542,127 | | | 411,246 | | | |
+| | | | | |
+Acquisition-related contract value, beginning balance | — | | | — | | | |
+| | | | | |
+| | | | | |
+| | | | | |
+| | | | | |
+Acquisition-related backlog, ending balance | — | | | — | | | |
+| | | | | |
+Contracted backlog, ending balance | $ | 542,127 | | | $ | 411,246 | | | |
+| | | | | |
+| | | | | |
+| | | | | |
+Contracted backlog by segment:
+| | | | | |
+Space
+| $ | 321,950 | | | $ | 299,804 | | | |
+Defense Tech
+| 220,177 | | | 111,442 | | | |
+
+
+
+We view growth in backlog as a key measure of our business growth. Contracted backlog represents the estimated dollar value of firm funded executed contracts for which work has not been performed (also known as the remaining performance obligations on a contract). Our contracted backlog includes $186.2 million and $81.0 million in remaining contract value from contracts which recognize revenue at a point in time as of June 30, 2026 and as of December 31, 2025, respectively.
+
+
+Organic backlog change excludes backlog activity from acquisitions for the first four full quarters since the entities’ acquisition date. Contracted backlog activity for the first four full quarters since the entities’ acquisition date is included in acquisition-related contracted backlog change. After the completion of four fiscal quarters, acquired entities are treated as organic for current and comparable historical periods.
+
+
+Organic contract value includes the remaining contract value as of January 1 not yet recognized as revenue and additional orders awarded during the period for those entities treated as organic. Acquisition-related contract value includes remaining contract value as of the acquisition date not yet recognized as revenue and additional orders awarded during the period for entities not treated as organic. Organic revenue includes revenue earned during the period presented for those entities treated as organic, while acquisition-related revenue includes the same for all other entities, excluding any pre-acquisition revenue earned during the period. There is no acquisition-related backlog activity presented in the table above as all acquired entities have completed four fiscal quarters post-acquisition.
+
+
+Although contracted backlog reflects business associated with contracts that are considered to be firm, terminations, amendments or contract cancellations may occur, which could result in a reduction in our total backlog. In addition, some of our multi-year contracts are subject to annual funding. Management expects all amounts reflected in contracted backlog to ultimately be fully funded. Contracted backlog from foreign operations was $229.0 million and $193.1 million as of June 30, 2026 and December 31, 2025, respectively. These amounts are primarily subject to foreign exchange rate translations from their respective local currencies to U.S. dollars that could cause the remaining backlog balance to fluctuate with the foreign exchange rate at the time of measurement.
+Page 14

--- a/modules/test-fixtures/earnings-filings/sndk.txt
+++ b/modules/test-fixtures/earnings-filings/sndk.txt
@@ -1,0 +1,502 @@
+EX-99.1
+2
+sndkq4-26ex991xpressrelease.htm
+EX-99.1
+
+
+
+
+Document
+Exhibit 99.1
+
+
+
+
+Sandisk Reports Fiscal Fourth Quarter 2026 Financial Results
+News Summary
+• Fiscal fourth quarter revenue was $8.97 billion, up 51% sequentially, with GAAP net income reported at $6.90 billion ($43.97 diluted net income per share). Sequential revenue growth came approximately one-third from higher volumes and two-thirds from higher pricing. Fourth quarter Non-GAAP diluted net income per share was $39.25.
+• Fiscal year 2026 revenue was $20.25 billion, up 175% year-over-year, with GAAP net income reported at $11.43 billion ($73.76 diluted net income per share). Revenue outperformance was driven by both our mix shift toward higher-value customers, with Datacenter up 437%, and higher pricing. Fiscal year 2026 Non-GAAP diluted net income per share was $70.88.
+• Since announcing five New Business Model (“NBM”) agreements during our April earnings call, we have signed five additional agreements, including three NBMs with new customers and two deals expanding on previously signed NBMs.
+• Expanded our share repurchase authorization, with Sandisk’s Board of Directors approving an additional $14 billion buyback program, bringing total remaining authorization to $15.5 billion.
+• Expect first quarter 2027 revenue to be in the range of $10.30 billion to $10.80 billion, with expected Non-GAAP diluted net income per share to be in the range of $44.00 to $46.00.
+MILPITAS, Calif. — August 5, 2026 — Sandisk Corporation (Nasdaq: SNDK) today reported fiscal fourth quarter financial results.
+
+
+"We closed fiscal 2026 with a leading technology portfolio, established datacenter as a key growth pillar, and deepened our customer partnerships," said David Goeckeler, Chairman and Chief Executive Officer of Sandisk. "Our technology and products are well positioned to create value for our customers and generate growing and durable free cash flow."
+
+
+
+
+1
+
+
+
+
+
+
+
+
+Q4 2026 Financial Highlights
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| GAAP | | Non-GAAP |
+($ in millions, except per share amounts)
+| Q4 2026 | | Q3 2026 | | Q/Q | | Q4 2026 | | Q3 2026 | | Q/Q |
+Revenue | $8,965 | | $5,950 | | up 51% | | $8,965 | | $5,950 | | up 51% |
+Gross Margin | 84.6% | | 78.4% | | up 6.2 ppt | | 84.6% | | 78.4% | | up 6.2 ppt |
+Operating Expenses | $545 | | $551 | | down 1% | | $484 | | $448 | | up 8% |
+Operating Income | $7,037 | | $4,111 | | up 71% | | $7,104 | | $4,218 | | up 68% |
+Net Income | $6,903 | | $3,615 | | up 91% | | $6,162 | | $3,675 | | up 68% |
+Diluted Net Income Per Share
+| $43.97 | | $23.03 | | up 91% | | $39.25 | | $23.41 | | up 68% |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| GAAP | | Non-GAAP |
+($ in millions, except per share amounts)
+| Q4 2026 | | Q4 2025 | | Y/Y | | Q4 2026 | | Q4 2025 | | Y/Y |
+Revenue | $8,965 | | $1,901 | | up 372% | | $8,965 | | $1,901 | | up 372% |
+Gross Margin | 84.6% | | 26.2% | | up 58.4 ppt | | 84.6% | | 26.4% | | up 58.2 ppt |
+Operating Expenses | $545 | | $480 | | up 14% | | $484 | | $402 | | up 20% |
+Operating Income | $7,037 | | $18 | | * | | $7,104 | | $100 | | * |
+Net Income (Loss) | $6,903 | | $(23) | | * | | $6,162 | | $42 | | * |
+Diluted Net Income (Loss) Per Share
+| $43.97 | | $(0.16) | | * | | $39.25 | | $0.29 | | * |
+
+* Not a meaningful figure
+Fiscal Year 2026 Financial Highlights
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| GAAP | | Non-GAAP |
+($ in millions, except per share amounts)
+| 2026 | | 2025 | | Y/Y | | 2026 | | 2025 | | Y/Y |
+Revenue | $20,248 | | $7,355 | | up 175% | | $20,248 | | $7,355 | | up 175% |
+Gross Margin | 71.5% | | 30.1% | | up 41.4 ppt | | 71.6% | | 30.3% | | up 41.3 ppt |
+Operating Expenses | $2,083 | | $3,589 | | down 42% | | $1,791 | | $1,539 | | up 16% |
+Operating Income (Loss) | $12,389 | | $(1,377) | | * | | $12,700 | | $689 | | * |
+Net Income (Loss) | $11,433 | | $(1,641) | | up 797% | | $10,987 | | $440 | | * |
+Diluted Net Income (Loss) Per Share
+| $73.76 | | $(11.32) | | up 752% | | $70.88 | | $2.99 | | * |
+
+* Not a meaningful figure
+
+End Market Summary
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Revenue ($ in millions) | Q4 2026 | | Q3 2026 | | Q/Q | | Q4 2025 | | Y/Y | | | | | | |
+Datacenter | $2,977 | | $1,467 | | up 103% | | $213 | | * | | | | | | |
+Edge | $5,432 | | $3,663 | | up 48% | | $1,103 | | up 392% | | | | | | |
+Consumer | $556 | | $820 | | down 32% | | $585 | | down 5% | | | | | | |
+Total Revenue | $8,965 | | $5,950 | | up 51% | | $1,901 | | up 372% | | | | | | |
+
+* Not a meaningful figure
+| | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Revenue ($ in millions) | | | | | | | | | | | 2026 | | 2025 | | Y/Y |
+Datacenter | | | | | | | | | | | $5,153 | | $960 | | up 437% |
+Edge | | | | | | | | | | | $12,160 | | $4,127 | | up 195% |
+Consumer | | | | | | | | | | | $2,935 | | $2,268 | | up 29% |
+Total Revenue | | | | | | | | | | | $20,248 | | $7,355 | | up 175% |
+
+Additional details can be found within the Company’s earnings presentation, which is accessible online at investor.sandisk.com .
+2
+
+
+
+
+
+
+
+
+Business Outlook for Fiscal First Quarter of 2027
+| | | | | | | | |
+(in millions, except per share amounts)
+| GAAP | Non-GAAP (1)
+|
+Revenue | $10,300 - $10,800 | $10,300 - $10,800 |
+Gross Margin | 83.0% - 84.9% | 83.0% - 85.0% |
+Operating Expenses | $574 - $614 | $520 - $540 |
+| | |
+Tax Expense (2)
+| N/A | 15.0% |
+Diluted Net Income Per Share | N/A | $44.00 - $46.00 |
+Diluted Shares Outstanding | ~ 155 | ~ 155 |
+
+(1) Non-GAAP gross margin guidance excludes stock-based compensation expense, totaling approximately $5 million to $7 million. The Company’s Non-GAAP operating expenses guidance excludes stock-based compensation expense, totaling approximately $54 million to $74 million. Non-GAAP diluted net income per share guidance excludes these items totaling $59 million to $81 million. The timing and amount of these charges excluded from Non-GAAP gross margin, Non-GAAP operating expenses, and Non-GAAP diluted net income per share cannot be further allocated or quantified with certainty. Additionally, the timing and amount of certain other adjustments included in the Company's Non-GAAP diluted net income per share guidance are dependent on the timing and determination of certain actions or events and cannot be reasonably predicted. Accordingly, full reconciliations of Non-GAAP gross margin, Non-GAAP operating expenses, and Non-GAAP diluted net income per share to the most directly comparable GAAP financial measures (gross margin, operating expenses, and diluted net income per share, respectively) are not available without unreasonable effort.
+(2) Non-GAAP tax expense is determined based on a Non-GAAP pre-tax income or loss. Our estimated Non-GAAP tax expense may differ from our GAAP tax expense (i) due to differences in the tax treatment of items excluded from our Non-GAAP net income or loss; (ii) due to the fact that our GAAP income tax expense or benefit recorded in any interim period is based on an estimated forecasted GAAP tax expense for the full year, excluding loss jurisdictions; and (iii) because our GAAP taxes recorded in any interim period are dependent on the timing and determination of certain GAAP operating expenses.
+3
+
+
+
+
+
+
+
+
+Basis of Presentation
+On February 21, 2025, Sandisk Corporation (the “Company”) completed its separation from Western Digital Corporation (“WDC”) and became a standalone publicly traded company.
+The Company’s financial and operating results after the separation are presented on a consolidated basis. For periods prior to the separation, the Company’s historical combined financial statements were prepared on a carve-out basis and were derived from WDC’s consolidated financial statements and accounting records and prepared as if the Company existed on a standalone basis. The financial statements for all periods presented, including the historical results of the Company prior to February 21, 2025, are now referred to as “Consolidated Financial Statements” and have been prepared in accordance with U.S. generally accepted accounting principles (“GAAP”).
+Investor Communications
+The investment community conference call to discuss these results and the Company’s business outlook for the fiscal first quarter of 2027 will be broadcast live online today at 1:30 p.m. Pacific/4:30 p.m. Eastern. The live and archived conference call/webcast and the earnings presentation can be accessed online at investor.sandisk.com .
+About Sandisk
+Sandisk is a leading global semiconductor memory company with more than 30 years of innovation in NAND flash technology. We are a vertically integrated solutions provider with ownership of chip-level design and IP, front and back-end manufacturing, as well as systems engineering and design. With a differentiated innovation engine driving advancements in storage and semiconductor technologies, our broad and ever-expanding portfolio delivers powerful flash storage solutions for artificial intelligence workloads in datacenters, edge devices, and consumer applications. Our technologies enable everyone from students, gamers and home offices, to the largest enterprises and public clouds to produce, analyze, and store data. Our solutions include a broad range of solid state drives, embedded products, removable cards, universal serial bus drives, and wafers and components. Learn more about Sandisk at www.sandisk.com .
+4
+
+
+
+
+
+
+
+Forward-Looking Statements
+This press release contains forward-looking statements within the meaning of U.S. federal securities laws, including statements regarding expectations for: the Company’s business outlook and operational and financial performance for the fiscal first quarter of 2027 and beyond; the market leadership of the Company’s technology; the contribution of the Company’s datacenter business to growth generation and the expected benefits of its customer partnerships; and the Company’s ability to create value for its customers through technology and generate growing and durable free cash flow. These forward-looking statements are based on management’s current expectations and are subject to risks and uncertainties that could cause actual results to differ materially from those expressed or implied in the forward looking statements. The financial results for the Company’s fiscal fourth quarter ended July 3, 2026 included in this press release represent the most current information available to management. Actual results when disclosed in the Company’s Form 10-K may differ from these results as a result of the completion of the Company’s financial closing procedures; final adjustments; completion of the audit by the Company’s independent registered accounting firm; and other developments that may arise between now and the filing of the Company’s Form 10-K. Other key risks and uncertainties that could cause actual results to differ materially from those expressed or implied in the forward-looking statements include: adverse changes in global or regional economic conditions, including the impact of evolving trade policies, tariff regimes and trade wars; volatility in demand for the Company’s products; pricing trends and fluctuations in average selling prices; inflation; changes in interest rates and a potential economic recession; future responses to and effects of global health crises; the impact of business and market conditions; the impact of competitive products and pricing; the Company’s development and introduction of products based on new technologies and management of technology transitions; risks associated with strategic initiatives, including restructurings, acquisitions, divestitures, cost saving measures and joint ventures; risks related to product defects; difficulties or delays in product ramps, manufacturing or other supply chain disruptions; our reliance on strategic relationships with key partners, including Kioxia Corporation; risks related to our long-term agreements; fluctuation of our operating results, including due to changes in demand, industry cycle and timing of customer deployments, and our ability to accurately forecast demand; the attraction, retention and development of skilled management and technical talent; risks associated with the use of artificial intelligence in our business operations; changes to the Company’s relationships with key customers or consolidation among our customer base; compromise, damage or interruption from cybersecurity incidents or other data system security risks; our reliance on intellectual property; fluctuations in currency exchange rates; actions by competitors; risks related to our share repurchase program; risks associated with compliance with changing legal and regulatory requirements; and other risks and uncertainties listed in the Company’s filings with the Securities and Exchange Commission, including our Annual Report on Form 10-K and Quarterly Reports on Form 10-Q, to which your attention is directed. You should not place undue reliance on these forward-looking statements, which speak only as of the date hereof, and the Company undertakes no obligation to update or revise these forward-looking statements to reflect new information or events, except as required by law.
+###
+Sandisk and the Sandisk logo are registered trademarks or trademarks of Sandisk Corporation or its affiliates in the United States and/or other countries.
+5
+
+
+
+
+
+
+
+
+SANDISK CORPORATION
+CONSOLIDATED BALANCE SHEETS
+(in millions; except par value, unaudited)
+| | | | | | | | | | | |
+| July 3,
+2026 | | June 27,
+2025 |
+ASSETS |
+Current assets: | | | |
+Cash and cash equivalents | $ | 4,762 | | | $ | 1,481 | |
+Accounts receivable, net | 4,708 | | | 1,068 | |
+Inventories | 2,698 | | | 2,079 | |
+Income tax receivable | 22 | | | 66 | |
+Other current assets | 590 | | | 392 | |
+Total current assets | 12,780 | | | 5,086 | |
+Marketable equity securities | 1,777 | | | — | |
+Property, plant and equipment, net | 674 | | | 619 | |
+Notes receivable and investments in Flash Ventures | 678 | | | 654 | |
+Goodwill | 4,994 | | | 4,999 | |
+Income tax receivable, non-current | 169 | | | 80 | |
+Deferred tax assets | 66 | | | 58 | |
+Other non-current assets | 1,369 | | | 1,489 | |
+Total assets | $ | 22,507 | | | $ | 12,985 | |
+LIABILITIES AND SHAREHOLDERS’ EQUITY |
+Current liabilities: | | | |
+Accounts payable | $ | 516 | | | $ | 366 | |
+Accounts payable to related parties | 460 | | | 400 | |
+Accrued expenses | 313 | | | 274 | |
+Accrued compensation | 657 | | | 173 | |
+Refund liabilities | 1,500 | | | 126 | |
+Contract liabilities | 849 | | | 25 | |
+Income tax payable, current | 1,286 | | | 43 | |
+Current portion of long-term debt | — | | | 20 | |
+Total current liabilities | 5,581 | | | 1,427 | |
+Deferred tax liabilities | 161 | | | 17 | |
+Income tax payable, non-current | 258 | | | 131 | |
+Long-term debt | — | | | 1,829 | |
+Non-current contract liabilities | 393 | | | — | |
+Other liabilities | 378 | | | 365 | |
+Total liabilities | 6,771 | | | 3,769 | |
+| | | |
+Shareholders’ equity: | | | |
+Common stock, $0.01 par value; authorized — 450 shares; issued and outstanding — 149 shares and 146 shares, respectively (issued and outstanding as of June 27, 2025 - 146 shares)
+| $ | 1 | | | $ | 1 | |
+Treasury stock | (4,537) | | | — | |
+Additional paid-in capital | 10,879 | | | 11,248 | |
+Accumulated other comprehensive loss | (256) | | | (249) | |
+Retained earnings (Accumulated deficit) | 9,649 | | | (1,784) | |
+Total shareholders’ equity | 15,736 | | | 9,216 | |
+Total liabilities and shareholders’ equity | $ | 22,507 | | | $ | 12,985 | |
+
+6
+
+
+
+
+
+
+
+
+SANDISK CORPORATION
+CONSOLIDATED STATEMENTS OF OPERATIONS
+(in millions, except per share amounts; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Year Ended |
+| July 3,
+2026 | | June 27,
+2025 | | July 3,
+2026 | | June 27,
+2025 |
+Revenue, net | $ | 8,965 | | | $ | 1,901 | | | $ | 20,248 | | | $ | 7,355 | |
+Cost of revenue | 1,383 | | | 1,403 | | | 5,776 | | | 5,143 | |
+Gross profit | 7,582 | | | 498 | | | 14,472 | | | 2,212 | |
+Operating expenses: | | | | | | | |
+Research and development | 348 | | | 285 | | | 1,328 | | | 1,132 | |
+Selling, general and administrative | 197 | | | 162 | | | 676 | | | 573 | |
+Goodwill impairment | — | | | — | | | — | | | 1,830 | |
+Loss on debt extinguishment | — | | | — | | | 46 | | | — | |
+Business separation costs | — | | | 17 | | | 25 | | | 67 | |
+Employee termination and other | — | | | 16 | | | (2) | | | 21 | |
+(Gain) loss on business divestiture | — | | | — | | | 10 | | | (34) | |
+Total operating expenses | 545 | | | 480 | | | 2,083 | | | 3,589 | |
+Operating income (loss) | 7,037 | | | 18 | | | 12,389 | | | (1,377) | |
+Interest and other income (expense), net: | | | | | | | |
+Gain (loss) on equity securities, net | 804 | | | (1) | | | 808 | | | (2) | |
+Interest income | 30 | | | 11 | | | 70 | | | 22 | |
+Interest expense | (2) | | | (41) | | | (73) | | | (63) | |
+Other income (expense), net | (20) | | | (5) | | | (177) | | | (59) | |
+Total interest and other income (expense), net | 812 | | | (36) | | | 628 | | | (102) | |
+Income (loss) before taxes | 7,849 | | | (18) | | | 13,017 | | | (1,479) | |
+Income tax expense | 946 | | | 5 | | | 1,584 | | | 162 | |
+Net income (loss) | $ | 6,903 | | | $ | (23) | | | $ | 11,433 | | | $ | (1,641) | |
+| | | | | | | |
+Net income (loss) per common share: | | | | | | | |
+Basic | $ | 46.96 | | | $ | (0.16) | | | $ | 77.78 | | | $ | (11.32) | |
+Diluted | $ | 43.97 | | | $ | (0.16) | | | $ | 73.76 | | | $ | (11.32) | |
+| | | | | | | |
+Weighted average shares outstanding: | | | | | | | |
+Basic | 147 | | | 145 | | | 147 | | | 145 | |
+Diluted | 157 | | | 145 | | | 155 | | | 145 | |
+
+7
+
+
+
+
+
+
+
+
+SANDISK CORPORATION
+CONSOLIDATED STATEMENTS OF CASH FLOWS
+(in millions; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Year Ended |
+| July 3,
+2026 | | June 27,
+2025 | | July 3,
+2026 | | June 27,
+2025 |
+Cash flows from operating activities | | | | | | | |
+Net income (loss) | $ | 6,903 | | | $ | (23) | | | $ | 11,433 | | | $ | (1,641) | |
+Adjustments to reconcile net income (loss) to net cash provided by operations: | | | | | | | |
+Depreciation and amortization | 37 | | | 36 | | | 149 | | | 163 | |
+Stock-based compensation | 67 | | | 49 | | | 232 | | | 182 | |
+Goodwill impairment | — | | | — | | | — | | | 1,830 | |
+Deferred income taxes | 162 | | | (19) | | | 120 | | | (12) | |
+(Gain) loss on disposal of assets | 4 | | | — | | | 5 | | | (1) | |
+(Gain) loss on equity securities, net | (804) | | | 1 | | | (808) | | | 2 | |
+Unrealized foreign exchange (gain) loss | 47 | | | (19) | | | 86 | | | (25) | |
+(Gain) loss on business divestiture | — | | | — | | | 10 | | | (34) | |
+Loss on debt extinguishment | — | | | — | | | 46 | | | — | |
+Amortization of debt issuance costs and discounts | 1 | | | 2 | | | 7 | | | 3 | |
+Equity loss in investees, net of dividends received | 102 | | | 5 | | | 160 | | | 73 | |
+Settlement of accrued interest on Notes due to Western Digital Corporation | — | | | — | | | — | | | (99) | |
+Other non-cash operating activities, net | (1) | | | 6 | | | 19 | | | 23 | |
+Changes in: | | | | | | | |
+Accounts receivable, net | (1,982) | | | (89) | | | (3,640) | | | (100) | |
+Inventories | (460) | | | 81 | | | (619) | | | (160) | |
+Accounts payable | 73 | | | (6) | | | 109 | | | 93 | |
+Accounts payable to related parties | 25 | | | 5 | | | 60 | | | (23) | |
+Accrued expenses | 45 | | | 2 | | | 10 | | | (1) | |
+Accrued compensation | 304 | | | 59 | | | 460 | | | 21 | |
+Refund liability | 1,360 | | | 4 | | | 1,374 | | | 25 | |
+Contract liabilities | 731 | | | 4 | | | 1,217 | | | (11) | |
+Income taxes payable | 730 | | | — | | | 1,370 | | | — | |
+Other assets and liabilities, net | (218) | | | (4) | | | (129) | | | (224) | |
+Net cash provided by operating activities | 7,126 | | | 94 | | | 11,671 | | | 84 | |
+Cash flows from investing activities | | | | | | | |
+Purchase of marketable equity securities | (970) | | | — | | | (970) | | | — | |
+Purchases of property, plant and equipment | (43) | | | (45) | | | (177) | | | (204) | |
+Proceeds from dispositions of business | — | | | — | | | 25 | | | 401 | |
+Notes receivable issuances to Flash Ventures | (123) | | | (59) | | | (462) | | | (333) | |
+Notes receivable proceeds from Flash Ventures | 13 | | | 87 | | | 187 | | | 515 | |
+Distributions from Flash Ventures | — | | | — | | | — | | | 176 | |
+Strategic investments and other, net | — | | | — | | | 11 | | | 1 | |
+Net cash provided by (used in) investing activities | (1,123) | | | (17) | | | (1,386) | | | 556 | |
+Cash flows from financing activities | | | | | | | |
+Issuance of stock under employee stock plans | 29 | | | 5 | | | 53 | | | 5 | |
+Taxes paid on vested stock awards under employee stock plans | (481) | | | (7) | | | (630) | | | (13) | |
+Repurchases of common stock | (4,524) | | | — | | | (4,524) | | | — | |
+Proceeds from debt | — | | | — | | | — | | | 1,970 | |
+Repayment of debt | — | | | (100) | | | (1,900) | | | (100) | |
+Debt issuance costs | — | | | — | | | — | | | (32) | |
+Proceeds from borrowings on Notes due to Western Digital Corporation | — | | | — | | | — | | | 550 | |
+Proceeds from principal repayments on Notes due from Western Digital Corporation | — | | | — | | | — | | | 101 | |
+Repayments of principal on Notes due to Western Digital Corporation | — | | | — | | | — | | | (76) | |
+Transfers from (to) Western Digital Corporation | — | | | — | | | — | | | (1,887) | |
+Net cash provided by (used in) financing activities | (4,976) | | | (102) | | | (7,001) | | | 518 | |
+Effect of exchange rate changes on cash | — | | | (1) | | | (3) | | | (5) | |
+Net increase (decrease) in cash and cash equivalents | 1,027 | | | (26) | | | 3,281 | | | 1,153 | |
+Cash and cash equivalents, beginning of year | 3,735 | | | 1,507 | | | 1,481 | | | 328 | |
+Cash and cash equivalents, end of year | $ | 4,762 | | | $ | 1,481 | | | $ | 4,762 | | | $ | 1,481 | |
+| | | | | | | |
+Supplemental disclosure of cash flow information: | | | | | | | |
+Cash paid for interest | $ | 5 | | | $ | 37 | | | $ | 116 | | | $ | 139 | |
+Cash received for interest | 30 | | | — | | | 70 | | | 2 | |
+Cash paid for income taxes | 29 | | | 40 | | | 146 | | | 50 | |
+Non-cash transfers of: | | | | | | | |
+Notes due to (from) Western Digital Corporation | — | | | — | | | — | | | 1,223 | |
+Other assets and liabilities, net, from Western Digital Corporation | — | | | — | | | — | | | 105 | |
+Contribution of equity interest in Unis Venture from Western Digital Corporation
+| — | | | — | | | — | | | 61 | |
+Property, plant and equipment from Western Digital Corporation | — | | | — | | | — | | | 27 | |
+Tax balances from (to) Western Digital Corporation | — | | | — | | | — | | | 8 | |
+Tax indemnification liability to Western Digital Corporation | — | | | — | | | — | | | (112) | |
+
+8
+
+
+
+
+
+
+
+
+SANDISK CORPORATION
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES
+(in millions; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Year Ended |
+| July 3,
+2026 | | April 3,
+2026 | | June 27,
+2025 | | July 3,
+2026 | | June 27,
+2025 |
+GAAP gross profit | $ | 7,582 | | | $ | 4,662 | | | $ | 498 | | | $ | 14,472 | | | $ | 2,212 | |
+Stock-based compensation expense | 6 | | | 4 | | | 4 | | | 19 | | | 16 | |
+| | | | | | | | | |
+Non-GAAP gross profit | $ | 7,588 | | | $ | 4,666 | | | $ | 502 | | | $ | 14,491 | | | $ | 2,228 | |
+| | | | | | | | | |
+GAAP operating expenses | $ | 545 | | | $ | 551 | | | $ | 480 | | | $ | 2,083 | | | $ | 3,589 | |
+Goodwill impairment | — | | | — | | | — | | | — | | | (1,830) | |
+Stock-based compensation expense | (61) | | | (50) | | | (45) | | | (213) | | | (166) | |
+Business separation costs | — | | | (7) | | | (17) | | | (25) | | | (67) | |
+Employee termination and other | — | | | — | | | (16) | | | 2 | | | (21) | |
+(Loss) gain on business divestiture | — | | | — | | | — | | | (10) | | | 34 | |
+| | | | | | | | | |
+Loss on debt extinguishment | — | | | (46) | | | — | | | (46) | | | — | |
+Non-GAAP operating expenses | $ | 484 | | | $ | 448 | | | $ | 402 | | | $ | 1,791 | | | $ | 1,539 | |
+| | | | | | | | | |
+GAAP operating income (loss) | $ | 7,037 | | | $ | 4,111 | | | $ | 18 | | | $ | 12,389 | | | $ | (1,377) | |
+Gross profit adjustments | 6 | | | 4 | | | 4 | | | 19 | | | 16 | |
+Operating expense adjustments | 61 | | | 103 | | | 78 | | | 292 | | | 2,050 | |
+Non-GAAP operating income | $ | 7,104 | | | $ | 4,218 | | | $ | 100 | | | $ | 12,700 | | | $ | 689 | |
+| | | | | | | | | |
+GAAP interest and other income (expense), net | $ | 812 | | | $ | (4) | | | $ | (36) | | | $ | 628 | | | $ | (102) | |
+(Gain) loss on equity securities, net | (804) | | | — | | | 1 | | | (808) | | | 2 | |
+Other, net | — | | | 1 | | | (2) | | | 111 | | | (9) | |
+Non-GAAP interest and other income (expense), net | $ | 8 | | | $ | (3) | | | $ | (37) | | | $ | (69) | | | $ | (109) | |
+| | | | | | | | | |
+GAAP income tax expense | $ | 946 | | | $ | 492 | | | $ | 5 | | | $ | 1,584 | | | $ | 162 | |
+Income tax adjustments | 4 | | | 48 | | | 16 | | | 60 | | | (22) | |
+Non-GAAP income tax expense | $ | 950 | | | $ | 540 | | | $ | 21 | | | $ | 1,644 | | | $ | 140 | |
+
+
+
+9
+
+
+
+
+
+
+
+SANDISK CORPORATION
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES
+(in millions, except per share amounts; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Year Ended |
+| July 3,
+2026 | | April 3,
+2026 | | June 27,
+2025 | | July 3,
+2026 | | June 27,
+2025 |
+GAAP net income (loss) | $ | 6,903 | | | $ | 3,615 | | | $ | (23) | | | $ | 11,433 | | | $ | (1,641) | |
+Goodwill impairment | — | | | — | | | — | | | — | | | 1,830 | |
+Stock-based compensation expense | 67 | | | 54 | | | 49 | | | 232 | | | 182 | |
+Business separation costs | — | | | 7 | | | 17 | | | 25 | | | 67 | |
+Employee termination and other | — | | | — | | | 16 | | | (2) | | | 21 | |
+| | | | | | | | | |
+(Gain) loss on business divestiture | — | | | — | | | — | | | 10 | | | (34) | |
+Loss on debt extinguishment | — | | | 46 | | | — | | | 46 | | | — | |
+(Gain) loss on equity securities, net | (804) | | | — | | | 1 | | | (808) | | | 2 | |
+Other, net | — | | | 1 | | | (2) | | | 111 | | | (9) | |
+Income tax adjustments | (4) | | | (48) | | | (16) | | | (60) | | | 22 | |
+Non-GAAP net income | $ | 6,162 | | | $ | 3,675 | | | $ | 42 | | | $ | 10,987 | | | $ | 440 | |
+| | | | | | | | | |
+Diluted net income (loss) per share
+| | | | | | | | | |
+GAAP | $ | 43.97 | | | $ | 23.03 | | | $ | (0.16) | | | $ | 73.76 | | | $ | (11.32) | |
+Non-GAAP | $ | 39.25 | | | $ | 23.41 | | | $ | 0.29 | | | $ | 70.88 | | | $ | 2.99 | |
+| | | | | | | | | |
+Diluted weighted average shares outstanding: | | | | | | | | | |
+GAAP | 157 | | | 157 | | | 145 | | | 155 | | | 145 | |
+Non-GAAP | 157 | | | 157 | | | 147 | | | 155 | | | 147 | |
+| | | | | | | | | |
+Cash flows | | | | | | | | | |
+Cash flow from operating activities | $ | 7,126 | | | $ | 3,038 | | | $ | 94 | | | $ | 11,671 | | | $ | 84 | |
+Purchases of property, plant and equipment, net | (43) | | | (45) | | | (45) | | | (177) | | | (204) | |
+Free cash flow | 7,083 | | | 2,993 | | | 49 | | | 11,494 | | | (120) | |
+Activity related to Flash Ventures, net | (110) | | | (38) | | | 28 | | (275) | | | 358 |
+Impact of NBM prepayments and deposits | (1,938) | | | (538) | | | — | | | (2,476) | | | — | |
+Adjusted free cash flow | $ | 5,035 | | | $ | 2,417 | | | $ | 77 | | | $ | 8,743 | | | $ | 238 | |
+
+10
+
+
+
+
+
+
+
+
+To supplement the consolidated financial statements presented in accordance with GAAP, the table above sets forth Non-GAAP gross profit; Non-GAAP operating expenses; Non-GAAP operating income; Non-GAAP interest and other income (expense), net; Non-GAAP income tax expense; Non-GAAP net income; Non-GAAP diluted net income (loss) per share; Non-GAAP diluted weighted average shares outstanding; Free cash flow; and Adjusted free cash flow (collectively, the “Non-GAAP measures”). These Non-GAAP measures are not in accordance with, or alternatives for measures prepared in accordance with GAAP and may be different from similarly titled Non-GAAP measures used by other companies. The Company believes the presentation of these Non-GAAP measures, when shown in conjunction with the corresponding GAAP measures, provides useful information to investors for measuring the Company’s earnings performance and comparing it against prior periods. Specifically, the Company believes these Non-GAAP measures provide useful information to both management and investors as they exclude certain expenses, gains, and losses that the Company believes are not indicative of its core operating results or because they are consistent with the financial models and estimates published by many analysts who follow the Company and its peers. As discussed further below, these Non-GAAP measures exclude, as applicable, goodwill impairment, stock-based compensation expense, business separation costs, employee termination and other, (gain) loss on business divestiture, loss on debt extinguishment, (gain) loss on equity securities, net, other adjustments, and income tax adjustments. The Company believes these measures, along with the related reconciliations to the most directly comparable GAAP measures, provide additional detail and comparability for assessing the Company’s results. These Non-GAAP measures are some of the primary indicators management uses for assessing the Company’s performance and planning and forecasting future periods. These measures should be considered in addition to results prepared in accordance with GAAP, but should not be considered a substitute for, or superior to, GAAP results.
+As described above, the Company excludes the following items from its Non-GAAP measures:
+Goodwill impairment. After the completion of the separation, in the third quarter of fiscal 2025, the Company identified potential impairment indicators related to the trading price of the Company’s common stock and resulting market capitalization that warranted a quantitative impairment analysis of long-lived assets and goodwill. Management performed a quantitative impairment analysis and determined that the carrying value of the reporting unit exceeded its fair value, resulting in the recognition of a $1.8 billion impairment charge for the year ended June 27, 2025. The Company believes this charge does not reflect the Company’s operating results and is not indicative of the underlying performance of the business.
+Stock-based compensation expense . Because of the variety of equity awards used by companies, the varying methodologies for determining stock-based compensation expense, the subjective assumptions involved in those determinations and the volatility in valuations that can be driven by market conditions outside the Company’s control, the Company believes excluding stock-based compensation expense enhances the ability of management and investors to understand and assess the underlying performance of the business over time and compare it against the Company’s peers, a majority of whom also exclude stock-based compensation expense from their Non-GAAP results.
+11
+
+
+
+
+
+
+
+Business separation costs . On October 30, 2023, Western Digital Corporation (“WDC”) announced that its board of directors (the “WDC Board of Directors”) authorized management to pursue a plan to separate the Company into an independent public company. The separation received final approval by the WDC Board of Directors and was completed on February 21, 2025. Prior to February 21, 2025, the Company was wholly owned by WDC. As a result of the plan, the Company incurred separation and transition costs through the completion of the separation of the companies. The separation and transition costs are recorded within Business separation costs in the Consolidated Statements of Operations. The Company believes these charges do not reflect the Company’s operating results and that they are not indicative of the underlying results of its business.
+Employee termination and other . From time to time, in order to realign the Company’s operations with anticipated market demand, the Company may terminate employees and/or restructure its operations. From time to time, the Company may also incur charges from the impairment of long-lived assets. In addition, the Company may record credits related to gains upon sale of property due to restructuring or reversals of charges recorded in prior periods as well as from taking actions to reduce the amount of capital invested in facilities, including the sale-leaseback of facilities. These charges or credits are inconsistent in amount and frequency, and the Company believes they are not indicative of the underlying performance of its business.
+(Gain) loss on business divestiture . In connection with the Company’s strategic decision to outsource the manufacturing of certain components and assemblies, on September 28, 2024, the Company completed the sale of 80% of its equity interest in one of its manufacturing subsidiaries. On September 25, 2025, the Company entered into an Amendment No. 1 to the Amended and Restated Equity Purchase Agreement that included a $10 million provision for working capital support. The Company recognized the adjustment as a Loss on business divestiture during the first fiscal quarter of 2026. The overall transaction resulted in a discrete gain, which the Company believes is not indicative of the underlying performance of its ongoing business operations.
+Loss on debt extinguishment . From time to time, the Company incurs debt extinguishment charges consisting of the costs to call the existing debt and/or the write-off of any related unamortized debt issuance costs. These charges do not reflect the Company’s operating results, and the Company believes these charges are not indicative of the underlying performance of its business.
+(Gain) loss on equity securities, net . (Gain) loss on equity securities, net consists of ongoing mark-to-market adjustments on the Company ’ s investments in marketable equity securities, the gains from the sale of equity investments and related impairment charges. These charges do not reflect the Company’s operating results, and the Company believes these charges are not indicative of the underlying performance of its business.
+Other adjustments . From time to time, the Company incurs charges or gains that the Company believes are not a part of the ongoing operation of its business. For the year ended July 3, 2026, Other adjustments include charges for the settlement of certain previously existing legal matters. The resulting expense or benefit is inconsistent in amount and frequency.
+Income tax adjustments . Income tax adjustments include the difference between income taxes based on a forecasted annual Non-GAAP tax rate and a forecasted annual GAAP tax rate as a result of the timing of certain Non-GAAP pre-tax adjustments. The income tax adjustments also include the re-measurement of certain unrecognized tax benefits primarily related to tax positions taken in prior quarters, including interest. These adjustments are excluded because the Company believes that they are not indicative of the underlying performance of its ongoing business.
+12
+
+
+
+
+
+
+
+Additionally, Free cash flow is defined as Cash Flow from operating activities less purchases of property, plant and equipment, net. Adjusted free cash flow is defined as Free cash flow plus the activity related to Flash Ventures, net less the impact of cash prepayments under NBM agreements (the “NBM Prepayments”) and deposits received and returned under NBM agreements (the “NBM Deposits” and together with the NBM Prepayments, the “NBM Payments”). The Company is adjusting for the NBM Payments because the Company believes that these cash flows are not indicative of the core underlying cash flows of the Company’s business. The Company considers Free cash flow and Adjusted free cash flow generated in any period to be useful indicators of cash that is available for strategic opportunities, including, among others, investing in the Company’s business, making strategic acquisitions and strengthening the balance sheet.
+Gross Margin and Non-GAAP Gross Margin are calculated by dividing Gross Profit and Non-GAAP Gross Profit, respectively, by Revenue. Cash flow from operating activities margin and Adjusted free cash flow margin are calculated by dividing Cash flow from operating activities and Adjusted free cash flow, respectively, by Revenue.
+
+
+
+| | | | | | | | |
+Company Contacts:
+|
+Sandisk Corporation
+| | |
+| | |
+Investor Contact: | | Media Contact: |
+Ivan Donaldson
+| | Media Relations
+|
+E: ivan.donaldson@sandisk.com
+| | mediainquiries@sandisk.com |
+investors@sandisk.com
+| | |
+
+13


### PR DESCRIPTION
## Audit result: 7 of 9 filings carried a wrong figure

| | Was | Correct | Cause |
|---|---|---|---|
| **APP** | Rev `$3.77B`, NI `$2.47B` | **`$1.92B`**, **`$1.27B`** | half-year columns |
| **FSLY** | Adj EPS `$0.11` | **`$0.15`** | guidance table |
| **SNDK** | Outlook `$10.3K`, Adj EPS `$59–81` | **`$10.3B`**, guidance dropped | section scale ignored; footnote of *excluded* items |
| **AXON** | `C$904M` | **`$904M`** | "CAD" the acronym |
| **ELF** | Adj EPS `$3.27` | **`$1.75`** | FY2027 guidance range |
| **ALB** | Rev `$423.5M` | **`$1.74B`** | segment table |
| **RDW** | NI `-$56M` | **`-$41.5M`** | the year-over-year *improvement* |
| BROS, BYND | — | already correct | — |

**Two things I expected to be wrong and weren't.** Sandisk's `$43.97` earnings per share is real — memory pricing. And Beyond Meat genuinely reports net income of `$16.4M` alongside a diluted loss per share of `$(0.06)`, from the if-converted treatment of its notes; that pair is recorded in the corpus so nobody "corrects" it later.

## Causes

- **A three-letter currency code is also an ordinary acronym.** *"typing the call into the CAD in another jurisdiction"* — Computer-Aided Dispatch, in a customer quote — put Axon's revenue in Canadian dollars. A code now counts only where it declares units or sits against an amount.
- **A row under a guidance heading is guidance**, whatever its caption says. This fixed ELF and FSLY, and *recovered* ELF's revenue and net income, which had been suppressed as implausible after being read from the same table.
- **"improved by"** was missing from the wording that marks a line as stating a change, so Redwire's `improved by $56.0 million ... to $(41.0) million` reported the improvement.
- **Any month name satisfied the monthly-and-quarterly test** — including the one in "Quarter Ended **June** 30" — so AppLovin's quarter columns were skipped for its half-year ones. It now requires the "month and quarter" wording it was written for (Progressive's layout, which still passes).
- **Guidance states its scale once, above the rows**, and a footnote states what the measures *exclude*. Both now handled.

## The gate caught one on its own

The per-share consistency gate from #1854 flagged **AppLovin** unprompted — 657M implied shares against 337M actual. First defect in this series found without being told where to look.

## Two changes deliberately left out

A segment-heading penalty and a widened non-GAAP caption. Both were made redundant by the fixes above — reverting either changed **no test and no filing** — so per #1850 they are not here. I only discovered that by mutation-checking; both looked load-bearing when written.

## Verification

**2,455 tests pass**; `audit`, `lint`, `typecheck`, `test:coverage` clean, no thresholds altered. Corpus grows to **33 filings**. All five surviving changes mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)