### PR TITLE
Label non-GAAP guidance and read Merck's share caption

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -338,8 +338,10 @@ const filingCorpus: {
   {
     // Guidance sits in a prior-versus-updated table whose captions and value cells are on
     // separate lines. Each figure is read from the updated column; the tax rate reads from the
-    // prior one because its update is stated as "unchanged". The per-share row is labelled by
-    // its own caption, though the table as a whole is the company's non-GAAP guidance.
+    // prior one because its update is stated as "unchanged". The per-share row is captioned
+    // plainly as "Earnings per Share", but the prose above the table declares the basis —
+    // "Lilly provides guidance for certain non-GAAP measures" — so it posts as adjusted.
+    // Revenue stays reported: the same sentence names it as the GAAP item.
     company: "Eli Lilly",
     metrics: [
       ["adjusted_eps", "$8.38"],
@@ -349,7 +351,7 @@ const filingCorpus: {
     ],
     outlook: [
       ["Revenue", "$85B to $87B"],
-      ["EPS", "$35.5 to $36.5"],
+      ["Adj EPS", "$35.5 to $36.5"],
       ["Tax rate", "18% to 19%"],
     ],
     quarterLabel: "Q2 2026",

--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -218,7 +218,12 @@ export function getDilutedShareMantissa(lines: string[]): number | undefined {
   for (const [lineIndex, line] of lines.entries()) {
     // The caption has to be about shares. "dollar-weighted average contract duration" is
     // boilerplate about contracts, and matching it reads an unrelated figure as a count.
-    const captionMatch = /weighted[-\s]average\s+(?:number\s+of\s+)?(?:[a-z]+\s+){0,3}shares\b|shares\s+used\s+in\s+(?:the\s+)?(?:comput|calculat)/i
+    //
+    // "Average Shares Outstanding Assuming Dilution" is the same row without the word
+    // "weighted" — how Merck captions it. Requiring "weighted" left such a filing with no
+    // share count at all, and a filing with no count is exempt from the per-share consistency
+    // check rather than failing it, so the caption went unnoticed.
+    const captionMatch = /weighted[-\s]average\s+(?:number\s+of\s+)?(?:[a-z]+\s+){0,3}shares\b|\baverage\s+shares\s+outstanding\b|shares\s+used\s+in\s+(?:the\s+)?(?:comput|calculat)/i
       .exec(line);
     if (null === captionMatch) {
       continue;

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -336,6 +336,47 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  // A guidance table states its basis once, in the prose above it, and then captions its rows
+  // plainly. Reading the caption alone posts the excluded items away: Lilly's "Earnings per
+  // Share | $35.50 to $36.50" is its non-GAAP guidance, not its reported guidance.
+  describe("a section that declares a non-GAAP basis", () => {
+    test("posts a plainly captioned per-share row as adjusted", () => {
+      expect(extractOutlookMetrics([
+        "2026 Financial Guidance",
+        "In addition to providing guidance for GAAP revenue, Lilly provides guidance for certain non-GAAP measures.",
+        "| | | Prior | Updated |",
+        "Revenue | | | $82 to $85 billion | $85 to $87 billion |",
+        "Earnings per Share",
+        "| | | $35.50 to $37.00 | $35.50 to $36.50 |",
+      ])).toEqual([
+        {key: "revenue", label: "Revenue", value: "$85B to $87B"},
+        {key: "adjusted_eps", label: "Adj EPS", value: "$35.5 to $36.5"},
+      ]);
+    });
+
+    test("leaves a row that names GAAP itself under the reported label", () => {
+      expect(extractOutlookMetrics([
+        "2026 Financial Guidance",
+        "The company is updating its non-GAAP financial guidance for full-year 2026.",
+        "The company expects GAAP EPS of $4.10 to $4.30.",
+      ])).toEqual([
+        {key: "eps", label: "EPS", value: "$4.1 to $4.3"},
+      ]);
+    });
+
+    test("is not declared by the boilerplate footnote about reconciliations", () => {
+      // Filings that guide on a non-GAAP measure carry this sentence whether or not the rows
+      // themselves are non-GAAP. It names the words without stating the basis.
+      expect(extractOutlookMetrics([
+        "2026 Financial Guidance",
+        "The company expects earnings per share of $4.10 to $4.30 for full-year 2026.",
+        "The company does not provide reconciliations of forward-looking non-GAAP measures to the most directly comparable GAAP measures.",
+      ])).toEqual([
+        {key: "eps", label: "EPS", value: "$4.1 to $4.3"},
+      ]);
+    });
+  });
+
   test("limits outlook scanning and ignores unusable fallback values", () => {
     const lines = [
       "Business Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -1,6 +1,6 @@
 import {isDefinitionalLine} from "./earnings-results-format-selection.ts";
 import {getMoneyScaleFromContextText} from "./earnings-results-money.ts";
-import {gaapTermSource} from "./earnings-results-terms.ts";
+import {gaapTermSource, hasStandaloneGaapTerm} from "./earnings-results-terms.ts";
 
 export type EarningsOutlookMetric = {
   key: string;
@@ -36,6 +36,11 @@ type OutlookSection = {
   moneyUnit?: string | undefined;
   lines: string[];
   mixedPeriods: boolean;
+  // A guidance section states its basis once, in the prose above the table ("Lilly provides
+  // guidance for certain non-GAAP measures"), and then captions its rows plainly — "Earnings
+  // per Share", not "non-GAAP EPS". Under the reported label such a row understates the
+  // guidance by whatever it excludes.
+  nonGaapMeasures: boolean;
   // A guidance table headed "Prior | Updated" restates each figure twice. Its rows are the
   // guidance, so they are read rather than dismissed as a comparison table, and the updated
   // column is the one that now applies.
@@ -46,6 +51,21 @@ const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:C\s*\$|[$€£�
 const moneyRangePattern = new RegExp(`(${moneyTokenPatternSource})\\s*(?:to|through|-|–|and)\\s*(${moneyTokenPatternSource})`, "gi");
 const singleMoneyPattern = new RegExp(moneyTokenPatternSource, "gi");
 
+// Held separately because a plainly captioned per-share row is relabelled to it when the
+// section declares a non-GAAP basis, and the two must not drift apart.
+const adjustedEpsDefinition: OutlookMetricDefinition = {
+  key: "adjusted_eps",
+  label: "Adj EPS",
+  patterns: [
+    /\badjusted\s+continuing(?:\s+operations?)?\s+(?:diluted\s+)?eps\b/i,
+    /\badjusted\s+continuing(?:\s+operations?)?\s+earnings\s+per\s+(?:common\s+)?share\b/i,
+    /\badjusted\s+(?:diluted\s+)?eps\b/i,
+    /\badjusted\s+(?:diluted\s+)?(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\b/i,
+    /\bnon-gaap\s+(?:diluted\s+)?(?:eps|(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share)\b/i,
+  ],
+  valueType: "eps",
+};
+
 const outlookMetricDefinitions: OutlookMetricDefinition[] = [
   {
     key: "revenue",
@@ -53,18 +73,7 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
     patterns: [/\brevenues?\b/i, /\bnet\s+sales\b/i],
     valueType: "text",
   },
-  {
-    key: "adjusted_eps",
-    label: "Adj EPS",
-    patterns: [
-      /\badjusted\s+continuing(?:\s+operations?)?\s+(?:diluted\s+)?eps\b/i,
-      /\badjusted\s+continuing(?:\s+operations?)?\s+earnings\s+per\s+(?:common\s+)?share\b/i,
-      /\badjusted\s+(?:diluted\s+)?eps\b/i,
-      /\badjusted\s+(?:diluted\s+)?(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\b/i,
-      /\bnon-gaap\s+(?:diluted\s+)?(?:eps|(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share)\b/i,
-    ],
-    valueType: "eps",
-  },
+  adjustedEpsDefinition,
   {
     key: "eps",
     label: "EPS",
@@ -159,6 +168,7 @@ export function extractOutlookMetrics(
       documentCurrencyCode,
       section.revisedColumns,
       section.moneyUnit,
+      section.nonGaapMeasures,
     );
     if (null === metric || true === seenKeys.has(metric.key)) {
       continue;
@@ -204,8 +214,18 @@ function getOutlookSection(lines: string[]): OutlookSection {
     moneyUnit: getSectionMoneyUnit(sectionLines),
     lines: sectionLines,
     mixedPeriods: mixedPeriods || hasMixedOutlookPeriods(sectionLines),
+    nonGaapMeasures: hasNonGaapGuidanceBasis(sectionLines),
     revisedColumns: sectionLines.some(line => hasRevisedColumnHeader(line)),
   };
+}
+
+// Only a sentence declaring what the guidance *is* counts. The boilerplate footnote that a
+// filer "does not provide reconciliations of forward-looking non-GAAP measures" mentions the
+// same words while saying nothing about the basis of these rows.
+function hasNonGaapGuidanceBasis(lines: string[]): boolean {
+  const sectionText = lines.join(" ");
+  return /\bnon-gaap\s+(?:financial\s+)?guidance\b/i.test(sectionText) ||
+    /\bguidance\s+for\s+(?:certain\s+)?non-gaap\s+measures\b/i.test(sectionText);
 }
 
 const unitByMoneyScale = new Map<number, string>([
@@ -311,6 +331,7 @@ function extractOutlookMetric(
   documentCurrencyCode: string,
   revisedColumns: boolean,
   sectionMoneyUnit: string | undefined,
+  nonGaapMeasures: boolean,
 ): EarningsOutlookMetric | null {
   let bestCandidate: OutlookMetricCandidate | null = null;
   for (const [lineIndex, line] of lines.entries()) {
@@ -354,9 +375,16 @@ function extractOutlookMetric(
         continue;
       }
 
+      // The row's own caption wins where it has one: a line naming GAAP keeps the reported
+      // label even inside a non-GAAP section, which is how a table guiding on both measures
+      // stays intelligible. Revenue is never relabelled — the sentence that declares the
+      // basis names revenue as the GAAP item.
+      const isAdjustedBySectionBasis = "eps" === definition.key &&
+        true === nonGaapMeasures &&
+        false === hasStandaloneGaapTerm(line);
       const metric: EarningsOutlookMetric = {
-        key: definition.key,
-        label: definition.label,
+        key: isAdjustedBySectionBasis ? adjustedEpsDefinition.key : definition.key,
+        label: isAdjustedBySectionBasis ? adjustedEpsDefinition.label : definition.label,
         value,
       };
       Object.defineProperty(metric, "sourceSnippet", {

--- a/modules/earnings-results-share-consistency.test.ts
+++ b/modules/earnings-results-share-consistency.test.ts
@@ -55,4 +55,26 @@ describe("per-share consistency gate", () => {
   test("says nothing when the filing states no share count", () => {
     expect(getInconsistentPerShareReasons(asMetrics(2_394_000_000, 0.63), undefined)).toEqual([]);
   });
+
+  // A caption the reader does not recognise leaves the filing with no count, and a filing with
+  // no count is exempt from the check rather than failing it — so an unread caption is a hole
+  // in the gate, not a visible error. Merck captions the row without the word "weighted".
+  test("reads a share count captioned without the word weighted", () => {
+    const document = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Reports Second Quarter 2026 Results</h1>
+          <p>($ in millions except per share amounts)</p>
+          <p>Three Months Ended June 30,</p>
+          <tr><td>Net Income (Loss)</td><td>$</td><td>(1,330)</td></tr>
+          <tr><td>Loss per Common Share Assuming Dilution</td><td>$</td><td>(0.54)</td></tr>
+          <tr><td>Average Shares Outstanding Assuming Dilution</td><td>2,470</td></tr>
+        </body>
+      </html>
+    `);
+
+    expect(document.dilutedShareMantissa).toBe(2_470);
+    expect(getInconsistentPerShareReasons(document.metrics, document.dilutedShareMantissa))
+      .toEqual([]);
+  });
 });


### PR DESCRIPTION
The two nuances left open from the audit series, both now settled by the filings themselves.

## Lilly's guidance was posted as reported when it is non-GAAP

The table captions its row plainly — `Earnings per Share | $35.50 to $36.50` — and states the basis in the prose above it: *"In addition to providing guidance for GAAP revenue, Lilly provides guidance for certain non-GAAP measures."* Read from the caption alone it posted as **EPS**, roughly a third below what that row means. It now posts as **Adj EPS**.

Three things keep that narrow:

- A row **naming GAAP itself** keeps the reported label, so a table guiding on both measures still reads correctly.
- **Revenue is never relabelled** — the same sentence names revenue as the GAAP item.
- The **boilerplate footnote** that a filer *"does not provide reconciliations of forward-looking non-GAAP measures"* does not count as a declaration. Nearly every filing guiding on a non-GAAP measure carries that sentence, including ones whose rows are reported figures; accepting it would have relabelled them all.

## Merck's share row was invisible to the consistency gate

Merck captions it `Average Shares Outstanding Assuming Dilution` — the same row, without the word "weighted" the reader required.

The failure mode here is worth naming: **a filing with no share count is exempt from the check, not failed by it.** So an unread caption is a hole in the gate that looks exactly like a passing filing. Merck's own figures reconcile fine (2,470M shares against -$0.54 on -$1.33B) — the value is that Merck-shaped filings are now checked at all. Across the corpus only Merck captions it this way, and the change moves no other filing's numbers.

## One change reverted

I also extended the diluted-column cue to "assuming dilution". Mutation-checking showed the caption match already lands on the right row, so it changed nothing — dropped, same standard as the two removed in #1861.

## Verification

All four guards mutation-checked: each fails exactly the test written for it and nothing else. **2,459 tests pass** (four new); `audit`, `lint`, `typecheck`, `test:coverage` clean with no thresholds altered. The corpus expectation for Lilly is updated to the adjusted label with the reason recorded alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)