### PR TITLE
Fix period, caption and guidance selection across twelve filings

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -422,9 +422,12 @@ const filingCorpus: {
   },
   {
     // "typing the call into the CAD in another jurisdiction" is Computer-Aided Dispatch in a
-    // customer quote, not a currency declaration.
+    // customer quote, not a currency declaration. The per-share figure is stated in a sentence
+    // that goes on to give the non-GAAP one, and it agrees with the statements table's
+    // "Diluted | $ | 0.36" and with $29.4M over 82.5M shares.
     company: "Axon Enterprise",
     metrics: [
+      ["gaap_eps", "$0.36"],
       ["revenue", "$904M"],
       ["net_income", "$29.43M"],
     ],
@@ -493,6 +496,189 @@ const filingCorpus: {
     source: "1655210/000165521026000053/ex991pressrelease-q22026ea.htm",
     ticker: "bynd",
   },
+  {
+    company: "Himax Technologies",
+    metrics: [
+      ["revenue", "$227.33M"],
+    ],
+    outlook: [
+      ["Gross margin", "34%"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1342338/000117184326005288/exh_991.htm",
+    ticker: "himx",
+  },
+  {
+    // Reported and adjusted per-share figures are genuinely equal this quarter — the release
+    // says so in its own subtitle, so the repeated value is not a duplicated read. Net income
+    // is $534 million; the figure is stored as printed because the statement's scale is
+    // declared too far above the row to reach it, and an unscaled value is dropped before
+    // posting rather than published.
+    company: "Howmet Aerospace",
+    metrics: [
+      ["adjusted_eps", "$1.33"],
+      ["gaap_eps", "$1.33"],
+      ["revenue", "$2.55B"],
+      ["net_income", "$534"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "4281/000110465926091610/tm2622325d1_ex99-1.htm",
+    ticker: "hwm",
+  },
+  {
+    company: "D-Wave Quantum",
+    metrics: [
+      ["gaap_eps", "-$0.13"],
+      ["revenue", "$3.08M"],
+      ["net_income", "-$48.03M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1907982/000190798226000127/qbts-20260806xexx991.htm",
+    ticker: "qbts",
+  },
+  {
+    // The adjusted measure is captioned "non-GAAP net income per diluted share" — "diluted"
+    // on the far side of "per". Unmatched, the only remaining source for the measure was the
+    // Q3 guidance range, whose low end ($0.63) was posted as the quarter's result.
+    company: "Datadog",
+    metrics: [
+      ["adjusted_eps", "$0.65"],
+      ["gaap_eps", "$0.12"],
+      ["revenue", "$1.12B"],
+      ["net_income", "$44.56M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1561550/000162828026053829/ex-991x20260630x8k.htm",
+    ticker: "ddog",
+  },
+  {
+    // "six-month 2026 earnings were $6.1 billion, or $5.00 per share" states the half year with
+    // a hyphen, so the year-to-date penalty missed it and both per-share figures were taken
+    // from the six-month sentence instead of the quarter's ($3.23 and $3.24).
+    company: "ConocoPhillips",
+    metrics: [
+      ["adjusted_eps", "$3.24"],
+      ["gaap_eps", "$3.23"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1163165/000116316526000030/cop-20260806x8kexx991.htm",
+    ticker: "cop",
+  },
+  {
+    // Revenue is $5.8 billion. The stored "$2.22K" is a North America segment row read under a
+    // "$ in mm" heading the reader does not treat as a scale; unscaled, it is dropped before
+    // posting. Scaling it without first distinguishing segment rows from consolidated ones
+    // would turn a dropped figure into a published wrong one.
+    company: "Parker-Hannifin",
+    metrics: [
+      ["adjusted_eps", "$9.27"],
+      ["gaap_eps", "$8.54"],
+      ["revenue", "$2.22K"],
+      ["net_income", "$1.09B"],
+    ],
+    outlook: [],
+    quarterLabel: "Q4 2026",
+    source: "76334/000007633426000082/exhibit991q4fy26.htm",
+    ticker: "ph",
+  },
+  {
+    // One clause states both per-share measures — "GAAP diluted net loss per share $0.16;
+    // non-GAAP diluted net loss per share $0.05" — and the non-GAAP half had the whole line
+    // discarded, leaving the adjusted figure posted alone. The share count comes from the
+    // statements, not from the non-GAAP section's prose definition of the same caption.
+    company: "Rigetti Computing",
+    metrics: [
+      ["adjusted_eps", "-$0.05"],
+      ["gaap_eps", "-$0.16"],
+      ["revenue", "$5.1M"],
+      ["net_income", "-$52.6M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1838359/000110465926091979/rgti-20260806xex99d1.htm",
+    ticker: "rgti",
+  },
+  {
+    // Net sales are $752.1 million, stored as printed: the table declares its scale as "$MM",
+    // which the reader does not recognise, so the figure is dropped before posting.
+    company: "Century Aluminum",
+    metrics: [
+      ["adjusted_eps", "$2.46"],
+      ["gaap_eps", "$2.39"],
+      ["revenue", "$752.1"],
+      ["net_income", "$249.3M"],
+    ],
+    outlook: [
+      ["Adj EBITDA", "$325M to $345M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "949157/000162828026054300/a20260630q2ex991earningsre.htm",
+    ticker: "cenx",
+  },
+  {
+    company: "Applied Optoelectronics",
+    metrics: [
+      ["gaap_eps", "-$0.28"],
+      ["revenue", "$191.9M"],
+      ["net_income", "-$22.8M"],
+    ],
+    outlook: [
+      ["Revenue", "$255M to $290M"],
+      ["Gross margin", "29% to 30.5%"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1158114/000168316826006055/aaoi_ex9901.htm",
+    ticker: "aaoi",
+  },
+  {
+    // A hard line break inside the paragraph leaves the prior-year clause standing as its own
+    // line, carrying the reported period's date: "...period ended June 30, 2026, compared to
+    // net income of $7.2 million". That comparison figure was posted as the quarter's; the
+    // quarter's is $14.41 million.
+    company: "Innodata",
+    metrics: [
+      ["gaap_eps", "$0.41"],
+      ["revenue", "$92.14M"],
+      ["net_income", "$14.41M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "903651/000110465926092010/tm2621499d1_ex99-1.htm",
+    ticker: "inod",
+  },
+  {
+    company: "Cloudflare",
+    metrics: [
+      ["adjusted_eps", "$0.29"],
+      ["gaap_eps", "-$0.48"],
+      ["revenue", "$696.1M"],
+      ["net_income", "-$169.98M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1477333/000147733326000053/q226exhibit991.htm",
+    ticker: "net",
+  },
+  {
+    // Guidance sits in a two-column table — one pipe per row — which scored below the prose
+    // around it. The prose that won carried a 2027 "midpoint opportunity" range the filing's
+    // own footnote calls "not intended to be guidance"; the reaffirmed 2026 range is the table's.
+    company: "Vistra",
+    metrics: [
+      ["revenue", "$4.02B"],
+      ["net_income", "$305M"],
+    ],
+    outlook: [
+      ["Adj EBITDA", "$6.8B to $7.6B"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1692819/000169281926000017/vistra-20260630xearningsre.htm",
+    ticker: "vst",
+  },
 ];
 
 describe("earnings result filing corpus", () => {
@@ -513,6 +699,6 @@ describe("earnings result filing corpus", () => {
   }
 
   test("covers every stored fixture", () => {
-    expect(filingCorpus).toHaveLength(33);
+    expect(filingCorpus).toHaveLength(45);
   });
 });

--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -1,5 +1,5 @@
 import moment from "moment-timezone";
-import {stripReferenceMarkers} from "./earnings-results-format-selection.ts";
+import {isDefinitionalLine, stripReferenceMarkers} from "./earnings-results-format-selection.ts";
 import {findNumericValues, getCurrencyCodeFromText} from "./earnings-results-money.ts";
 import {type EarningsResultMetric} from "./earnings-results-metrics.ts";
 import {type EarningsOutlookMetric} from "./earnings-results-outlook.ts";
@@ -216,6 +216,15 @@ function getQuarterFromName(name: string): string | undefined {
 // column, a misplaced decimal — are off by far more.
 export function getDilutedShareMantissa(lines: string[]): number | undefined {
   for (const [lineIndex, line] of lines.entries()) {
+    // The non-GAAP section defines its per-share measure in words — "non-GAAP net loss
+    // divided by the weighted average shares used to compute net loss per share" — which
+    // carries the caption without any count, so the reader took a figure out of the prose
+    // that followed. A count read from the wrong place is worse than none: the consistency
+    // check then contradicts a correct filing.
+    if (true === isDefinitionalLine(line)) {
+      continue;
+    }
+
     // The caption has to be about shares. "dollar-weighted average contract duration" is
     // boilerplate about contracts, and matching it reads an unrelated figure as a count.
     //

--- a/modules/earnings-results-format-regressions.test.ts
+++ b/modules/earnings-results-format-regressions.test.ts
@@ -482,4 +482,67 @@ describe("earnings result filing regressions", () => {
     expect(values).not.toContain("€2.65");
   });
 
+  // The half-year wording ("six-month 2026 earnings ... or $5.00 per share") and the comparison
+  // clause left on its own line by a paragraph break are pinned by the ConocoPhillips and
+  // Innodata corpus entries. Reduced to a synthetic document neither reproduces the tie they
+  // lost — the surrounding filing is what makes the wrong line competitive — so a synthetic
+  // here would pass with or without the guard and imply coverage that is not there.
+
+  test("reads a non-GAAP measure captioned with diluted after per", () => {
+    // Without this spelling the measure's only source was the guidance range below it, whose
+    // low end was posted as the quarter's result.
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Announces Second Quarter 2026 Financial Results</h1>
+          <p>Three Months Ended June 30, 2026</p>
+          <p>GAAP net income per diluted share was $0.12; non-GAAP net income per diluted share was $0.65.</p>
+          <p>Third Quarter 2026 Outlook:</p>
+          <p>Non-GAAP net income per share between $0.63 and $0.65, assuming approximately 378 million weighted average diluted shares outstanding.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", numericValue: 0.65}),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$0.63");
+  });
+
+  test("keeps the reported figure from a clause that goes on to give the non-GAAP one", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Announces Second Quarter 2026 Results</h1>
+          <p>Three Months Ended June 30, 2026</p>
+          <p>For the three months ended June 30, 2026: GAAP diluted net loss per share $0.16; non-GAAP diluted net loss per share $0.05</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: -0.16}),
+      expect.objectContaining({key: "adjusted_eps", numericValue: -0.05}),
+    ]));
+  });
+
+  test("signs a loss stated beside the value under a combined caption", () => {
+    // "loss / earnings per share" carries no sign of its own, so the words introducing the
+    // value are the only place the sign appears.
+    const parsedDocument = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Announces Second Quarter 2026 Results</h1>
+          <p>Three Months Ended June 30, 2026</p>
+          <p>Generally Accepted Accounting Principles (GAAP) loss / earnings per share (EPS) assuming dilution was a loss per share of $0.54 and non-GAAP loss per share was $0.13.</p>
+        </body>
+      </html>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "gaap_eps", numericValue: -0.54}),
+    ]));
+    expect(parsedDocument.metrics.map(metric => metric.value)).not.toContain("$0.54");
+  });
+
 });

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -4,8 +4,13 @@ type MetricValueType = "eps" | "money" | "number";
 // the GAAP statement is complete before the word appears — "GAAP earnings per share of
 // $0.03. Generated $92 million of adjusted EBITDA" — the line still reports GAAP EPS, and
 // discarding it loses the only place the figure is stated.
+//
+// "Non-GAAP" bounds the GAAP statement the same way, and a filer that states both measures in
+// one clause uses that word rather than "adjusted": "GAAP diluted net loss per share $0.16;
+// non-GAAP diluted net loss per share $0.05". Reading only "adjusted" here discarded the line
+// and with it the reported figure, leaving the adjusted one posted alone.
 export function hasGaapNarrativeBeforeAdjustment(line: string, patterns: RegExp[]): boolean {
-  const adjustedIndex = line.search(/\badjusted\b/i);
+  const adjustedIndex = line.search(/\badjusted\b|\bnon-gaap\b/i);
   if (-1 === adjustedIndex) {
     return false;
   }
@@ -53,7 +58,9 @@ export function getMetricCandidateScore({
   // A combined statement names both periods in one header ("Three Months Ended | Six Months
   // Ended"); its quarter columns come first and are chosen by column index, so it must not
   // be treated as a year-to-date line.
-  if (/\b(?:YTD|year[-\s]to[-\s]date|six\s+months|nine\s+months|full\s+year|annual)\b/i.test(metricLine) &&
+  // "six-month 2026 earnings were $6.1 billion, or $5.00 per share" states the half-year as an
+  // adjective, so the period words have to be matched with the hyphen as well as the space.
+  if (/\b(?:YTD|year[-\s]to[-\s]date|six[-\s]months?|nine[-\s]months?|full\s+year|annual)\b/i.test(metricLine) &&
       "quarter" !== getPeriodEndedScope(metricLine)) {
     score -= 60;
   }
@@ -95,6 +102,10 @@ export function getMetricCandidateScore({
   // positionally, so the leading value is not the reported quarter.
   if (/\brespectively\b/i.test(metricLine)) {
     score -= 100;
+  }
+
+  if (null !== patternMatch && true === isComparisonClause(metricLine, patternMatch.index)) {
+    score -= 150;
   }
 
   if (("eps" === valueType || "money" === valueType) && /[$€£¥]/.test(metricLine)) {
@@ -373,8 +384,21 @@ function getLineScope(line: string): PeriodScope {
   return undefined;
 }
 
-// "compared with earnings per share of $1.76 for the second quarter of 2025" states a
-// prior-year figure; the leading value on such a line is not the reported quarter.
+// A figure introduced by "compared to" is the comparison, not the reported period. Normally
+// the caption comes first and the whole line reads as current — "Revenue was $10.2 billion,
+// compared with $9.1 billion" — but a hard line break inside a paragraph can leave the
+// comparison clause standing alone as its own line, carrying the reported period's date with
+// it: "...period ended June 30, 2026, compared to net income of $7.2 million". So the clause
+// is recognised from the caption's position, and only where the caption follows the comparison
+// marker directly. A caption further along the line ("compared with $9.1 billion, and adjusted
+// EPS was $1.42") still states the reported period.
+function isComparisonClause(line: string, captionIndex: number): boolean {
+  return /\b(?:compared\s+(?:to|with)|versus|vs\.?)\s+(?:a\s+|the\s+)?$/i
+    .test(line.slice(0, captionIndex));
+}
+
+// A row under a guidance heading is guidance whatever its caption says, so the heading is
+// searched for upwards from the row, stopping at whatever heading ends that section.
 function isUnderGuidanceHeading(lines: string[], lineIndex: number): boolean {
   for (let index = lineIndex - 1, examined = 0; index >= 0 && examined < 14; index--, examined++) {
     const line = lines[index];

--- a/modules/earnings-results-format.ts
+++ b/modules/earnings-results-format.ts
@@ -405,8 +405,14 @@ function extractMetricValue(
   const isLossCaption = undefined !== patternMatch?.[0] &&
     /\bloss\b/i.test(patternMatch[0]) &&
     false === /\b(?:income|earnings|profit)\b/i.test(patternMatch[0]);
+  // Prose can state the sign beside the value instead, which is the only place it appears when
+  // the caption is a combined one: "(GAAP) loss / earnings per share (EPS) assuming dilution
+  // was a loss per share of $0.54". Only the wording directly introducing the first value
+  // counts, so a later mention of an unrelated loss does not flip the figure.
+  const isLossIntroducedValue = /\ba?\s*loss\s+(?:per\s+(?:common\s+)?share\s+)?of\s*$/i
+    .test(getValueIntroText(preferredSearchText));
   const signedValue = (value: number): number =>
-    true === isLossCaption && value > 0 ? -value : value;
+    (true === isLossCaption || true === isLossIntroducedValue) && value > 0 ? -value : value;
 
   if ("eps" === valueType) {
     const perShareTableValue = findPerShareTableValue(preferredSearchText, currentPeriodColumnIndex);
@@ -517,6 +523,12 @@ function getMetricValueSentenceText(text: string): string {
   }
 
   return text.slice(0, boundaryMatch.index + 1);
+}
+
+// The wording that introduces the first value in the text, up to and excluding that value.
+function getValueIntroText(text: string): string {
+  const valueIndex = text.search(/[$€£¥(]?\s*-?\d/);
+  return -1 === valueIndex ? text : text.slice(0, valueIndex);
 }
 
 function getQuarterColumnSearchText(text: string): string {

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -52,8 +52,10 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?eps\b/i,
       /\bnon-gaap\s+(?:diluted\s+)?(?:earnings\s+per\s+share|eps)\b/i,
       // "Non-GAAP diluted net income per share" / "Non-GAAP Diluted Loss Per Share" are
-      // the reconciliation-table labels for the same measure.
-      /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?(?:earnings|net\s+income|net\s+loss|loss)(?:\s*\/?\s*\(loss(?:es)?\))?\s+per\s+(?:common\s+)?share\b/i,
+      // the reconciliation-table labels for the same measure. "Diluted" also appears on the
+      // far side of "per" — "non-GAAP net income per diluted share" — and without that
+      // spelling the measure's only remaining source in a release is a guidance range.
+      /\bnon-gaap\s+(?:fully\s+)?(?:diluted\s+)?(?:earnings|net\s+income|net\s+loss|loss)(?:\s*\/?\s*\(loss(?:es)?\))?\s+per\s+(?:common\s+)?(?:diluted\s+)?share\b/i,
       // A reconciliation table can name the measure after the caption instead of before
       // it ("Earnings per share - Non-GAAP").
       /\b(?:earnings|net\s+income)\s+per\s+(?:common\s+)?share\s*[–—-]\s*non-gaap\b/i,

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -377,6 +377,22 @@ describe("extractOutlookMetrics", () => {
     });
   });
 
+  test("prefers a two-column guidance row over the prose around it", () => {
+    // One caption cell and one value cell is one pipe. Scored as prose, the row lost to a
+    // sentence carrying a different year's "midpoint opportunity" — which the filing's own
+    // footnote calls not intended to be guidance.
+    expect(extractOutlookMetrics([
+      "Guidance 3",
+      "($ in millions)",
+      "| Reaffirmed 2026",
+      "Guidance Ranges",
+      "Ongoing Operations Adjusted EBITDA | $6,800 - $7,600",
+      "The company's comprehensive hedging program provides support for the reaffirmed 2026 guidance ranges and the previously announced Ongoing Operations Adjusted EBITDA midpoint opportunity 2 range of $7.4 billion to $7.8 billion for 2027.",
+    ])).toEqual([
+      {key: "adjusted_ebitda", label: "Adj EBITDA", value: "$6.8B to $7.6B"},
+    ]);
+  });
+
   test("limits outlook scanning and ignores unusable fallback values", () => {
     const lines = [
       "Business Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -442,7 +442,11 @@ function getOutlookMetricCandidateScore(line: string): number {
   // A guidance table states the figures; the paragraph introducing it only describes them,
   // and any amount it happens to mention belongs to that description rather than to the
   // metric ("...guidance, reflecting the continued strong revenue performance in Q2").
-  if (2 <= (line.match(/\|/g)?.length ?? 0)) {
+  //
+  // One pipe is enough: a two-column guidance table is a caption and a value cell, so
+  // requiring two left its rows scoring below the surrounding prose — which is how a range
+  // the filing itself disclaims as "not intended to be guidance" was posted as the guidance.
+  if (1 <= (line.match(/\|/g)?.length ?? 0)) {
     score += 30;
   } else if (200 < line.length) {
     score -= 20;

--- a/modules/earnings-results-share-consistency.test.ts
+++ b/modules/earnings-results-share-consistency.test.ts
@@ -77,4 +77,28 @@ describe("per-share consistency gate", () => {
     expect(getInconsistentPerShareReasons(document.metrics, document.dilutedShareMantissa))
       .toEqual([]);
   });
+
+  // A count read from the wrong place is worse than none: the check then contradicts a correct
+  // filing and suppresses it. The non-GAAP section defines its per-share measure in words,
+  // carrying the share caption with no count of its own.
+  test("ignores the share caption inside a prose definition", () => {
+    const document = parseEarningsDocument(`
+      <html>
+        <body>
+          <h1>ExampleCo Announces Second Quarter 2026 Results</h1>
+          <p>(in thousands, except per share data)</p>
+          <p>Three Months Ended June 30, 2026</p>
+          <p>Non-GAAP net loss per share is defined as non-GAAP net loss divided by the weighted average shares used to compute net loss per share attributable to common stockholders-basic and diluted. The Company excludes stock-based compensation of $100 and other items.</p>
+          <p>GAAP diluted net loss per share $0.16</p>
+          <p>Net loss | $ | (52,600) | |</p>
+          <p>Weighted average shares used to compute net loss per share - basic and diluted</p>
+          <p>| 333,215 | |</p>
+        </body>
+      </html>
+    `);
+
+    expect(document.dilutedShareMantissa).toBe(333_215);
+    expect(getInconsistentPerShareReasons(document.metrics, document.dilutedShareMantissa))
+      .toEqual([]);
+  });
 });

--- a/modules/test-fixtures/earnings-filings/aaoi.txt
+++ b/modules/test-fixtures/earnings-filings/aaoi.txt
@@ -1,0 +1,1325 @@
+EX-99.1
+2
+aaoi_ex9901.htm
+PRESS RELEASE
+
+
+
+
+
+
+
+Exhibit 99.1
+
+
+
+
+
+
+
+
+
+
+
+Applied Optoelectronics
+Reports Second Quarter 2026 Results
+
+
+
+
+
+Sugar Land, Texas, August 6, 2026 &ndash; Applied Optoelectronics,
+Inc. (NASDAQ: AAOI) (&ldquo;AOI&rdquo;), a leading provider of advanced optical and HFC networking products that power AI, today announced
+financial results for its second quarter ended June 30, 2026.
+
+
+
+
+
+&ldquo;Q2 was a pivotal quarter for AOI. We delivered record revenue
+for our fifth consecutive quarter and achieved an important milestone as we returned to non-GAAP profitability in the quarter. Further,
+we saw a strong volume ramp of our 800G products, which more than doubled sequentially,&rdquo; said Dr. Thompson Lin, AOI&rsquo;s Founder,
+President and Chief Executive Officer. &ldquo;Strong demand for high-speed optics alongside high-volume adoption of our 1.8 GHz CATV products
+generated powerful results during the quarter. We continue to see robust customer engagement around our 800G transceivers and 1.6 Tb products,
+and we forecast that demand will continue to outpace our production capacity through mid-2027. We continue to believe the fundamental
+drivers of long-term demand for our business remain robust and we are uniquely positioned as a key supplier to the AI, cloud infrastructure,
+and CATV markets.&rdquo;
+
+
+
+
+
+&ldquo;We&rsquo;re pleased to deliver second quarter results that were
+in line with or better than our expectations,&rdquo; said Dr. Stefan Murry, AOI&rsquo;s Chief Financial Officer and Chief Strategy Officer.
+&ldquo;During Q2, we continued to make solid progress on our production capacity ramp, particularly for our 800G and 1.6Tb products. We
+have a total manufacturing capacity approaching 200,000 units per month and continue to expect by the end of this year that we will be
+capable of producing around 650,000 pieces of 800G and 1.6 Tb products per month. We&rsquo;re working hard to expand our capacity, and
+we continue to anticipate steady sequential revenue growth this year.&rdquo;
+
+
+
+
+
+Second Quarter 2026 Financial Summary
+
+
+
+
+
+
+| &middot; | GAAP revenue was $191.9 million, compared with $103.0 million in the second
+quarter of 2025 and $151.1 million in the first quarter of 2026. |
+
+
+| | |
+
+
+| &middot; | GAAP gross margin was 27.7%, compared with 30.3% in the second quarter of
+2025 and 29.1% in the first quarter of 2026. Non-GAAP gross margin was 29.8%, compared with 30.4% in the second quarter of 2025 and 29.2%
+in the first quarter of 2026. |
+
+
+| | |
+
+
+| &middot; | GAAP net loss was $22.8 million, or $0.28 per basic share, compared with
+net loss of $9.1 million, or $0.16 per basic share in the second quarter of 2025, and a net loss of $14.3 million, or $0.19 per basic
+share in the first quarter of 2026. |
+
+
+| | |
+
+
+| &middot; | Non-GAAP net income was $5.5 million, or $0.06 per diluted share, compared
+with non-GAAP net loss of $8.8 million, or $0.16 per basic share in the second quarter of 2025, and a non-GAAP net loss of $4.9 million,
+or $0.07 per basic share in the first quarter of 2026. |
+
+
+
+
+
+A reconciliation between all GAAP and non-GAAP information referenced
+above is contained in the tables below. Please also refer to &ldquo;Non-GAAP Financial Measures&rdquo; below for a description of these
+non-GAAP financial measures.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| 1 | |
+
+
+
+
+
+
+
+
+
+
+Third Quarter 2026 Business Outlook (+)
+
+
+
+
+
+For third quarter of 2026, the company currently expects:
+
+
+
+
+
+
+| &middot; | Revenue in the range of $255 million to $290 million. |
+
+
+| &middot; | Non-GAAP gross margin in the range of 29% to 30.5%. |
+
+
+| &middot; | Non-GAAP net income in the range of $10.1 million to $24.0 million, and non-GAAP
+income per share in the range of $0.11 to $0.26 using approximately 92.8 million shares. |
+
+
+
+
+
+(+) Please refer to the note below on forward-looking
+statements and the risks involved with such statements as well as the note on non-GAAP financial measures.
+
+
+
+
+
+Conference Call Information
+
+
+
+
+
+The company will host a conference call and webcast for analysts and
+investors today, August 6, 2026 to discuss its second quarter 2026 financial results and outlook for its third quarter 2026 at 4:30 p.m.
+Eastern time / 3:30 p.m. Central time. This call will be open to the public, and investors may access the call by dialing 844-890-1794
+(domestic) or 412-717-9586 (international). A live audio webcast of the conference call along with supplemental financial information
+will also be accessible on the company's website at investors.ao-inc.com.
+Following the webcast, an archived version will be available on the website for one year. A telephonic replay of the call will be available
+one hour after the call and will run for five business days and may be accessed by dialing 855-669-9658 (domestic) or 412-317-0088 (international)
+and entering passcode 6704856.
+
+
+
+
+
+Forward-Looking Information
+
+
+
+
+
+This press release contains forward-looking statements within the meaning
+of the Private Securities Litigation Reform Act of 1995. In some cases, you can identify forward-looking statements by terminology such
+as "believe," "may," "estimate," "continue," "anticipate," "intend," "should,"
+"could," "would," "target," "seek," "aim," "predicts," "think,"
+"objectives," "optimistic," "new," "goal," &ldquo;priorities,&rdquo; "strategy," "potential,"
+"is likely," "will," "expect," &ldquo;momentum,&rdquo; "plan" "project," "permit,"
+&ldquo;positions&rdquo; or by other similar expressions that convey uncertainty of future events or outcomes. These statements include
+management&rsquo;s beliefs and expectations related to our outlook for the third quarter of 2026, the remainder of the year, and the first
+half of 2027. Such forward-looking statements reflect the views of management at the time such statements are made. These forward-looking
+statements involve risks and uncertainties, as well as assumptions and current expectations, which could cause the company's actual results
+to differ materially from those anticipated in such forward-looking statements. These risks and uncertainties include but are not limited
+to: reduction in the size or quantity of customer orders; change in demand for the company's products due to industry conditions; changes
+in manufacturing operations; volatility in manufacturing costs; delays in shipments of products; disruptions in the supply chain; change
+in the rate of design wins or the rate of customer acceptance of new products; the company's reliance on a small number of customers for
+a substantial portion of its revenues; potential pricing pressure; a decline in demand for our customers' products or their rate of deployment
+of their products; general conditions in the internet datacenter, cable television (CATV) broadband, telecom, or fiber-to-the-home (FTTH)
+markets; changes in the world economy (particularly in the United States and China); changes in the regulation and taxation of international
+trade, including the imposition of tariffs; changes in currency exchange rates; the negative effects of seasonality; and other risks and
+uncertainties described more fully in the company's documents filed with or furnished to the Securities and Exchange Commission, including
+our Annual Report on Form 10-K for the year ended December 31, 2025 and our Quarterly report on Form
+10-Q for the quarter ended June 30, 2026 . More information about these and other risks that may impact the company's business are
+set forth in the "Risk Factors" section of the company's quarterly and annual reports on file with the Securities and Exchange
+Commission. You should not rely on forward-looking statements as predictions of future events. All forward-looking statements in this
+press release are based upon information available to us as of the date hereof, and qualified in their entirety by this cautionary statement.
+Except as required by law, we assume no obligation to update forward-looking statements for any reason after the date of this press release
+to conform these statements to actual results or to changes in the company's expectations.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| 2 | |
+
+
+
+
+
+
+
+
+
+
+Non-GAAP Financial Measures
+
+
+
+
+
+We provide non-GAAP gross margin, non-GAAP net income (loss), and non-GAAP
+earnings (loss) per share, and non-GAAP Adjusted EBITDA to eliminate the impact of items that we do not consider indicative of our overall
+operating performance. To arrive at our non-GAAP gross margin, we exclude stock-based compensation and related expenses, expenses associated
+with discontinued products, and non-recurring (income) expenses, if any, from our GAAP gross margin. To arrive at our non-GAAP net income
+(loss), we exclude all amortization of intangible assets, stock-based compensation expense, non-recurring expenses, unrealized foreign
+exchange loss (gain), losses from the disposal of idle assets, if any, and non-GAAP tax benefit (expenses) from our GAAP net income (loss).
+Included in our non-recurring expenses in Q2 2026 and Q2 2025 are employee severance expenses
+(if any) and legal expenses associated with litigation and certain legal and advisory expenses associated with purchase termination or
+patent protection. In computing our non-GAAP income tax benefit (expense), we have applied an estimate of our annual effective income
+tax rate and applied it to our net income before income taxes. Our non-GAAP Adjusted EBITDA is calculated by excluding depreciation expense,
+non-GAAP tax benefit (expense), and interest (income) expense, as well as the items excluded from non-GAAP net income (loss), from our
+GAAP net income (loss). Our non-GAAP diluted net earnings (loss) per share is calculated by dividing our non-GAAP net gain (loss) by the
+fully diluted share count (for periods in which non-GAAP net income is positive) or basic share count (for periods in which our non-GAAP
+net income is negative).
+
+
+
+
+
+We believe that our non-GAAP measures are useful to investors in evaluating
+our operating performance for the following reasons:
+
+
+
+
+
+| • | We
+believe that elimination of items such as amortization of intangible assets, stock-based compensation expense, non-recurring revenue
+and expenses, losses from the disposal of idle assets, unrealized foreign exchange gain or loss, and depreciation on certain equipment
+undergoing reconfiguration is appropriate because treatment of these items may vary for reasons unrelated to our overall operating performance; |
+
+| • | We
+believe that elimination of expenses associated with discontinued products, including depreciation and inventory obsolescence is appropriate
+because these expenses are not indicative of our ongoing operations; |
+
+| • | We
+believe that estimating non-GAAP income taxes allows comparison with prior periods and provides additional information regarding the
+generation of potential future deferred tax assets; |
+
+| • | We
+believe that non-GAAP measures provide better comparability with our past financial performance, period-to-period results and with our
+peer companies, many of which also use similar non-GAAP financial measures; and |
+
+| • | We
+anticipate that investors and securities analysts will utilize non-GAAP measures as a supplement to GAAP measures to evaluate our overall
+operating performance. |
+
+
+
+
+
+A reconciliation of our GAAP net income (loss), GAAP total gross profit,
+GAAP earnings (loss), and GAAP earnings (loss) per share for Q2 2026 to our non-GAAP net income (loss), non-GAAP total gross profit, Adjusted
+EBITDA, and earnings (loss) per share, respectively, is provided below, together with corresponding reconciliations for Q2 2025.
+
+
+
+
+
+Non-GAAP measures should not be considered as an alternative to gross
+profit, net income (loss), earnings (loss) per share, or any other measure of financial performance calculated and presented in accordance
+with GAAP. Our non-GAAP measures may not be comparable to similarly titled measures of other organizations because other organizations
+may not calculate such other non-GAAP measures in the same manner. We have not reconciled the non-GAAP measures included in our guidance
+to the appropriate GAAP financial measures because the GAAP measures are not readily determinable on a forward-looking basis. GAAP measures
+that impact our non-GAAP financial measures may include stock-based compensation expense, non-recurring expenses, amortization of intangible
+assets, unrealized exchange loss (gain), asset impairment charges, loss (gain) from disposal of idle assets, and changes in the fair value
+of our convertible notes. These GAAP measures cannot be reasonably predicted and may directly impact our non-GAAP gross margin, our non-GAAP
+net income and our non-GAAP fully-diluted earnings per share, although changes with respect to certain of these measures may offset other
+changes. In addition, certain of these measures are out of our control. Accordingly, a reconciliation of the non-GAAP financial measure
+guidance to the corresponding GAAP measures is not available without unreasonable effort.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| 3 | |
+
+
+
+
+
+
+
+
+
+
+About Applied Optoelectronics
+
+
+
+
+
+Applied Optoelectronics,
+Inc. (AOI) is a leading developer and manufacturer of advanced optical and HFC networking products that are the building blocks for AI
+datacenters, CATV and broadband fiber access networks around the world. AOI supplies this critical infrastructure to tier-one customers
+across cloud computing, CATV broadband, telecom, and FTTH markets. The company has R&D facilities in Atlanta, GA, and engineering
+and manufacturing facilities at its corporate headquarters in Sugar Land, TX, as well as in Taipei, Taiwan and Ningbo, China. For
+additional information, visit www.ao-inc.com .
+
+
+
+
+
+
+# # #
+
+
+
+
+
+Investor Relations Contacts:
+
+
+
+
+
+The Blueshirt Group, Investor Relations
+
+
+Lindsay Savarese
+
+
++1-212-331-8417
+
+
+ir@ao-inc.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| 4 | |
+
+
+
+
+
+
+
+
+
+
+Applied Optoelectronics, Inc.
+
+
+Preliminary Condensed Consolidated Balance Sheets
+
+
+(In thousands)
+
+
+(Unaudited)
+
+
+
+
+
+
+
+
+
+
+
+
+| |
+June 30, 2026 | | |
+December 31, 2025 | |
+
+
+ASSETS | |
+| | | |
+| | |
+
+
+CURRENT ASSETS | |
+| | | |
+| | |
+
+
+Cash, Cash Equivalents and Restricted Cash | |
+$ | 508,758 | | |
+$ | 216,035 | |
+
+
+Accounts Receivable, Net | |
+| 314,009 | | |
+| 244,404 | |
+
+
+Inventories | |
+| 278,791 | | |
+| 183,105 | |
+
+
+Prepaid Expenses and Other Current Assets | |
+| 88,316 | | |
+| 32,183 | |
+
+
+Total Current Assets | |
+| 1,189,874 | | |
+| 675,727 | |
+
+
+| |
+| | | |
+| | |
+
+
+Property, Plant And Equipment, Net | |
+| 697,086 | | |
+| 376,050 | |
+
+
+Land Use Rights, Net | |
+| 4,917 | | |
+| 4,825 | |
+
+
+Operating Right of Use Asset | |
+| 75,168 | | |
+| 49,697 | |
+
+
+Intangible Assets, Net | |
+| 3,633 | | |
+| 3,623 | |
+
+
+Other Assets | |
+| 330,514 | | |
+| 58,501 | |
+
+
+TOTAL ASSETS | |
+$ | 2,301,192 | | |
+$ | 1,168,423 | |
+
+
+| |
+| | | |
+| | |
+
+
+LIABILITIES AND STOCKHOLDERS' EQUITY | |
+| | | |
+| | |
+
+
+CURRENT LIABILITIES | |
+| | | |
+| | |
+
+
+Accounts Payable | |
+$ | 286,088 | | |
+$ | 143,932 | |
+
+
+Bank Acceptance Payable | |
+| 33,940 | | |
+| 33,363 | |
+
+
+Accrued Expenses | |
+| 46,939 | | |
+| 42,491 | |
+
+
+Current Lease Liability-Operating | |
+| 4,223 | | |
+| 3,522 | |
+
+
+Current Portion of Notes Payable and Long Term Debt | |
+| 57,258 | | |
+| 33,975 | |
+
+
+Total Current Liabilities | |
+| 428,448 | | |
+| 257,283 | |
+
+
+Convertible Senior Notes | |
+| 129,142 | | |
+| 129,829 | |
+
+
+Other Long-Term Liabilities | |
+| 75,577 | | |
+| 47,393 | |
+
+
+TOTAL LIABILITIES | |
+| 633,167 | | |
+| 434,505 | |
+
+
+| |
+| | | |
+| | |
+
+
+STOCKHOLDERS' EQUITY | |
+| | | |
+| | |
+
+
+Common Stock | |
+| 84 | | |
+| 75 | |
+
+
+Additional Paid-in Capital | |
+| 2,192,682 | | |
+| 1,224,538 | |
+
+
+Cumulative Translation Adjustment | |
+| 2,399 | | |
+| (617 | ) |
+
+
+Retained Earnings | |
+| (527,140 | ) | |
+| (490,078 | ) |
+
+
+TOTAL STOCKHOLDERS' EQUITY | |
+| 1,668,025 | | |
+| 733,918 | |
+
+
+| |
+| | | |
+| | |
+
+
+TOTAL LIABILITIES AND STOCKHOLDERS' EQUITY | |
+$ | 2,301,192 | | |
+$ | 1,168,423 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| 5 | |
+
+
+
+
+
+
+
+
+
+
+Applied Optoelectronics, Inc.
+
+
+Preliminary Condensed Consolidated Statements of Operations
+
+
+(In thousands)
+
+
+(Unaudited)
+
+
+
+
+
+
+
+
+
+
+
+
+| |
+Three Months Ended June 30, | | |
+Six Months Ended June 30, | |
+
+
+| |
+2026 | | |
+2025 | | |
+2026 | | |
+2025 | |
+
+
+Revenue | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+CATV | |
+$ | 80,578 | | |
+$ | 56,019 | | |
+$ | 147,419 | | |
+$ | 120,520 | |
+
+
+Datacenter | |
+| 107,662 | | |
+| 44,791 | | |
+| 189,066 | | |
+| 76,841 | |
+
+
+Telecom | |
+| 3,411 | | |
+| 1,940 | | |
+| 5,971 | | |
+| 4,876 | |
+
+
+Other | |
+| 271 | | |
+| 202 | | |
+| 610 | | |
+| 574 | |
+
+
+Total Revenue | |
+| 191,922 | | |
+| 102,952 | | |
+| 343,066 | | |
+| 202,811 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Total Cost of Goods Sold | |
+| 138,715 | | |
+| 71,790 | | |
+| 245,943 | | |
+| 141,105 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Total Gross Profit | |
+| 53,207 | | |
+| 31,162 | | |
+| 97,123 | | |
+| 61,706 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Operating Expenses: | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Research and Development | |
+| 34,871 | | |
+| 20,612 | | |
+| 60,527 | | |
+| 38,422 | |
+
+
+Sales and Marketing | |
+| 11,490 | | |
+| 8,135 | | |
+| 17,837 | | |
+| 13,492 | |
+
+
+General and Administrative | |
+| 31,573 | | |
+| 18,391 | | |
+| 56,477 | | |
+| 34,706 | |
+
+
+Total Operating Expenses | |
+| 77,934 | | |
+| 47,138 | | |
+| 134,841 | | |
+| 86,620 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Operating Loss | |
+| (24,727 | ) | |
+| (15,976 | ) | |
+| (37,718 | ) | |
+| (24,914 | ) |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Other Income (Expense): | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Interest Income | |
+| 3,248 | | |
+| 286 | | |
+| 4,985 | | |
+| 511 | |
+
+
+Interest Expense | |
+| (927 | ) | |
+| (818 | ) | |
+| (1,790 | ) | |
+| (1,752 | ) |
+
+
+Other Income (Expense), net | |
+| 914 | | |
+| 7,410 | | |
+| (201 | ) | |
+| 7,885 | |
+
+
+Total Other Income (Expense): | |
+| 3,235 | | |
+| 6,878 | | |
+| 2,994 | | |
+| 6,644 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Net loss before Income Taxes | |
+| (21,492 | ) | |
+| (9,098 | ) | |
+| (34,724 | ) | |
+| (18,270 | ) |
+
+
+Income Tax Expense | |
+| (1,289 | ) | |
+| &ndash; | | |
+| (2,338 | ) | |
+| &ndash; | |
+
+
+Net loss | |
+$ | (22,781 | ) | |
+$ | (9,098 | ) | |
+$ | (37,062 | ) | |
+$ | (18,270 | ) |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Net loss per share attributable to common stockholders | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+basic | |
+$ | (0.28 | ) | |
+$ | (0.16 | ) | |
+$ | (0.47 | ) | |
+$ | (0.34 | ) |
+
+
+diluted | |
+$ | (0.28 | ) | |
+$ | (0.16 | ) | |
+$ | (0.47 | ) | |
+$ | (0.34 | ) |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Weighted-average shares used to compute net loss per share attributable to common stockholders | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+basic | |
+| 81,568 | | |
+| 56,772 | | |
+| 78,789 | | |
+| 53,426 | |
+
+
+diluted | |
+| 81,568 | | |
+| 56,772 | | |
+| 78,789 | | |
+| 53,426 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| 6 | |
+
+
+
+
+
+
+
+
+
+
+Applied Optoelectronics, Inc.
+
+
+Reconciliation of Statements of Operations under GAAP and Non-GAAP
+
+
+(In thousands)
+
+
+(Unaudited)
+
+
+
+
+
+
+
+
+
+
+
+
+| |
+Three Months Ended June 30, | | |
+Six Months Ended June 30, | |
+
+
+| |
+2026 | | |
+2025 | | |
+2026 | | |
+2025 | |
+
+
+GAAP total gross profit (a) | |
+$ | 53,207 | | |
+$ | 31,162 | | |
+$ | 97,123 | | |
+$ | 61,706 | |
+
+
+Share-based compensation expense | |
+| 170 | | |
+| 94 | | |
+| 326 | | |
+| 177 | |
+
+
+Non-recurring expense | |
+| 282 | | |
+| 41 | | |
+| 298 | | |
+| 41 | |
+
+
+Expenses associated with discontinued products | |
+| 3,594 | | |
+| &ndash; | | |
+| 3,594 | | |
+| &ndash; | |
+
+
+Non-GAAP total gross profit (a) | |
+$ | 57,253 | | |
+$ | 31,297 | | |
+$ | 101,341 | | |
+$ | 61,924 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+GAAP net loss | |
+$ | (22,781 | ) | |
+$ | (9,098 | ) | |
+$ | (37,062 | ) | |
+$ | (18,270 | ) |
+
+
+Share-based compensation expense | |
+| 4,863 | | |
+| 3,164 | | |
+| 9,254 | | |
+| 5,726 | |
+
+
+Expenses associated with discontinued products | |
+| 3,594 | | |
+| &ndash; | | |
+| 3,594 | | |
+| &ndash; | |
+
+
+Non-cash expenses associated with discontinued products | |
+| 1,102 | | |
+| 1,073 | | |
+| 2,017 | | |
+| 2,118 | |
+
+
+Amortization of intangible assets | |
+| 123 | | |
+| 110 | | |
+| 244 | | |
+| 218 | |
+
+
+Non-recurring (income) expense | |
+| 4,744 | | |
+| 862 | | |
+| 5,021 | | |
+| 1,255 | |
+
+
+Unrealized exchange loss (gain) | |
+| (432 | ) | |
+| (5,278 | ) | |
+| 745 | | |
+| (5,061 | ) |
+
+
+Tax (benefit) expense related to the above | |
+| 14,262 | | |
+| 337 | | |
+| 16,722 | | |
+| 4,325 | |
+
+
+Non-GAAP net Gain (loss) | |
+$ | 5,475 | | |
+$ | (8,830 | ) | |
+$ | 535 | | |
+$ | (9,689 | ) |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+GAAP net loss | |
+$ | (22,781 | ) | |
+$ | (9,098 | ) | |
+$ | (37,062 | ) | |
+$ | (18,270 | ) |
+
+
+Share-based compensation expense | |
+| 4,863 | | |
+| 3,164 | | |
+| 9,254 | | |
+| 5,726 | |
+
+
+Expenses associated with discontinued products | |
+| 3,594 | | |
+| &ndash; | | |
+| 3,594 | | |
+| &ndash; | |
+
+
+Non-cash expenses associated with discontinued products | |
+| 1,102 | | |
+| 1,073 | | |
+| 2,017 | | |
+| 2,118 | |
+
+
+Amortization of intangible assets | |
+| 123 | | |
+| 110 | | |
+| 244 | | |
+| 218 | |
+
+
+Non-recurring expense (income) | |
+| 4,744 | | |
+| 862 | | |
+| 5,021 | | |
+| 1,255 | |
+
+
+Unrealized exchange loss (gain) | |
+| (432 | ) | |
+| (5,278 | ) | |
+| 745 | | |
+| (5,061 | ) |
+
+
+Depreciation expense | |
+| 9,276 | | |
+| 5,217 | | |
+| 17,467 | | |
+| 9,790 | |
+
+
+Interest (income) expense, net | |
+| (2,321 | ) | |
+| 532 | | |
+| (3,195 | ) | |
+| 1,241 | |
+
+
+Income tax expenses (credit) | |
+| 1,289 | | |
+| &ndash; | | |
+| 2,338 | | |
+| &ndash; | |
+
+
+Adjusted EBITDA | |
+$ | (543 | ) | |
+$ | (3,418 | ) | |
+$ | 423 | | |
+$ | (2,983 | ) |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+GAAP diluted net loss per share | |
+$ | (0.28 | ) | |
+$ | (0.16 | ) | |
+$ | (0.47 | ) | |
+$ | (0.34 | ) |
+
+
+Share-based compensation expense | |
+| 0.06 | | |
+| 0.06 | | |
+| 0.11 | | |
+| 0.11 | |
+
+
+Expenses associated with discontinued products | |
+| 0.04 | | |
+| &ndash; | | |
+| 0.04 | | |
+| &ndash; | |
+
+
+Non-cash expenses associated with discontinued products | |
+| 0.01 | | |
+| 0.02 | | |
+| 0.02 | | |
+| 0.04 | |
+
+
+Non-recurring (income) expense | |
+| 0.05 | | |
+| 0.01 | | |
+| 0.06 | | |
+| 0.02 | |
+
+
+Unrealized exchange loss (gain) | |
+| &ndash; | | |
+| (0.10 | ) | |
+| 0.01 | | |
+| (0.09 | ) |
+
+
+Non-GAAP tax benefit | |
+| 0.18 | | |
+| 0.01 | | |
+| 0.24 | | |
+| 0.08 | |
+
+
+Non-GAAP diluted net earnings (loss) per share | |
+$ | 0.06 | | |
+$ | (0.16 | ) | |
+$ | 0.01 | | |
+$ | (0.18 | ) |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Shares used to compute diluted loss per share | |
+| 81,568 | | |
+| 56,772 | | |
+| 78,789 | | |
+| 53,426 | |
+
+
+Shares used to compute diluted earnings per share | |
+| 88,152 | | |
+| 62,037 | | |
+| 85,373 | | |
+| 58,690 | |
+
+
+
+
+
+
+
+
+(a) Provided for the purpose of calculating gross profit as a percentage of revenue (gross margin).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| 7 | |

--- a/modules/test-fixtures/earnings-filings/cenx.txt
+++ b/modules/test-fixtures/earnings-filings/cenx.txt
@@ -1,0 +1,369 @@
+EX-99.1
+2
+a20260630q2ex991earningsre.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+
+
+
+
+Century Aluminum Company Reports Second Quarter 2026 Results
+
+
+Chicago, August 6, 2026 (GLOBE NEWSWIRE) -- Century Aluminum Company (NASDAQ: CENX) today announced its second quarter 2026 results.
+
+
+Second Quarter 2026 Financial Results
+
+
+| | | | | | | | | | | | | | | | | |
+$MM (except shipments and per share data) |
+| | Q2 2026 | | Q1 2026 | |
+Aluminum shipments (tonnes) | | 130,632 | | | 122,865 | | |
+Net sales | | $ | 752.1 | | | $ | 649.2 | | |
+Net income attributable to Century | | $ | 249.3 | | | $ | 337.5 | | |
+Diluted earnings per share attributable to Century | | $ | 2.39 | | | $ | 3.23 | | |
+Adjusted net income attributable to Century (1)
+| | $ | 257.3 | | | $ | 170.7 | | |
+Adjusted earnings per common share (1)
+| | $ | 2.46 | | | $ | 1.63 | | |
+Adjusted EBITDA attributable to Century (1)
+| | $ | 326.9 | | | $ | 231.4 | | |
+| | | | | |
+Notes: | | | | | |
+(1) Non-GAAP measure; see reconciliation of GAAP to non-GAAP financial measures.
+|
+
+Business Highlights
+
+
+• Completed restart of last 90 pots at Mt. Holly
+• Returned Line 2 at Grundartangi to near full production
+• New Jamalco power generation turbine (TG4) online in August
+• Received 2025 45X refund totaling $94.3 million in July
+• As of the end of July, Century cash exceeded total debt
+Net sales for the second quarter ended June 30, 2026 increased by $102.9 million sequentially primarily driven by an increase in realized metal prices and higher shipments attributable to increased production from the Mt. Holly expansion and restart of Line 2 at Grundartangi during the quarter.
+Century reported Net income attributable to Century of $249.3 million for the second quarter of 2026, a $88.2 million decrease sequentially. The decrease in net earnings during the second quarter of 2026 was primarily attributable to the one-time gain on sale of Hawesville of $287.9 million in the first quarter, offset by favorable realized LME and regional premium prices, and an increase in gain on insurance proceeds related to Iceland equipment failure of $7.1 million and favorable power price realization due to improved weather conditions in the United States, partially offset by unfavorable raw material price realization.
+Second quarter results were also impacted by $8.0 million of net exceptional items, in particular, $61.3 million related to equipment failures in Iceland, net of tax; $38.9 million of unrealized gains on derivative instruments, net of tax; $2.5 million of share-based compensation and Mt. Holly expansion project expenses of $10.7 million. Therefore, Century reported an Adjusted net income attributable to Century of $257.3 million for the second quarter of 2026, a $86.6 million increase sequentially.
+Adjusted EBITDA attributable to Century for the second quarter of 2026 was $326.9 million. This was an increase of $95.5 million from the prior quarter, mainly from favorable realized metal prices, sales mix and operating expenses, favorable power price, partially offset by unfavorable raw material price realization.
+Century's liquidity position at June 30, 2026 was $784.9 million, comprised of cash and cash equivalents of $343.4 million, restricted cash of $44.8 million, and $396.7 million in combined borrowing availability.
+Third Quarter 2026 Outlook
+The Company expects third quarter Adjusted EBITDA attributable to Century to range between $325 million to $345 million .
+
+
+
+
+
+
+
+About Century Aluminum Company
+With its corporate headquarters located in Chicago, IL, Century Aluminum owns and operates primary aluminum smelting facilities in the United States and Iceland and is the majority owner and managing partner of the Jamalco alumina refinery in Jamaica. Visit www.centuryaluminum.com for more information.
+Non-GAAP Financial Measures
+Adjusted net income (loss), adjusted earnings (loss) per share and adjusted EBITDA are non-GAAP financial measures that management uses to evaluate Century's financial performance. These non-GAAP financial measures facilitate comparisons of this period’s results with prior periods on a consistent basis by excluding items that management does not believe are indicative of Century’s ongoing operating performance and ability to generate cash. Management believes these non-GAAP financial measures enhance an overall understanding of Century’s performance and our investors’ ability to review Century’s business from the same perspective as management. The tables below, under the heading "Reconciliation of Non-GAAP Financial Measures," provide a reconciliation of each non-GAAP financial measure to the most directly comparable GAAP financial measure. Non-GAAP financial measures should be viewed in addition to, and not as an alternative for, Century's reported results prepared in accordance with GAAP. In addition, because not all companies use identical calculations, adjusted net income (loss), adjusted earnings (loss) per share and adjusted EBITDA included in this press release may not be comparable to similarly titled measures of other companies. Investors are encouraged to review the reconciliations in conjunction with the presentation of these non-GAAP financial measures. We do not provide a reconciliation of forward-looking Adjusted EBITDA because the corresponding forward-looking GAAP financial measures is not currently available and management cannot reliably predict all the necessary components of such forward-looking GAAP measures without unreasonable effort or expense due to the inherent difficulty of forecasting and quantifying certain amounts that are necessary for such a reconciliation, including adjustments that could be made for restructuring, the variability of our tax rate, the impact of foreign currency fluctuation, and other charges reflected in our historical results. The probable significance of each of these items is high and, based on historical experience, could be material.
+Cautionary Statement
+This press release and statements made by Century Aluminum Company management on the quarterly conference call contain "forward-looking statements" within the meaning of the Private Securities Litigation Reform Act of 1995, which are subject to the "safe harbor" created by section 27A of the Securities Act of 1933, as amended (the "Securities Act"), and section 21E of the Securities Exchange Act of 1934, as amended (the "Exchange Act"). Forward-looking statements are statements about future events and are based on our current expectations. These forward-looking statements may be identified by the words "believe," "expect," "hope," "target," "anticipate," "intend," "plan," "seek," "estimate," "potential," "project," "scheduled," "forecast" or words of similar meaning, or future or conditional verbs such as "will," "would," "should," "could," "might," or "may." Forward-looking statements, for example, may include statements regarding: Our assessment of global and local financial and economic conditions; Our assessment of the alum inum market and aluminum prices (including premiums); Our assessment of prices of our key raw materials and supply and availability of those key raw materials, including alumina, coke, pitch and aluminum fluoride; Our assessment of power prices and availability, including any potential curtailments or other disruptions in the supply of power; The impact of the wars in Ukraine and in the Middle East, including any sanctions and export controls targeting Russia and businesses or individuals tied to Russia; The future financial and operating performance of the Company and its subsidiaries; Our ability to successfully manage market risk and to control or reduce costs; Our plans and expectations with respect to future operations of the Company and its subsidiaries, including any plans and expectations to curtail or restart production, including the expected impact of any such actions on our future financial and operating performance; Our plans and expectations with regards to the restart of curtailed production at Mt. Holly including the timing, costs and benefits associated with restarting curtailed production; Any future impact of the equipment failure at Grundartangi and related events on our financial and operating performance; The timing of our ability to return our operating facilities to full and normal operation following equipment failure or other extraordinary events including our expectations as to timing for bringing our Grundartangi facility back to 100% and returning Jamalco to full and normal operation following the restart after Hurricane Melissa; Our ability to recover losses from our insurance, including with respect to losses incurred in connection with the October 2025 equipment failure at Grundartangi; The timing and terms of the data center being constructed on our former Hawesville site to commence commercial operations and our ability to require Raylan Data Holdings LLC to repurchase our minority interest therein; The impact of Section 232 and 301 and other trade actions, including tariffs or other trade remedies, the extent to which any such remedies may be changed, including through exclusions or exemptions, and the duration of any trade remedy; The impact of any new or changed law or regulation, including, without limitation, sanctions or other similar remedies or restrictions or any changes in interpretation of existing laws or regulations; Our anticipated tax liabilities, benefits or refunds including the realization of U.S. and certain foreign deferred tax assets and liabilities; Our ability to qualify for and realize potential tax benefits under the Inflation Reduction Act of 2022 and the anticipated amounts of such benefits; Our expectations regarding the availability of the $500 million DOE funding to our new smelter project, including our ability to raise additional capital through additional grants, incentives, subsidized loans and other debt and equity funding to support construction of a new aluminum smelter and our ability to successfully complete our new smelter project; The likelihood of our
+
+
+
+
+
+
+
+formalizing a joint venture with Emirates Global Aluminium for the new smelter project, and if we do, our ability to secure necessary power arrangements for the project on commercially reasonable terms, to timely complete construction of the project on budget, and to commence profitable operations; Our ability to access existing or future financing arrangements and the terms of any such future financing arrangements; Our ability to repay or refinance debt in the future; Our assessment and estimates of our pension and other postretirement liabilities, legal and environmental liabilities and other contingent liabilities; Our assessment of any future tax audits and expected outcomes; Negotiations with current labor unions or future representation by a union of our employees; Our assessment of any information technology-related risks, including the risk from cyberattacks or other data security breaches; Our plans and expectations regarding potential M&A and joint venture activity including our ability to consummate such transactions and our assessments of certain risks associated with the same, including, for example, unforeseen costs and expenses associated with unidentified liabilities, and difficulties integrating an acquired asset into our existing operations; and Our future business objectives, plans, strategies and initiatives, including our competitive position and prospects.
+Where we express an expectation or belief as to future events or results, such expectation or belief is expressed in good faith and believed to have a reasonable basis. However, our forward-looking statements are based on current expectations and assumptions that are subject to risks and uncertainties which may cause actual results to differ materially from future results expressed, projected or implied by those forward-looking statements. Important factors that could cause actual results and events to differ from those described in such forward-looking statements can be found in the risk factors and forward-looking statements cautionary language contained in our Annual Report on Form 10-K, our Quarterly Reports on Form 10-Q and in other filings made with the Securities and Exchange Commission. Although we have attempted to identify those material factors that could cause actual results or events to differ from those described in such forward-looking statements, there may be other factors that could cause actual results or events to differ from those anticipated, estimated or intended. Many of these factors are beyond our ability to control or predict. Given these uncertainties, the reader is cautioned not to place undue reliance on our forward-looking statements. We undertake no obligation to update or revise publicly any forward-looking statements, whether as a result of new information, future events, or otherwise.
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | |
+CENTURY ALUMINUM COMPANY |
+CONSOLIDATED STATEMENTS OF OPERATIONS |
+(in millions, except per share amounts) |
+(Unaudited) |
+| | Three months ended |
+| | June 30, | | March 31, |
+| | 2026 | | 2026 |
+Net sales | | | | |
+Related parties | | $ | 330.9 | | | $ | 305.9 | |
+Other customers | | 421.2 | | | 343.3 | |
+Total net sales | | 752.1 | | | 649.2 | |
+Cost of goods sold | | 524.2 | | | 530.4 | |
+Gross profit | | 227.9 | | | 118.8 | |
+Selling, general and administrative expenses | | 15.9 | | | 25.8 | |
+Gain on the sale of Hawesville | | — | | | (287.9) | |
+Other operating expenses - net | | 0.4 | | | 6.9 | |
+Operating income | | 211.6 | | | 374.0 | |
+Interest expense - nonaffiliates | | (9.5) | | | (9.9) | |
+Interest expense - affiliates | | (0.6) | | | (0.6) | |
+Interest income | | 4.4 | | | 3.1 | |
+Net gain (loss) on forward and derivative contracts - nonaffiliates | | 7.1 | | | (65.3) | |
+| | | | |
+| | | | |
+Gain on insurance proceeds - net | | 40.1 | | | 33.0 | |
+Other income (expense) - net | | 3.8 | | | (5.5) | |
+Income before income taxes | | 256.9 | | | 328.8 | |
+Income tax expense | | (12.1) | | | (1.8) | |
+Equity in losses of unconsolidated subsidiaries | | (1.0) | | | — | |
+Net income | | 243.8 | | | 327.0 | |
+Net loss attributable to noncontrolling interests | | (5.5) | | | (10.5) | |
+Net income attributable to Century | | 249.3 | | | 337.5 | |
+| | | | |
+Net income attributable to Century per common share: | | |
+Basic | | $ | 2.52 | | | $ | 3.41 | |
+Diluted | | $ | 2.39 | | | $ | 3.23 | |
+Weighted-average common shares outstanding: | | | | |
+Basic | | 99.0 | | | 99.0 | |
+Diluted | | 104.8 | | | 104.6 | |
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+CENTURY ALUMINUM COMPANY |
+CONSOLIDATED BALANCE SHEETS |
+(in millions, except per share amounts) |
+(Unaudited) |
+| June 30, 2026 | | December 31, 2025 |
+ASSETS | | | |
+Cash and cash equivalents | $ | 343.4 | | | $ | 134.2 | |
+Restricted cash | 46.3 | | | 1.4 | |
+Accounts receivable - net | 136.2 | | | 109.9 | |
+Non-trade receivables | 65.1 | | | 38.1 | |
+Due from affiliates | 13.0 | | | 29.6 | |
+Manufacturing credit receivable | 176.8 | | | 172.6 | |
+Inventories | 582.9 | | | 519.6 | |
+Derivative assets | 6.5 | | | 1.5 | |
+Prepaid and other current assets | 31.4 | | | 24.4 | |
+Total current assets | 1,401.6 | | | 1,031.3 | |
+Property, plant and equipment - net | 1,253.0 | | | 1,167.6 | |
+Manufacturing credit receivable - less current portion | 48.4 | | | — | |
+Other assets | 172.1 | | | 70.4 | |
+Total assets | $ | 2,875.1 | | | $ | 2,269.3 | |
+LIABILITIES AND SHAREHOLDERS’ EQUITY | | | |
+LIABILITIES: | | | |
+Accounts payable, trade | $ | 216.6 | | | $ | 187.2 | |
+Accrued compensation and benefits | 77.1 | | | 74.4 | |
+Due to affiliates | 71.9 | | | 70.8 | |
+Accrued and other current liabilities | 43.6 | | | 35.6 | |
+Derivative liabilities | 71.6 | | | 58.2 | |
+Carbon credit repurchase liability | 28.6 | | | 28.6 | |
+Current maturities of long-term debt | — | | | 68.8 | |
+Total current liabilities | 509.4 | | | 523.6 | |
+Long-term debt | 480.0 | | | 479.5 | |
+Accrued benefits costs - less current portion | 92.1 | | | 97.7 | |
+Other liabilities | 114.3 | | | 104.9 | |
+Deferred taxes | 70.5 | | | 58.4 | |
+Asset retirement obligations - less current portion | 74.3 | | | 75.3 | |
+Total noncurrent liabilities | 831.2 | | | 815.8 | |
+SHAREHOLDERS’ EQUITY: | | | |
+Series A Preferred stock ($0.01 par value, 5,000,000 shares authorized; no shares issued or outstanding at June 30, 2026 and December 31, 2025)
+| — | | | — | |
+Common stock ($0.01 value, 195,000,000 authorized; 106,179,816 issued and 98,993,295 outstanding at June 30, 2026; 106,155,528 issued and 98,969,007 outstanding at December 31, 2025)
+| 1.1 | | | 1.1 | |
+Additional paid-in capital | 2,574.5 | | | 2,571.5 | |
+Treasury stock, at cost | (86.3) | | | (86.3) | |
+Accumulated other comprehensive loss | (47.6) | | | (55.2) | |
+Accumulated deficit | (1,038.6) | | | (1,625.5) | |
+Total shareholders’ equity | 1,403.1 | | | 805.6 | |
+Noncontrolling interest | 131.4 | | | 124.3 | |
+Total equity | 1,534.5 | | | 929.9 | |
+Total liabilities and equity | $ | 2,875.1 | | | $ | 2,269.3 | |
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+CENTURY ALUMINUM COMPANY |
+CONSOLIDATED STATEMENTS OF CASH FLOWS |
+(in millions) |
+(Unaudited) |
+| Six months ended June 30, |
+| 2026 | | 2025 |
+CASH FLOWS FROM OPERATING ACTIVITIES: |
+| |
+|
+Net income | $ | 570.8 | | | $ | 10.7 | |
+Adjustments to reconcile Net income to net cash provided by operating activities: |
+Unrealized loss on derivative instruments | 8.8 | | | 14.5 | |
+Depreciation, depletion and amortization | 39.6 | | | 47.3 | |
+Share-based compensation | 11.9 | | | 4.7 | |
+Net periodic benefit cost | 9.5 | | | 5.5 | |
+Change in deferred tax provision | 10.4 | | | 2.4 | |
+Gain on the sale of Hawesville | (287.9) | | | — | |
+Gain on insurance proceeds received for property damage | (3.6) | | | — | |
+Other non-cash items - net | 5.6 | | | (3.6) | |
+Change in operating assets and liabilities: | | | |
+Accounts receivable | (40.9) | | | (15.2) | |
+Non-trade receivables | (31.7) | | | 11.6 | |
+Manufacturing credit receivable | (52.6) | | | (43.1) | |
+Due from affiliates | 16.5 | | | 11.3 | |
+Inventories | (68.4) | | | 27.5 | |
+Prepaid and other current assets | (7.0) | | | 3.5 | |
+Accounts payable, trade | 53.9 | | | 18.0 | |
+Due to affiliates | 1.1 | | | (11.8) | |
+Accrued and other current liabilities | 10.5 | | | (3.9) | |
+Other - net | (10.5) | | | 0.8 | |
+Net cash provided by operating activities | 236.0 | | | 80.2 | |
+CASH FLOWS FROM INVESTING ACTIVITIES: | | | |
+Purchase of property, plant and equipment | (134.4) | | | (45.0) | |
+Proceeds from the sale of Hawesville | 200.0 | | | — | |
+Insurance proceeds received for property damage | 13.6 | | | — | |
+Net cash provided by (used in) investing activities | 79.2 | | | (45.0) | |
+CASH FLOWS FROM FINANCING ACTIVITIES: | | | |
+Borrowings under revolving credit facilities | 265.0 | | | 586.7 | |
+Repayments under revolving credit facilities | (326.1) | | | (621.0) | |
+Repayments of Industrial Revenue Bonds | (7.8) | | | — | |
+Repayments under Grundartangi casthouse debt facility | — | | | (4.5) | |
+Payment of incentive compensation withholding taxes | (4.7) | | | — | |
+Contributions from joint venture partner | 12.5 | | | 11.4 | |
+Net cash used in financing activities | (61.1) | | | (27.4) | |
+CHANGE IN CASH, CASH EQUIVALENTS AND RESTRICTED CASH | 254.1 | | | 7.8 | |
+Cash, cash equivalents and restricted cash, beginning of period | 135.6 | | | 35.7 | |
+Cash, cash equivalents and restricted cash, end of period | $ | 389.7 | | | $ | 43.5 | |
+
+
+
+
+
+
+
+
+CENTURY ALUMINUM COMPANY
+SELECTED OPERATING DATA
+(in millions, except shipments)
+(Unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+SHIPMENTS - PRIMARY ALUMINUM (1)
+| | | | |
+| | | | | | | | | | | | |
+| | United States | | Iceland | | Total |
+| | Tonnes | | Sales $ | | Tonnes | | Sales $ | | Tonnes | | Sales $ |
+2026 | | | | | | | | | | | | |
+| | | | | | | | | | | | |
+| | | | | | | | | | | | |
+2nd Quarter | | 95,057 | | | $ | 572.3 | | | 35,575 | | | $ | 121.2 | | | 130,632 | | | $ | 693.5 | |
+1st Quarter | | 93,668 | | | $ | 494.3 | | | 29,197 | | | $ | 87.3 | | | 122,865 | | | $ | 581.6 | |
+| | | | | | | | | | | | |
+2025 | | | | | | | | | | | | |
+| | | | | | | | | | | | |
+| | | | | | | | | | | | |
+2nd Quarter | | 94,519 | | | $ | 324.4 | | | 81,222 | | | $ | 233.7 | | | 175,741 | | | $ | 558.1 | |
+1st Quarter | | 94,601 | | | $ | 306.6 | | | 74,071 | | | $ | 217.3 | | | 168,672 | | | $ | 523.9 | |
+
+(1) Excludes scrap aluminum sales, purchased aluminum and alumina sales.
+
+
+
+
+
+
+
+
+
+CENTURY ALUMINUM COMPANY
+RECONCILIATION OF NON-GAAP FINANCIAL MEASURES
+(in millions, except per share amounts)
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three months ended |
+| | June 30, 2026 | | March 31, 2026 |
+| | $MM | | EPS | | $MM | | EPS |
+Net income attributable to Century | | $ | 249.3 | | | $ | 2.39 | | | $ | 337.5 | | | $ | 3.23 | |
+Lower of cost or NRV inventory adjustment | | 4.3 | | | 0.04 | | | — | | | — | |
+Unrealized (gain) loss on derivative contracts, net of tax | | (38.9) | | | (0.37) | | | 48.1 | | | 0.46 | |
+| | | | | | | | |
+Share-based compensation | | 2.5 | | | 0.02 | | | 9.4 | | | 0.09 | |
+Gain on the sale of Hawesville | | — | | | — | | | (287.9) | | | (2.75) | |
+Hawesville inventory write-down | | — | | | — | | | 3.3 | | | 0.03 | |
+Gain on insurance proceeds - net, net of tax | | (32.1) | | | (0.31) | | | (26.4) | | | (0.25) | |
+Iceland equipment failure (1) , net of tax
+| | 61.3 | | | 0.59 | | | 60.0 | | | 0.56 | |
+Jamalco hurricane impact (2)
+| | — | | | — | | | 5.9 | | | 0.06 | |
+Mt. Holly expansion (3)
+| | 10.7 | | | 0.10 | | | 7.5 | | | 0.07 | |
+Mt. Holly emergency energy charges | | 0.2 | | | — | | | 13.3 | | | 0.13 | |
+| | | | | | | | |
+| | | | | | | | |
+Adjusted net income attributable to Century | | $ | 257.3 | | | $ | 2.46 | | | $ | 170.7 | | | $ | 1.63 | |
+
+(1) Represents impact of property damage and business interruption as a result of equipment failure at Grundartangi
+(2) Represents Century's 55% share of incremental and fixed costs incurred while alumina production at Jamalco was restarted after Hurricane Melissa
+(3) Represents incremental costs associated with the Mt. Holly expansion project
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | |
+| | Three months ended |
+| | June 30, 2026 | | March 31, 2026 |
+Net income attributable to Century | | $ | 249.3 | | | $ | 337.5 | |
+Add: Net loss attributable to noncontrolling interests | | (5.5) | | | (10.5) | |
+Net income | | 243.8 | | | 327.0 | |
+Interest expense - nonaffiliates | | 9.5 | | | 9.9 | |
+Interest expense - affiliates | | 0.6 | | | 0.6 | |
+Interest income | | (4.4) | | | (3.1) | |
+Net (gain) loss on forward and derivative contracts - nonaffiliates | | (7.1) | | | 65.3 | |
+| | | | |
+| | | | |
+Gain on insurance proceeds - net | | (40.1) | | | (33.0) | |
+Other (income) expense - net | | (3.8) | | | 5.5 | |
+Income tax expense | | 12.1 | | | 1.8 | |
+Equity in losses of unconsolidated subsidiaries | | 1.0 | | | — | |
+Operating income | | 211.6 | | | 374.0 | |
+Depreciation, depletion and amortization | | 16.9 | | | 22.7 | |
+Lower of cost or NRV inventory adjustment | | 4.3 | | | — | |
+Share-based compensation | | 2.5 | | | 9.4 | |
+Gain on the sale of Hawesville | | — | | | (287.9) | |
+Hawesville inventory write-down | | — | | | 3.3 | |
+Iceland equipment failure (1)
+| | 76.6 | | | 75.0 | |
+Jamalco hurricane impact (2)
+| | — | | | 10.6 | |
+Mt. Holly expansion (3)
+| | 10.7 | | | 7.5 | |
+Mt. Holly emergency energy charges | | 0.2 | | | 13.3 | |
+Adjusted EBITDA | | 322.8 | | | 227.9 | |
+Less: Adjusted EBITDA attributable to noncontrolling interests | | (4.1) | | | (3.5) | |
+Adjusted EBITDA attributable to Century | | $ | 326.9 | | | $ | 231.4 | |
+
+(1) Represents impact of property damage and business interruption as a result of equipment failure at Grundartangi
+(2) Represents incremental and fixed costs incurred while alumina production at Jamalco was restarted after Hurricane Melissa
+(3) Represents incremental costs associated with the Mt. Holly expansion project
+
+
+| | | | | | | | |
+INVESTOR CONTACT | | MEDIA CONTACT |
+Chad Rigg | | Tawn Earnest |
+312-696-3132 | | 614-698-6351 |
+Source: Century Aluminum Company |

--- a/modules/test-fixtures/earnings-filings/cop.txt
+++ b/modules/test-fixtures/earnings-filings/cop.txt
@@ -1,0 +1,210 @@
+EX-99.1
+2
+cop-20260806x8kexx991.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+ConocoPhillips announces second-quarter 2026 results and quarterly dividend
+
+• Reported second-quarter 2026 earnings per share of $3.23 and adjusted earnings per share of $3.24.
+• Generated cash provided by operating activities of $7.4 billion and cash from operations (CFO) of $7.2 billion.
+• Doubled share repurchases in the second quarter, increasing total shareholder distributions to $3.0 billion; on track for 45% return of CFO in 2026.
+• Declared third-quarter ordinary dividend of $0.84 per share.
+• Reaffirmed full-year guidance items.
+
+HOUSTON—Aug. 6, 2026—ConocoPhillips (NYSE: COP) today reported second-quarter 2026 earnings of $3.9 billion, or $3.23 per share, compared with second-quarter 2025 earnings of $2.0 billion, or $1.56 per share. Excluding special items, second-quarter 2026 adjusted earnings were $4.0 billion, or $3.24 per share, compared with second-quarter 2025 adjusted earnings of $1.8 billion, or $1.42 per share.
+
+
+“ConocoPhillips delivered strong second-quarter results with exceptional operational performance, record production from our peer-leading Permian position and disciplined execution across the business, all while continuing to progress our strategic priorities,” said Ryan Lance, chairman and chief executive officer. “We doubled our quarterly share repurchases, achieved our $5 billion asset disposition target ahead of schedule, secured low cost of supply opportunities in the Middle East, and increased our LNG offtake to 12 MTPA. We are executing well, delivering on our strategy, and remain on track to achieve our $7 billion free cash flow inflection by 2029.”
+
+Second-quarter highlights and recent announcements
+• Delivered total company and Lower 48 production of 2,248 thousand barrels of oil equivalent per day (MBOED) and 1,479 MBOED, respectively.
+• Increased shareholder distributions to $3.0 billion, including $2.0 billion through share repurchases and $1.0 billion through the ordinary dividend.
+• Signed agreements to sell noncore Lower 48 assets for $1.7 billion, which closed in July, achieving $5 billion disposition target ahead of schedule.
+• Signed an agreement to acquire a 42% interest in a joint venture in the Kirkuk area of northern Iraq, accessing long-life, conventional redevelopment opportunities at an attractive entry cost and competitive cost of supply; closing expected by year-end 2026.
+• Executed an agreement for re-entry into Syria, leveraging existing infrastructure to restore and increase production at onshore fields.
+• Advanced commercial LNG strategy with additional 2 million tonnes per annum (MTPA) of offtake agreements, bringing total LNG offtake to 12 MTPA.
+• Ended the quarter with cash and short-term investments of $8.1 billion and long-term investments of $1.2 billion.
+
+Quarterly dividend
+ConocoPhillips declared a third-quarter ordinary dividend of $0.84 per share, payable Sept. 1, 2026, to stockholders of record at the close of business on Aug. 17, 2026.
+
+Second-quarter review
+
+
+
+
+ConocoPhillips announces second-quarter 2026 results and quarterly dividend
+
+
+
+
+
+
+
+
+
+
+
+Production for the second quarter of 2026 was 2,248 MBOED, a decrease of 143 MBOED from the same period a year ago. After adjusting for closed acquisitions and dispositions, second-quarter 2026 production decreased 98 MBOED or 4% from the same period a year ago. Organic growth from Lower 48 was more than offset by the impact of the Middle East conflict on Qatar and higher Surmont royalties.
+Lower 48 delivered production of 1,479 MBOED, including 720 MBOED from the Delaware Basin, 202 MBOED from the Midland Basin, 363 MBOED from the Eagle Ford and 189 MBOED from the Bakken.
+Earnings and adjusted earnings increased from the second quarter of 2025, primarily due to higher prices. The company’s total average realized price was $62.33 per BOE, 36% higher than the $45.77 per BOE realized in the second quarter of 2025.
+For the quarter, cash provided by operating activities was $7.4 billion. Excluding a change in working capital, ConocoPhillips generated CFO of $7.2 billion. In addition, ConocoPhillips received $0.2 billion of disposition proceeds from the sale of noncore assets. The company funded $3.0 billion of capital expenditures and investments, repurchased $2.0 billion of shares, and paid $1.0 billion in ordinary dividends.
+
+Six-month review
+ConocoPhillips’ six-month 2026 earnings were $6.1 billion, or $5.00 per share, compared with six-month 2025 earnings of $4.8 billion, or $3.79 per share. Six-month 2026 adjusted earnings were $6.3 billion, or $5.13 per share, compared with six-month 2025 adjusted earnings of $4.5 billion, or $3.52 per share.
+Production for the first six months of 2026 was 2,278 MBOED, a decrease of 113 MBOED from the same period a year ago. After adjusting for closed acquisitions and dispositions, production decreased 57 MBOED or 2% from the same period a year ago. Organic growth from Lower 48 was more than offset by the impact of the Middle East conflict on Qatar and higher Surmont royalties.
+The company’s total realized price during this period was $56.37 per BOE, 14% higher than the $49.54 per BOE realized in the first six months of 2025.
+In the first six months of 2026, cash provided by operating activities was $11.7 billion. Excluding a change in working capital, ConocoPhillips generated CFO of $12.6 billion and received disposition proceeds of $0.2 billion. The company funded $6.0 billion of capital expenditures and investments, repurchased $3.0 billion of shares, and paid $2.1 billion in ordinary dividends.
+
+Outlook
+
+
+Third-quarter 2026 production is expected to be 2.29 to 2.32 million barrels of oil equivalent per day.
+
+
+All full-year guidance items remain unchanged.
+
+ConocoPhillips will host a conference call today at 12:00 p.m. Eastern time to discuss this announcement. To listen to the call and view related presentation materials and supplemental information, go to www.conocophillips.com/investor . A recording and transcript of the call will be posted afterward.
+--- # # # ---
+
+
+
+
+ConocoPhillips announces second-quarter 2026 results and quarterly dividend
+
+
+
+About ConocoPhillips
+As a leading global exploration and production company, ConocoPhillips is uniquely equipped to deliver reliable, responsibly produced oil and gas. Our deep, durable and diverse portfolio is built to meet growing global energy demands. Together with our high-performing operations and continuously advancing technology, we are well positioned to deliver strong, consistent financial results, now and for decades to come. Visit us at www.conocophillips.com.
+
+Contacts
+Media Relations
+281-293-1149
+media@conocophillips.com
+Investor Relations
+281-293-5000
+investor.relations@conocophillips.com
+
+CAUTIONARY STATEMENT FOR THE PURPOSES OF THE "SAFE HARBOR" PROVISIONS OF THE PRIVATE SECURITIES LITIGATION REFORM ACT OF 1995
+This news release contains forward-looking statements as defined under the federal securities laws. Forward-looking statements relate to future events, including, without limitation, statements regarding our future financial position, business strategy, budgets, projected revenues, costs and plans, and objectives of management for future operations. Words and phrases such as “ambition,” “anticipate,” “believe,” “budget,” “continue,” “could,” “effort,” “estimate,” “expect,” “forecast,” “goal,” “guidance,” “intend,” “may,” “objective,” “outlook,” “plan,” “potential,” “predict,” “projection,” “seek,” “should,” “target,” “will,” “would,” and other similar words can be used to identify forward-looking statements. However, the absence of these words does not mean that the statements are not forward-looking. Where, in any forward-looking statement, the company expresses an expectation or belief as to future results, such expectation or belief is expressed in good faith and believed to be reasonable at the time such forward-looking statement is made. However, these statements are not guarantees of future performance and involve certain risks, uncertainties and other factors beyond our control. Therefore, actual outcomes and results may differ materially from what is expressed or forecast in the forward-looking statements. Factors that could cause actual results or events to differ materially from what is presented include, but are not limited to, the following: effects of volatile commodity prices, including prolonged periods of low commodity prices, which may adversely impact our operating results and our ability to execute on our strategy and could result in recognition of impairment charges on our long-lived assets, leaseholds and nonconsolidated equity investments; global and regional changes in the demand, supply, prices, differentials or other market conditions affecting oil and gas, including changes as a result of any ongoing military conflict and the global response to such conflict, security threats on facilities and infrastructure, global health crises, the imposition or lifting of crude oil production quotas or other actions that might be imposed by OPEC and other producing countries or the resulting company or third-party actions in response to such changes; the potential for insufficient liquidity or other factors that could impact our ability to repurchase shares and declare and pay dividends; potential failures or delays in achieving expected reserve or production levels from existing and future oil and gas developments, including due to operating hazards, drilling risks and the inherent uncertainties in predicting reserves and reservoir performance; reductions in our reserve replacement rates, whether as a result of significant declines in commodity prices or otherwise; unsuccessful exploratory drilling activities or the inability to obtain access to exploratory acreage; failure to progress or complete announced and future development plans related to constructing, modifying or operating E&P and LNG facilities, or unexpected changes in costs, inflationary pressures or technical equipment related to such plans; significant operational or investment changes imposed by legislative and regulatory initiatives and international agreements addressing environmental concerns, including initiatives addressing the impact of global climate change, such as limiting or reducing GHG emissions, regulations concerning hydraulic fracturing, methane emissions, flaring or water disposal and prohibitions on commodity exports; substantial investment in and increased adoption of competing or alternative energy sources; risks, uncertainties and high costs that may prevent us from successfully executing on our Climate-related Risk Strategy; lack or inadequacy of, or disruptions in reliable transportation for our crude oil, bitumen, natural gas, LNG and NGLs; inability to timely obtain or maintain permits, including those necessary for construction, drilling and/or development, or inability to make capital expenditures required to maintain compliance with any necessary permits or applicable laws or regulations; potential disruption or interruption of our operations and any resulting consequences due to accidents, extraordinary weather events, supply chain disruptions, civil unrest, political events, war, terrorism, cybersecurity threats or information technology failures, constraints or disruptions; liability for remedial actions, including removal and reclamation obligations, under existing or future environmental regulations and litigation; liability resulting from pending or future litigation or our failure to comply with applicable laws and regulations; general domestic and international economic, political and diplomatic developments, including deterioration of international trade relationships, the imposition of trade restrictions or tariffs relating to commodities and material or products (such as aluminum and steel) used in the operation of our business, expropriation of assets, changes in governmental policies relating to commodity pricing, including the imposition of price caps, sanctions or other adverse regulations or taxation policies; competition and consolidation in the oil and gas E&P industry, including competition for sources of supply, services, personnel and equipment; any limitations on our access to capital or increase in our cost of capital or insurance, including as a result of illiquidity, changes or uncertainty in domestic or international financial markets, foreign currency exchange rate fluctuations or investment sentiment;
+
+
+
+
+ConocoPhillips announces second-quarter 2026 results and quarterly dividend
+
+
+
+challenges or delays to our execution of, or successful implementation of any asset dispositions or acquisitions we elect to pursue; potential disruption of our operations, including the diversion of management time and attention; our inability to realize anticipated cost savings or capital expenditure reductions; difficulties integrating acquired businesses and technologies; or other unanticipated changes; our inability to deploy the net proceeds from any asset dispositions that are pending or that we elect to undertake in the future in the manner and timeframe we anticipate, if at all; the operation, financing and management of risks of our joint ventures; the ability of our customers and other contractual counterparties to satisfy their obligations to us, including our ability to collect payments when due from the government of Venezuela or PDVSA; uncertainty as to the long-term value of our common stock; and other economic, business, competitive and/or regulatory factors affecting our business generally as set forth in our filings with the Securities and Exchange Commission. Unless legally required, ConocoPhillips expressly disclaims any obligation to update any forward-looking statements, whether as a result of new information, future events or otherwise.
+Cautionary Note to U.S. Investors – The SEC permits oil and gas companies, in their filings with the SEC, to disclose only proved, probable and possible reserves. We may use the term “resource” in this news release that the SEC’s guidelines prohibit us from including in filings with the SEC. U.S. investors are urged to consider closely the oil and gas disclosures in our Form 10-K and other reports and filings with the SEC. Copies are available from the SEC and from the ConocoPhillips website.
+Use of Non-GAAP Financial Information – To supplement the presentation of the company’s financial results prepared in accordance with U.S. generally accepted accounting principles (GAAP), this news release and the accompanying supplemental financial information contain certain financial measures that are not prepared in accordance with GAAP, including adjusted earnings (calculated on a consolidated and on a segment-level basis), adjusted earnings per share (EPS), free cash flow (FCF) and cash from operations (CFO).
+The company believes that the non-GAAP measure adjusted earnings (both on an aggregate and a per-share basis) is useful to investors to help facilitate comparisons of the company’s operating performance associated with the company’s core business operations across periods on a consistent basis and with the performance and cost structures of peer companies by excluding items that do not directly relate to the company’s core business operations. Adjusted earnings is defined as earnings removing the impact of special items. Adjusted EPS is a measure of the company’s diluted net earnings per share excluding special items. The company further believes that the non-GAAP measure CFO is useful to investors to help understand changes in cash provided by operating activities excluding the timing effects associated with operating working capital changes across periods on a consistent basis and for comparison with the performance of peer companies. The company believes that the above-mentioned non-GAAP measures, when viewed in combination with the company’s results prepared in accordance with GAAP, provide a more complete understanding of the factors and trends affecting the company’s business and performance. The company’s Board of Directors and management also use these non-GAAP measures to analyze the company’s operating performance across periods when overseeing and managing the company’s business.
+Each of the non-GAAP measures included in this news release and the accompanying supplemental financial information has limitations as an analytical tool and should not be considered in isolation or as a substitute for an analysis of the company’s results calculated in accordance with GAAP. In addition, because not all companies use identical calculations, the company’s presentation of non-GAAP measures in this news release and the accompanying supplemental financial information may not be comparable to similarly titled measures disclosed by other companies, including companies in our industry. The company may also change the calculation of any of the non-GAAP measures included in this news release and the accompanying supplemental financial information from time to time in light of its then existing operations to include other adjustments that may impact its operations.
+Reconciliations of each non-GAAP measure presented in this news release to the most directly comparable financial measure calculated in accordance with GAAP are included in the release.
+Other Terms – This news release also may contain the term pro forma underlying production. Pro forma underlying production reflects the impact of closed acquisitions and closed dispositions as of June 30, 2026. The impact of closed acquisitions and dispositions assumes a closing date of Jan. 1, 2025. The company believes that underlying production is useful to investors to compare production reflecting the impact of closed acquisitions and dispositions on a consistent go-forward basis across periods and with peer companies. Return of capital is defined as the total of the ordinary dividend and share repurchases. References in the release to project capital exclude capitalized interest and references to earnings refer to net income.
+
+
+
+
+
+ConocoPhillips announces second-quarter 2026 results and quarterly dividend
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+ConocoPhillips | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Table 1: Reconciliation of earnings to adjusted earnings | | | | | | | | | |
+$ millions, except as indicated | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| 2Q26 | | 2Q25 | | 2026 YTD | | 2025 YTD | | | | | | | | | |
+| Pre-tax | Income
+tax | After-tax | Per share of common stock (dollars) | | Pre-tax | Income
+tax | After-tax | Per share of common stock (dollars) | | Pre-tax | Income
+tax | After-tax | Per share of common stock (dollars) | | Pre-tax | Income
+tax | After-tax | Per share of common stock (dollars) | | | | | | | | | |
+Earnings | | | $ | 3,931 | | 3.23 | | | | | 1,971 | | 1.56 | | | | | 6,114 | | 5.00 | | | | | 4,820 | | 3.79 | | | | | | | | | | |
+Adjustments: | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+(Gain) loss on asset sales | — | | — | | — | | — | | | (274) | | 64 | | (210) | | (0.17) | | | | | — | | — | | | (338) | | 23 | | (315) | | (0.25) | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Transaction, integration and restructuring expenses | 32 | | (7) | | 25 | | 0.02 | | | 58 | | (12) | | 46 | | 0.04 | | | 47 | | (10) | | 37 | | 0.03 | | | 111 | | (24) | | 87 | | 0.07 | | | | | | | | | | |
+(Gain) loss in interest rate hedge¹ | (37) | | 9 | | (28) | | (0.02) | | | (18) | | 4 | | (14) | | (0.01) | | | (28) | | 7 | | (21) | | (0.02) | | | (33) | | 7 | | (26) | | (0.02) | | | | | | | | | | |
+Pending claims and settlements | 30 | | (7) | | 23 | | 0.02 | | | — | | — | | — | | — | | | 113 | | (27) | | 86 | | 0.07 | | | (123) | | 29 | | (94) | | (0.07) | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+(Gain) loss on contingent liability measurement 2
+| — | | — | | — | | — | | | — | | — | | — | | — | | | 78 | | (19) | | 59 | | 0.05 | | | — | | — | | — | | — | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Adjusted earnings / (loss) | | | $ | 3,951 | | 3.24 | | | | | 1,793 | | 1.42 | | | | | 6,275 | | 5.13 | | | | | 4,472 | | 3.52 | | | | | | | | | | |
+¹Interest rate hedging (gain) loss from PALNG Phase 1 Investment. | | | | | | | | | |
+2 Related to our Surmont acquisition.
+| | | | | | | | | |
+The income tax effects of the special items are primarily calculated based on the statutory rate of the jurisdiction in which the discrete item resides. | | | | | | | | | |
+Certain totals may differ from the sum of the underlying components due to rounding. | | | | | | | | | |
+
+
+
+
+| | | | | | | | | | | |
+ConocoPhillips | | |
+Table 2: Reconciliation of net cash provided by operating activities to cash from operations | | |
+$ millions, except as indicated | | | |
+| | | |
+| 2Q26 | | 2026 YTD |
+Net Cash Provided by Operating Activities | $ | 7,434 | | | 11,729 |
+| | | |
+Adjustments: | | | |
+Net operating working capital changes | 258 | | | (834) |
+Cash from operations | $ | 7,176 | | | 12,563 |
+| | | |
+| | | |
+| | | |
+| | | |
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | |
+ConocoPhillips | | | | | | | | |
+Table 3: Reconciliation of reported production to pro forma underlying production | | | | | |
+MBOED, except as indicated | | | | | | | | |
+| | | | | | | | |
+| 2Q26 | | 2Q25 | | 2026 YTD | | 2025 YTD | |
+Total reported ConocoPhillips production | 2,248 | | | 2,391 | | | 2,278 | | | 2,391 | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Closed Dispositions 1
+| — | | | (45) | | | — | | | (56) | | |
+Closed Acquisitions
+| — | | | — | | | — | | | — | | |
+Total pro forma underlying production | 2,248 | | | 2,346 | | | 2,278 | | | 2,335 | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | |
+1 Includes production related to various Lower 48 noncore dispositions.
+| | | | | |
+Certain totals may differ from the sum of the underlying components due to rounding. | | | | | |
+| | | | | |
+|
+|
+|
+| | | | | | | | |

--- a/modules/test-fixtures/earnings-filings/ddog.txt
+++ b/modules/test-fixtures/earnings-filings/ddog.txt
@@ -1,0 +1,1735 @@
+EX-99.1
+2
+ex-991x20260630x8k.htm
+EX-99.1
+
+
+
+
+Document
+
+
+Exhibit 99.1
+
+
+
+Datadog Announces Second Quarter 2026 Financial Results
+
+
+August 6, 2026
+
+
+Second quarter revenue grew 36% year-over-year to $1.12 billion
+Robust growth of larger customers, with about 4,720 $100k+ ARR customers, up from about 3,850 a year ago
+Launched AI-powered Bits Code, Bits Chat, and Bits Agent Builder for general availability
+
+
+NEW YORK-- Datadog, Inc. (NASDAQ:DDOG), the leading AI-powered observability and security platform, today announced financial results for its second quarter ended June 30, 2026.
+"Datadog delivered a strong quarter, with 36% year-over-year revenue growth, $316 million in operating cash flow, and $279 million in free cash flow," said Olivier Pomel, co-founder and CEO of Datadog. "Our customers are building and deploying with AI, and they are using the Datadog platform to observe, secure, and act on their AI-enabled solutions."
+Pomel added, "We are innovating rapidly to help our customers manage rising complexity, and increasingly build autonomy into their operations."
+Second Quarter 2026 Financial Highlights:
+• Revenue was $1.12 billion, an increase of 36% year-over-year.
+• GAAP operating income was $5 million; GAAP operating margin was 0%.
+• Non-GAAP operating income was $257 million; non-GAAP operating margin was 23%.
+• GAAP net income per diluted share was $0.12; non-GAAP net income per diluted share was $0.65.
+• Operating cash flow was $316 million, with free cash flow of $279 million.
+• Cash, cash equivalents, and marketable securities were $5.0 billion as of June 30, 2026.
+Second Quarter & Recent Business Highlights:
+• As of June 30, 2026, we had about 4,720 customers with ARR of $100,000 or more, an increase of 23% from about 3,850 as of June 30, 2025.
+• Named a Leader in the Gartner Magic Quadrant for Observability Platforms, 2026. This is the sixth consecutive year Gartner has positioned Datadog as a Leader in the Magic Quadrant.
+
+
+
+
+
+
+
+
+
+• Acquired Adaptive ML, a frontier AI startup developing the world’s first Reinforcement Learning Operations platform, to accelerate Datadog AI Research’s investment in world models and agentic LLM post-training for observability—combining Datadog’s access to real-world infrastructure and security data with Adaptive ML’s expertise in building specialized, high-performance AI agents.
+• Launched more than 100 new capabilities at DASH 2026 to help customers drive autonomy and manage growing AI and security complexity. Highlights included fully autonomous Bits AI for end-to-end incident detection, investigation, and remediation; AI Guard to protect AI agents from prompt injection and poisoning attacks; Bring Your Own Cloud for deploying Datadog within customer environments; and Bits Agent Builder for creating custom AI agents.
+Third Quarter and Full Year 2026 Outlook:
+Based on information as of today, August 6, 2026, Datadog is providing the following guidance:
+• Third Quarter 2026 Outlook:
+◦ Revenue between $1.135 billion and $1.145 billion.
+◦ Non-GAAP operating income between $260 million and $270 million.
+◦ Non-GAAP net income per share between $0.63 and $0.65, assuming approximately 378 million weighted average diluted shares outstanding.
+• Full Year 2026 Outlook:
+◦ Revenue between $4.45 billion and $4.47 billion.
+◦ Non-GAAP operating income between $1.01 billion and $1.03 billion.
+◦ Non-GAAP net income per share between $2.50 and $2.54, assuming approximately 376 million weighted average diluted shares outstanding.
+Datadog has not reconciled its expectations as to non-GAAP operating income, or as to non-GAAP net income per share, to their most directly comparable GAAP measure as a result of uncertainty regarding, and the potential variability of, reconciling items such as stock-based compensation and employer payroll taxes on equity incentive plans. Accordingly, reconciliation is not available without unreasonable effort, although it is important to note that these factors could be material to Datadog’s results computed in accordance with GAAP.
+Co nference Call Details:
+• W hat: Datadog financial results for the second quarter of 2026 and outlook for the third quarter and the full year 2026
+• When: August 6, 2026 a t 8:00 A.M. Eastern Time (5:00 A.M. Pacific Time)
+
+
+
+
+
+
+
+
+
+• Dial in: To access the call in the U.S., please register here . Callers are encouraged to dial into the call 10 to 15 minutes prior to the start to prevent any delay in joining.
+• Webcast: https://investors.datadoghq.com (live and replay)
+• Replay: A replay of the call will be archived on the investor relations website
+About Datadog
+Datadog is the leading observability and security platform for the AI era, providing businesses with unified visibility across the technology stack to manage complexity at scale. It brings applications, infrastructure, data, models, and security into one place, using AI to detect and resolve issues before they impact customers. Trusted globally by Fortune 500 companies and high-growth AI leaders, Datadog enables businesses to move faster with clarity and confidence.
+Forward-Looking Statements
+This press release and the earnings call referencing this press release contain “forward-looking” statements, as that term is defined under the federal securities laws, including but not limited to statements regarding Datadog’s strategy, product and platform capabilities, the growth in and ability to capitalize on long-term market opportunities including the pace and scope of cloud migration, digital transformation and AI deployment, gross margins, operating margins including with respect to sales and marketing, research and development expenses, net interest and other income, cash taxes, capital expenditures and capitalized software, and Datadog’s future financial performance, including its outlook for the third quarter and the full year 2026 third quarter and the full year 2026 and related notes and assumptions. These forward-looking statements are based on Datadog’s current assumptions, expectations and beliefs and are subject to substantial risks, uncertainties, assumptions and changes in circumstances that may cause Datadog’s actual results, performance or achievements to differ materially from those expressed or implied in any forward-looking statement.
+The risks and uncertainties referred to above include, but are not limited to (1) our recent rapid growth may not be indicative of our future growth; (2) our history of operating losses; (3) our limited operating history; (4) our dependence on existing customers purchasing additional subscriptions and products from us and renewing their subscriptions; (5) our ability to attract new customers; (6) our ability to effectively develop and expand our sales and marketing capabilities; (7) risk of a security breach; (8) risk of interruptions or performance problems associated with our products and platform capabilities; (9) our ability to adapt and respond to rapidly changing technology or customer needs; (10) the competitive markets in which we participate; (11) risks associated with successfully managing our growth; (12) risks associated with changing laws, regulations, and contractual obligations related to data privacy and security and (13) general market, political, economic, and business conditions including concerns about trade policies, tariffs, reduced economic growth and associated decreases in information technology spending. These risks and uncertainties are more fully described in our filings with
+
+
+
+
+
+
+
+
+
+the Securities and Exchange Commission (SEC), including in the section entitled “Risk Factors” in our Annual Report on Form 10-K for the year ended December 31, 2025, filed with the SEC on February 18, 2026. Additional information will be made available in our Quarterly Report on Form 10-Q for the quarter ended June 30, 2026 and other filings and reports that we may file from time to time with the SEC. Moreover, we operate in a very competitive and rapidly changing environment. New risks emerge from time to time. It is not possible for our management to predict all risks, nor can we assess the impact of all factors on our business or the extent to which any factor, or combination of factors, may cause actual results to differ materially from those contained in any forward-looking statements we may make. In light of these risks, uncertainties and assumptions, we cannot guarantee future results, levels of activity, performance, achievements, or events and circumstances reflected in the forward-looking statements will occur. Forward-looking statements represent our beliefs and assumptions only as of the date of this press release. We disclaim any obligation to update forward-looking statements.
+About Non-GAAP Financial Measures
+Datadog discloses the following non-GAAP financial measures in this release and the earnings call referencing this press release: non-GAAP gross profit, non-GAAP gross margin, non-GAAP operating expenses (research and development, sales and marketing and general and administrative), non-GAAP operating income (loss), non-GAAP operating margin, non-GAAP net income (loss), non-GAAP net income (loss) per diluted share, non-GAAP net income (loss) per basic share, free cash flow and free cash flow margin. Datadog uses each of these non-GAAP financial measures internally to understand and compare operating results across accounting periods, for internal budgeting and forecasting purposes, for short- and long-term operating plans, and to evaluate Datadog’s financial performance. Datadog believes they are useful to investors, as a supplement to GAAP measures, in evaluating its operational performance, as further discussed below. Datadog’s non-GAAP financial measures may not provide information that is directly comparable to that provided by other companies in its industry, as other companies in its industry may calculate non-GAAP financial results differently, particularly related to non-recurring and unusual items. In addition, there are limitations in using non-GAAP financial measures because the non-GAAP financial measures are not prepared in accordance with GAAP and may be different from non-GAAP financial measures used by other companies and exclude expenses that may have a material impact on Datadog’s reported financial results.
+Non-GAAP financial measures should not be considered in isolation from, or as a substitute for, financial information prepared in accordance with GAAP. A reconciliation of the historical non-GAAP financial measures to their most directly comparable GAAP measures has been provided in the financial statement tables included below in this press release.
+Datadog defines non-GAAP gross profit, non-GAAP gross margin, non-GAAP operating expenses (research and development, sales and marketing and general and administrative), non-GAAP operating income (loss), non-GAAP operating margin and non-GAAP net income (loss) as the respective GAAP balances, adjusted for,
+
+
+
+
+
+
+
+
+
+as applicable: (1) stock-based compensation expense; (2) the amortization of acquired intangibles; (3) employer payroll taxes on employee stock transactions; (4) M&A transaction costs; (5) amortization of issuance costs; and (6) an assumed provision for income taxes based on our long-term projected tax rate. Non-GAAP financial measures prior to April 1, 2025 have not been adjusted for M&A transaction costs, as such costs were not material to our results of operations in such prior periods. Our estimated long-term projected tax rate is subject to change for a variety of reasons, including the rapidly evolving global tax environment, significant changes in Datadog's geographic earnings mix, or other changes to our strategy or business operations. We will re-evaluate our long-term projected tax rate as appropriate. Datadog defines free cash flow as net cash provided by operating activities, minus capital expenditures and minus capitalized software development costs, if any. Investors are encouraged to review the reconciliation of these historical non-GAAP financial measures to their most directly comparable GAAP financial measures.
+Management believes these non-GAAP financial measures are useful to investors and others in assessing Datadog’s operating performance due to the following factors:
+Stock-based compensation. Datadog utilizes stock-based compensation to attract and retain employees. It is principally aimed at aligning their interests with those of its stockholders and at long-term retention, rather than to address operational performance for any particular period. As a result, stock-based compensation expenses vary for reasons that are generally unrelated to financial and operational performance in any particular period.
+Amortization of acquired intangibles. Datadog views amortization of acquired intangible assets as items arising from pre-acquisition activities determined at the time of an acquisition. While these intangible assets are evaluated for impairment regularly, amortization of the cost of acquired intangibles is an expense that is not typically affected by operations during any particular period.
+Employer payroll taxes on employee stock transactions. Datadog excludes employer payroll tax expense on equity incentive plans as these expenses are tied to the exercise or vesting of underlying equity awards and the price of Datadog’s common stock at the time of vesting or exercise. As a result, these taxes may vary in any particular period independent of the financial and operating performance of Datadog’s business.
+M&A transaction costs . Datadog views acquisition-related expenses, such as transaction costs, as costs that are not necessarily reflective of operational performance during a period. In particular, Datadog believes the consideration of measures that exclude such expenses can assist in the comparison of operational performance in different periods which may or may not include such expenses.
+Amortization of issuance costs. In June 2020 and December 2024, Datadog issued $747.5 million of 0.125% convertible senior notes due 2025 and $1.0 billion of 0% convertible senior notes due 2029, respectively. Debt issuance costs, which reduce the carrying value of the convertible debt instrument, are amortized as interest expense over the term. The expense for the amortization of debt issuance costs is a non-cash item, and we believe the exclusion of this interest expense will provide for a more useful comparison of our operational performance in different periods.
+
+
+
+
+
+
+
+
+
+Additionally, Datadog’s management believes that the non-GAAP financial measure free cash flow is meaningful to investors because it is a measure of liquidity that provides useful information in understanding and evaluating the strength of our liquidity and future ability to generate cash that can be used for strategic opportunities or investing in our business. Free cash flow represents net cash provided by operating activities, reduced by capital expenditures and capitalized software development costs, if any. The reduction of capital expenditures and amounts capitalized for software development facilitates comparisons of Datadog's liquidity on a period-to-period basis and excludes items that management does not consider to be indicative of our liquidity.
+Operating Metrics
+Datadog’s number of customers with ARR of $100,000 or more is based on the ARR of each customer, as of the last month of the quarter.
+We define the number of customers as the number of accounts with a unique account identifier for which we have an active subscription in the period indicated. Users of our free trials or tier are not included in our customer count. A single organization with multiple divisions, segments or subsidiaries is generally counted as a single customer. However, in some cases where they have separate billing terms, we may count separate divisions, segments or subsidiaries as multiple customers.
+We define ARR as the annualized revenue run-rate of subscription agreements from all customers at a point in time. We calculate ARR by taking the monthly recurring revenue, or MRR, and multiplying it by 12. MRR for each month is calculated by aggregating, for all customers during that month, monthly revenue from committed contractual amounts, additional usage, usage from subscriptions for a committed contractual amount of usage that is delivered as used, and monthly subscriptions. ARR and MRR should be viewed independently of revenue, and do not represent our revenue under GAAP on a monthly or annualized basis, as they are operating metrics that can be impacted by contract start and end dates and renewal rates. ARR and MRR are not intended to be replacements or forecasts of revenue.
+
+
+
+
+
+
+
+
+
+
+
+
+Datadog, Inc.
+Condensed Consolidated Statements of Operations
+(In thousands, except per share data; unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30,
+| | Six Months Ended
+June 30,
+|
+| | 2026
+| | 2025
+| | 2026
+| | 2025
+|
+Revenue
+| | $
+| 1,121,454
+|
+| | $
+| 826,760
+|
+| | $
+| 2,127,880
+|
+| | $
+| 1,588,313
+|
+|
+Cost of revenue (1)(2)(3)
+| | 240,113
+|
+| | 165,978
+|
+| | 449,341
+|
+| | 323,606
+|
+|
+Gross profit
+| | 881,341
+|
+| | 660,782
+|
+| | 1,678,539
+|
+| | 1,264,707
+|
+|
+Operating expenses:
+| | | | | | | | |
+Research and development (1)(3)
+| | 477,968
+|
+| | 387,482
+|
+| | 913,266
+|
+| | 728,543
+|
+|
+Sales and marketing (1)(2)(3)
+| | 311,519
+|
+| | 239,026
+|
+| | 591,342
+|
+| | 453,317
+|
+|
+General and administrative (1)(3)(4)
+| | 86,399
+|
+| | 69,774
+|
+| | 161,149
+|
+| | 130,767
+|
+|
+Total operating expenses
+| | 875,886
+|
+| | 696,282
+|
+| | 1,665,757
+|
+| | 1,312,627
+|
+|
+Operating income (loss)
+| | 5,455
+|
+| | (35,500)
+|
+| | 12,782
+|
+| | (47,920)
+|
+|
+Other income:
+| | | | | | | | |
+Interest expense (5)
+| | (3,255)
+|
+| | (3,075)
+|
+| | (6,374)
+|
+| | (6,038)
+|
+|
+Interest income and other income, net
+| | 49,533
+|
+| | 44,663
+|
+| | 104,255
+|
+| | 91,842
+|
+|
+Other income, net
+| | 46,278
+|
+| | 41,588
+|
+| | 97,881
+|
+| | 85,804
+|
+|
+Income before provision for income taxes
+| | 51,733
+|
+| | 6,088
+|
+| | 110,663
+|
+| | 37,884
+|
+|
+Provision for income taxes
+| | 7,175
+|
+| | 3,441
+|
+| | 13,531
+|
+| | 10,595
+|
+|
+Net income
+| | $
+| 44,558
+|
+| | $
+| 2,647
+|
+| | $
+| 97,132
+|
+| | $
+| 27,289
+|
+|
+Net income per share - basic
+| | $
+| 0.13
+|
+| | $
+| 0.01
+|
+| | $
+| 0.27
+|
+| | $
+| 0.08
+|
+|
+| | | | | | | | |
+Net income per share - diluted
+| | $
+| 0.12
+|
+| | $
+| 0.01
+|
+| | $
+| 0.27
+|
+| | $
+| 0.08
+|
+|
+Weighted average shares used in calculating net income per share:
+| | | | | | | | |
+Basic
+| | 356,253
+|
+| | 346,185
+|
+| | 354,771
+|
+| | 344,650
+|
+|
+Diluted
+| | 371,023
+|
+| | 358,725
+|
+| | 368,271
+|
+| | 361,289
+|
+|
+| | | | | | | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+(1) Includes stock-based compensation expense as follows:
+| | | | | | | | |
+Cost of revenue
+| | $
+| 9,256
+|
+| | $
+| 6,783
+|
+| | $
+| 17,815
+|
+| | $
+| 13,434
+|
+|
+Research and development
+| | 131,682
+|
+| | 112,445
+|
+| | 255,353
+|
+| | 218,180
+|
+|
+Sales and marketing
+| | 47,098
+|
+| | 37,442
+|
+| | 89,396
+|
+| | 71,567
+|
+|
+General and administrative
+| | 32,215
+|
+| | 23,792
+|
+| | 54,529
+|
+| | 41,546
+|
+|
+Total
+| | $
+| 220,251
+|
+| | $
+| 180,462
+|
+| | $
+| 417,093
+|
+| | $
+| 344,727
+|
+|
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+(2) Includes amortization of acquired intangibles as follows:
+| | | | | | | | | | | | |
+Cost of revenue
+| | $
+| 1,310
+|
+| | $
+| 1,518
+|
+| | $
+| 2,592
+|
+| | $
+| 2,412
+|
+| | | | |
+Sales and marketing
+| | 362
+|
+| | 188
+|
+| | 719
+| | 391
+| | | | |
+Total
+| | $
+| 1,672
+|
+| | $
+| 1,706
+|
+| | $
+| 3,311
+|
+| | $
+| 2,803
+|
+| | | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+(3) Includes employer payroll taxes on employee stock transactions as follows:
+|
+Cost of revenue
+| | $
+| 392
+|
+| | $
+| 165
+|
+| | $
+| 580
+|
+| | $
+| 351
+|
+|
+Research and development
+| | 21,211
+|
+| | 11,819
+|
+| | 32,487
+|
+| | 21,401
+|
+|
+Sales and marketing
+| | 3,632
+|
+| | 1,359
+|
+| | 5,527
+|
+| | 2,929
+|
+|
+General and administrative
+| | 2,408
+|
+| | 2,724
+|
+| | 6,045
+|
+| | 4,949
+|
+|
+Total
+| | $
+| 27,643
+|
+| | $
+| 16,067
+|
+| | $
+| 44,639
+|
+| | $
+| 29,630
+|
+|
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+(4) Includes M&A transaction costs as follows:
+| | | | | | | | |
+General and administrative
+| | $
+| 2,010
+|
+| | $
+| 1,373
+|
+| | $
+| 2,704
+|
+| | $
+| 1,373
+|
+|
+Total
+| | $
+| 2,010
+|
+| | $
+| 1,373
+|
+| | $
+| 2,704
+|
+| | $
+| 1,373
+|
+|
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+(5) Includes amortization of issuance costs as follows:
+| | | | | | | | |
+Interest expense
+| | $
+| 1,049
+|
+| | $
+| 1,691
+|
+| | $
+| 2,096
+|
+| | $
+| 3,510
+|
+|
+Total
+| | $
+| 1,049
+|
+| | $
+| 1,691
+|
+| | $
+| 2,096
+|
+| | $
+| 3,510
+|
+|
+
+
+
+
+
+
+
+
+
+
+
+Datadog, Inc.
+Condensed Consolidated Balance Sheets
+(In thousands; unaudited)
+| | | | | | | | | | | | | | |
+| | June 30,
+2026
+| | December 31,
+2025
+|
+ASSETS
+| | | | |
+CURRENT ASSETS:
+| | | | |
+Cash and cash equivalents
+| | $
+| 434,957
+|
+| | $
+| 401,305
+|
+|
+Marketable securities
+| | 4,550,481
+|
+| | 4,073,531
+|
+|
+Accounts receivable, net of allowance for credit losses of $24,021 and $19,292 as of June 30, 2026 and December 31, 2025, respectively
+| | 827,345
+|
+| | 741,262
+|
+|
+Deferred contract costs, current
+| | 87,350
+|
+| | 76,022
+|
+|
+Prepaid expenses and other current assets
+| | 108,424
+|
+| | 90,160
+|
+|
+Total current assets
+| | 6,008,557
+|
+| | 5,382,280
+|
+|
+Property and equipment, net
+| | 409,634
+|
+| | 338,093
+|
+|
+Operating lease assets
+| | 206,037
+|
+| | 214,674
+|
+|
+Goodwill
+| | 706,721
+|
+| | 530,568
+|
+|
+Intangible assets, net
+| | 23,157
+|
+| | 14,968
+|
+|
+Deferred contract costs, non-current
+| | 145,028
+|
+| | 126,708
+|
+|
+| | | | |
+Other assets
+| | 48,541
+|
+| | 36,553
+|
+|
+TOTAL ASSETS
+| | $
+| 7,547,675
+|
+| | $
+| 6,643,844
+|
+|
+LIABILITIES AND STOCKHOLDERS' EQUITY
+| | | | |
+CURRENT LIABILITIES:
+| | | | |
+Accounts payable
+| | $
+| 313,529
+|
+| | $
+| 148,791
+|
+|
+Accrued expenses and other current liabilities
+| | 230,548
+|
+| | 209,595
+|
+|
+Operating lease liabilities, current
+| | 44,218
+|
+| | 39,369
+|
+|
+| | | | |
+Deferred revenue, current
+| | 1,286,690
+|
+| | 1,193,646
+|
+|
+Total current liabilities
+| | 1,874,985
+|
+| | 1,591,401
+|
+|
+Operating lease liabilities, non-current
+| | 248,038
+|
+| | 256,187
+|
+|
+Convertible senior notes, net, non-current
+| | 985,545
+|
+| | 983,449
+|
+|
+Deferred revenue, non-current
+| | 50,860
+|
+| | 68,711
+|
+|
+Other liabilities
+| | 21,087
+|
+| | 11,890
+|
+|
+Total liabilities
+| | 3,180,515
+|
+| | 2,911,638
+|
+|
+STOCKHOLDERS' EQUITY:
+| | | | |
+Common stock
+| | 3
+|
+| | 3
+|
+|
+Additional paid-in capital
+| | 4,139,000
+|
+| | 3,579,010
+|
+|
+Accumulated other comprehensive (loss) income
+| | (6,764)
+|
+| | 15,404
+|
+|
+Retained earnings
+| | 234,921
+|
+| | 137,789
+|
+|
+Total stockholders’ equity
+| | 4,367,160
+|
+| | 3,732,206
+|
+|
+TOTAL LIABILITIES AND STOCKHOLDERS' EQUITY
+| | $
+| 7,547,675
+|
+| | $
+| 6,643,844
+|
+|
+| | | | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Datadog, Inc.
+Condensed Consolidated Statements of Cash Flow
+(In thousands; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30,
+| | Six Months Ended
+June 30,
+|
+| | 2026
+| | 2025
+| | 2026
+| | 2025
+|
+CASH FLOWS FROM OPERATING ACTIVITIES:
+| | | | | | | | |
+Net income
+| | $
+| 44,558
+|
+| | $
+| 2,647
+|
+| | $
+| 97,132
+|
+| | $
+| 27,289
+|
+|
+Adjustments to reconcile net income to net cash provided by operating activities:
+| | | | | | | | |
+Depreciation and amortization
+| | 19,489
+|
+| | 12,822
+|
+| | 37,412
+|
+| | 24,077
+|
+|
+Accretion of discounts on marketable securities
+| | (12,480)
+|
+| | (10,927)
+|
+| | (24,360)
+|
+| | (21,297)
+|
+|
+Amortization of issuance costs
+| | 1,049
+|
+| | 1,691
+|
+| | 2,096
+|
+| | 3,510
+|
+|
+Amortization of deferred contract costs
+| | 22,077
+|
+| | 15,977
+|
+| | 42,402
+|
+| | 30,830
+|
+|
+Stock-based compensation, net of amounts capitalized
+| | 220,251
+|
+| | 180,462
+|
+| | 417,093
+|
+| | 344,727
+|
+|
+Non-cash lease expense
+| | 9,517
+|
+| | 9,001
+|
+| | 18,590
+|
+| | 17,390
+|
+|
+Allowance for credit losses on accounts receivable
+| | 5,641
+|
+| | 3,895
+|
+| | 10,594
+|
+| | 8,415
+|
+|
+Loss on disposal of property and equipment
+| | 534
+|
+| | 977
+|
+| | 1,668
+|
+| | 832
+|
+|
+Changes in operating assets and liabilities:
+| | | | | | | | |
+Accounts receivable, net
+| | (151,649)
+|
+| | (115,899)
+|
+| | (95,775)
+|
+| | (11,672)
+|
+|
+Deferred contract costs
+| | (36,505)
+|
+| | (24,301)
+|
+| | (72,050)
+|
+| | (45,820)
+|
+|
+Prepaid expenses and other current assets
+| | (730)
+|
+| | 11,343
+|
+| | (15,175)
+|
+| | 1,080
+|
+|
+Other assets
+| | (1,955)
+|
+| | (1,821)
+|
+| | (2,477)
+|
+| | (3,038)
+|
+|
+Accounts payable
+| | 133,620
+|
+| | 96,352
+|
+| | 155,120
+|
+| | 85,640
+|
+|
+Accrued expenses and other liabilities
+| | 6,975
+|
+| | (3,250)
+|
+| | 3,098
+|
+| | 2,398
+|
+|
+Deferred revenue
+| | 55,480
+|
+| | 21,086
+|
+| | 75,127
+|
+| | 7,235
+|
+|
+Net cash provided by operating activities
+| | 315,872
+|
+| | 200,055
+|
+| | 650,495
+|
+| | 471,596
+|
+|
+CASH FLOWS FROM INVESTING ACTIVITIES:
+| | | | | | | | |
+Purchases of marketable securities
+| | (1,132,495)
+|
+| | (751,477)
+|
+| | (2,437,460)
+|
+| | (1,721,779)
+|
+|
+Maturities of marketable securities
+| | 598,288
+|
+| | 697,172
+|
+| | 1,644,703
+|
+| | 1,253,110
+|
+|
+Proceeds from sale of marketable securities
+| | 323,146
+|
+| | 13,212
+|
+| | 323,089
+|
+| | 13,136
+|
+|
+Purchases of property and equipment
+| | (9,889)
+|
+| | (15,152)
+|
+| | (21,247)
+|
+| | (23,900)
+|
+|
+Capitalized software development costs
+| | (27,279)
+|
+| | (19,550)
+|
+| | (61,452)
+|
+| | (37,952)
+|
+|
+Cash paid for acquisition of businesses; net of cash acquired
+| | (101,650)
+|
+| | (115,272)
+|
+| | (112,310)
+|
+| | (117,090)
+|
+|
+Net cash used in investing activities
+| | (349,879)
+|
+| | (191,067)
+|
+| | (664,677)
+|
+| | (634,475)
+|
+|
+CASH FLOWS FROM FINANCING ACTIVITIES:
+| | | | | | | | |
+Proceeds from exercise of stock options
+| | 2,754
+|
+| | 1,685
+|
+| | 12,465
+|
+| | 3,358
+|
+|
+Proceeds for issuance of common stock under the employee stock purchase plan
+| | 39,067
+|
+| | 28,578
+|
+| | 39,067
+|
+| | 28,578
+|
+|
+Proceeds from issuance of 2029 Convertible Senior Notes, net of issuance costs
+| | —
+|
+| | (190)
+|
+| | —
+|
+| | (190)
+|
+|
+Repayments of 2025 Convertible Senior Notes
+| | —
+|
+| | (635,527)
+|
+| | —
+|
+| | (635,547)
+|
+|
+Net cash provided by (used in) financing activities
+| | 41,821
+|
+| | (605,454)
+|
+| | 51,532
+|
+| | (603,801)
+|
+|
+| | | | | | | | |
+Effect of exchange rate changes on cash and cash equivalents
+| | 783
+|
+| | 5,642
+|
+| | (3,698)
+|
+| | 8,727
+|
+|
+| | | | | | | | |
+NET INCREASE (DECREASE) IN CASH AND CASH EQUIVALENTS
+| | 8,597
+|
+| | (590,824)
+|
+| | 33,652
+|
+| | (757,953)
+|
+|
+CASH AND CASH EQUIVALENTS—Beginning of period
+| | 426,360
+|
+| | 1,079,854
+|
+| | 401,305
+|
+| | 1,246,983
+|
+|
+CASH AND CASH EQUIVALENTS—End of period
+| | $
+| 434,957
+|
+| | $
+| 489,030
+|
+| | $
+| 434,957
+|
+| | $
+| 489,030
+|
+|
+| | | | | | | | |
+|
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+Datadog, Inc.
+Reconciliation from GAAP to Non-GAAP Results
+(In thousands; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30,
+| | Six Months Ended
+June 30,
+|
+| | 2026
+| | 2025
+| | 2026
+| | 2025
+|
+Reconciliation of gross profit and gross margin
+| | | | | | | | |
+GAAP gross profit
+| | $
+| 881,341
+| | $
+| 660,782
+| | $
+| 1,678,539
+| | $
+| 1,264,707
+|
+Plus: Stock-based compensation expense
+| | 9,256
+| | 6,783
+| | 17,815
+| | 13,434
+|
+Plus: Amortization of acquired intangibles
+| | 1,310
+| | 1,518
+| | 2,592
+| | 2,412
+|
+Plus: Employer payroll taxes on employee stock transactions
+| | 392
+| | 165
+| | 580
+| | 351
+|
+Non-GAAP gross profit
+| | $
+| 892,299
+| | $
+| 669,248
+| | $
+| 1,699,526
+| | $
+| 1,280,904
+|
+GAAP gross margin
+| | 79%
+| | 80%
+| | 79%
+| | 80%
+|
+Non-GAAP gross margin
+| | 80%
+| | 81%
+| | 80%
+| | 81%
+|
+| | | | | | | | |
+Reconciliation of operating expenses
+| | | | | | | | |
+GAAP research and development
+| | $
+| 477,968
+| | $
+| 387,482
+| | $
+| 913,266
+| | $
+| 728,543
+|
+Less: Stock-based compensation expense
+| | (131,682)
+| | (112,445)
+| | (255,353)
+| | (218,180)
+|
+Less: Employer payroll taxes on employee stock transactions
+| | (21,211)
+| | (11,819)
+| | (32,487)
+| | (21,401)
+|
+Non-GAAP research and development
+| | $
+| 325,075
+| | $
+| 263,218
+| | $
+| 625,426
+| | $
+| 488,962
+|
+| | | | | | | | |
+GAAP sales and marketing
+| | $
+| 311,519
+| | $
+| 239,026
+| | $
+| 591,342
+| | $
+| 453,317
+|
+Less: Stock-based compensation expense
+| | (47,098)
+| | (37,442)
+| | (89,396)
+| | (71,567)
+|
+Less: Amortization of acquired intangibles
+| | (362)
+| | (188)
+| | (719)
+| | (391)
+|
+Less: Employer payroll taxes on employee stock transactions
+| | (3,632)
+| | (1,359)
+| | (5,527)
+| | (2,929)
+|
+Non-GAAP sales and marketing
+| | $
+| 260,427
+| | $
+| 200,037
+| | $
+| 495,700
+| | $
+| 378,430
+|
+| | | | | | | | |
+GAAP general and administrative
+| | $
+| 86,399
+| | $
+| 69,774
+| | $
+| 161,149
+| | $
+| 130,767
+|
+Less: Stock-based compensation expense
+| | (32,215)
+| | (23,792)
+| | (54,529)
+| | (41,546)
+|
+Less: Employer payroll taxes on employee stock transactions
+| | (2,408)
+| | (2,724)
+| | (6,045)
+| | (4,949)
+|
+Less: M&A transaction costs
+| | (2,010)
+| | (1,373)
+| | (2,704)
+| | (1,373)
+|
+Non-GAAP general and administrative
+| | $
+| 49,766
+| | $
+| 41,885
+| | $
+| 97,871
+| | $
+| 82,899
+|
+| | | | | | | | |
+Reconciliation of operating (loss) income and operating margin
+| | | | | | | | |
+GAAP operating income (loss)
+| | $
+| 5,455
+| | $
+| (35,500)
+| | $
+| 12,782
+| | $
+| (47,920)
+|
+Plus: Stock-based compensation expense
+| | 220,251
+| | 180,462
+| | 417,093
+| | 344,727
+|
+Plus: Amortization of acquired intangibles
+| | 1,672
+| | 1,706
+| | 3,311
+| | 2,803
+|
+Plus: Employer payroll taxes on employee stock transactions
+| | 27,643
+| | 16,067
+| | 44,639
+| | 29,630
+|
+Plus: M&A transaction costs
+| | 2,010
+| | 1,373
+| | 2,704
+| | 1,373
+|
+Non-GAAP operating income
+| | $
+| 257,031
+| | $
+| 164,108
+| | $
+| 480,529
+| | $
+| 330,613
+|
+GAAP operating margin
+| | 0%
+| | (4)%
+| | 1%
+| | (3)%
+|
+Non-GAAP operating margin
+| | 23%
+| | 20%
+| | 23%
+| | 21%
+|
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+
+
+
+
+
+
+
+
+
+
+
+
+Datadog, Inc.
+Reconciliation from GAAP to Non-GAAP Results
+(In thousands, except per share data; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30,
+| | Six Months Ended
+June 30,
+|
+| | 2026
+| | 2025
+| | 2026
+| | 2025
+|
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Reconciliation of net income
+| | | | | | | | |
+GAAP net income
+| | $
+| 44,558
+| | $
+| 2,647
+| | $
+| 97,132
+| | $
+| 27,289
+|
+Plus: Stock-based compensation expense
+| | 220,251
+| | 180,462
+| | 417,093
+| | 344,727
+|
+Plus: Amortization of acquired intangibles
+| | 1,672
+| | 1,706
+| | 3,311
+| | 2,803
+|
+Plus: Employer payroll taxes on employee stock transactions
+| | 27,643
+| | 16,067
+| | 44,639
+| | 29,630
+|
+Plus: M&A transaction costs
+| | 2,010
+| | 1,373
+| | 2,704
+| | 1,373
+|
+Plus: Amortization of issuance costs
+| | 1,049
+| | 1,691
+| | 2,096
+| | 3,510
+|
+Non-GAAP net income before non-GAAP tax adjustments
+| | $
+| 297,183
+| | $
+| 203,946
+| | $
+| 566,975
+| | $
+| 409,332
+|
+Income tax effects and adjustments (1)
+| | 56,740
+| | 40,110
+| | 108,374
+| | 77,589
+|
+Non-GAAP net income after non-GAAP tax adjustments
+| | $
+| 240,443
+| | $
+| 163,836
+| | $
+| 458,601
+| | $
+| 331,743
+|
+Net income per share before non-GAAP tax adjustments - basic
+| | $
+| 0.83
+| | $
+| 0.59
+| | $
+| 1.60
+| | $
+| 1.19
+|
+Net income per share before non-GAAP tax adjustments - diluted
+| | $
+| 0.80
+| | $
+| 0.57
+| | $
+| 1.54
+| | $
+| 1.13
+|
+| | | | | | | | |
+Net income per share after non-GAAP tax adjustments - basic
+| | $
+| 0.67
+| | $
+| 0.47
+| | $
+| 1.29
+| | $
+| 0.96
+|
+Net income per share after non-GAAP tax adjustments - diluted
+| | $
+| 0.65
+| | $
+| 0.46
+| | $
+| 1.25
+| | $
+| 0.92
+|
+| | | | | | | | |
+Shares used in non-GAAP net income per share calculations:
+| | | | | | | | |
+Basic
+| | 356,253
+| | 346,185
+| | 354,771
+| | 344,650
+|
+Diluted
+| | 371,023
+| | 358,725
+| | 368,271
+| | 361,289
+|
+
+| | |
+|
+
+1) Non-GAAP financial information for the periods shown are adjusted for an assumed provision for income taxes based on our long-term projected tax rate of 21%. Due to the differences in the tax treatment of items excluded from non-GAAP earnings, our estimated tax rate on non-GAAP income may differ from our GAAP tax rate and from our actual tax liabilities.
+
+
+
+
+
+
+
+
+
+
+
+
+Datadog, Inc.
+Reconciliation of GAAP Cash Flow from Operating Activities to Free Cash Flow
+(In thousands; unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30,
+| | Six Months Ended
+June 30,
+|
+| | 2026
+| | 2025
+| | 2026
+| | 2025
+|
+Net cash provided by operating activities
+| | $
+| 315,872
+| | $
+| 200,055
+| | $
+| 650,495
+| | $
+| 471,596
+|
+Less: Purchases of property and equipment
+| | (9,889)
+| | (15,152)
+| | (21,247)
+| | (23,900)
+|
+Less: Capitalized software development costs
+| | (27,279)
+| | (19,550)
+| | (61,452)
+| | (37,952)
+|
+Free cash flow
+| | $
+| 278,704
+| | $
+| 165,353
+| | $
+| 567,796
+| | $
+| 409,744
+|
+Free cash flow margin
+| | 25%
+| | 20%
+| | 27%
+| | 26%
+|
+
+
+
+
+
+Contact Information
+Yuka Broderick
+Datadog Investor Relations
+IR@datadoghq.com
+
+
+Dan Haggerty
+Datadog Public Relations
+Press@datadoghq.com
+
+
+Datadog is a registered trademark of Datadog, Inc.
+All product and company names herein may be trademarks of their registered owners.

--- a/modules/test-fixtures/earnings-filings/himx.txt
+++ b/modules/test-fixtures/earnings-filings/himx.txt
@@ -1,0 +1,409 @@
+EX-99.1
+2
+exh_991.htm
+PRESS RELEASE
+
+EdgarFiling EXHIBIT 99.1
+Himax Technologies, Inc. Reports Second Quarter 2026 Financial Results; Provides Third Quarter 2026 Guidance
+
+
+Q2 2026 Revenue, GM and EPS All Exceeded the Guidance Issued on May 7, 2026
+Company Q3 2026 Guidance: Revenues to Increase 7% to 11% QoQ, Gross Margin is Expected to be around 34%. Profit per Diluted ADS to be 8.0 Cents to 10.0 Cents
+
+Q2 2026 revenues were $227.4 million, a sequential increase of 14.2%, exceeding the guidance range of a 10.0% to 13.0% increase QoQ, primarily driven by better-than-expected automotive IC sales Q2 GM reached 33.1%, substantially exceeding the guidance of around 32%, primarily due to a more favorable product mix, with increased sales from higher-margin automotive IC products Q2 2026 after-tax profit was $19.9 million, or 11.4 cents per diluted ADS, exceeding the guidance range of 8.6 to 10.3 cents Himax Q3 2026 revenues to increase 7% to 11% QoQ. GM to be around 34%. Profit per diluted ADS to be in the range of 8.0 cents to 10.0 cents Himax remains optimistic about the long-term growth of automotive display IC business and is well positioned to capitalize on the secular growth of smart vehicle interiors through its comprehensive LCD and OLED portfolio, broad global customer base, and robust design-win pipeline Automakers are accelerating new vehicle launches, driving broader platform standardization across vehicle models. Himax is well positioned to benefit through its comprehensive and validated automotive display IC portfolio, enabling customers to rapidly deploy proven solutions across multiple vehicle models while reducing engineering effort, lowering system costs, and shortening product development cycles Himax expects full-year 2026 auto IC sales to grow by double digits YoY, with strong growth momentum extending into 2027 as adoption of smart car interiors continues to drive increases in number, size, and sophistication of displays in both EV and conventional vehicles Himax remains particularly optimistic about smart glasses market and is one of the few companies offering both ultralow power AI sensing and microdisplay technologies. A leading global brand launching WiseEye powered smart glasses this fall, with growing engagement from platform providers, ODMs, and consumer electronics companies worldwide, and several projects poised to enter MP in 2027 Aggressive CPO customer development timelines, with demand showing no signs of slowing. CPO products entered engineering production ramps as scheduled in Q3. 2027 CPO shipments significantly exceed 2026, with meaningful financial contribution starting in 2027
+
+TAINAN, Taiwan, Aug. 06, 2026 (GLOBE NEWSWIRE) -- Himax Technologies, Inc. (Nasdaq: HIMX) (“Himax” or “Company”), a leading supplier and fabless manufacturer of display drivers and other semiconductor products, announced its financial results for the second quarter 2026 ended June 30, 2026.
+“Notwithstanding industry-wide supply constraints, we remain optimistic about the long-term growth prospects of our automotive display IC business. We continue to view automotive as one of the industry's most attractive secular growth markets, driven by rapid advancements in smart vehicle interiors, characterized by a growing number of displays per vehicle, along with larger, higher-resolution displays and more diverse vehicle cabin configurations. Himax is well positioned to capitalize on these industry trends through our comprehensive automotive display portfolio spanning both LCD and OLED technologies, a broad and diversified global customer base, and a robust design-win pipeline. The industry's ongoing pursuit of richer human-machine interfaces, immersive infotainment, and enhanced in-cabin user experiences is driving the adoption of a broader range of our display technologies. This not only increases Himax's dollar content per vehicle but also creates multiple long-term growth opportunities,” said Mr. Jordan Wu, President and Chief Executive Officer of Himax.
+“We remain particularly optimistic about the smart glasses market. Recently, a leading global brand just launched a smart glasses product powered by our WiseEye technology. We are seeing growing engagement with leading global brands, technology platform providers, ODMs, as well as hyperscalers, with some projects poised to enter mass production as we move into 2027. Meanwhile, Himax’s CPO products have begun engineering production ramps as scheduled in Q3. These products are expected to drive sequential shipment growth quarter over quarter, laying the foundation for a more meaningful volume shipment beginning in 2027. The official mass-production timing remains subject to customer deployment schedules. Nevertheless, we expect our shipments in 2027 to be significantly higher than in 2026, starting to make meaningful contribution to our financials,” concluded Mr. Jordan Wu.
+Second Quarter 2026 Financial Results
+Himax net revenues registered $227.4 million, representing a sequential increase of 14.2%, exceeding the guidance range of a 10.0% to 13.0% increase, primarily driven by better-than-expected automotive IC sales. Gross margin was 33.1%, substantially exceeding the guidance of around 32%, up from 30.4% in the previous quarter. Q2 profit per diluted ADS was 11.4 cents, significantly exceeding the guidance range of 8.6 to 10.3 cents.
+Revenue from large display drivers came in at $19.2 million, representing a decline of 21.0% from the previous quarter, attributable to panel makers pulling forward their inventory purchases for high-end TV ICs in prior quarters. In contrast, sales for both monitor and notebook IC products increased quarter-over-quarter due to higher legacy product shipments to key customers. Sales of large panel driver ICs accounted for 8.4% of total revenues for the quarter, compared to 12.2% last quarter and 11.6% a year ago.
+Revenue from the small and medium-sized display driver segment totaled $162.3 million, reflecting an increase of 19.6% sequentially. Q2 automotive driver sales, including both traditional DDIC and TDDI, increased by double digits quarter over quarter, primarily driven by broad-based customer replenishment of TDDI and DDIC following seasonally lower shipments during the Lunar New Year in Q1. The ramp-up of new TDDI and DDIC projects for a leading panel customer also contributed to the sequential increase. Customers continued to operate under a make-to-order model while maintaining lean inventory levels. Himax’s automotive business, comprising DDIC, TDDI, Tcon, and OLED IC sales, remained the largest revenue contributor in the second quarter, representing well over 50% of total revenues.
+Second quarter tablet IC sales, covering both LCD and OLED products, also increased sequentially, attributable to customers’ early pull-in demand against the backdrop of rising memory price sentiment in the market, together with continued shipments for a customer’s premium OLED model. In contrast, smartphone IC sales decreased sequentially following the initial ramp up of an OLED IC for a leading smartphone brand’s mainstream model in Q1. The small and medium-sized driver IC segment accounted for 71.4% of total sales for the quarter, compared to 68.2% in the previous quarter and 67.3% a year ago.
+Q2 non-driver sales reached $45.9 million, a 17.7% increase from the previous quarter, attributable to robust automotive Tcon shipments, supported by replenishment across a broad customer base. Tcon business accounted for over 10% of total sales, with more than half contributed by automotive Tcon. As the market leader in automotive Tcon, particularly in solutions featuring local dimming functionality, Himax expects strong growth momentum to continue into next year. Non-driver products accounted for 20.2% of total revenues, as compared to 19.6% in the previous quarter and 21.1% a year ago.
+Second quarter operating expenses were $50.7 million, an increase of 0.8% from the previous quarter and 3.6% compared to the same period last year. The year-over-year increase was mainly attributable to higher tape-out expenses. Himax remains disciplined in managing costs while continuing to invest strategically in select non-driver IC businesses with compelling long-term growth potential.
+Second quarter operating income was $24.6 million, representing an operating margin of 10.8%, compared to 5.1% in the previous quarter and 8.4% for the same period last year. Both the quarter-over-quarter and year-over-year changes were primarily driven by higher revenues and gross margin. Second-quarter after-tax profit was $19.9 million, or 11.4 cents per diluted ADS, compared to $8.0 million, or 4.6 cents per diluted ADS last quarter, and up from $16.5 million, or 9.5 cents in the same period last year.
+Balance Sheet and Cash Flow
+Himax had $298.7 million of cash, cash equivalents and other financial assets as of June 30, 2026. This compares to $332.8 million at the same time last year and $287.6 million a quarter ago. The sequential increase was mainly driven by operating cash flow of $17.5 million in the second quarter. As is the Company’s usual practice, income tax payments are made in the second quarter. Under a new Taiwan government policy, Himax is entitled to defer approximately $11.0 million of these payments for one year without interest. Excluding this deferral, second-quarter operating cash flow would have been approximately $6.5 million. Looking ahead to Q3, Himax anticipates a decline in cash, cash equivalents, and other financial assets, primarily due to a payment of $44 million for annual dividends to shareholders made on July 10. In addition, subject to the final Board decision, Himax will distribute around $11.7 million, the immediately vested portion of this year's employee bonus awards, at the end of Q3.
+Himax’s quarter-end inventories as of June 30, 2026 were $151.5 million, about the same as $151.7 million last quarter but higher than $134.6 million in the same period last year. After maintaining lean inventory levels for several years, Himax proactively adjusted its inventory strategy about a year ago, selectively building inventory in anticipation of tightening supply across the industry. Accounts receivable at the end of June was $220.3 million, up from $190.9 million last quarter and $219.0 million a year ago. DSO was 93 days at the quarter end, as compared to 86 days last quarter and 92 days a year ago. Second quarter capital expenditure, primarily for R&D-related equipment for Himax’s IC design business, was $4.3 million, versus $2.9 million last quarter and $4.6 million a year ago.
+Outstanding Share
+As of June 30, 2026, Himax had 174.4 million ADS outstanding, unchanged from last quarter. On a fully diluted basis, the total number of ADS outstanding for the second quarter was 174.4 million.
+Investment Portfolio Update
+
+During the quarter, on July 1, Himax announced the proposed divestiture of investment in one of the Company’s equity-method investees. Based on the information provided by the said investee company, Himax expects to recognize a pre-tax gain of approximately $23 to $24 million upon closing. The transaction is expected to close in the fourth quarter of this year subject to customary closing conditions and regulatory approvals. Himax will provide more updates as appropriate as the transaction progresses.
+Q3 2026 Outlook
+The ongoing surge in AI demand continues to impact non-AI applications. This has rippled across the broader semiconductor supply chain, resulting in capacity constraints at foundry, packaging and testing facilities on the mature process nodes where many of Himax’s products are manufactured. Consequently, Himax is experiencing higher manufacturing and procurement costs, extended lead times, and increased difficulty in securing sufficient capacity across a broad range of its product lines. Himax expects the supply environment to remain challenging in the near term.
+To enhance production flexibility and secure the capacity needed to meet customer needs and support upcoming production ramps, Himax continues to leverage its established supply chain in Taiwan while further strengthening its presence across China, Singapore, Korea, Japan and Malaysia. In parallel, as Himax mentioned last quarter, the company has been working closely with customers on pricing adjustments to share these increased costs. Some adjustments took effect in the second quarter with additional pricing adjustments possibly implemented over time as market conditions warrant.
+Notwithstanding these industry-wide supply constraints, Himax remains optimistic about the long-term growth prospects of its automotive display IC business. Himax continues to view automotive as one of the industry's most attractive secular growth markets, driven by rapid advancements in smart vehicle interiors. This trend is characterized by, among other things, a growing number of displays per vehicle, now averaging more than three and continuing to rise, along with larger, higher-resolution displays and more diverse vehicle cabin configurations, including curved, integrated, multi-display, and pillar-to-pillar designs.
+Himax is well positioned to capitalize on these industry trends through its comprehensive automotive display portfolio spanning both LCD and OLED technologies, a broad and diversified global customer base, and a robust design-win pipeline. Himax further differentiates itself by continuously introducing next-generation automotive display technologies, including LTDI solutions for ultra-large displays, advanced Tcon solutions for head-up displays, OLED driver and touch controller ICs and Micro LED display technologies. Himax’s portfolio also includes Knob-on-Display solutions and capacitive physical buttons where customer interest continues to grow, driven in part by regulatory and vehicle safety initiatives in key automotive markets, including China and Europe, where greater emphasis is being placed on intuitive physical controls to enhance driving safety and reduce driver distraction. The industry's ongoing pursuit of richer human-machine interfaces, immersive infotainment, and enhanced in-cabin user experiences is driving the adoption of a broader range of Himax’s display technologies. This not only increases Himax's dollar content per vehicle but also creates multiple long-term growth opportunities. In addition, Himax’s well-established global supply chain provides the Company with greater flexibility to navigate the current supply environment while securing the capacity needed to support both existing projects and upcoming production ramps.
+Himax is also seeing an important trend in the automotive industry with automakers introducing new vehicle models at an accelerating pace amid intensifying competition. As a result, product lifecycles are becoming shorter, creating greater pressure to improve engineering efficiency, reduce development costs, and shorten time to market of new car models. These challenges are driving broader adoption of platform standardization across multiple vehicle models, favoring suppliers with comprehensive and validated technology portfolios and proven track records. Himax is one such supplier, boasting the industry's most compelling automotive display IC offerings, market-leading positions across automotive DDIC, TDDI, and Tcon, and continued leadership in next-generation technologies such as LTDI and OLED technologies. By adopting Himax’s solutions as part of their standardized platforms, customers can quickly deploy validated display IC products across multiple new vehicle developments, reducing engineering effort, lowering system costs, and shortening development cycle of each project.
+In addition to automotive, Himax is also making solid progress across several strategic growth areas, including smart glasses, ultralow power AI, and CPO. These emerging businesses diversify Himax’s revenue base into markets with attractive long-term growth prospects and margin profiles while strengthening its overall competitive position. Himax believes these businesses are poised to become increasingly meaningful contributors to the Company’s future growth.
+Smart glasses market is an area Himax remains particularly optimistic about. Himax is one of the few companies offering both ultralow power AI sensing and microdisplay technologies, both critical building blocks for next-generation smart glasses. On the AI sensing front, WiseEye enables ultralow power, always-on outward and inward sensing, supporting an expanding range of AI use cases, including contextual awareness, real-time visual assistance, and personalized user experiences. Recently, a leading global brand just launched a smart glasses product powered by Himax’s WiseEye technology, and the Company continues to see strong design-in momentum across customers worldwide. In particular, Himax is seeing growing engagement with leading global brands, technology platform providers, ODMs, as well as hyperscalers who traditionally do not offer hardware products but are now entering smart glasses market, with some projects poised to enter mass production as Himax moves into 2027.
+In microdisplays for AR glasses, Himax’s Front-lit LCoS microdisplay delivers an optimal balance of size, weight, resolution, image quality, power consumption, and cost. It can also be configured to operate in a high-brightness, ultralow power green-only mode and seamlessly switch to full-color operation as needed. This flexibility differentiates Himax’s solution from alternative display technologies, letting customers optimize power efficiency while maintaining visual performance and meeting their system design and cost targets. Together, these capabilities make Himax’s Front-lit LCoS a compelling display platform for next-generation AR glasses equipped with see-through displays. Currently Himax is working closely with multiple waveguide partners across Asia, Europe, and North America to deliver integrated AR display solutions that simplify system integration and shorten customers' development cycles. This is driving broader customer engagement and positioning Himax to convert more opportunities into design wins. Backed by well over a decade of LCoS expertise and a proven track record of successful production shipments, Himax is well positioned to support the next generation of AR glasses.
+In the field of Co-Packaged Optics (CPO), customer development timelines remain aggressive with demand showing no sign of slowing. Together with Himax’s strategic partner, FOCI, the Company continues to deepen customer engagements by offering a flexible portfolio of solutions, including customized designs tailored specifically for customers’ needs as well as a standardized technology platform developed in collaboration with a leading foundry partner. Himax and FOCI’s solutions support both co-packaged and pluggable packaging architectures to address diverse customer needs.
+Himax’s primary focus for the second half of this year remains on achieving mass production readiness, including key customer qualification milestones, while continuing to improve manufacturing yields and establish stable mass-production capabilities. The Company has already made encouraging progress toward these objectives. Both Gen 1 product, supporting 1.6T and 3.2T transmission bandwidths, and Gen 2 product, designed for 6.4T bandwidth, have begun engineering production ramps as scheduled in the third quarter. These products are expected to drive sequential shipment growth quarter over quarter, laying the foundation for a more meaningful volume shipment beginning in 2027. The official mass-production timing remains subject to customer deployment schedules. Nevertheless, Himax expects its shipments in 2027 to be significantly higher than in 2026, starting to make meaningful contribution to the Company’s financials.
+At the same time, Himax and FOCI are also co-developing next-generation optical solutions with customers, featuring higher fiber-count architectures, enhanced optical precision, and increasingly sophisticated designs such as CWDM (Coarse Wavelength Division Multiplexing), to address the explosive bandwidth demands of HPC and AI data center applications.
+Display Driver IC Businesses
+LDDIC
+In Q3 2026, Himax anticipates large display driver IC sales to decline by single digit from last quarter. Monitor IC sales are expected to decline quarter over quarter, as customers already pulled forward inventory purchases in prior quarters. In contrast, TV IC sales are poised for sequential increases, driven by higher legacy product shipments to key customers.
+Looking ahead in the notebook market, Himax is seeing encouraging design-in momentum, particularly in OLED notebooks with several industry trends creating favorable tailwinds. Rising memory prices are accelerating the shift from entry-level to premium notebook models, while the scheduled ramp-up of new Gen 8.6 OLED fabs in China later this year and into 2027 is expected to further drive OLED penetration in the notebook market. Himax is well positioned to capitalize on these favorable industry trends with its comprehensive notebook display OLED IC portfolio, spanning DDIC, Tcon, power management IC and touch controllers. This one-stop offering lets Himax serve customers with a complete solution while increasing the Company’s value content per device.
+SMDDIC
+Q3 small and medium-sized display driver IC business is expected to increase by high-single-digits from last quarter. Q3 automotive driver IC sales, including TDDI and traditional DDIC, are set to increase by a solid double-digit quarter-over quarter. This increase reflects broader customer demand of DDIC and TDDI products, together with the mass production of multiple LTDI projects across car brands worldwide. Strong sequential growth underscores the accelerating adoption of larger and more sophisticated automotive displays, with Chinese automakers leading the charge.
+Himax continues to see healthy underlying customer demand, supported by multiple new projects entering mass production in the coming quarters. Himax expects its full-year 2026 automotive driver IC sales to grow by double digits from last year with strong growth momentum extending into next year as adoption of smart car interiors continues to drive increases in the number, size, and sophistication of displays in both electric and conventional vehicles.
+Meanwhile, the industry's shift toward platform standardization is creating meaningful opportunities for Himax. This is evidenced by the growing number of customers adopting Himax’s industry-pioneering LTDI and local dimming Tcon solutions as the standard platform for their ultra-large automotive displays. Following years of customer engagement, several of these projects are now entering mass production across multiple car brands. These ultra-large display panels typically require four or more LTDI chips, and in some cases more than ten, together with at least one local dimming Tcon per panel. As customers increasingly adopt Himax’s solution across multiple ultra-large display platforms, this not only strengthens customer stickiness and makes it more difficult for competitors to compete with the Company, but also increases Himax’s content value on a per-panel and per-vehicle basis.
+Looking ahead, the accelerating adoption of OLED displays in automotive presents a compelling long-term growth opportunity and is poised to become a key pillar of Himax’s automotive business. For several years, Himax has been collaborating closely with leading OLED panel makers in Korea and China, and the Company’s comprehensive portfolio of DDICs, Tcons, touch controller ICs, and customized ASIC solutions gives customers the flexibility to select the solutions that best meet their specific requirements. This broad product coverage and Himax’s early customer engagements have already translated into numerous development programs, providing a solid foundation for future growth as premium automotive displays transition from LCD to OLED.
+With OLED adoption on the way, Himax continues to introduce innovative IC solutions to address evolving customer needs. For example, Himax’s latest TED (Tcon Embedded Driver IC) solution, which integrates DDIC and Tcon into a single chip, offers a cost-effective, flexible, and highly integrated solution ideal for smaller, lower-resolution automotive displays. Himax’s TED technology is now being adopted across a diverse range of applications, including automotive, robotics, and IT applications, with several projects involving customized ASIC solutions co-developed with leading global end customers.
+Himax expects Q3 smartphone IC revenue to increase quarter over quarter, driven by continued shipments for a leading smartphone brand's mainstream models and inventory build-up for its upcoming premium models. Q3 tablet IC sales are expected to decrease sequentially, as capacity constraints limit Himax’s ability to support additional shipments.
+Non-Driver Product Categories
+Q3 non-driver IC revenues are expected to increase by low-teens sequentially.
+Timing Controller (Tcon)
+Himax anticipates Q3 2026 Tcon sales to increase by low-teens quarter over quarter. Himax’s automotive Tcon business is expected to deliver decent double-digit growth in Q3, extending the strong momentum from Q2 and far outpacing the Company’s corporate average. This growth is driven by continued legacy product shipments across a broad, diversified customer base, along with several new projects entering mass production. Despite ongoing industry-wide capacity constraints, Himax is confident in the strong growth trajectory of its automotive Tcon business. With hundreds of design wins already secured and new design-ins continuing to expand, Himax is well positioned for another robust growth year in automotive Tcon as the Company moves into 2027.
+During the quarter, Himax was pleased to announce that its T2000 Tcon has been adopted into E Ink's next-generation color ePaper platform. Himax's proprietary parallel-processing architecture is at the core of this ASIC product, enabling simultaneous display refresh and data transmission, significantly enhancing dynamic display performance while preserving the ultralow power advantage of ePaper technology. This breakthrough enables smoother display of dynamic content on large format ePaper displays, helping accelerate the transition from traditional static signage to dynamic applications such as retail advertising, public information displays, and smart commercial environments.
+WiseEye  Ultralow Power AI Sensing
+On the update of WiseEye ultralow power AI sensing solution, a cutting-edge ultralow power AI sensing total solution, targeting battery-powered endpoint devices. WiseEye differentiates itself with an industry-leading ultralow power architecture, consuming only a few milliwatts while delivering on-device AI inferencing, 24/7 always-on image and voice sensing, and an exceptionally compact form factor. This unique combination enables endpoint AI devices that were previously impractical due to power and size constraints, driving broad adoption across applications including notebooks, surveillance systems, access control, palm vein authentication, smart office, and smart glasses, with design-in activities continuing to expand across leading customers worldwide.
+WiseEye modules’ design-in activities continue to expand, driven by its plug-and-play architecture, ultralow power consumption, and on-device AI capabilities. During the quarter, Himax’s WiseEye biometric palm vein modules achieved the verification of TÜV Rheinland, one of the world's leading and most credible independent testing, inspection, and certification organizations. The assessment validated recognition accuracy, response speed and liveness detection. This verification, together with Himax’s earlier achievement of GDPR compliance, one of the world's strictest data privacy standards, reinforces the privacy, security, and performance of Himax’s biometric authentication solutions, giving customers greater confidence to accelerate deployment across security-sensitive applications. Himax is seeing expanding design-in activities for its PalmVein modules across smart access, workforce management, smart door locks, and, more recently, computer monitors and smart office solutions.
+Built on the same core hardware platform as the WiseEye technology, Himax’s WiseGuard module is specifically designed for security applications, delivering ultralow power operation, a wide field of view, long-range detection, and exceptional low-light performance. WiseGuard accurately detects and continuously tracks multiple individuals, including their presence, location, and movement, substantially reducing the false triggers commonly associated with traditional PIR-based solutions. Its proactive, 24/7 sensing capability enables security systems to detect and continuously track activity from the outset, capturing the full sequence of events rather than only the moment motion is detected, providing a significant advantage over traditional reactive solutions. WiseGuard delivers up to 5 years of battery life while maintaining high-precision detection over long distances, even in environments with illumination as low as 1 lux. Since its debut just six months ago, WiseGuard has seen encouraging customer engagement across a wide range of applications, including surveillance cameras, access control, IoT, and wildlife monitoring. Himax is also pleased to share that WiseGuard has already been adopted by a U.S. customer for surveillance applications, with mass production scheduled to begin toward the end of this year.
+Meanwhile, WiseEye is gaining broad market recognition for smart glasses as a compact, ultralow power, always-on AI perception front end. WiseEye supports outward-facing environmental sensing, first through scene understanding by analyzing the user’s contextual surroundings and environment, followed by object classification to recognize and identify specific objects typically associated with the identified scene. It also supports inward-facing capabilities, including eyeball tracking for intuitive gaze-based interaction and iris authentication for secure identity verification. Together, these capabilities enable AI glasses to continuously capture visual snapshots of the real world and enable intelligent, responsive, low-latency human-machine interaction while consuming only a few milliwatts of power. With a leading global brand launching WiseEye powered smart glasses this fall, Himax is seeing growing engagement from platform providers, ODMs, and consumer electronics companies worldwide. Some of these projects are expected to enter mass production in the upcoming quarters.
+Third Quarter 2026 Guidance |
+|
+Net Revenue: | 7% to 11% QoQ |
+Gross Margin: | Around 34%, depending on final product mix |
+Profit: | 8.0 cents to 10.0 cents per diluted ADS |
+| |
+As Himax has done historically, the Company will grant employees’ annual bonus, including RSUs and cash awards, on or around September 30 this year. Q3 guidance for profit per diluted ADS has taken into account the expected 2026 annual bonus, which, subject to Board approval, is now estimated to be around $13 million, out of which $11.7 million will be vested and expensed immediately on the grant date. As a reminder, the total annual bonus amount and the immediately vested portion are Himax’s current best estimates only and the actual amounts could vary materially depending on, among other things, the Company’s Q4 profit expectations and the final Board decision for the total bonus amount and its vesting scheme. The $13 million expected annual bonus does not include the above-mentioned gain on investment from divestiture of an equity-method investee, as the transaction is pending regulatory approvals and has not yet closed. As is the case for previous years, Himax expects the annual bonus grant in 2026 to lead to higher third quarter operating expenses compared to the other quarters of the year. In comparison, the annual bonus for 2025 and 2024 were $7.7 million and $12.5 million respectively, of which $7.5 million and $11.2 million vested immediately.
+In providing Himax’s Q3 financial guidance, the Q3 expense related to employee bonus is estimated to be $11.8 million, representing 6.8 cents per diluted ADS before tax, comprised of $11.7 million of the immediately vested portion of this year’s bonus, and $0.1 million of the amortized portion of the unvested bonuses from previous years. By comparison, employee bonus expense in each of the last three quarters was around $0.2 million.
+HIMAX TECHNOLOGIES INC. SECOND QUARTER 2026 EARNINGS CONFERENCE CALL |
+DATE: | Thursday, August 6, 2026
+|
+TIME: | U.S. | 8:00 a.m. EDT |
+| Taiwan | 8:00 p.m. |
+
+
+Live Webcast (Video and Audio): https://www.zucast.com/webcast/Hp09k4XB
+|
+Toll Free Dial-in Number (Audio Only):
+|
+| Hong Kong 2112-1444
+Taiwan 0080-119-6666
+Australia 1-800-015-763
+Canada 1-877-252-8508
+China (1) 4008-423-888
+China (2) 4006-786-286
+Singapore 800-492-2072
+UK 0800-068-8186
+United States (1) 1-800-811-0860
+United States (2) 1-866-212-5567 |
+Dial-in Number (Audio Only):
+|
+| Taiwan Domestic Access 02-3396-1191
+International Access +886-2-3396-1191 |
+Participant PIN Code: | 1116006# |
+| |
+If you choose to attend the call by dialing in via phone, please enter the Participant PIN Code 1116006# after the call is connected. A replay of the webcast will be available beginning two hours after the call on www.himax.com.tw. This webcast can be accessed by clicking on this link or visiting Himax’s website, where it will remain available until August 6, 2027.
+About Himax Technologies, Inc.
+Himax Technologies, Inc. (NASDAQ: HIMX) is a leading global fabless semiconductor solution provider dedicated to display imaging processing technologies. The Company’s display driver ICs and timing controllers have been adopted at scale across multiple industries worldwide including TVs, PC monitors, laptops, mobile phones, tablets, automotive, ePaper devices, industrial displays, among others. As the global market share leader in automotive display technology, the Company offers innovative and comprehensive automotive IC solutions, including traditional driver ICs, advanced in-cell Touch and Display Driver Integration (TDDI), local dimming timing controllers (Local Dimming Tcon), Large Touch and Display Driver Integration (LTDI) and OLED display technologies. Himax is also a pioneer in tinyML visual-AI and optical technology related fields. The Company’s industry-leading WiseEye Ultralow Power AI Sensing technology which incorporates Himax proprietary ultralow power AI processor, always-on CMOS image sensor, and CNN-based AI algorithm has been widely deployed in consumer electronics and AIoT related applications. Himax optics technologies, such as diffractive wafer level optics, LCoS microdisplays and 3D sensing solutions, are critical for facilitating emerging AR/VR/metaverse technologies. Additionally, Himax designs and provides touch controllers, OLED ICs, LED ICs, EPD ICs, power management ICs, and CMOS image sensors for diverse display application coverage. Founded in 2001 and headquartered in Tainan, Taiwan, Himax currently employs around 2,200 people from three Taiwan-based offices in Tainan, Hsinchu and Taipei and country offices in China, Korea, and the US. Himax has 2,555 patents granted and 318 patents pending approval worldwide as of June 30, 2026.
+http://www.himax.com.tw
+Forward Looking Statements
+Factors that could cause actual events or results to differ materially from the effect of the Covid-19 pandemic on the Company’s business; general business and economic conditions and the state of the semiconductor industry; market acceptance and competitiveness of the driver and non-driver products developed by the Company; demand for end-use applications products; reliance on a small group of principal customers; the uncertainty of continued success in technological innovations; our ability to develop and protect our intellectual property; pricing pressures including declines in average selling prices; changes in customer order patterns; changes in estimated full-year effective tax rate; shortage in supply of key components; changes in environmental laws and regulations; changes in export license regulated by Export Administration Regulations (EAR); exchange rate fluctuations; regulatory approvals for further investments in our subsidiaries; our ability to collect accounts receivable and manage inventory and other risks described from time to time in the Company's SEC filings, including those risks identified in the section entitled "Risk Factors" in its Form 20-F for the year ended December 31, 2025 filed with the SEC, as may be amended.
+Company Contacts:
+Karen Tiao, Head of IR/PR
+Himax Technologies, Inc.
+Tel: +886-2-2370-3999
+Fax: +886-2-2314-0877
+Email: hx_ir@himax.com.tw
+www.himax.com.tw
+Mark Schwalenberg, Director
+Investor Relations - US Representative
+MZ North America
+Tel: +1-312-261-6430
+Email: HIMX@mzgroup.us
+www.mzgroup.us
+
+
+
+-Financial Tables-
+Himax Technologies, Inc. |
+Unaudited Condensed Consolidated Statements of Profit or Loss |
+(These interim financials do not fully comply with IFRS because they omit all interim disclosure required by IFRS) |
+(Amounts in Thousands of U.S. Dollars, Except Share and Per Share Data) |
+|
+| Three Months
+Ended June 30, | | Three Months
+Ended
+March 31 , |
+| | 2026 | | | | 2025 | | | | 2026 | |
+| | | | | |
+Revenues | | | | | |
+Revenues from third parties, net | $ | 227,334 | | | $ | 214,761 | | | $ | 199,003 | |
+Revenues from related parties, net | | 38 | | | | 37 | | | | 10 | |
+| | 227,372 | | | | 214,798 | | | | 199,013 | |
+| | | | | |
+Costs and expenses: | | | | | |
+Cost of revenues | | 152,135 | | | | 147,791 | | | | 138,568 | |
+Research and development | | 37,922 | | | | 37,542 | | | | 38,179 | |
+General and administrative | | 6,656 | | | | 5,806 | | | | 6,027 | |
+Sales and marketing | | 6,096 | | | | 5,550 | | | | 6,079 | |
+Total costs and expenses | | 202,809 | | | | 196,689 | | | | 188,853 | |
+| | | | | |
+Operating income | | 24,563 | | | | 18,109 | | | | 10,160 | |
+| | | | | |
+Non operating income: | | | | | |
+Interest income | | 2,224 | | | | 2,737 | | | | 1,979 | |
+Changes in fair value of financial assets at fair value through profit or loss | | 137 | | | | 274 | | | | 139 | |
+Foreign currency exchange gains (losses), net | | (103 | ) | | | 2,396 | | | | (51 | ) |
+Finance costs | | (815 | ) | | | (870 | ) | | | (807 | ) |
+Share of losses of associates | | (1,005 | ) | | | (588 | ) | | | (881 | ) |
+Other income (losses) | | (1 | ) | | | 6 | | | | 9 | |
+| | 437 | | | | 3,955 | | | | 388 | |
+Profit before income taxes | | 25,000 | | | | 22,064 | | | | 10,548 | |
+Income tax expense | | 4,645 | | | | 5,054 | | | | 2,109 | |
+Profit for the period | | 20,355 | | | | 17,010 | | | | 8,439 | |
+Profit attributable to noncontrolling interests | | (476 | ) | | | (466 | ) | | | (450 | ) |
+Profit attributable to Himax Technologies, Inc. stockholders | $ | 19,879 | | | $ | 16,544 | | | $ | 7,989 | |
+| | | | | |
+Basic earnings per ADS attributable to Himax Technologies, Inc. stockholders | $ | 0.114 | | | $ | 0.095 | | | $ | 0.046 | |
+Diluted earnings per ADS attributable to Himax Technologies, Inc. stockholders | $ | 0.114 | | | $ | 0.095 | | | $ | 0.046 | |
+| | | | | |
+Basic Weighted Average Outstanding ADS | | 174,426 | | | | 174,380 | | | | 174,426 | |
+Diluted Weighted Average Outstanding ADS | | 174,426 | | | | 174,544 | | | | 174,426 | |
+
+
+Himax Technologies, Inc. |
+Unaudited Condensed Consolidated Statements of Profit or Loss |
+(Amounts in Thousands of U.S. Dollars, Except Share and Per Share Data) |
+|
+| | Six Months
+Ended June 30, |
+| | | 2026 | | | | 2025 | |
+| | | | |
+Revenues | | | | |
+Revenues from third parties, net | | $ | 426,337 | | | $ | 429,856 | |
+Revenues from related parties, net | | | 48 | | | | 75 | |
+| | | 426,385 | | | | 429,931 | |
+| | | | |
+Costs and expenses: | | | | |
+Cost of revenues | | | 290,703 | | | | 297,372 | |
+Research and development | | | 76,101 | | | | 72,529 | |
+General and administrative | | | 12,683 | | | | 11,363 | |
+Sales and marketing | | | 12,175 | | | | 10,752 | |
+Total costs and expenses | | | 391,662 | | | | 392,016 | |
+| | | | |
+Operating income | | | 34,723 | | | | 37,915 | |
+| | | | |
+Non operating income: | | | | |
+Interest income | | | 4,203 | | | | 5,049 | |
+Changes in fair value of financial assets at fair value through profit or loss | | | 276 | | | | 257 | |
+Foreign currency exchange gains (losses), net | | | (154 | ) | | | 2,741 | |
+Finance costs | | | (1,622 | ) | | | (1,773 | ) |
+Share of losses of associates | | | (1,886 | ) | | | (1,330 | ) |
+Other gains | | | - | | | | 3,205 | |
+Other income | | | 8 | | | | 23 | |
+| | | 825 | | | | 8,172 | |
+Profit before income taxes | | | 35,548 | | | | 46,087 | |
+Income tax expense | | | 6,754 | | | | 8,895 | |
+Profit for the period | | | 28,794 | | | | 37,192 | |
+Profit attributable to noncontrolling interests | | | (926 | ) | | | (661 | ) |
+Profit attributable to Himax Technologies, Inc. stockholders | | $ | 27,868 | | | $ | 36,531 | |
+| | | | |
+Basic earnings per ADS attributable to Himax Technologies, Inc. stockholders | | $ | 0.160 | | | $ | 0.209 | |
+Diluted earnings per ADS attributable to Himax Technologies, Inc. stockholders | | $ | 0.160 | | | $ | 0.209 | |
+| | | | |
+Basic Weighted Average Outstanding ADS | | | 174,426 | | | | 174,645 | |
+Diluted Weighted Average Outstanding ADS | | | 174,426 | | | | 174,806 | |
+
+
+Himax Technologies, Inc. |
+IFRS Unaudited Condensed Consolidated Statements of Financial Position |
+(Amounts in Thousands of U.S. Dollars) |
+|
+| | June 30,
+2026 | | June 30,
+2025 | | March 31,
+2026 |
+Assets | | | | | | |
+Current assets: | | | | | | |
+Cash and cash equivalents | | $ | 271,296 | | | $ | 304,678 | | | $ | 259,693 | |
+Financial assets at amortized cost | | | 4,113 | | | | 3,517 | | | | 3,881 | |
+Financial assets at fair value through profit or loss | | | 23,328 | | | | 24,556 | | | | 24,036 | |
+Accounts receivable, net (including related parties) | | | 220,250 | | | | 219,035 | | | | 190,940 | |
+Inventories | | | 151,471 | | | | 134,573 | | | | 151,671 | |
+Income taxes receivable | | | 21 | | | | 802 | | | | 41 | |
+Restricted deposit | | | 568,200 | | | | 503,700 | | | | 568,200 | |
+Other receivable from related parties | | | 10 | | | | 7 | | | | 18 | |
+Other current assets | | | 53,536 | | | | 40,165 | | | | 56,941 | |
+Total current assets | | | 1,292,225 | | | | 1,231,033 | | | | 1,255,421 | |
+Financial assets at fair value through profit or loss | | | 26,250 | | | | 23,645 | | | | 25,587 | |
+Financial assets at fair value through other
+comprehensive income | | | 85,796 | | | | 33,828 | | | | 76,252 | |
+Equity method investments | | | 9,865 | | | | 12,729 | | | | 10,254 | |
+Property, plant and equipment, net | | | 117,263 | | | | 121,248 | | | | 118,501 | |
+Deferred tax assets | | | 21,950 | | | | 23,642 | | | | 21,865 | |
+Goodwill | | | 28,138 | | | | 28,138 | | | | 28,138 | |
+Other intangible assets, net | | | 1,769 | | | | 563 | | | | 2,146 | |
+Restricted deposit | | | - | | | | 34 | | | | - | |
+Refundable deposits | | | 172,690 | | | | 215,320 | | | | 172,706 | |
+Other non-current assets | | | 18,226 | | | | 17,954 | | | | 18,012 | |
+| | | 481,947 | | | | 477,101 | | | | 473,461 | |
+Total assets | | $ | 1,774,172 | | | $ | 1,708,134 | | | $ | 1,728,882 | |
+Liabilities and Equity | | | | | | |
+Current liabilities: | | | | | | |
+Short-term unsecured borrowings | | $ | - | | | $ | 1,024 | | | $ | - | |
+Current portion of long-term unsecured borrowings | | | 6,000 | | | | 6,000 | | | | 6,000 | |
+Short-term secured borrowings | | | 568,200 | | | | 503,700 | | | | 568,200 | |
+Accounts payable | | | 132,055 | | | | 143,048 | | | | 128,307 | |
+Income taxes payable | | | 19,520 | | | | 17,359 | | | | 15,758 | |
+Other payable to related parties | | | - | | | | 47 | | | | - | |
+Contract liabilities-current | | | 4,418 | | | | 4,563 | | | | 2,986 | |
+Other current liabilities | | | 105,590 | | | | 122,678 | | | | 54,443 | |
+Total current liabilities | | | 835,783 | | | | 798,419 | | | | 775,694 | |
+Long-term unsecured borrowings | | | 19,500 | | | | 25,500 | | | | 21,000 | |
+Deferred tax liabilities | | | 699 | | | | 631 | | | | 709 | |
+Other non-current liabilities | | | 8,740 | | | | 12,297 | | | | 8,541 | |
+| | | 28,939 | | | | 38,428 | | | | 30,250 | |
+Total liabilities | | | 864,722 | | | | 836,847 | | | | 805,944 | |
+Equity | | | | | | |
+Ordinary shares | | | 107,010 | | | | 107,010 | | | | 107,010 | |
+Additional paid-in capital | | | 115,157 | | | | 115,853 | | | | 115,136 | |
+Treasury shares | | | (9,760 | ) | | | (9,431 | ) | | | (9,760 | ) |
+Accumulated other comprehensive income | | | 61,305 | | | | 14,666 | | | | 49,774 | |
+Retained earnings | | | 625,799 | | | | 636,538 | | | | 651,577 | |
+Equity attributable to owners of Himax Technologies, Inc. | | | 899,511 | | | | 864,636 | | | | 913,737 | |
+Noncontrolling interests | | | 9,939 | | | | 6,651 | | | | 9,201 | |
+Total equity | | | 909,450 | | | | 871,287 | | | | 922,938 | |
+Total liabilities and equity | | $ | 1,774,172 | | | $ | 1,708,134 | | | $ | 1,728,882 | |
+
+
+Himax Technologies, Inc. |
+Unaudited Condensed Consolidated Statements of Cash Flows |
+(Amounts in Thousands of U.S. Dollars) |
+|
+| | Three Months
+Ended June 30, | | Three Months Ended
+March 31 , |
+| | | 2026 | | | | 2025 | | | | 2026 | |
+| | | | | | |
+Cash flows from operating activities: | | | | | | |
+Profit for the period | | $ | 20,355 | | | $ | 17,010 | | | $ | 8,439 | |
+Adjustments for: | | | | | | |
+Depreciation and amortization | | | 5,905 | | | | 5,275 | | | | 5,938 | |
+Share-based compensation expenses | | | 50 | | | | 147 | | | | 98 | |
+Losses on disposals and scrap of property, plant and equipment, net | | | - | | | | - | | | | 4 | |
+Changes in fair value of financial assets at fair value through profit or loss | | | (137 | ) | | | (274 | ) | | | (139 | ) |
+Interest income | | | (2,224 | ) | | | (2,737 | ) | | | (1,979 | ) |
+Finance costs | | | 815 | | | | 870 | | | | 807 | |
+Income tax expense | | | 4,645 | | | | 5,054 | | | | 2,109 | |
+Share of losses of associates | | | 1,005 | | | | 588 | | | | 881 | |
+Inventories write downs | | | 1,722 | | | | 6,006 | | | | 3,041 | |
+Unrealized foreign currency exchange losses | | | 481 | | | | 118 | | | | 440 | |
+| | | 32,617 | | | | 32,057 | | | | 19,639 | |
+Changes in: | | | | | | |
+Accounts receivable (including related parties) | | | (29,310 | ) | | | (1,483 | ) | | | 9,934 | |
+Inventories | | | (1,517 | ) | | | (10,712 | ) | | | (2,047 | ) |
+Other receivable from related parties | | | 7 | | | | 4 | | | | 4 | |
+Other current assets | | | 2,413 | | | | 1,046 | | | | 1,774 | |
+Accounts payable | | | 3,746 | | | | 37,390 | | | | (10,380 | ) |
+Other payable to related parties | | | - | | | | 47 | | | | (364 | ) |
+Contract liabilities | | | 1,431 | | | | (613 | ) | | | (334 | ) |
+Other current liabilities | | | 6,543 | | | | 3,441 | | | | (14,544 | ) |
+Other non-current liabilities | | | 20 | | | | 71 | | | | 21 | |
+Cash generated from operating activities | | | 15,950 | | | | 61,248 | | | | 3,703 | |
+Interest received | | | 3,399 | | | | 4,315 | | | | 585 | |
+Interest paid | | | (772 | ) | | | (939 | ) | | | (596 | ) |
+Income tax refunded (paid), net | | | (1,039 | ) | | | (4,150 | ) | | | 318 | |
+Net cash provided by operating activities | | | 17,538 | | | | 60,474 | | | | 4,010 | |
+| | | | | | |
+Cash flows from investing activities: | | | | | | |
+Acquisitions of property, plant and equipment | | | (4,349 | ) | | | (4,596 | ) | | | (2,858 | ) |
+Acquisitions of intangible assets | | | (160 | ) | | | - | | | | (104 | ) |
+Acquisitions of financial assets at amortized cost | | | (1,500 | ) | | | (3,517 | ) | | | (1,145 | ) |
+Proceeds from disposal of financial assets at amortized cost | | | 1,291 | | | | 2,286 | | | | - | |
+Acquisitions of financial assets at fair value through profit or loss | | | (12,374 | ) | | | (44,557 | ) | | | (9,508 | ) |
+Proceeds from disposal of financial assets at fair value through profit or loss | | | 12,250 | | | | 26,225 | | | | 10,257 | |
+Acquisitions of financial assets at fair value through other comprehensive income | | | - | | | | - | | | | (6,385 | ) |
+Acquisitions of equity method investment | | | - | | | | (2,500 | ) | | | (244 | ) |
+Decrease in refundable deposits | | | 9 | | | | 30 | | | | 10,270 | |
+Net cash provided by (used in) investing activities | | | (4,833 | ) | | | (26,629 | ) | | | 283 | |
+Cash flows from financing activities: | | | | | | |
+Purchase of treasury shares | | | - | | | | (3,885 | ) | | | - | |
+Prepayments for purchase of treasury shares | | | - | | | | 885 | | | | - | |
+Payment of cash dividends | | | - | | | | (442 | ) | | | - | |
+Proceeds from issuance of new shares by subsidiaries | | | 411 | | | | - | | | | - | |
+Proceeds of short-term unsecured borrowings | | | - | | | | 334 | | | | - | |
+Repayments of short-term unsecured borrowings | | | - | | | | - | | | | (140 | ) |
+Repayments of long-term unsecured borrowings | | | (1,500 | ) | | | (1,500 | ) | | | (1,500 | ) |
+Proceeds from short-term secured borrowings | | | 580,900 | | | | 484,300 | | | | 580,900 | |
+Repayments of short-term secured borrowings | | | (580,900 | ) | | | (484,300 | ) | | | (580,900 | ) |
+Payment of lease liabilities | | | (558 | ) | | | (584 | ) | | | (518 | ) |
+Guarantee deposits received | | | 400 | | | | - | | | | - | |
+Net cash used in financing activities | | | (1,247 | ) | | | (5,192 | ) | | | (2,158 | ) |
+Effect of foreign currency exchange rate changes on cash and cash equivalents | | | 145 | | | | 580 | | | | 54 | |
+Net increase in cash and cash equivalents | | | 11,603 | | | | 29,233 | | | | 2,189 | |
+Cash and cash equivalents at beginning of period | | | 259,693 | | | | 275,445 | | | | 257,504 | |
+Cash and cash equivalents at end of period | | $ | 271,296 | | | $ | 304,678 | | | $ | 259,693 | |
+
+
+Himax Technologies, Inc. |
+Unaudited Condensed Consolidated Statements of Cash Flows |
+(Amounts in Thousands of U.S. Dollars) |
+| | Six Months
+Ended June 30, |
+| | | 2026 | | | | 2025 | |
+| | | | |
+Cash flows from operating activities: | | | | |
+Profit for the period | | $ | 28,794 | | | $ | 37,192 | |
+Adjustments for: | | | | |
+Depreciation and amortization | | | 11,843 | | | | 10,431 | |
+Share-based compensation expenses | | | 148 | | | | 247 | |
+Losses (gains)on disposals and scrap of property, plant and equipment, net | | | 4 | | | | (3,205 | ) |
+Changes in fair value of financial assets at fair value through profit or loss | | | (276 | ) | | | (257 | ) |
+Interest income | | | (4,203 | ) | | | (5,049 | ) |
+Finance costs | | | 1,622 | | | | 1,773 | |
+Income tax expense | | | 6,754 | | | | 8,895 | |
+Share of losses of associates | | | 1,886 | | | | 1,330 | |
+Inventories write downs | | | 4,763 | | | | 10,450 | |
+Unrealized foreign currency exchange losses | | | 921 | | | | 559 | |
+| | | 52,256 | | | | 62,366 | |
+Changes in: | | | | |
+Accounts receivable (including related parties) | | | (19,376 | ) | | | 11,600 | |
+Inventories | | | (3,564 | ) | | | 13,723 | |
+Other receivable from related parties | | | 11 | | | | 6 | |
+Other current assets | | | 4,187 | | | | 68 | |
+Accounts payable | | | (6,634 | ) | | | 30,140 | |
+Other payable to related parties | | | (364 | ) | | | 47 | |
+Contract liabilities | | | 1,097 | | | | 122 | |
+Other current liabilities | | | (8,001 | ) | | | (322 | ) |
+Other non-current liabilities | | | 41 | | | | 142 | |
+Cash generated from operating activities | | | 19,653 | | | | 117,892 | |
+Interest received | | | 3,984 | | | | 4,753 | |
+Interest paid | | | (1,368 | ) | | | (1,774 | ) |
+Income tax paid | | | (721 | ) | | | (4,350 | ) |
+Net cash provided by operating activities | | | 21,548 | | | | 116,521 | |
+| | | | |
+Cash flows from investing activities: | | | | |
+Acquisitions of property, plant and equipment | | | (7,207 | ) | | | (9,817 | ) |
+Acquisitions of intangible assets | | | (264 | ) | | | (52 | ) |
+Acquisitions of financial assets at amortized cost | | | (2,645 | ) | | | (3,517 | ) |
+Proceeds from disposal of financial assets at amortized cost | | | 1,291 | | | | 4,286 | |
+Acquisitions of financial assets at fair value through profit or loss | | | (21,882 | ) | | | (50,717 | ) |
+Proceeds from disposal of financial assets at fair value through profit or loss | | | 22,507 | | | | 31,242 | |
+Acquisitions of financial assets at fair value through other comprehensive income | | | (6,385 | ) | | | (2,500 | ) |
+Acquisitions of equity method investments | | | (244 | ) | | | (2,500 | ) |
+Decrease in refundable deposits | | | 10,279 | | | | 10,313 | |
+Net cash used in investing activities | | | (4,550 | ) | | | (23,262 | ) |
+Cash flows from financing activities: | | | | |
+Purchase of treasury stock | | | - | | | | (3,885 | ) |
+Decrease in prepayments for purchase of treasury stock | | | - | | | | 885 | |
+Payments of cash dividends | | | - | | | | (442 | ) |
+Proceeds from issuance of new shares by subsidiary | | | 411 | | | | - | |
+Proceeds from short-term unsecured borrowings | | | - | | | | 946 | |
+Repayments of short-term unsecured borrowings | | | (140 | ) | | | - | |
+Repayments of long-term unsecured borrowings | | | (3,000 | ) | | | (3,000 | ) |
+Proceeds from short-term secured borrowings | | | 1,161,800 | | | | 968,600 | |
+Repayments of short-term secured borrowings | | | (1,161,800 | ) | | | (968,600 | ) |
+Payment of lease liabilities | | | (1,076 | ) | | | (2,032 | ) |
+Guarantee deposits received | | | 400 | | | | - | |
+Net cash used in financing activities | | | (3,405 | ) | | | (7,528 | ) |
+Effect of foreign currency exchange rate changes on cash and cash equivalents | | | 199 | | | | 799 | |
+Net increase in cash and cash equivalents | | | 13,792 | | | | 86,530 | |
+Cash and cash equivalents at beginning of period | | | 257,504 | | | | 218,148 | |
+Cash and cash equivalents at end of period | | $ | 271,296 | | | $ | 304,678 | |

--- a/modules/test-fixtures/earnings-filings/hwm.txt
+++ b/modules/test-fixtures/earnings-filings/hwm.txt
@@ -1,0 +1,3272 @@
+EX-99.1
+2
+tm2622325d1_ex99-1.htm
+EXHIBIT 99.1
+
+
+
+
+
+
+
+
+
+
+Exhibit
+99.1
+
+
+
+
+
+
+
+
+
+
+
+FOR
+IMMEDIATE RELEASE
+
+
+
+
+
+
+
+Investor
+Contact |
+Media
+Contact |
+
+
+Paul
+T. Luther |
+Rob
+Morrison |
+
+
+(412)
+553-1950 |
+(412)
+553-2666 |
+
+
+Paul.Luther@howmet.com |
+Rob.Morrison@howmet.com |
+
+
+
+
+
+Howmet
+Aerospace Reports Second Quarter 2026 Results
+
+
+Revenue
+up 24% Year over Year, Organic Growth 21% ; G AAP EPS $1.33, Adjusted EPS $1.33
+
+
+Strong
+Second Quarter Cash Generation; $300 Million Deployed for Common Stock Repurchases
+
+
+Full
+Year 2026 Guidance Increased
+
+
+
+
+
+Summary
+Financial Results
+
+
+
+
+
+
+
+| |
+Second
+Quarter | | |
+|
+|
+| | |
+Six Months | | |
+| |
+
+
+Dollars in Millions; Per share amounts in dollars,
+diluted | |
+2026 | | |
+2025 | | |
+|
+Change |
+| | |
+2026 | | |
+2025 | | |
+Change |
+| |
+
+
+Revenue | |
+$ | 2,547 | | |
+$ | 2,053 | | |
+| 24 | % |
+| |
+$ | 4,860 | | |
+$ | 3,995 | | |
+22 | % |
+|
+
+
+| |
+| | | |
+| | | |
+| | |
+| |
+| | | |
+| | | |
+| |
+|
+
+
+GAAP Metrics | |
+| | | |
+| | | |
+| | |
+| |
+| | | |
+| | | |
+| |
+|
+
+
+Operating Income | |
+$ | 711 | | |
+$ | 521 | | |
+| 36 | % |
+| |
+$ | 1,464 | | |
+$ | 1,015 | | |
+44 | % |
+|
+
+
+Operating Income Margin | |
+| 27.9 | % | |
+| 25.4 | % | |
+| 250 | bps |
+| |
+| 30.1 | % | |
+| 25.4 | % | |
+470 | bps |
+|
+
+
+Earnings per Share (EPS) | |
+$ | 1.33 | | |
+$ | 1.00 | | |
+| 33 | % |
+| |
+$ | 2.77 | | |
+$ | 1.84 | | |
+51 | % |
+|
+
+
+Cash from Operations | |
+$ | 583 | | |
+$ | 446 | | |
+| 31 | % |
+| |
+$ | 1,036 | | |
+$ | 699 | | |
+48 | % |
+|
+
+
+| |
+| | | |
+| | | |
+| | |
+| |
+| | | |
+| | | |
+| |
+|
+
+
+Non-GAAP
+Metrics 1 | |
+| | | |
+| | | |
+| | |
+| |
+| | | |
+| | | |
+| |
+|
+
+
+Adjusted EBITDA | |
+$ | 817 | | |
+$ | 589 | | |
+| 39 | % |
+| |
+$ | 1,557 | | |
+$ | 1,149 | | |
+36 | % |
+|
+
+
+Adjusted EBITDA Margin | |
+| 32.1 | % | |
+| 28.7 | % | |
+| 340 | bps |
+| |
+| 32.0 | % | |
+| 28.8 | % | |
+320 | bps |
+|
+
+
+Adjusted Operating Income | |
+$ | 733 | | |
+$ | 520 | | |
+| 41 | % |
+| |
+$ | 1,399 | | |
+$ | 1,011 | | |
+38 | % |
+|
+
+
+Adjusted Operating Income Margin | |
+| 28.8 | % | |
+| 25.3 | % | |
+| 350 | bps |
+| |
+| 28.8 | % | |
+| 25.3 | % | |
+350 | bps |
+|
+
+
+Adjusted Earnings per Share (EPS) | |
+$ | 1.33 | | |
+$ | 0.91 | | |
+| 46 | % |
+| |
+$ | 2.56 | | |
+$ | 1.77 | | |
+45 | % |
+|
+
+
+Free Cash Flow | |
+$ | 479 | | |
+$ | 344 | | |
+| 39 | % |
+| |
+$ | 838 | | |
+$ | 478 | | |
+75 | % |
+|
+
+
+
+
+
+
+1
+For more information, see &ldquo;Non-GAAP Financial Measures&rdquo; and the schedules to this release.
+
+
+
+
+
+Key
+Activity
+
+
+
+
+
+
+| &middot; | Completed
+acquisition of CAM on April 6, 2026 for approximately $1.8 billion |
+
+
+| &middot; | Paid
+down the Company's $186 million Japanese Yen-denominated term loan facility and entered into
+a separate $300 million cross-currency swap, reducing annualized interest expense by $12
+million |
+
+
+| &middot; | Increased
+the third quarter common stock dividend by 17% to $0.14
+per s hare |
+
+
+
+
+
+
+
+
+
+1
+
+
+
+
+
+
+
+
+
+
+PITTSBURGH,
+PA, August 6, 2026 &ndash; Howmet Aerospace (NYSE: HWM) announced results today for the second quarter 2026.
+
+
+
+
+
+Howmet
+Aerospace Executive Chairman and Chief Executive Officer John Plant said, &ldquo;The Howmet team delivered a strong set of results, with
+revenue, adjusted EBITDA, adjusted EBITDA margin, and adjusted earnings per share all exceeding the high end of guidance. Revenue growth
+was healthy at 24% year over year and 21% excluding the net impact of the three asset transactions completed this year. Adjusted EBITDA
+margin expanded 340 basis points year over year to 32.1%, including the absorption of the CAM fastener acquisition in April. Free cash
+flow performance was excellent at $479 million after $104 million in capital expenditures, supporting the future growth rate of the Company.
+The free cash flow also enabled $800 million in common stock repurchases year to date through July, an amount already greater than total
+repurchases in 2025.&rdquo;
+
+
+
+
+
+Mr.
+Plant continued, &ldquo;Looking ahead, Howmet is well positioned, with all our major markets in growth mode. More robust build rates
+for commercial aircraft are supported by record backlogs, while engine spares needs continue to increase. Defense markets remain healthy,
+and the focus for missiles, drones and collaborative combat aircraft continues with growth expected over the medium term. Demand in the
+gas turbines market is extraordinary with customers already revisiting and adding to their demand
+outlooks . The commercial transportation market has begun to recover, as anticipated.&rdquo;
+
+
+
+
+
+"Our
+capital expenditure requirements continue to increase, and we already see the need to increase this further in 2027 to support future
+organic growth expectations in both the aerospace and gas turbines markets. We closed the CAM acquisition in April, and the integration
+is on track. Continued healthy cash generation will allow us to achieve pre-CAM leverage levels in short order, with the Company well
+positioned to consider all paths of capital deployment optionality going forward."
+
+
+
+
+
+2026
+Guidance
+
+
+
+
+
+
+
+| |
+Q3 2026
+Guidance | | |
+FY 2026
+Guidance | |
+
+
+Dollars in Millions; Per share amounts in dollars,
+diluted | |
+Low | | |
+Baseline | | |
+High | | |
+Low | | |
+Baseline | | |
+High | |
+
+
+Revenue | |
+$ | 2,565 | | |
+$ | 2,575 | | |
+$ | 2,585 | | |
+$ | 10,000 | | |
+$ | 10,050 | | |
+$ | 10,100 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Baseline | | |
+| +$ 400 | | |
+| | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Change | | |
+| | | |
+| | |
+
+
+Adj.
+EBITDA 1 | |
+$ | 825 | | |
+$ | 830 | | |
+$ | 835 | | |
+$ | 3,210 | | |
+$ | 3,230 | | |
+$ | 3,250 | |
+
+
+Adj.
+EBITDA Margin 1 | |
+| 32.2 | % | |
+| 32.2 | % | |
+| 32.3 | % | |
+| 32.1 | % | |
+| 32.1 | % | |
+| 32.2 | % |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Baseline | | |
+| +$170
+
+| | |
+| | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Change | | |
+| +
+40 bps | | |
+| | |
+
+
+Adj.
+Earnings per Share 1 | |
+$ | 1.34 | | |
+$ | 1.35 | | |
+$ | 1.36 | | |
+$ | 5.23 | | |
+$ | 5.27 | | |
+$ | 5.31 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Baseline | | |
+| +$ 0.33 | | |
+| | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Change | | |
+| | | |
+| | |
+
+
+Free
+Cash Flow 1 | |
+| | | |
+| | | |
+| | | |
+$ | 1,850 | | |
+$ | 1,900 | | |
+$ | 1,950 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Baseline | | |
+| +$ 150 | | |
+| | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| Change | | |
+| | | |
+| | |
+
+
+
+
+
+
+1
+Reconciliations of the forward-looking non-GAAP financial measures to the most directly comparable GAAP financial measures, as well as
+the directly comparable GAAP measures, are not available without unreasonable efforts due to the variability and complexity of the charges
+and other components excluded from the non-GAAP measures, such as gains or losses on sales of assets, taxes, and any future restructuring
+or impairment charges. In addition, there is inherent variability already included in the GAAP measures, including, but not limited to,
+price/mix and volume. Howmet Aerospace believes such reconciliations would imply a degree of precision that would be confusing or misleading
+to investors.
+
+
+
+
+
+Consolidated
+Results
+
+
+
+
+
+Howmet
+Aerospace reported second quarter 2026 revenue of $2.55 billion, up 24% year ov er year with organic
+growth of 21%, and Adjusted EPS of $1.33, up 46% year over year. Revenue was driv en by 28% growth in the commercial aerospace
+market, 11% growth in the defense aerospace market and 38% growth in the gas turbines market.
+
+
+
+
+
+
+
+
+
+2
+
+
+
+
+
+
+
+
+
+
+The
+Company reported adjusted EBITDA of $817 million, up 39% year over year. The year-over-year increase was driven
+by strong growth in the commercial aerospace, defense aerospace, and gas turbines markets. Adj usted EBITDA margin was up approximately
+340 basis points year over year at 32.1%.
+
+
+
+
+
+Segment
+Results
+
+
+
+
+
+Engine
+Products
+
+
+
+
+
+
+
+| |
+Second
+Quarter | | |
+| |
+
+
+Dollars in Millions | |
+2026 | | |
+2025 | | |
+Change | |
+
+
+Third-party sales | |
+$ | 1,373 | | |
+$ | 1,038 | | |
+| 32 | % |
+
+
+Segment adjusted EBITDA | |
+$ | 517 | | |
+$ | 343 | | |
+| 51 | % |
+
+
+Segment adjusted EBITDA margin | |
+| 37.7 | % | |
+| 33.0 | % | |
+| 470
+| bps |
+
+
+Provision for depreciation and amortization | |
+$ | 42 | | |
+$ | 35 | | |
+| | |
+
+
+
+
+
+
+Engine
+Products reported second quarter 2026 revenue of $1.37 billion, an increase of 32% year
+over year, driven by growth in t he commercial aerospace, defense aerospace, and gas turbines markets.
+Segment Adjusted EBITDA was $517 million, up 51% year over year, driven by growth in the commercial aerospace, defense aerospace, and
+gas t urbines markets. The Segment absorbed approximately 485 net headcount in the quarter in support of expected revenue increases.
+Segment Adjusted EBITDA margin increased approximately 470 basis points year over year to 37.7%.
+
+
+
+
+
+Fastening
+Systems
+
+
+
+
+
+
+
+| |
+Second
+Quarter | | |
+| |
+
+
+Dollars in Millions | |
+2026 | | |
+2025 | | |
+Change | |
+
+
+Third-party sales | |
+$ | 589 | | |
+$ | 431 | | |
+| 37 | % |
+
+
+Segment adjusted EBITDA | |
+$ | 177 | | |
+$ | 126 | | |
+| 40 | % |
+
+
+Segment adjusted EBITDA margin | |
+| 30.1 | % | |
+| 29.2 | % | |
+| 90
+| bps |
+
+
+Provision for depreciation and amortization | |
+$ | 20 | | |
+$ | 12 | | |
+| | |
+
+
+
+
+
+
+Fastening
+Systems repor ted revenue of $589 million, an increase
+of 37% year over year, driven by growth in the commercial aerospace and defense aerospace markets. Revenue includes the impacts from
+the CAM and Brunner acquisitions. Segment Adjusted EBITDA was $177 million, up 40% year
+over year, driven by growth in the commercial aerospace and defense aerospace markets and including contributions from the acquisitions.
+Segm ent Adjusted EBITDA margin increased approximately 90 basis points year over year to 30.1%.
+
+
+
+
+
+Engineered
+Structures
+
+
+
+
+
+
+
+| |
+Second
+Quarter | | |
+| |
+
+
+Dollars in Millions | |
+2026 | | |
+2025 | | |
+Change | |
+
+
+Third-party sales | |
+$ | 269 | | |
+$ | 308 | | |
+| (13 | )% |
+
+
+Segment adjusted EBITDA | |
+$ | 64 | | |
+$ | 68 | | |
+| (6 | )% |
+
+
+Segment adjusted EBITDA margin | |
+| 23.8 | % | |
+| 22.1 | % | |
+| 170
+| bps |
+
+
+Provision for depreciation and amortization | |
+$ | 11 | | |
+$ | 10 | | |
+| | |
+
+
+
+
+
+
+Engineered
+Structures reported revenue of $269 million, a decrease of 13% year over year, driven by the divestiture
+of the Savannah disk forging facility and product rationalization. Se gment Adjusted EBITDA was $64 million, a decrease of 6% year
+over year on the exit of lower-margin business including the divestiture . Se gment Adjusted
+EBITDA margin increased approximately 170 basis points year over year to 23.8%.
+
+
+
+
+
+
+
+
+
+3
+
+
+
+
+
+
+
+
+
+
+Forged
+Wheels
+
+
+
+
+
+
+
+| |
+Second
+Quarter | | |
+| |
+
+
+Dollars in Millions | |
+2026 | | |
+2025 | | |
+Change | |
+
+
+Third-party sales | |
+$ | 316 | | |
+$ | 276 | | |
+| 14 | % |
+
+
+Segment adjusted EBITDA | |
+$ | 88 | | |
+$ | 76 | | |
+| 16 | % |
+
+
+Segment adjusted EBITDA margin | |
+| 27.8 | % | |
+| 27.5 | % | |
+| 30 | bps |
+
+
+Provision for depreciation and amortization | |
+$ | 10 | | |
+$ | 10 | | |
+| | |
+
+
+
+
+
+
+Forged
+Wheels reported revenue of $316 million, an increase of 14% year over year, with 8% lower volumes in the commercial transportation
+market more than offset by an increase in aluminum and other inflationary cost pass through. Volumes increased 7% sequentially from the
+first quarter 2026, reflecting the beginning of the recovery of the North American commercial transportation market. Segm ent Adjusted
+EBITDA was $88 million and increased 16% year over year, driven by cost reductions, including lower net headcount, in response to lower
+volumes. Segment Adjusted EBITDA margin increased approximately 30 basis points year over year to 27.8% despite the impact of higher
+aluminum cost pass through.
+
+
+
+
+
+Completed
+Acquisition of CAM for Approximately $1.8 Billion
+
+
+
+
+
+On
+April 6, 2026, the Company completed the acquisition of Consolidated Aerospace Manufacturing, LLC (CAM) for approximately $1.8 billion
+from Stanley Black & Decker, Inc. CAM is a leading global designer and manufacturer of precision fasteners, fluid fittings, and other
+complex, highly engineered products for demanding aerospace and defense applications.
+
+
+
+
+
+Debt
+Actions in Second Quarter Reduce Annualized Interest Expense by Approximately $12 Million
+
+
+
+
+
+On
+May 22, 2026, the Company repaid the outstanding principal amount of its Japanese Yen-denominated, senior unsecured term loan facility
+for approximately $186 million with cash on hand. The Company also entered into a cross-currency swap to synthetically convert the outstanding
+$300 million aggregate principal amount of its 6.75% Bonds due 2028 into a Japanese Yen liability for a fixed interest rate of approximately
+3.88%. The combined effect of these debt actions will reduce annualized interest expense by $12 million.
+
+
+
+
+
+Repurchased
+$300 Million of Common Stock in Second Quarter 2026; $200 Million in July 2026
+
+
+
+
+
+In
+the second quarter 2026, Howmet Aerospace repurchased $300 million of common stock at an average price of $250.61 per share, retiring
+approximately 1.2 million shares. In July 2026, the Company repurchased an additional $20 0 million
+of common stock at an average price of $276.61 per share, retiring approximately 0.7 million shares. Year to date through July, the Company
+has repurchased $800 million of shares at an average price of $248.29 per share, exceeding the $700 million of shares repurchased in
+all of 2025. As of August 6, 2026, total share repurchase authorization available was $697
+million.
+
+
+
+
+
+Quarterly
+Common Stock Dividend Increas es 17% to $0.14 Per Sh are in Third Quarter 2026
+
+
+
+
+
+On
+July 27 , 2026, the Board of Directors declared a dividend o f
+$0.14 pe r share on its common stock to be paid on August 25 , 2026 to holders of record
+as of the close of business on August 7 , 2026. The quarterly dividend represents a
+17% inc rease from the second quarter 2026 dividend of $0.12 per share.
+
+
+
+
+
+
+
+
+
+4
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace will hold its quarterly conference call at 10:00 AM Eastern Time on Thursday, August 6, 2026. The call will be webcast via
+www.howmet.com. The press release and presentation materials will be available at approximately 7:00 AM ET on August 6, via the &ldquo;Investors&rdquo;
+section of the Howmet Aerospace website.
+
+
+
+
+
+About
+Howmet Aerospace
+
+
+
+
+
+Howmet
+Aerospace Inc., headquartered in Pittsburgh, Pennsylvania, is a leading global provider of advanced engineered solutions for the aerospace,
+gas turbine, and transportation industries. The Company&rsquo;s primary businesses focus on engine components, fastening systems, and
+airframe structural components necessary for mission-critical performance and efficiency, including in aerospace, defense, and gas turbine
+applications, as well as forged aluminum wheels for commercial transportation. With approximately 1,200 granted and pending patents,
+the Company&rsquo;s differentiated technologies enable lighter, more fuel-efficient aircraft and commercial trucks to operate with a
+lower carbon footprint. For more information, visit www.howmet.com.
+
+
+
+
+
+Dissemination
+of Company Information
+
+
+
+
+
+Howmet
+Aerospace intends to make future announcements regarding Company developments and financial performance through its website at www.howmet.com.
+
+
+
+
+
+Forward-Looking
+Statements
+
+
+
+
+
+This
+release contains statements that relate to future events and expectations and as such constitute forward-looking statements within the
+meaning of the Private Securities Litigation Reform Act of 1995. Forward-looking statements include those containing such words as "anticipates,"
+"believes," "could," &ldquo;envisions,&rdquo; "estimates," "expects," "forecasts,"
+"goal," "guidance," "intends," "may," "outlook," "plans," &ldquo;poised,&rdquo;
+"projects," "seeks," "sees," "should," "targets," "will," "would,"
+or other words of similar meaning. All statements that reflect Howmet Aerospace&rsquo;s expectations, assumptions or projections about
+the future, other than statements of historical fact, are forward-looking statements, including, without limitation, statements, forecasts
+and outlook relating to the condition of markets; future financial results or operating performance; future strategic actions; Howmet
+Aerospace's strategies, outlook, and business and financial prospects; any future dividends, debt issuances, debt reduction and repurchases
+of its common stock; and statements regarding any acquisitions, including expected benefits. These statements reflect beliefs and assumptions
+that are based on Howmet Aerospace&rsquo;s perception of historical trends, current conditions and expected future developments, as well
+as other factors Howmet Aerospace believes are appropriate in the circumstances. Forward-looking statements are not guarantees of future
+performance and are subject to risks, uncertainties and changes in circumstances that are difficult to predict, which could cause actual
+results to differ materially from those indicated by these statements. Such risks and uncertainties include, but are not limited to:
+(a) deterioration in global economic and financial market conditions generally, or unfavorable changes in the markets served by Howmet
+Aerospace, including due to escalating tariff and other trade policies and energy costs, and the resulting impacts on Howmet Aerospace&rsquo;s
+supply and distribution chains, as well as on market volatility and global trade generally; (b) the impact of potential cyber attacks
+and information technology or data security breaches; (c) the loss of significant customers or adverse changes in customers&rsquo; business
+or financial conditions; (d) manufacturing difficulties or other issues that impact product performance, quality or safety; (e) inability
+of suppliers to meet obligations due to supply chain disruptions or otherwise; (f) failure to attract and retain a qualified workforce
+and key personnel, labor disputes or other employee relations issues; (g) the inability to achieve anticipated or targeted financial
+performance, operations or competitiveness, or realization of expected benefits from acquisitions, including the effective integration
+of acquired businesses; (h) inability to meet increased demand, production targets or commitments; (i) competition from new product offerings,
+disruptive technologies or other developments; (j) geopolitical, economic, and regulatory risks relating to Howmet Aerospace&rsquo;s
+global operations, including geopolitical and diplomatic tensions, instabilities, conflicts and wars, as well as compliance with U.S.
+and foreign trade and tax laws, sanctions, embargoes and other regulations; (k) the outcome of contingencies, including legal proceedings,
+government or regulatory investigations, and environmental remediation; (l) failure to comply with government contracting regulations;
+(m) adverse changes in discount rates or investment returns on pension assets; and (n) the other risk factors summarized in Howmet Aerospace&rsquo;s
+Form 10-K for the year ended December 31, 2025 and other reports filed with the U.S. Securities and Exchange Commission. Market projections
+are subject to the risks discussed above and other risks in the market. Under its share repurchase program, the Company may repurchase
+shares from time to time, in amounts, at prices, and at such times as the Company deems appropriate, subject to market conditions, legal
+requirements and other considerations. The Company is not obligated to repurchase any specific number of shares or to do so at any particular
+time. The declaration of any future dividends is subject to the discretion and approval of the Board of Directors after the Board&rsquo;s
+consideration of all factors it deems relevant and subject to applicable law. The Company may modify, suspend, or cancel its share repurchase
+program or any dividend policy in any manner and at any time that it may deem necessary or appropriate. Credit ratings are not a recommendation
+to buy or hold any Howmet Aerospace securities, and they may be revised or revoked at any time at the sole discretion of the credit rating
+organizations. The statements in this release are made as of the date of this release, even if subsequently made available by Howmet
+Aerospace on its website or otherwise. Howmet Aerospace disclaims any intention or obligation to update publicly any forward-looking
+statements, whether in response to new information, future events, or otherwise, except as required by applicable law.
+
+
+
+
+
+
+
+
+
+5
+
+
+
+
+
+
+
+
+
+
+Non-GAAP
+Financial Measures
+
+
+
+
+
+Some
+of the information included in this release is derived from Howmet Aerospace&rsquo;s consolidated financial information but is not presented
+in Howmet Aerospace&rsquo;s financial statements prepared in accordance with accounting principles generally accepted in the United States
+of America (GAAP). Certain of these data are considered &ldquo;non-GAAP financial measures&rdquo; under SEC rules. These non-GAAP financial
+measures supplement our GAAP disclosures and should not be considered an alternative to the GAAP measure. Reconciliations to the most
+directly comparable GAAP financial measures and management&rsquo;s rationale for the use of the non-GAAP financial measures can be found
+in the schedules to this release.
+
+
+
+
+
+Adjusted
+EBITDA is defined as Operating Income excluding Restructuring and other (credits) charges, Special Items and provision for depreciation
+and amortization.
+
+
+
+
+
+Other
+Information
+
+
+
+
+
+In
+this press release, the acronym &ldquo;FY&rdquo; means &ldquo;full year&rdquo;; &ldquo;Q&rdquo; means &ldquo;quarter&rdquo;; &ldquo;YoY&rdquo;
+means year over year; &ldquo;Adj.&rdquo; means adjusted; Howmet, Howmet Aerospace, or the Company means Howmet Aerospace Inc.; "organic
+growth" refers to the Company's revenue growth excluding the impact of acquisitions and divestitures; and references to performance
+by Howmet Aerospace or its segments as &ldquo;record&rdquo; mean its best result since April 1, 2020 when Howmet Aerospace Inc. (previously
+named Arconic Inc.) separated from Arconic Corporation.
+
+
+
+
+
+
+
+
+
+6
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Statement
+of Consolidated Operations (unaudited)
+
+
+(in
+U.S. dollar millions, except per-share and share amounts)
+
+
+
+
+
+
+
+| |
+Quarter
+ended | |
+
+
+| |
+June 30,
+2026 | | |
+March 31,
+2026 | | |
+June 30,
+2025 | |
+
+
+Sales | |
+$ | 2,547 | | |
+$ | 2,313 | | |
+$ | 2,053 | |
+
+
+Cost of goods sold (exclusive of expenses below) | |
+| 1,596 | | |
+| 1,459 | | |
+| 1,365 | |
+
+
+Selling, general administrative, and other expenses | |
+| 148 | | |
+| 111 | | |
+| 89 | |
+
+
+Research and development expenses | |
+| 8 | | |
+| 9 | | |
+| 9 | |
+
+
+Provision for depreciation and amortization | |
+| 84 | | |
+| 74 | | |
+| 69 | |
+
+
+Restructuring and other credits | |
+| &mdash; | | |
+| (93 | ) | |
+| &mdash; | |
+
+
+Operating income | |
+| 711 | | |
+| 753 | | |
+| 521 | |
+
+
+Interest expense, net | |
+| 51 | | |
+| 43 | | |
+| 38 | |
+
+
+Other expense, net | |
+| 11 | | |
+| 2 | | |
+| 14 | |
+
+
+Income before income taxes | |
+| 649 | | |
+| 708 | | |
+| 469 | |
+
+
+Provision for income taxes | |
+| 115 | | |
+| 128 | | |
+| 62 | |
+
+
+Net income | |
+$ | 534 | | |
+$ | 580 | | |
+$ | 407 | |
+
+
+| |
+| | | |
+| | | |
+| | |
+
+
+Amounts Attributable to Howmet Aerospace Common Shareholders: | |
+| | | |
+| | | |
+| | |
+
+
+Earnings
+per share - basic (1) : | |
+| | | |
+| | | |
+| | |
+
+
+Net income per share | |
+$ | 1.33 | | |
+$ | 1.45 | | |
+$ | 1.01 | |
+
+
+Average
+number of shares (2)(3) | |
+| 400 | | |
+| 401 | | |
+| 404 | |
+
+
+Earnings
+per share - diluted (1) : | |
+| | | |
+| | | |
+| | |
+
+
+Net income per share | |
+$ | 1.33 | | |
+$ | 1.44 | | |
+$ | 1.00 | |
+
+
+Average
+number of shares (2)(3) | |
+| 402 | | |
+| 403 | | |
+| 406 | |
+
+
+Common stock outstanding at the end
+of the period | |
+| 400 | | |
+| 401 | | |
+| 404 | |
+
+
+
+
+
+
+
+| (1) | In
+order to calculate both basic and diluted earnings per share through December 31, 2025, preferred
+stock dividends declared of less than $1 for the quarters presented need to be subtracted
+from Net income. |
+
+
+| (2) | For
+the quarters presented, the difference between the diluted average number of shares and the
+basic average number of shares relates to share equivalents associated with outstanding restricted
+stock unit awards and employee stock options. |
+
+
+| (3) | As
+average shares outstanding are used in the calculation of both basic and diluted earnings
+per share, the full impact of share repurchases is not fully realized in earnings per share
+("EPS") in the period of repurchase since share repurchases may occur at varying
+points during a period. |
+
+
+
+
+
+
+
+
+
+7
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Consolidated
+Balance Sheet (unaudited)
+
+
+(in
+U.S. dollar millions)
+
+
+
+
+
+
+
+| |
+June
+30, 2026 | | |
+December
+31, 2025 | |
+
+
+Assets | |
+| | | |
+| | |
+
+
+Current assets: | |
+| | | |
+| | |
+
+
+Cash and cash equivalents | |
+$ | 563 | | |
+$ | 742 | |
+
+
+Receivables from customers, less allowances
+of $&mdash; in both 2026 and 2025 | |
+| 1,040 | | |
+| 779 | |
+
+
+Inventories | |
+| 2,183 | | |
+| 1,849 | |
+
+
+Prepaid expenses
+and other current assets | |
+| 407 | | |
+| 409 | |
+
+
+Total current assets | |
+| 4,193 | | |
+| 3,779 | |
+
+
+Properties, plants, and equipment, net | |
+| 2,817 | | |
+| 2,593 | |
+
+
+Goodwill | |
+| 5,084 | | |
+| 4,022 | |
+
+
+Deferred income taxes | |
+| 48 | | |
+| 40 | |
+
+
+Intangibles, net | |
+| 869 | | |
+| 457 | |
+
+
+Other noncurrent assets | |
+| 240 | | |
+| 288 | |
+
+
+Total assets | |
+$ | 13,251 | | |
+$ | 11,179 | |
+
+
+| |
+| | | |
+| | |
+
+
+Liabilities | |
+| | | |
+| | |
+
+
+Current liabilities: | |
+| | | |
+| | |
+
+
+Accounts payable, trade | |
+$ | 1,149 | | |
+$ | 845 | |
+
+
+Accrued compensation and retirement
+costs | |
+| 304 | | |
+| 343 | |
+
+
+Taxes, including income taxes | |
+| 87 | | |
+| 77 | |
+
+
+Accrued interest payable | |
+| 62 | | |
+| 47 | |
+
+
+Deferred revenue | |
+| 119 | | |
+| 147 | |
+
+
+Other current liabilities | |
+| 134 | | |
+| 121 | |
+
+
+Long-term debt due within one year | |
+| 1 | | |
+| 191 | |
+
+
+Short-term borrowings | |
+| 450 | | |
+| &mdash; | |
+
+
+Total current liabilities | |
+| 2,306 | | |
+| 1,771 | |
+
+
+Long-term debt, less amount due within one year | |
+| 4,050 | | |
+| 2,859 | |
+
+
+Accrued pension benefits | |
+| 511 | | |
+| 546 | |
+
+
+Accrued other postretirement benefits | |
+| 34 | | |
+| 38 | |
+
+
+Other noncurrent liabilities and deferred
+credits | |
+| 618 | | |
+| 612 | |
+
+
+Total liabilities | |
+| 7,519 | | |
+| 5,826 | |
+
+
+| |
+| | | |
+| | |
+
+
+Equity | |
+| | | |
+| | |
+
+
+Howmet Aerospace shareholders&rsquo; equity: | |
+| | | |
+| | |
+
+
+Common stock | |
+| 400 | | |
+| 402 | |
+
+
+Additional capital | |
+| 1,919 | | |
+| 2,531 | |
+
+
+Retained earnings | |
+| 5,110 | | |
+| 4,093 | |
+
+
+Accumulated other
+comprehensive loss | |
+| (1,697 | ) | |
+| (1,673 | ) |
+
+
+Total equity | |
+| 5,732 | | |
+| 5,353 | |
+
+
+Total liabilities
+and equity | |
+$ | 13,251 | | |
+$ | 11,179 | |
+
+
+
+
+
+
+
+
+
+
+8
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Statement
+of Consolidated Cash Flows (unaudited)
+
+
+(in
+U.S. dollar millions)
+
+
+
+
+
+
+
+| |
+Six months ended | |
+
+
+| |
+June 30, | |
+
+
+| |
+2026 | | |
+2025 | |
+
+
+Operating activities | |
+| | | |
+| | |
+
+
+Net income | |
+$ | 1,114 | | |
+$ | 751 | |
+
+
+Adjustments to reconcile net income
+to cash provided from operations: | |
+| | | |
+| | |
+
+
+Depreciation and amortization | |
+| 158 | | |
+| 138 | |
+
+
+Deferred income taxes | |
+| 9 | | |
+| 12 | |
+
+
+Restructuring and other credits | |
+| (93 | ) | |
+| (4 | ) |
+
+
+Net realized and unrealized losses | |
+| 8 | | |
+| 11 | |
+
+
+Net periodic pension cost | |
+| 23 | | |
+| 21 | |
+
+
+Stock-based compensation | |
+| 57 | | |
+| 39 | |
+
+
+Other | |
+| 5 | | |
+| 2 | |
+
+
+Changes in assets
+and liabilities, excluding effects of acquisitions, divestitures, and foreign currency translation adjustments: | |
+| | | |
+| | |
+
+
+Increase in receivables | |
+| (196 | ) | |
+| (170 | ) |
+
+
+Increase in inventories | |
+| (165 | ) | |
+| (81 | ) |
+
+
+(Increase) decrease in prepaid expenses
+and other current assets | |
+| (53 | ) | |
+| 6 | |
+
+
+Increase in accounts payable, trade | |
+| 279 | | |
+| 74 | |
+
+
+Decrease in accrued expenses | |
+| (59 | ) | |
+| (47 | ) |
+
+
+Decrease in taxes, including income
+taxes | |
+| (27 | ) | |
+| (20 | ) |
+
+
+Pension contributions | |
+| (21 | ) | |
+| (15 | ) |
+
+
+Increase in noncurrent assets | |
+| (7 | ) | |
+| (2 | ) |
+
+
+Increase (decrease) in noncurrent liabilities | |
+| 4 | | |
+| (16 | ) |
+
+
+Cash provided
+from operations | |
+| 1,036 | | |
+| 699 | |
+
+
+Financing Activities | |
+| | | |
+| | |
+
+
+Net change in commercial paper | |
+| 450 | | |
+| &mdash; | |
+
+
+Additions to debt | |
+| 1,200 | | |
+| &mdash; | |
+
+
+Repurchases and payments on debt | |
+| (186 | ) | |
+| (77 | ) |
+
+
+Debt issuance costs | |
+| (12 | ) | |
+| &mdash; | |
+
+
+Repurchases of common stock | |
+| (600 | ) | |
+| (300 | ) |
+
+
+Dividends paid to shareholders | |
+| (97 | ) | |
+| (83 | ) |
+
+
+Taxes paid for net share settlement
+of equity awards | |
+| (65 | ) | |
+| (44 | ) |
+
+
+Other | |
+| (5 | ) | |
+| (2 | ) |
+
+
+Cash provided
+from (used for) financing activities | |
+| 685 | | |
+| (506 | ) |
+
+
+Investing Activities | |
+| | | |
+| | |
+
+
+Capital expenditures | |
+| (198 | ) | |
+| (221 | ) |
+
+
+Acquisitions, net of cash acquired | |
+| (1,929 | ) | |
+| &mdash; | |
+
+
+Proceeds from the sale of assets and
+businesses | |
+| 225 | | |
+| 8 | |
+
+
+Other | |
+| 2 | | |
+| 1 | |
+
+
+Cash used
+for investing activities | |
+| (1,900 | ) | |
+| (212 | ) |
+
+
+Effect of exchange rate changes
+on cash, cash equivalents and restricted cash | |
+| &mdash; | | |
+| &mdash; | |
+
+
+Net change in cash, cash equivalents
+and restricted cash | |
+| (179 | ) | |
+| (19 | ) |
+
+
+Cash, cash equivalents
+and restricted cash at beginning of period | |
+| 743 | | |
+| 565 | |
+
+
+Cash, cash
+equivalents and restricted cash at end of period | |
+$ | 564 | | |
+$ | 546 | |
+
+
+
+
+
+
+
+
+
+
+9
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Segment
+Information (unaudited)
+
+
+(in
+U.S. dollar millions)
+
+
+
+
+
+
+
+| |
+| 1Q25 | | |
+| 2Q25 | | |
+| 3Q25 | | |
+| 4Q25 | | |
+| 2025 | | |
+| 1Q26 | | |
+| 2Q26 | |
+
+
+Engine Products | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Third-party sales | |
+$ | 974 | | |
+$ | 1,038 | | |
+$ | 1,087 | | |
+$ | 1,143 | | |
+$ | 4,242 | | |
+$ | 1,253 | | |
+$ | 1,373 | |
+
+
+Inter-segment sales | |
+$ | 2 | | |
+$ | 3 | | |
+$ | 2 | | |
+$ | 1 | | |
+$ | 8 | | |
+$ | 2 | | |
+$ | 3 | |
+
+
+Provision for depreciation and amortization | |
+$ | 33 | | |
+$ | 35 | | |
+$ | 37 | | |
+$ | 39 | | |
+$ | 144 | | |
+$ | 38 | | |
+$ | 42 | |
+
+
+Segment Adjusted EBITDA | |
+$ | 318 | | |
+$ | 343 | | |
+$ | 362 | | |
+$ | 393 | | |
+$ | 1,416 | | |
+$ | 458 | | |
+$ | 517 | |
+
+
+Segment Adjusted EBITDA Margin | |
+| 32.6 | % | |
+| 33.0 | % | |
+| 33.3 | % | |
+| 34.4 | % | |
+| 33.4 | % | |
+| 36.6 | % | |
+| 37.7 | % |
+
+
+Restructuring and other charges | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | 88 | | |
+$ | 88 | | |
+$ | &mdash; | | |
+$ | &mdash; | |
+
+
+Capital expenditures | |
+$ | 85 | | |
+$ | 74 | | |
+$ | 73 | | |
+$ | 84 | | |
+$ | 316 | | |
+$ | 59 | | |
+$ | 77 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Fastening Systems | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Third-party sales | |
+$ | 412 | | |
+$ | 431 | | |
+$ | 448 | | |
+$ | 454 | | |
+$ | 1,745 | | |
+$ | 471 | | |
+$ | 589 | |
+
+
+Inter-segment sales | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | 1 | | |
+$ | 1 | | |
+$ | &mdash; | | |
+$ | &mdash; | |
+
+
+Provision for depreciation and amortization | |
+$ | 12 | | |
+$ | 12 | | |
+$ | 12 | | |
+$ | 12 | | |
+$ | 48 | | |
+$ | 13 | | |
+$ | 20 | |
+
+
+Segment Adjusted EBITDA | |
+$ | 127 | | |
+$ | 126 | | |
+$ | 138 | | |
+$ | 139 | | |
+$ | 530 | | |
+$ | 150 | | |
+$ | 177 | |
+
+
+Segment Adjusted EBITDA Margin | |
+| 30.8 | % | |
+| 29.2 | % | |
+| 30.8 | % | |
+| 30.6 | % | |
+| 30.4 | % | |
+| 31.8 | % | |
+| 30.1 | % |
+
+
+Restructuring and other charges (credits) | |
+$ | &mdash; | | |
+$ | 1 | | |
+$ | &mdash; | | |
+$ | (1 | ) | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | &mdash; | |
+
+
+Capital expenditures | |
+$ | 10 | | |
+$ | 9 | | |
+$ | 13 | | |
+$ | 20 | | |
+$ | 52 | | |
+$ | 17 | | |
+$ | 11 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Engineered Structures | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Third-party sales | |
+$ | 304 | | |
+$ | 308 | | |
+$ | 307 | | |
+$ | 307 | | |
+$ | 1,226 | | |
+$ | 294 | | |
+$ | 269 | |
+
+
+Inter-segment sales | |
+$ | 7 | | |
+$ | 8 | | |
+$ | 7 | | |
+$ | 4 | | |
+$ | 26 | | |
+$ | 8 | | |
+$ | 8 | |
+
+
+Provision for depreciation and amortization | |
+$ | 13 | | |
+$ | 10 | | |
+$ | 10 | | |
+$ | 10 | | |
+$ | 43 | | |
+$ | 10 | | |
+$ | 11 | |
+
+
+Segment Adjusted EBITDA | |
+$ | 67 | | |
+$ | 68 | | |
+$ | 64 | | |
+$ | 66 | | |
+$ | 265 | | |
+$ | 66 | | |
+$ | 64 | |
+
+
+Segment Adjusted EBITDA Margin | |
+| 22.0 | % | |
+| 22.1 | % | |
+| 20.8 | % | |
+| 21.5 | % | |
+| 21.6 | % | |
+| 22.4 | % | |
+| 23.8 | % |
+
+
+Restructuring and other credits | |
+$ | (4 | ) | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | (4 | ) | |
+$ | (93 | ) | |
+$ | &mdash; | |
+
+
+Capital expenditures | |
+$ | 6 | | |
+$ | 7 | | |
+$ | 10 | | |
+$ | 13 | | |
+$ | 36 | | |
+$ | 12 | | |
+$ | 8 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Forged Wheels | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Third-party sales | |
+$ | 252 | | |
+$ | 276 | | |
+$ | 247 | | |
+$ | 264 | | |
+$ | 1,039 | | |
+$ | 295 | | |
+$ | 316 | |
+
+
+Provision for depreciation and amortization | |
+$ | 10 | | |
+$ | 10 | | |
+$ | 11 | | |
+$ | 11 | | |
+$ | 42 | | |
+$ | 11 | | |
+$ | 10 | |
+
+
+Segment Adjusted EBITDA | |
+$ | 68 | | |
+$ | 76 | | |
+$ | 73 | | |
+$ | 79 | | |
+$ | 296 | | |
+$ | 90 | | |
+$ | 88 | |
+
+
+Segment Adjusted EBITDA Margin | |
+| 27.0 | % | |
+| 27.5 | % | |
+| 29.6 | % | |
+| 29.9 | % | |
+| 28.5 | % | |
+| 30.5 | % | |
+| 27.8 | % |
+
+
+Restructuring and other credits | |
+$ | &mdash; | | |
+$ | (1 | ) | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | (1 | ) | |
+$ | &mdash; | | |
+$ | &mdash; | |
+
+
+Capital expenditures | |
+$ | 15 | | |
+$ | 8 | | |
+$ | 9 | | |
+$ | 4 | | |
+$ | 36 | | |
+$ | 3 | | |
+$ | 4 | |
+
+
+
+
+
+
+Differences
+between the total segment and consolidated totals are in Corporate.
+
+
+
+
+
+
+
+
+
+10
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Calculation
+of Financial Measures (unaudited)
+
+
+(in
+U.S. dollar millions)
+
+
+
+
+
+Reconciliation
+of Total Segment Adjusted EBITDA to Consolidated Operating income
+
+
+
+
+
+
+
+
+
+| |
+| 1Q25 | | |
+| 2Q25 | | |
+| 3Q25 | | |
+| 4Q25 | | |
+| 2025 | | |
+| 1Q26 | | |
+| 2Q26 | |
+
+
+Operating income | |
+$ | 494 | | |
+$ | 521 | | |
+$ | 542 | | |
+$ | 489 | | |
+$ | 2,046 | | |
+$ | 753 | | |
+$ | 711 | |
+
+
+Segment provision for depreciation and amortization | |
+| 68 | | |
+| 67 | | |
+| 70 | | |
+| 72 | | |
+| 277 | | |
+| 72 | | |
+| 83 | |
+
+
+Unallocated amounts: | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Restructuring and other (credits) charges | |
+| (4 | ) | |
+| &mdash; | | |
+| &mdash; | | |
+| 88 | | |
+| 84 | | |
+| (93 | ) | |
+| &mdash; | |
+
+
+Corporate
+expense (1) | |
+| 22 | | |
+| 25 | | |
+| 25 | | |
+| 28 | | |
+| 100 | | |
+| 32 | | |
+| 52 | |
+
+
+Total Segment Adjusted EBITDA | |
+$ | 580 | | |
+$ | 613 | | |
+$ | 637 | | |
+$ | 677 | | |
+$ | 2,507 | | |
+$ | 764 | | |
+$ | 846 | |
+
+
+
+
+
+
+Total
+Segment Adjusted EBITDA is a non-GAAP financial measure. Management
+believes that this measure is meaningful to investors because Total Segment Adjusted EBITDA provides additional information with respect
+to the Company's operating performance and the Company&rsquo;s ability to meet its financial obligations. The Total Segment Adjusted
+EBITDA presented may not be comparable to similarly titled measures of other companies. Howmet&rsquo;s definition of Total Segment Adjusted
+EBITDA is defined as Operating Income excluding Restructuring and other (credits) charges and Special items and Provision for depreciation
+and amortization. Special items, including Restructuring and other (credits) charges, are excluded from Adjusted EBITDA.
+
+
+
+
+
+(1)
+Pre-tax special items included in Corporate expense
+
+
+
+
+
+
+
+
+
+| |
+| 1Q25 | | |
+| 2Q25 | | |
+| 3Q25 | | |
+| 4Q25 | | |
+| 2025 | | |
+| 1Q26 | | |
+| 2Q26 | |
+
+
+Acquisition
+and acquisition-related costs (2) | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | &mdash; | | |
+$ | 2 | | |
+$ | 2 | | |
+$ | 6 | | |
+$ | 22 | |
+
+
+Costs (benefits) associated with closures,
+supply chain disruptions, and other items | |
+| 1 | | |
+| (1 | ) | |
+| &mdash; | | |
+| 1 | | |
+| 1 | | |
+| &mdash; | | |
+| &mdash; | |
+
+
+Total Pre-tax special items included
+in Corporate expense | |
+$ | 1 | | |
+$ | (1 | ) | |
+$ | &mdash; | | |
+$ | 3 | | |
+$ | 3 | | |
+$ | 6 | | |
+$ | 22 | |
+
+
+
+
+
+
+
+
+| (2) | Interest
+expense of $1 related to the CAM acquisition financing in 1Q26. |
+
+
+
+
+
+
+
+
+
+11
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Calculation
+of Financial Measures (unaudited), continued
+
+
+(in
+U.S. dollars millions)
+
+
+
+
+
+Reconciliation
+of Free cash flow
+
+
+
+
+
+
+
+
+| |
+Quarter
+ended | | |
+Six
+months ended | |
+
+
+| |
+1Q26 | | |
+2Q26 | | |
+2Q26 | |
+
+
+Cash provided from operations | |
+$ | 453 | | |
+$ | 583 | | |
+$ | 1,036 | |
+
+
+Capital expenditures | |
+| (94 | ) | |
+| (104 | ) | |
+| (198 | ) |
+
+
+Free cash flow | |
+$ | 359 | | |
+$ | 479 | | |
+$ | 838 | |
+
+
+| |
+| | | |
+| | | |
+| | |
+
+
+Cash provided from (used for) financing activities | |
+$ | 1,226 | | |
+| (541 | ) | |
+| 685 | |
+
+
+Cash provided from (used for) investing activities | |
+$ | 14 | | |
+| (1,914 | ) | |
+| (1,900 | ) |
+
+
+
+
+
+
+
+The
+Accounts Receivable Securitization program remains unchanged at $250 outstanding.
+
+
+
+
+
+Free
+cash flow is a non-GAAP financial measure. Management believes that this measure is meaningful to investors because management reviews
+cash flows generated from operations after taking into consideration capital expenditures (due to the fact that these expenditures are
+considered necessary to maintain and expand the Company's asset base and are expected to generate future cash flows from operations).
+It is important to note that Free cash flow does not represent the residual cash flow available for discretionary expenditures since
+other non-discretionary expenditures, such as mandatory debt service requirements, are not deducted from the measure.
+
+
+
+
+
+
+
+
+
+12
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Calculation
+of Financial Measures (unaudited), continued
+
+
+(in
+U.S. dollar millions, except per-share and share amounts)
+
+
+
+
+
+Reconciliation
+of Adjusted Net income
+
+
+
+
+
+
+
+| |
+Quarter
+ended | | |
+Six months
+ended | |
+
+
+| |
+2Q25 | | |
+1Q26 | | |
+2Q26 | | |
+June 30,
+2025 | | |
+June 30,
+2026 | |
+
+
+Net income | |
+$ | 407 | | |
+$ | 580 | | |
+$ | 534 | | |
+$ | 751 | | |
+$ | 1,114 | |
+
+
+Diluted earnings per share ("EPS") | |
+$ | 1.00 | | |
+$ | 1.44 | | |
+$ | 1.33 | | |
+$ | 1.84 | | |
+$ | 2.77 | |
+
+
+Average number of diluted shares | |
+| 406 | | |
+| 403 | | |
+| 402 | | |
+| 407 | | |
+| 402 | |
+
+
+Special items: | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Restructuring
+and other credits (1) | |
+| &mdash; | | |
+| (93 | ) | |
+| &mdash; | | |
+| (4 | ) | |
+| (93 | ) |
+
+
+Acquisition
+and acquisition-related costs (2) | |
+| &mdash; | | |
+| 7 | | |
+| 22 | | |
+| &mdash; | | |
+| 29 | |
+
+
+Benefits
+associated with closures, supply chain disruptions, and other items | |
+| (1 | ) | |
+| &mdash; | | |
+| &mdash; | | |
+| &mdash; | | |
+| &mdash; | |
+
+
+Subtotal: Pre-tax special items | |
+| (1 | ) | |
+| (86 | ) | |
+| 22 | | |
+| (4 | ) | |
+| (64 | ) |
+
+
+Tax
+impact of Pre-tax special items (3) | |
+| &mdash; | | |
+| 30 | | |
+| (4 | ) | |
+| 1 | | |
+| 26 | |
+
+
+Subtotal | |
+| (1 | ) | |
+| (56 | ) | |
+| 18 | | |
+| (3 | ) | |
+| (38 | ) |
+
+
+Discrete
+and other tax special items (4) | |
+| (35 | ) | |
+| (30 | ) | |
+| (18 | ) | |
+| (26 | ) | |
+| (48 | ) |
+
+
+Total: After-tax special items | |
+| (36 | ) | |
+| (86 | ) | |
+| &mdash; | | |
+| (29 | ) | |
+| (86 | ) |
+
+
+Adjusted Net income | |
+$ | 371 | | |
+$ | 494 | | |
+$ | 534 | | |
+$ | 722 | | |
+$ | 1,028 | |
+
+
+Adjusted EPS | |
+$ | 0.91 | | |
+$ | 1.22 | | |
+$ | 1.33 | | |
+$ | 1.77 | | |
+$ | 2.56 | |
+
+
+
+
+
+
+
+Adjusted
+Net income and Adjusted EPS are non-GAAP financial measures. Management believes that these measures are meaningful to investors because
+management reviews the operating results of the Company excluding the impacts of Restructuring and other credits, Discrete tax items,
+and Other special items (collectively, &ldquo;Special items&rdquo;). There can be no assurances that additional Special items will not
+occur in future periods. To compensate for this limitation, management believes that it is appropriate to consider both Net income and
+Diluted EPS determined under GAAP as well as Adjusted Net income and Adjusted EPS.
+
+
+
+
+
+
+| (1) | Restructuring
+and other credits for the quarter ended 1Q26 and the six months ended June 30, 2026 included
+a gain on the sale of the Company's disk forging facility in Savannah, GA within Engineered
+Structures. |
+
+
+
+
+
+
+| (2) | Includes
+legal and advisory costs, amortization expense of inventory step-up recorded in accordance
+with purchase accounting, and other acquisition-related costs for CAM and Brunner. Additionally,
+interest expense of $1 related to the CAM acquisition financing in 1Q26. |
+
+
+
+
+
+
+| (3) | The
+Tax impact of Pre-tax special items is based on the applicable statutory rates whereby the
+difference between such rates and the Company&rsquo;s consolidated estimated annual effective
+tax rate is itself a Special item. |
+
+
+
+
+
+
+| (4) | Discrete
+tax items for each period included the following: |
+
+
+
+
+
+
+| &middot; | for
+2Q25, benefits related to U.S. accounting method changes for certain prior period transaction
+and other costs ($17), an excess benefit for stock compensation ($13), and a net benefit
+related to U.S. federal and state research and development ("R&D") credits
+claimed for prior years ($5). |
+
+
+
+
+
+
+| &middot; | for
+1Q26, an excess benefit for stock compensation ($21); |
+
+
+
+
+
+
+| &middot; | for
+2Q26, a benefit to release a valuation allowance related to U.S. foreign tax credits ($22),
+a benefit to release a valuation allowance related to U.S. state tax losses ($10), a benefit
+to release a tax reserve in Germany ($3), an excess benefit for stock compensation ($1),
+and a charge to establish an international withholding tax reserve $16; |
+
+
+
+
+
+
+| &middot; | for
+the six months ended 2Q25, benefits related to U.S. accounting method changes for certain
+prior period transaction and other costs ($17), an excess benefit for stock compensation
+($14), a net benefit related to U.S. federal and state R&D credits claimed for prior
+years ($5), a net charge related to the expiration of a tax holiday in China $6, a charge
+for a tax reserve established in Germany $2, and a net charge for other small items $2; and |
+
+
+
+
+
+
+| &middot; | for
+the six months ended 2Q26, a benefit to release a valuation allowance related to U.S. foreign
+tax credits ($22), an excess benefit for stock compensation ($22), a benefit to release a
+valuation allowance related to U.S. state tax losses ($10), a benefit to release a tax reserve
+in Germany ($3), and a charge to establish an international withholding tax reserve $16. |
+
+
+
+
+
+
+
+
+
+13
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Calculation
+of Financial Measures (unaudited), continued
+
+
+(in
+U.S. dollar millions)
+
+
+
+
+
+Reconciliation
+of Operational tax rate
+
+
+
+
+
+
+
+| |
+Quarter
+ended | | |
+Six months
+ended | |
+
+
+| |
+2Q26 | | |
+2Q26 | |
+
+
+| |
+Effective
+
+
+tax rate,
+
+as reported | | |
+Special
+
+
+items (1)(2) | | |
+Operational
+
+
+tax rate, as
+
+adjusted | | |
+Effective
+
+
+tax rate,
+
+as
+
+reported | | |
+Special
+
+
+items (1)(2) | | |
+Operational
+
+
+tax rate, as
+
+adjusted | |
+
+
+Income before income taxes | |
+$ | 649 | | |
+$ | 22 | | |
+$ | 671 | | |
+$ | 1,357 | | |
+$ | (64 | ) | |
+$ | 1,293 | |
+
+
+Provision for income taxes | |
+$ | 115 | | |
+$ | 22 | | |
+$ | 137 | | |
+$ | 243 | | |
+$ | 22 | | |
+$ | 265 | |
+
+
+Tax rate | |
+| 17.7 | % | |
+| | | |
+| 20.4 | % | |
+| 17.9 | % | |
+| | | |
+| 20.5 | % |
+
+
+
+
+
+
+
+Operational
+tax rate is a non-GAAP financial measure. Management believes that this measure is meaningful to investors because management reviews
+the operating results of the Company excluding the impacts of Special items. There can be no assurances that additional Special items
+will not occur in future periods. To compensate for this limitation, management believes that it is appropriate to consider both the
+Effective tax rate determined under GAAP as well as the Operational tax rate.
+
+
+
+
+
+
+| (1) | Pre-tax
+special items for 2Q26 included Acquisition and acquisition-related costs $22. Pre-tax special
+items for the six months ended 2Q26 included Restructuring and other credits ($93) and Acquisition
+and acquisition-related costs $29. |
+
+
+
+
+
+
+| (2) | Tax
+Special items includes discrete tax items, the tax impact on Special items based on the applicable
+statutory rates, the difference between such rates and the Company&rsquo;s consolidated estimated
+annual effective tax rate and other tax related items. Discrete tax items for each period
+included the following: |
+
+
+
+
+
+
+| &middot; | for
+the quarter ended 2Q26, a benefit to release a valuation allowance related to U.S. foreign
+tax credits ($22), a benefit to release a valuation allowance related to U.S. state tax losses
+($10), a benefit to release a tax reserve in Germany ($3), an excess benefit for stock compensation
+($1), and a charge to establish an international withholding tax reserve $16. |
+
+
+
+
+
+
+| &middot; | for
+the six months ended 2Q26, a benefit to release a valuation allowance related to U.S. foreign
+tax credits ($22), an excess benefit for stock compensation ($22), a benefit to release a
+valuation allowance related to U.S. state tax losses ($10), a benefit to release a tax reserve
+in Germany ($3), and a charge to establish an international withholding tax reserve $16. |
+
+
+
+
+
+
+
+
+
+14
+
+
+
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Calculation
+of Financial Measures (unaudited), continued
+
+
+(in
+U.S. dollars millions)
+
+
+
+
+
+Reconciliation
+of Adjusted Operating Income, Adjusted Operating Income Margin, Adjusted EBITDA, and Adjusted EBITDA margin
+
+
+
+
+
+
+
+| |
+Quarter
+ended | | |
+Six months
+ended | |
+
+
+| |
+2Q25 | | |
+1Q26 | | |
+2Q26 | | |
+June 30,
+2025 | | |
+June 30,
+2026 | |
+
+
+Sales | |
+$ | 2,053 | | |
+$ | 2,313 | | |
+$ | 2,547 | | |
+$ | 3,995 | | |
+$ | 4,860 | |
+
+
+Operating income | |
+$ | 521 | | |
+$ | 753 | | |
+$ | 711 | | |
+$ | 1,015 | | |
+$ | 1,464 | |
+
+
+Operating income margin | |
+| 25.4 | % | |
+| 32.6 | % | |
+| 27.9 | % | |
+| 25.4 | % | |
+| 30.1 | % |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Operating income | |
+$ | 521 | | |
+$ | 753 | | |
+$ | 711 | | |
+$ | 1,015 | | |
+$ | 1,464 | |
+
+
+Add: | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Restructuring and other credits | |
+$ | &mdash; | | |
+$ | (93 | ) | |
+$ | &mdash; | | |
+| (4 | ) | |
+| (93 | ) |
+
+
+Acquisition
+and acquisition-related costs (1) | |
+| &mdash; | | |
+| 6 | | |
+| 22 | | |
+| &mdash; | | |
+| 28 | |
+
+
+Benefits associated
+with closures, supply chain disruptions, and other items | |
+| (1 | ) | |
+| &mdash; | | |
+| &mdash; | | |
+| &mdash; | | |
+| &mdash; | |
+
+
+Adjusted operating income | |
+$ | 520 | | |
+$ | 666 | | |
+$ | 733 | | |
+$ | 1,011 | | |
+$ | 1,399 | |
+
+
+Adjusted operating income margin | |
+| 25.3 | % | |
+| 28.8 | % | |
+| 28.8 | % | |
+| 25.3 | % | |
+| 28.8 | % |
+
+
+Provision for
+depreciation and amortization | |
+| 69 | | |
+| 74 | | |
+| 84 | | |
+| 138 | | |
+| 158 | |
+
+
+Adjusted EBITDA | |
+$ | 589 | | |
+$ | 740 | | |
+$ | 817 | | |
+$ | 1,149 | | |
+$ | 1,557 | |
+
+
+Adjusted EBITDA margin | |
+| 28.7 | % | |
+| 32.0 | % | |
+| 32.1 | % | |
+| 28.8 | % | |
+| 32.0 | % |
+
+
+
+
+
+
+
+Adjusted
+operating income and Adjusted operating income margin are non-GAAP financial measures. Special items, including Restructuring and other
+credits, are excluded from Adjusted operating income. Management believes that these measures are meaningful to investors because management
+reviews the operating results of the Company excluding the impacts of Special items. There can be no assurances that additional Special
+items will not occur in future periods. To compensate for this limitation, management believes that it is appropriate to consider both
+Operating income and Operating income margin determined under GAAP as well as Adjusted operating income and Adjusted operating income
+margin.
+
+
+
+
+
+Adjusted
+EBITDA and Adjusted EBITDA margin are non-GAAP financial measures. Management believes that these measures are meaningful to investors
+because they provide additional information with respect to the Company's operating performance and the Company&rsquo;s ability to meet
+its financial obligations. The Adjusted EBITDA presented may not be comparable to similarly titled measures of other companies. The Company's
+definition of Adjusted EBITDA is defined as Operating Income excluding Restructuring and other credits and Special items and Provision
+for depreciation and amortization. Special items, including Restructuring and other credits, are excluded from Adjusted EBITDA.
+
+
+
+
+
+
+| (1) | Interest
+expense of $1 related to the CAM acquisition financing in 1Q26. |
+
+
+
+
+
+
+
+
+
+15
+
+
+
+
+
+
+
+
+
+
+Howmet
+Aerospace Inc. and subsidiaries
+
+
+Calculation
+of Financial Measures (unaudited), continued
+
+
+(in
+U.S. dollars millions)
+
+
+
+
+
+Reconciliation of Organic Revenue
+
+
+
+
+
+
+
+| |
+Quarter
+ended | | |
+| | |
+Six months
+ended | | |
+| |
+
+
+| |
+2Q25 | | |
+2Q26 | | |
+% Change | | |
+June 30,
+2025 | | |
+June 30,
+2026 | | |
+% Change | |
+
+
+Sales | |
+$ | 2,053 | | |
+$ | 2,547 | | |
+| 24 | % | |
+$ | 3,995 | | |
+$ | 4,860 | | |
+| 22 | % |
+
+
+Less: | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Net Acquisitions and Divestitures | |
+$ | 34 | | |
+$ | 100 | | |
+| | | |
+$ | 65 | | |
+$ | 146 | | |
+| | |
+
+
+Total: Organic Revenue | |
+$ | 2,019 | | |
+$ | 2,447 | | |
+| 21 | % | |
+$ | 3,930 | | |
+$ | 4,714 | | |
+| 20 | % |
+
+
+
+
+
+
+
+Organic
+revenue is a non-GAAP financial measure. Management believes this measure is meaningful to investors as it presents revenue on a comparable
+basis for all periods presented excluding the impact of the acquisitions of CAM (acquired April 2026) and Brunner (acquired February
+2026) and the sale of the disk forging facility in Savannah, GA (divested March 2026). Management believes that it is appropriate to
+consider both Sales determined under GAAP as well as Organic Revenue.
+
+
+
+
+
+
+
+
+
+16

--- a/modules/test-fixtures/earnings-filings/inod.txt
+++ b/modules/test-fixtures/earnings-filings/inod.txt
@@ -1,0 +1,1414 @@
+EX-99.1
+2
+tm2621499d1_ex99-1.htm
+EXHIBIT 99.1
+
+
+
+
+
+
+
+
+
+
+Exhibit 99.1
+
+
+
+
+
+
+
+
+
+
+
+Innodata Reports Record Second Quarter 2026 Results
+
+
+
+
+
+
+| &middot; | Revenue
+Up 58% Year-Over-Year, Beats Consensus by 7% |
+
+
+
+| &middot; | Adjusted
+EBITDA of $25.4 Million, Beats Consensus by 50% |
+
+
+
+| &middot; | Adjusted
+Gross Margin Expands to 49% |
+
+
+
+| &middot; | Announces
+Planned Leadership Transition Effective September 30: Rahul Singhal to Become President and
+CEO, Jack Abuhoff to Become Executive Chairman |
+
+
+
+
+
+NEW YORK &ndash; August 6, 2026 &ndash; INNODATA
+INC. (Nasdaq: INOD) today reported results for the second quarter ended June 30, 2026.
+
+
+
+
+
+
+| &middot; | Revenue
+of $92.1 million, representing 58% year-over-year revenue growth. |
+
+
+
+
+
+
+| &middot; | Adjusted
+Gross Profit of $45.4 million, representing Adjusted Gross Margin of 49%.* |
+
+
+
+
+
+
+| &middot; | Adjusted
+EBITDA of $25.4 million, or 27.5% of revenue, an increase of $12.1 million from $13.2
+million in the same period last year.* |
+
+
+
+
+
+
+| &middot; | Net
+income of $14.4 million, or $0.43 per basic share and $0.41 per diluted share for the
+three-month period ended June 30, 2026, compared to net income of $7.2 million, or $0.23
+per basic share and $0.20 per diluted share, in the same period last year. |
+
+
+
+
+
+
+| &middot; | Cash,
+cash equivalents and short-term investments of $250.4 million as of June 30, 2026, an
+increase of $168.2 million from $82.2 million as of December 31, 2025. Cash as of June 30,
+2026 includes customer prepayments related to pass-through costs; net of these prepayments,
+cash was approximately $134 million as of June 30, 2026. |
+
+
+
+
+
+* Adjusted Gross Profit, Adjusted Gross Margin,
+and Adjusted EBITDA are non-GAAP financial measures and are defined below.
+
+
+
+
+
+Jack Abuhoff, CEO, said,
+&ldquo;Q2 was another record quarter for Innodata - and another across-the-board beat. Revenue, Adjusted Gross Profit, Adjusted EBITDA,
+and cash all reached new highs, and we exceeded analyst consensus on every key metric. Revenue of $92.1 million grew 58% year-over-year
+while Adjusted EBITDA grew 92% - operating leverage by definition. This was our 12th consecutive quarter of year-over-year growth, and,
+as in Q1, our quarterly revenue exceeded our annual revenue of just three years ago. Adjusted Gross Margin of 49% now stands
+nine points above our publicly stated 40% target, driven by mix: off-the-shelf datasets, where we retain intellectual property and monetize
+the same asset across multiple customers, as well as high-value pre-training programs. Once again, we delivered growth, margin expansion,
+and cash generation together - while investing in innovation that converts to revenue within quarters, not years. That is the business
+model working as designed.
+
+
+
+
+
+&ldquo;The diversification
+we planned for has now been delivered. In Q2, our largest customer represented 37% of revenue, down from 56% in Q1, while the Big Tech
+customer we announced last quarter scaled from 17% of revenue to 34%. While our largest customer contributed less revenue in Q2 than
+in Q1, we continue to forecast it to grow year-over-year for the full year. We also landed an important new customer in the quarter,
+one of the fastest-scaling frontier labs. Our base continues to broaden, in both customers and customer programs.
+
+
+
+
+
+&ldquo;We are reiterating
+our full-year 2026 revenue growth guidance of 40% or more year-over-year. There are large potential programs from both new and anticipated
+customers - likely wins, in our judgment - that are not factored into our 40% number. Once their scope and timing are finalized, we will
+include them and update guidance accordingly.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+&ldquo;Our growth is
+increasingly research driven. Through our research efforts, we have established an early position in agentic reinforcement learning,
+one of the most important frontiers in AI development, winning a significant new program with our largest customer covering personalization
+of long-horizon agents - now scaling - and a second program covering reinforcement-learning environments for computer-use agentic tasks.
+We released two public benchmarks designed to surface the failure modes that standard leaderboards miss as well as the first stage of
+our AI Cyber Training Suite - twelve datasets and evaluation systems that train AI coding agents to write secure code and repair vulnerabilities.
+We also ran successful egocentric data-collection pilots with leading robotics companies and shifted our data-collection practice from
+individual pilots to scoping enterprise-scale, multi-modal programs.&rdquo;
+
+
+
+
+
+A Planned Leadership
+Transition
+
+
+
+
+
+Innodata also announced
+today a planned leadership transition. Effective September 30, 2026, Rahul Singhal will become President and Chief Executive Officer
+of Innodata and will join the Company&rsquo;s Board of Directors, and Jack Abuhoff, the Company&rsquo;s founder and CEO, will transition
+into the role of Executive Chairman.
+
+
+
+
+
+&ldquo;This is a planned
+transition, made from a position of strength,&rdquo; said Abuhoff. &ldquo;Rahul has been a principal architect of Innodata&rsquo;s transformation
+into a strategic partner to the world&rsquo;s leading AI builders. He knows our customers, he knows our technology, and he knows our
+people - and he has been central to every element of the strategy behind the results you have seen quarter after quarter. The Board and
+I didn&rsquo;t have to look far for the right leader. Rahul earned this role &ndash; taking on expanding responsibility year after year
+and delivering every time. As Executive Chairman, I will remain deeply engaged, focused on partnering with Rahul to build capabilities
+enabled by our research team. Bringing these capabilities to the federal government and to the enterprise, I believe, is where I can
+best contribute to creating significant shareholder value, and as one of the company's largest shareholders, that is exactly what I want
+to be doing. Our work with the Mag 7 and the leading AI labs is on a firm path to greater heights and greater diversification. Our Enterprise
+AI and Federal strategies - built on the differentiated technology we develop for the frontier labs - represent opportunities for potentially
+driving high quality recurring revenue that results in significant value creation.&rdquo;
+
+
+
+
+
+Rahul Singhal, incoming
+President and Chief Executive Officer, said, &ldquo;I am truly honored by the confidence Jack and the Board have placed in me, and I
+intend to repay it with results. Innodata has extraordinary momentum, an extraordinary team, and an extraordinary opportunity in front
+of it. I intend to build on all three. Research and innovation have become our growth engine - the means by which we differentiate, expand
+existing partnerships, and forge new customer relationships across the full model training lifecycle, from pre-training and post-training
+to model evaluation and benchmarking.&rdquo;
+
+
+
+
+
+The Company also recently
+announced that Jayant Chauhan has joined Innodata as Chief Financial Officer, with Mariz Espineli stepping into the role of Chief Accounting
+Officer. Beyond the traditional CFO mandate, Jayant will work strategically on capital allocation and capital markets, customer partnerships,
+M&A, and investor communications.
+
+
+
+
+
+Abuhoff concluded, &ldquo;We
+are confident that 2026 will be a tremendous year for Innodata and its shareholders, and we are excited about the opportunities that
+lie ahead in 2027 and beyond.&rdquo;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Amounts in this press release have been
+rounded. All percentages have been calculated using unrounded amounts.
+
+
+
+
+
+Timing of Conference Call with Q&A
+
+
+
+
+
+Innodata will conduct an earnings conference call,
+including a question-and-answer period, at 5:00 PM eastern time today. You can participate in this call by dialing the following call-in
+numbers:
+
+
+
+
+
+The call-in numbers for the conference call are:
+
+
+
+
+
+
+
+(+1) 800 715 9871 |
+North America, Toll Free |
+
+
+
+(+44) 800 358 0970 |
+United Kingdom |
+
+
+
+(+1) 646 307 1963 |
+International |
+
+
+
+Participant Access Code |
+3150581 |
+
+
+
+
+
+
+
+For Replay:
+
+
+
+
+
+
+
+(+1) 800 770 2030 |
+North America-Toll Free |
+
+
+
+(+44) 203 433 3849 |
+United Kingdom |
+
+
+
+(+1) 609 800 9909 |
+International |
+
+
+
+Replay ID |
+3150581# |
+
+
+
+
+
+
+
+It is recommended that
+participants dial in approximately 10 minutes prior to the start of the call. Investors are also invited
+to access a live Webcast of the conference call at the Investor Relations section of Innodata&rsquo;s website at https://investor.innodata.com/events-and-presentations/ .
+Please note that the Webcast feature will be in listen-only mode.
+
+
+
+
+
+Call-in replay will be available for seven days following the conference
+call, and Webcast replay will be available for 30 days following the conference call, at the Investor Relations
+section of Innodata&rsquo;s website at https://investor.innodata.com/events-and-presentations/ .
+
+
+
+
+
+About Innodata
+
+
+
+
+
+Innodata (Nasdaq: INOD) is a global data
+engineering company. We believe that data and Artificial Intelligence (AI) are inextricably linked. Our mission is to enable the
+responsible advancement of artificial intelligence by providing the data, evaluation frameworks, and human expertise required to build
+AI systems that can be trusted at scale. We provide a range of transferable solutions, platforms, and services for Generative AI
+/ AI builders and adopters. In every relationship, we honor our 36+ year legacy delivering the highest quality data and outstanding outcomes
+for our customers.
+
+
+
+
+
+Visit www.innodata.com
+to learn more.
+
+
+
+
+
+Forward-Looking Statements
+
+
+
+
+
+This press release may contain certain forward-looking
+statements within the meaning of Section 21E of the Securities Exchange Act of 1934, as amended, and Section 27A of the Securities
+Act of 1933, as amended. These forward-looking statements include, without limitation, statements concerning our operations, economic
+performance, financial condition, developmental program expansion and position in the AI services market. Words such as &ldquo;project,&rdquo;
+&ldquo;forecast,&rdquo; &ldquo;believe,&rdquo; &ldquo;expect,&rdquo; &ldquo;can,&rdquo; &ldquo;continue,&rdquo; &ldquo;could,&rdquo; &ldquo;intend,&rdquo;
+&ldquo;may,&rdquo; &ldquo;should,&rdquo; &ldquo;will,&rdquo; &ldquo;anticipate,&rdquo; &ldquo;indicate,&rdquo; &ldquo;guide,&rdquo; &ldquo;predict,&rdquo;
+&ldquo;likely,&rdquo; &ldquo;estimate,&rdquo; &ldquo;plan,&rdquo; &ldquo;potential,&rdquo; &ldquo;possible,&rdquo; &ldquo;promises,&rdquo;
+or the negatives thereof, and other similar expressions generally identify forward-looking statements.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+These forward-looking statements are based on
+management&rsquo;s current expectations, assumptions and estimates and are subject to a number of risks and uncertainties, including,
+without limitation, impacts resulting from ongoing geopolitical conflicts; anticipated and actual use cases and outcomes; investments
+in large language models; that contracts may be terminated by customers; projected or committed volumes of work may not materialize; pipeline
+opportunities and customer discussions which may not materialize into work or expected volumes of work; the likelihood of continued development
+of the AI markets, particularly new and emerging markets, that our services support; the ability and willingness of our customers and
+prospective customers to execute business plans that give rise to requirements for our services; continuing reliance on project-based
+work and the primarily at-will nature of such contracts and the ability of these customers to reduce, delay or cancel projects; potential
+inability to replace projects that are completed, canceled or reduced; revenue concentration among a limited number of customers; our
+dependency on third-party providers and partners; our ability to achieve revenue and growth targets; difficulty in integrating and deriving
+synergies from acquisitions, joint ventures and strategic investments; potential undiscovered liabilities of companies and businesses
+that we may acquire; potential impairment of the carrying value of goodwill and other acquired intangible assets of companies and businesses
+that we acquire; a continued downturn in or depressed market conditions; changes in external market factors; the potential effects of
+U.S. global trade and monetary policy, including the interest rate policies of the Federal Reserve; changes in our business or growth
+strategy; the emergence of new, or growth in existing competitors; various other competitive and technological factors; our use of and
+reliance on information technology systems, including potential security breaches, cyber-attacks, privacy breaches or data breaches that
+result in the unauthorized disclosure of consumer, customer, employee or company information, or service interruptions; and other risks
+and uncertainties indicated from time to time in our filings with the Securities and Exchange Commission (&ldquo;SEC&rdquo;).
+
+
+
+
+
+Our actual results could differ materially from
+the results referred to in any forward-looking statements. Factors that could cause or contribute to such differences include, but are
+not limited to, the risks discussed in Part I, Item 1A. &ldquo;Risk Factors,&rdquo; Part II, Item 7. &ldquo;Management&rsquo;s
+Discussion and Analysis of Financial Condition and Results of Operations,&rdquo; and other parts of our Annual Report on Form 10-K,
+filed with the SEC on February 26, 2026, and in our other filings that we may make with the SEC. In light of these risks and uncertainties,
+there can be no assurance that the results referred to in any forward-looking statements will occur, and you should not place undue reliance
+on these forward-looking statements. These forward-looking statements speak only as of the date hereof.
+
+
+
+
+
+We undertake no obligation to update or review
+any guidance or other forward-looking statements, whether as a result of new information, future developments or otherwise, except as
+may be required by the U.S. federal securities laws.
+
+
+
+
+
+Company Contact
+
+
+
+
+
+Aneesh Pendharkar
+
+
+investor@innodata.com
+
+
+(201) 371-8000
+
+
+
+
+
+Non-GAAP Financial Measures
+
+
+
+
+
+In addition to the financial information prepared
+in conformity with U.S. GAAP (&ldquo;GAAP&rdquo;), we provide certain non-GAAP financial information. We believe that these non-GAAP financial
+measures assist investors in making comparisons of period-to-period operating results. In some respects, management believes non-GAAP
+financial measures are more indicative of our ongoing core operating performance than their GAAP equivalents by making adjustments that
+management believes are reflective of the ongoing performance of the business.
+
+
+
+
+
+We believe that the presentation of this non-GAAP
+financial information provides investors a more complete understanding of our financial performance, competitive position, and prospects
+for the future, particularly by providing the same information that management and our Board of Directors use to evaluate our performance
+and manage the business. However, the non-GAAP financial measures presented in this press release have certain limitations in that they
+do not reflect all of the costs associated with the operations of our business as determined in accordance with GAAP. Therefore, investors
+should consider non-GAAP financial measures in addition to, and not as a substitute for, or as superior to, measures of financial performance
+prepared in accordance with GAAP. Further, the non-GAAP financial measures that we present may differ from similar non-GAAP financial
+measures used by other companies.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Adjusted Gross Profit and Adjusted Gross Margin
+
+
+
+
+
+We define Adjusted Gross Profit as revenues less
+direct operating costs attributable to Innodata Inc. and its subsidiaries in accordance with GAAP, plus depreciation and amortization
+of intangible assets, stock-based compensation and other one-time costs included within direct operating cost.
+
+
+
+
+
+We define Adjusted Gross Margin by dividing Adjusted
+Gross Profit over total GAAP revenues.
+
+
+
+
+
+We use Adjusted Gross Profit and Adjusted Gross
+Margin to evaluate results of operations and trends between fiscal periods and believe that these measures are important components of
+our internal performance measurement process.
+
+
+
+
+
+A reconciliation of Adjusted Gross Profit and
+Adjusted Gross Margin to the most directly comparable GAAP measure is included in the tables that accompany this release.
+
+
+
+
+
+Adjusted EBITDA
+
+
+
+
+
+We define Adjusted EBITDA as net income attributable
+to Innodata Inc. and its subsidiaries in accordance with GAAP before interest expense, income taxes, depreciation and amortization of
+intangible assets (which derives EBITDA), plus additional adjustments for loss on impairment of intangible assets and goodwill, stock-based
+compensation, income attributable to non-controlling interests and other one-time costs.
+
+
+
+
+
+We use Adjusted EBITDA to evaluate core results
+of operations and trends between fiscal periods and believe that these measures are important components of our internal performance measurement
+process.
+
+
+
+
+
+A reconciliation of Adjusted EBITDA to the most
+directly comparable GAAP measure is included in the tables that accompany this release.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+INNODATA INC. AND SUBSIDIARIES
+
+
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+
+
+(Unaudited)
+
+
+(In thousands, except per-share amounts)
+
+
+
+
+
+
+
+| |
+Three Months Ended | | |
+Six Months Ended | |
+
+
+| |
+June 30, | | |
+June 30, | |
+
+
+| |
+2026 | | |
+2025 | | |
+2026 | | |
+2025 | |
+
+
+Revenues | |
+$ | 92,142 | | |
+$ | 58,393 | | |
+$ | 182,238 | | |
+$ | 116,737 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Operating costs and expenses: | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Direct operating costs | |
+| 49,682 | | |
+| 35,370 | | |
+| 99,986 | | |
+| 70,462 | |
+
+
+Selling and administrative expenses | |
+| 26,600 | | |
+| 14,112 | | |
+| 49,492 | | |
+| 29,092 | |
+
+
+Interest income, net | |
+| (1,695 | ) | |
+| (577 | ) | |
+| (2,137 | ) | |
+| (704 | ) |
+
+
+| |
+| 74,587 | | |
+| 48,905 | | |
+| 147,341 | | |
+| 98,850 | |
+
+
+Income before provision for income taxes | |
+| 17,555 | | |
+| 9,488 | | |
+| 34,897 | | |
+| 17,887 | |
+
+
+Provision for income taxes | |
+| 3,143 | | |
+| 2,269 | | |
+| 5,587 | | |
+| 2,881 | |
+
+
+Consolidated net income | |
+| 14,412 | | |
+| 7,219 | | |
+| 29,310 | | |
+| 15,006 | |
+
+
+Income attributable to non-controlling interests | |
+| - | | |
+| - | | |
+| - | | |
+| - | |
+
+
+Net income attributable to Innodata Inc. and Subsidiaries | |
+$ | 14,412 | | |
+$ | 7,219 | | |
+$ | 29,310 | | |
+$ | 15,006 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Income per share attributable to Innodata Inc. and Subsidiaries: | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Basic | |
+$ | 0.43 | | |
+$ | 0.23 | | |
+$ | 0.89 | | |
+$ | 0.47 | |
+
+
+Diluted | |
+$ | 0.41 | | |
+$ | 0.20 | | |
+$ | 0.86 | | |
+$ | 0.43 | |
+
+
+Weighted average shares outstanding: | |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Basic | |
+| 33,468 | | |
+| 31,785 | | |
+| 33,044 | | |
+| 31,609 | |
+
+
+Diluted | |
+| 34,771 | | |
+| 35,301 | | |
+| 34,268 | | |
+| 35,120 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+INNODATA INC. AND SUBSIDIARIES
+
+
+CONDENSED CONSOLIDATED BALANCE SHEETS
+
+
+(Unaudited)
+
+
+(In thousands)
+
+
+
+
+
+
+
+| |
+June 30,
+2026 | | |
+December 31,
+2025 | |
+
+
+ASSETS | |
+| | | |
+| | |
+
+
+Current assets: | |
+| | | |
+| | |
+
+
+Cash and cash equivalents | |
+$ | 240,278 | | |
+$ | 82,216 | |
+
+
+Short term investments | |
+| 10,093 | | |
+| 14 | |
+
+
+Accounts receivable, net | |
+| 47,560 | | |
+| 46,510 | |
+
+
+Prepaid expenses and other current assets | |
+| 22,833 | | |
+| 6,654 | |
+
+
+Total current assets | |
+| 320,764 | | |
+| 135,394 | |
+
+
+Property and equipment, net | |
+| 8,392 | | |
+| 7,966 | |
+
+
+Right-of-use asset, net | |
+| 3,571 | | |
+| 4,094 | |
+
+
+Other assets | |
+| 3,206 | | |
+| 1,648 | |
+
+
+Deferred income taxes, net | |
+| 4,515 | | |
+| 3,429 | |
+
+
+Intangibles, net | |
+| 14,189 | | |
+| 13,983 | |
+
+
+Goodwill | |
+| 2,036 | | |
+| 2,079 | |
+
+
+Total assets | |
+$ | 356,673 | | |
+$ | 168,593 | |
+
+
+| |
+| | | |
+| | |
+
+
+LIABILITIES AND STOCKHOLDERS&rsquo; EQUITY | |
+| | | |
+| | |
+
+
+| |
+| | | |
+| | |
+
+
+Current liabilities: | |
+| | | |
+| | |
+
+
+Accounts payable | |
+$ | 53,039 | | |
+$ | 9,615 | |
+
+
+Advances from customers | |
+| 66,962 | | |
+| 1,812 | |
+
+
+Accrued expenses and other liabilities | |
+| 36,346 | | |
+| 7,800 | |
+
+
+Accrued salaries, wages and related benefits | |
+| 15,568 | | |
+| 16,480 | |
+
+
+Deferred revenues | |
+| 6,246 | | |
+| 7,493 | |
+
+
+Income and other taxes | |
+| 3,900 | | |
+| 4,471 | |
+
+
+Long-term obligations - current portion | |
+| 2,255 | | |
+| 1,659 | |
+
+
+Operating lease liability - current portion | |
+| 1,287 | | |
+| 1,202 | |
+
+
+Total current liabilities | |
+| 185,603 | | |
+| 50,532 | |
+
+
+Deferred income taxes, net | |
+| 47 | | |
+| 146 | |
+
+
+Long-term obligations, net of current portion | |
+| 8,944 | | |
+| 7,625 | |
+
+
+Operating lease liability, net of current portion | |
+| 2,545 | | |
+| 3,228 | |
+
+
+Total liabilities | |
+| 197,139 | | |
+| 61,531 | |
+
+
+STOCKHOLDERS' EQUITY | |
+| 159,534 | | |
+| 107,062 | |
+
+
+Total liabilities and stockholders&rsquo; equity | |
+$ | 356,673 | | |
+$ | 168,593 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+INNODATA INC. AND SUBSIDIARIES
+
+
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+
+
+(Unaudited) (In thousands)
+
+
+
+
+
+
+
+| |
+Six Months Ended | |
+
+
+| |
+June
+30, | |
+
+
+| |
+2026 | | |
+2025 | |
+
+
+Cash flows from operating activities: | |
+| | | |
+| | |
+
+
+Consolidated net income | |
+$ | 29,310 | | |
+$ | 15,006 | |
+
+
+Adjustments to reconcile consolidated net income to net
+cash | |
+| | | |
+| | |
+
+
+provided by operating activities: | |
+| | | |
+| | |
+
+
+Stock-based compensation | |
+| 13,104 | | |
+| 5,602 | |
+
+
+Depreciation and amortization | |
+| 4,475 | | |
+| 3,164 | |
+
+
+Deferred income taxes, net | |
+| (1,175 | ) | |
+| 1,355 | |
+
+
+Pension cost | |
+| 818 | | |
+| 672 | |
+
+
+Loss on lease termination | |
+| | | |
+| | |
+
+
+Changes in operating assets and liabilities: | |
+| | | |
+| | |
+
+
+Accounts receivable | |
+| (1,228 | ) | |
+| (5,716 | ) |
+
+
+Prepaid expenses
+and other current assets | |
+| (15,384 | ) | |
+| (387 | ) |
+
+
+Other assets | |
+| 236 | | |
+| (76 | ) |
+
+
+Accounts payable,
+accrued expenses and other | |
+| 135,827 | | |
+| (1,499 | ) |
+
+
+Accrued salaries,
+wages and related benefits | |
+| (894 | ) | |
+| (1,490 | ) |
+
+
+Income and
+other taxes | |
+| (532 | ) | |
+| (1,529 | ) |
+
+
+Pension
+benefit payments | |
+| (116 | ) | |
+| (112 | ) |
+
+
+Net
+cash provided by operating activities | |
+| 164,441 | | |
+| 14,990 | |
+
+
+| |
+| | | |
+| | |
+
+
+Cash flows from investing activities: | |
+| | | |
+| | |
+
+
+Capital expenditures | |
+| (5,309 | ) | |
+| (4,058 | ) |
+
+
+Purchase of short
+term investments | |
+| (10,079 | ) | |
+| - | |
+
+
+Net
+cash used in investing activities | |
+| (15,388 | ) | |
+| (4,058 | ) |
+
+
+| |
+| | | |
+| | |
+
+
+Cash flows from financing activities: | |
+| | | |
+| | |
+
+
+Proceeds from exercise of stock options | |
+| 10,904 | | |
+| 1,468 | |
+
+
+Withholding taxes on net settlement
+of restricted stock units | |
+| (62 | ) | |
+| - | |
+
+
+Payment of long-term
+obligations | |
+| (877 | ) | |
+| (117 | ) |
+
+
+Net
+cash provided by financing activities | |
+| 9,965 | | |
+| 1,351 | |
+
+
+| |
+| | | |
+| | |
+
+
+Effect of exchange
+rate changes on cash and cash equivalents | |
+| (956 | ) | |
+| 612 | |
+
+
+| |
+| | | |
+| | |
+
+
+Net increase in cash and cash equivalents | |
+| 158,062 | | |
+| 12,895 | |
+
+
+| |
+| | | |
+| | |
+
+
+Cash and cash
+equivalents, beginning of period | |
+| 82,216 | | |
+| 46,897 | |
+
+
+| |
+| | | |
+| | |
+
+
+Cash and cash
+equivalents, end of period | |
+$ | 240,278 | | |
+$ | 59,792 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+INNODATA INC. AND SUBSIDIARIES
+
+
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL
+MEASURES
+
+
+(Unaudited)
+
+
+(In thousands)
+
+
+
+
+
+Adjusted Gross Profit and Adjusted Gross Margin
+
+
+
+
+
+
+
+| |
+For the Three Months Ended
+June 30, | | |
+For the Six Months Ended
+June 30, | |
+
+
+| |
+2026 | | |
+2025 | | |
+2026 | | |
+2025 | |
+
+
+Gross Profit attributable to Innodata Inc. and Subsidiaries | |
+$ | 42,460 | | |
+$ | 23,023 | | |
+$ | 82,252 | | |
+$ | 46,275 | |
+
+
+Depreciation and amortization | |
+| 2,242 | | |
+| 1,583 | | |
+| 4,361 | | |
+| 3,127 | |
+
+
+Stock-based compensation | |
+| 681 | | |
+| 441 | | |
+| 1,345 | | |
+| 868 | |
+
+
+Adjusted Gross Profit | |
+$ | 45,383 | | |
+$ | 25,047 | | |
+$ | 87,958 | | |
+$ | 50,270 | |
+
+
+| |
+| | | |
+| | | |
+| | | |
+| | |
+
+
+Gross Margin | |
+| 46 | % | |
+| 39 | % | |
+| 45 | % | |
+| 40 | % |
+
+
+Adjusted Gross Margin | |
+| 49 | % | |
+| 43 | % | |
+| 48 | % | |
+| 43 | % |
+
+
+
+
+
+
+
+
+Adjusted EBITDA
+
+
+
+
+
+
+
+| |
+For
+the Three Months Ended
+June 30, | | |
+For
+the Six Months Ended
+June 30, | |
+
+
+| |
+2026 | | |
+2025 | | |
+2026 | | |
+2025 | |
+
+
+Net income attributable to Innodata Inc.
+and Subsidiaries | |
+$ | 14,412 | | |
+$ | 7,219 | | |
+$ | 29,310 | | |
+$ | 15,006 | |
+
+
+Provision for income taxes | |
+| 3,143 | | |
+| 2,269 | | |
+| 5,587 | | |
+| 2,881 | |
+
+
+Interest income, net | |
+| (1,695 | ) | |
+| (577 | ) | |
+| (2,137 | ) | |
+| (704 | ) |
+
+
+Depreciation and amortization | |
+| 2,299 | | |
+| 1,602 | | |
+| 4,475 | | |
+| 3,164 | |
+
+
+Stock-based
+compensation | |
+| 7,196 | | |
+| 2,721 | | |
+| 13,104 | | |
+| 5,602 | |
+
+
+Adjusted EBITDA | |
+$ | 25,355 | | |
+$ | 13,234 | | |
+$ | 50,339 | | |
+$ | 25,949 | |

--- a/modules/test-fixtures/earnings-filings/net.txt
+++ b/modules/test-fixtures/earnings-filings/net.txt
@@ -1,0 +1,610 @@
+EX-99.1
+2
+q226exhibit991.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+
+
+
+Cloudflare Announces Second Quarter 2026 Financial Results
+
+
+• Second quarter revenue totaled $696.1 million, representing an increase of 36% year-over-year
+• GAAP loss from operations of $205.7 million, or 30% of total revenue, and non-GAAP income from operations of $96.1 million, or 14% of revenue
+• Delivered Current RPO year-over-year growth of 35%
+San Francisco, CA, August 6, 2026 — Cloudflare, Inc. (NYSE: NET), the leading connectivity cloud company, today announced financial results for its second quarter ended June 30, 2026.
+
+
+“We delivered a stellar second quarter, highlighted by revenue accelerating to $696.1 million, up 36% year-over-year, and record growth in total paying customers, large customers, and developers on our platform,” said Matthew Prince, co-founder & CEO of Cloudflare. “As the web shifts to AI answer engines and agent-driven commerce, we are seeing a fundamental rewrite of the Internet for machine-to-machine traffic. Cloudflare sits at the center of this paradigm shift—building the infrastructure, controls, developer tools, and payment rails for the Agentic Internet. The business model of the web is changing, and no company is better positioned than Cloudflare to help define its future.”
+
+
+Second Quarter Fiscal 2026 Financial Highlights
+
+
+• Revenue : Total revenue of $696.1 million, representing an increase of 36% year-over-year.
+• Gross Profit : GAAP gross profit was $499.5 million, or 71.8% gross margin, compared to $383.6 million, or 74.9%, in the second quarter of 2025. Non-GAAP gross profit was $508.9 million, or 73.1% gross margin, compared to $390.7 million, or 76.3%, in the second quarter of 2025.
+• Operating Income (Loss) : GAAP loss from operations was $205.7 million, or 29.6% of revenue, compared to $67.3 million, or 13.1% of revenue, in the second quarter of 2025. Non-GAAP income from operations was $96.1 million, or 13.8% of revenue, compared to $72.3 million, or 14.1% of revenue, in the second quarter of 2025.
+• Net Income (Loss) : GAAP net loss was $170.0 million, compared to $50.4 million in the second quarter of 2025. GAAP net loss per basic and diluted share was $0.48, compared to $0.15 in the second quarter of 2025. Non-GAAP net income was $107.8 million, compared to $75.1 million in the second quarter of 2025. Non-GAAP net income per diluted share was $0.29, compared to $0.21 in the second quarter of 2025.
+• Cash Flow : Net cash flow from operating activities was $117.6 million, compared to $99.8 million for the second quarter of 2025. Free cash flow was $56.4 million, or 8% of revenue, compared to $33.3 million, or 6% of revenue, in the second quarter of 2025.
+• Cash, cash equivalents, and available-for-sale securities were $4,162.8 million as of June 30, 2026.
+
+
+The section titled "Non-GAAP Financial Information" below describes our usage of non-GAAP financial measures. Reconciliations between historical GAAP and non-GAAP information are contained at the end of this press release following the accompanying financial data.
+
+
+Financial Outlook
+
+
+For the third quarter of fiscal 2026, we expect:
+
+
+• Total revenue of $736.0 to $737.0 million
+• Non-GAAP income from operations of $129.0 to $130.0 million
+• Non-GAAP net income per share of $0.34, utilizing weighted average common shares outstanding of approximately 374 million
+
+
+
+
+
+
+
+
+
+
+
+For the full year fiscal 2026, we expect:
+
+
+• Total revenue of $2,864.0 to $2,870.0 million
+• Non-GAAP income from operations of $443.0 to $445.0 million
+• Non-GAAP net income per share of $1.25 to $1.26, utilizing weighted average common shares outstanding of approximately 374 million
+
+
+These statements are forward-looking and actual results may differ materially. Refer to the Forward-Looking Statements safe harbor below for information on the factors that could cause our actual results to differ materially from these forward-looking statements.
+
+
+
+Conference Call Information
+
+
+Cloudflare will host an investor conference call to discuss its second quarter ended June 30, 2026 earnings results today at 2:00 p.m. Pacific time (5:00 p.m. Eastern time). Interested parties can access the call by dialing (646) 968-2727 or toll-free at (888) 596-4244 with conference ID 3723782. A live webcast of the conference call will be accessible from the investor relations website at https://cloudflare.NET. A replay will be available approximately two hours after the conclusion of the live event and will remain available for approximately one year.
+
+
+
+Supplemental Financial and Other Information
+
+
+Supplemental financial and other information can be accessed through the Company’s investor relations website at https://cloudflare.NET.
+
+
+
+Non-GAAP Financial Information
+
+
+Cloudflare believes that the presentation of non-GAAP financial information provides important supplemental information to management and investors regarding financial and business trends relating to the Company’s financial condition and results of operations. Reconciliations of non-GAAP financial measures to the most directly comparable financial results as determined in accordance with GAAP are included at the end of this press release following the accompanying financial data. A reconciliation of non-GAAP guidance measures to corresponding GAAP measures is not available on a forward-looking basis without unreasonable effort due to the uncertainty of expenses that may be incurred in the future. For further information regarding why Cloudflare believes that these non-GAAP measures provide useful information to investors, the specific manner in which management uses these measures, and some of the limitations associated with the use of these measures, please refer to the “Explanation of Non-GAAP Financial Measures” section at the end of this press release.
+
+
+
+Available Information
+
+
+Cloudflare intends to use its press releases, website, investor relations website, news site, blog, X account, Facebook account, and Instagram account, in addition to filings made with the Securities and Exchange Commission (SEC) and public conference calls, as a means of disclosing material non-public information and for complying with its disclosure obligations under Regulation FD.
+
+
+
+Forward-Looking Statements
+
+
+This press release contains forward-looking statements within the meaning of Section 27A of the Securities Act of 1933, as amended, and Section 21E of the Securities Exchange Act of 1934, as amended, which statements involve substantial risks and uncertainties. In some cases, you can identify forward-looking statements because they contain words such as “may,” “will,” “should,” “expect,” “explore,” “plan,” “anticipate,” “could,” “intend,” “target,” “project,” “contemplate,” “believe,” “estimate,” “predict,” “potential,” or “continue,” or the negative of these words, or other similar terms or expressions that concern our expectations, strategy, plans, or intentions. However, not all forward-looking statements contain these identifying words. Forward-looking statements expressed or implied in this press release include, but are not limited to, statements regarding our future financial and operating performance, our reputation and performance in the market, general market trends, our estimated and projected revenue, non-GAAP income from operations and non-GAAP net income per share, shares outstanding, the benefits to customers from using our products, the expected functionality and performance of our products, the demand by customers for our products, our plans and objectives for future operations, growth, initiatives, or strategies, our
+
+
+
+
+
+
+
+
+
+market opportunity, the plan to further accelerate our evolution to an agentic AI-first operating model and the intent for the plan to align our organizational structure with this new operating model, the estimated reduction of our current workforce, the estimated charges in connection with this plan, including the primary components of such charges, the anticipated timing of the implementation of this plan and the timing of such charges, the expected benefits from this plan and related actions, and comments made by our CEO and others. There are a significant number of factors that could cause actual results to differ materially from statements made in this press release, including: the impact of adverse macroeconomic conditions on our and our customers’, vendors’, and partners’ operations and future financial performance; the impact of conflicts and geopolitical tension around the world, particularly in Eastern Europe or the Middle East, or any worsening or expansion of those conflicts or tensions, as well as other geopolitical events such as elections and other governmental changes, threats of tariffs and other impediments to cross-border trade; our history of net losses; risks associated with managing our growth; our ability to attract and retain new customers (including new large customers); our ability to retain and upgrade paying customers and convert free customers to paying customers; our ability to expand the number of products we sell to paying customers; our ability to effectively increase sales to large customers; our ability to incorporate AI tools and automation to increase productivity and maintain operational efficiency; our ability to increase brand awareness; our ability to continue to innovate and develop new products and product features; our ability to generate demand for our products; our ability to effectively attract, train, and retain our sales force to be able to sell our existing and new products and product features; our sales team’s productivity; our ability to effectively attract, integrate and retain key personnel; problems with our internal systems, network, or data, including actual or perceived breaches or failures; rapidly evolving technological developments in the market, including advancements in AI; length of our sales cycles and the timing of payments by our customers; activities of our paying and free customers or the content of their websites and other Internet properties that use our network and products; foreign currency fluctuations; changes in the legal, tax, and regulatory environment applicable to our business; and other general market, political, economic, and business conditions. Our actual results could differ materially from those stated or implied in forward-looking statements due to a number of factors, including but not limited to, risks detailed in our filings with the SEC, including our Quarterly Report on Form 10-Q filed on May 8, 2026, as well as other filings that we may make from time to time with the SEC.
+
+
+The forward-looking statements made in this press release relate only to events as of the date on which the statements are made. We undertake no obligation to update any forward-looking statements made in this press release to reflect events or circumstances after the date of this press release or to reflect new information or the occurrence of unanticipated events, except as required by law. We may not actually achieve the plans, intentions, or expectations disclosed in our forward-looking statements, and you should not place undue reliance on our forward-looking statements.
+
+
+
+
+About Cloudflare
+
+
+Cloudflare, Inc. (NYSE: NET) is the leading connectivity cloud company on a mission to help build a better Internet. It empowers organizations to make their employees, applications and networks faster and more secure everywhere, while reducing complexity and cost. Cloudflare’s connectivity cloud delivers the most full-featured, unified platform of cloud-native products and developer tools, so any organization can gain the control they need to work, develop, and accelerate their business.
+
+
+Powered by one of the world’s largest and most interconnected networks, Cloudflare blocks billions of threats online for its customers every day. It is trusted by millions of organizations – from the largest brands to entrepreneurs and small businesses to nonprofits, humanitarian groups, and governments across the globe.
+
+
+Learn more about Cloudflare’s connectivity cloud at cloudflare.com/connectivity-cloud. Learn more about the latest Internet trends and insights at radar.cloudflare.com.
+
+
+
+
+Investor Relations Information
+Phil Winslow
+ir@cloudflare.com
+
+
+Press Contact Information
+Daniella Vallurupalli
+press@cloudflare.com
+
+
+Source: Cloudflare, Inc.
+
+
+
+
+
+
+
+
+
+
+CLOUDFLARE, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(in thousands, except per share data)
+(unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Revenue | $ | 696,061 | | | $ | 512,316 | | | $ | 1,335,816 | | | $ | 991,403 | |
+Cost of revenue (1)(2)
+| 196,544 | | | 128,677 | | | 380,702 | | | 244,253 | |
+Gross profit | 499,517 | | | 383,639 | | | 955,114 | | | 747,150 | |
+Operating expenses: | | | | | | | |
+Sales and marketing (1)(2)(3)
+| 276,122 | | | 219,359 | | | 547,722 | | | 433,370 | |
+Research and development (1)
+| 159,486 | | | 134,557 | | | 310,458 | | | 249,646 | |
+General and administrative (1)(3)(5)(6)
+| 118,912 | | | 96,987 | | | 213,931 | | | 184,645 | |
+Restructuring and other charges | 150,693 | | | — | | | 150,693 | | | — | |
+Total operating expenses | 705,213 | | | 450,903 | | | 1,222,804 | | | 867,661 | |
+Loss from operations | (205,696) | | | (67,264) | | | (267,690) | | | (120,511) | |
+Non-operating income (expense): | | | | | | | |
+Interest income | 39,932 | | | 25,406 | | | 80,098 | | | 46,805 | |
+Interest expense (4)
+| (3,089) | | | (1,524) | | | (5,652) | | | (2,967) | |
+| | | | | | | |
+Other income (expense), net | 913 | | | (3,907) | | | 3,903 | | | (7,375) | |
+Total non-operating income, net | 37,756 | | | 19,975 | | | 78,349 | | | 36,463 | |
+Loss before income taxes
+| (167,940) | | | (47,289) | | | (189,341) | | | (84,048) | |
+Provision for income taxes | 2,041 | | | 3,157 | | | 3,567 | | | 4,852 | |
+Net loss | $ | (169,981) | | | $ | (50,446) | | | $ | (192,908) | | | $ | (88,900) | |
+Net loss per share attributable to common stockholders, basic and diluted | $ | (0.48) | | | $ | (0.15) | | | $ | (0.55) | | | $ | (0.26) | |
+Weighted-average shares used in computing net loss per share attributable to common stockholders, basic and diluted | 354,334 | | | 347,489 | | | 353,485 | | | 346,605 | |
+| | | | | | | |
+
+____________
+(1) Includes stock-based compensation and related employer payroll taxes as follows: | | | | | | | | | | | | | | | | | | | | | | | |
+Cost of revenue | $ | 4,311 | | | $ | 3,693 | | | $ | 8,455 | | | $ | 6,599 | |
+Sales and marketing | 41,246 | | | 36,818 | | | 84,070 | | | 67,023 | |
+Research and development | 55,435 | | | 50,956 | | | 104,936 | | | 89,225 | |
+General and administrative | 39,601 | | | 40,526 | | | 70,589 | | | 75,041 | |
+Total stock-based compensation and related employer payroll taxes | $ | 140,593 | | | $ | 131,993 | | | $ | 268,050 | | | $ | 237,888 | |
+
+(2) Includes amortization of acquired intangible assets as follows: | | | | | | | | | | | | | | | | | | | | | | | |
+Cost of revenue | $ | 5,050 | | | $ | 3,329 | | | $ | 11,011 | | | $ | 6,182 | |
+Sales and marketing | 2,391 | | | 417 | | | 3,641 | | | 805 | |
+Total amortization of acquired intangible assets | $ | 7,441 | | | $ | 3,746 | | | $ | 14,652 | | | $ | 6,987 | |
+
+(3) Includes acquisition-related and other expenses as follows: | | | | | | | | | | | | | | | | | | | | | | | |
+Sales and marketing | $ | 33 | | | $ | — | | | $ | 33 | | | $ | — | |
+General and administrative | 2,047 | | | — | | | 2,470 | | | 112 | |
+Total acquisition-related and other expenses | $ | 2,080 | | | $ | — | | | $ | 2,503 | | | $ | 112 | |
+
+(4) Includes amortization of debt issuance costs as follows: | | | | | | | | | | | | | | | | | | | | | | | |
+Interest expense | $ | 2,439 | | | $ | 1,199 | | | $ | 4,865 | | | $ | 2,189 | |
+Total amortization of debt issuance costs | $ | 2,439 | | | $ | 1,199 | | | $ | 4,865 | | | $ | 2,189 | |
+
+
+
+
+
+
+
+
+
+
+(5) Includes lease impairment charges as follows: | | | | | | | | | | | | | | | | | | | | | | | |
+General and administrative | $ | — | | | $ | 3,840 | | | $ | — | | | $ | 3,840 | |
+Total lease impairment charges | $ | — | | | $ | 3,840 | | | $ | — | | | $ | 3,840 | |
+
+(6) Includes legal reserve and settlements as follows: | | | | | | | | | | | | | | | | | | | | | | | |
+General and administrative | $ | 1,000 | | | $ | — | | | $ | 1,000 | | | $ | — | |
+Total legal reserve and settlements | $ | 1,000 | | | $ | — | | | $ | 1,000 | | | $ | — | |
+
+
+
+
+
+
+
+
+
+
+
+CLOUDFLARE, INC.
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(in thousands, except par value)
+(unaudited)
+| | | | | | | | | | | |
+| June 30,
+2026 | | December 31,
+2025 |
+Assets | | | |
+Current assets: | | | |
+Cash and cash equivalents | $ | 1,663,773 | | | $ | 943,536 | |
+Available-for-sale securities | 2,499,025 | | | 3,157,715 | |
+Accounts receivable, net | 422,945 | | | 382,488 | |
+Contract assets | 27,187 | | | 23,531 | |
+Restricted cash short-term | 12,163 | | | 9,364 | |
+Prepaid expenses and other current assets | 153,282 | | | 128,203 | |
+Total current assets | 4,778,375 | | | 4,644,837 | |
+Property and equipment, net | 703,209 | | | 618,691 | |
+Goodwill | 376,204 | | | 226,563 | |
+Acquired intangible assets, net | 57,369 | | | 41,799 | |
+Operating lease right-of-use assets | 247,675 | | | 237,646 | |
+Deferred contract acquisition costs, noncurrent | 240,523 | | | 219,499 | |
+Restricted cash | — | | | 1,457 | |
+Other noncurrent assets | 70,772 | | | 45,764 | |
+Total assets | $ | 6,474,127 | | | $ | 6,036,256 | |
+Liabilities and Stockholders’ Equity | | | |
+Current liabilities: | | | |
+Accounts payable | $ | 127,032 | | | $ | 84,115 | |
+Accrued expenses and other current liabilities | 165,788 | | | 109,054 | |
+Accrued compensation | 151,528 | | | 111,005 | |
+Operating lease liabilities | 78,239 | | | 70,901 | |
+| | | |
+Deferred revenue | 812,187 | | | 684,207 | |
+Current portion of convertible senior notes, net | 1,293,260 | | | 1,291,281 | |
+Total current liabilities | 2,628,034 | | | 2,350,563 | |
+Convertible senior notes, net | 1,977,006 | | | 1,974,120 | |
+Operating lease liabilities, noncurrent | 180,845 | | | 182,025 | |
+Deferred revenue, noncurrent | 40,252 | | | 41,088 | |
+Other noncurrent liabilities | 27,970 | | | 29,337 | |
+Total liabilities | 4,854,107 | | | 4,577,133 | |
+| | | |
+| | | |
+| | | |
+Stockholders’ Equity | | | |
+Class A common stock; $0.001 par value; 2,250,000 shares authorized as of June 30, 2026 and December 31, 2025; 322,176 and 317,319 shares issued and outstanding as of June 30, 2026 and December 31, 2025, respectively
+| 322 | | | 317 | |
+Class B common stock; $0.001 par value; 315,000 shares authorized as of June 30, 2026 and December 31, 2025; 33,755 and 34,568 shares issued and outstanding as of June 30, 2026 and December 31, 2025, respectively
+| 33 | | | 34 | |
+Additional paid-in capital | 3,027,713 | | | 2,651,420 | |
+Accumulated deficit | (1,397,815) | | | (1,204,907) | |
+Accumulated other comprehensive income (loss) | (10,233) | | | 12,259 | |
+Total stockholders’ equity | 1,620,020 | | | 1,459,123 | |
+Total liabilities and stockholders’ equity | $ | 6,474,127 | | | $ | 6,036,256 | |
+
+
+
+
+
+
+
+
+
+
+
+CLOUDFLARE, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(in thousands)
+(unaudited) | | | | | | | | | | | |
+| Six Months Ended June 30, |
+| 2026 | | 2025 |
+Cash Flows from Operating Activities | | | |
+Net loss | $ | (192,908) | | | $ | (88,900) | |
+Adjustments to reconcile net loss to cash provided by operating activities: | | | |
+Depreciation and amortization expense | 123,170 | | | 87,688 | |
+Non-cash operating lease costs | 41,696 | | | 29,872 | |
+Amortization of deferred contract acquisition costs | 63,486 | | | 47,296 | |
+Stock-based compensation expense | 274,113 | | | 217,912 | |
+Amortization of debt issuance costs | 4,865 | | | 2,189 | |
+Net accretion of discounts and amortization of premiums on available-for-sale securities | (13,233) | | | (11,987) | |
+Deferred income taxes | (7,013) | | | (480) | |
+Provision for bad debt | 5,157 | | | 7,815 | |
+| | | |
+| | | |
+Other | (6,814) | | | 3,227 | |
+Changes in operating assets and liabilities, net of effect of asset acquisitions and business combinations: | | | |
+Accounts receivable, net | (45,614) | | | 1,431 | |
+Contract assets | (3,656) | | | (4,707) | |
+Deferred contract acquisition costs | (84,510) | | | (58,998) | |
+Prepaid expenses and other current assets | (60,612) | | | (46,339) | |
+Other noncurrent assets | 7,142 | | | 4,312 | |
+Accounts payable | 1,205 | | | (247) | |
+Accrued expenses and other current liabilities | 48,699 | | | 758 | |
+Accrued compensation | 40,523 | | | (2,914) | |
+Operating lease liabilities | (45,567) | | | (24,973) | |
+Deferred revenue | 127,144 | | | 82,643 | |
+| | | |
+Other noncurrent liabilities | (1,379) | | | (18) | |
+Net cash provided by operating activities | 275,894 | | | 245,580 | |
+Cash Flows from Investing Activities | | | |
+Purchases of property and equipment | (115,192) | | | (145,786) | |
+Capitalized internal-use software | (20,244) | | | (13,647) | |
+Asset acquisitions and business combinations, net of cash acquired | (75,098) | | | (6,462) | |
+Purchases of available-for-sale securities | (783,933) | | | (1,530,775) | |
+| | | |
+Maturities of available-for-sale securities | 1,442,199 | | | 810,825 | |
+Other investing activities | 1,636 | | | 382 | |
+| | | |
+Net cash provided by (used in) investing activities | 449,368 | | | (885,463) | |
+Cash Flows from Financing Activities | | | |
+| | | |
+Proceeds from settlement of the 2025 capped calls
+| — | | | 309,616 | |
+Gross proceeds from issuance of 2030 convertible senior notes
+| — | | | 2,000,000 | |
+Purchases of capped calls related to the 2030 convertible senior notes
+| — | | | (283,400) | |
+| | | |
+Cash paid for issuance costs on 2030 convertible senior notes
+| — | | | (27,873) | |
+| | | |
+| | | |
+Proceeds from the exercise of stock options | 9,815 | | | 17,942 | |
+| | | |
+| | | |
+| | | |
+Proceeds from the issuance of common stock for employee stock purchase plan | 16,075 | | | 13,057 | |
+| | | |
+Payment of tax withholding obligation on RSU and PSU settlement | (29,473) | | | (18,217) | |
+Payment of indemnity holdback | (100) | | | — | |
+Net cash provided by (used in) financing activities | (3,683) | | | 2,011,125 | |
+Net increase in cash, cash equivalents, and restricted cash | 721,579 | | | 1,371,242 | |
+Cash, cash equivalents, and restricted cash, beginning of period | 954,357 | | | 154,214 | |
+Cash, cash equivalents, and restricted cash, end of period | $ | 1,675,936 | | | $ | 1,525,456 | |
+
+
+
+
+
+
+
+
+
+
+
+CLOUDFLARE, INC.
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES
+(in thousands, except per share amounts)
+(unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Reconciliation of cost of revenue: | | | | | | | | |
+GAAP cost of revenue | | $ | 196,544 | | | $ | 128,677 | | | $ | 380,702 | | | $ | 244,253 | |
+Less: Stock-based compensation and related employer payroll taxes | | (4,311) | | | (3,693) | | | (8,455) | | | (6,599) | |
+Less: Amortization of acquired intangible assets | | (5,050) | | | (3,329) | | | (11,011) | | | (6,182) | |
+Non-GAAP cost of revenue | | $ | 187,183 | | | $ | 121,655 | | | $ | 361,236 | | | $ | 231,472 | |
+Reconciliation of gross profit: | | | | | | | | |
+GAAP gross profit | | $ | 499,517 | | | $ | 383,639 | | | $ | 955,114 | | | $ | 747,150 | |
+Add: Stock-based compensation and related employer payroll taxes | | 4,311 | | | 3,693 | | | 8,455 | | | 6,599 | |
+Add: Amortization of acquired intangible assets | | 5,050 | | | 3,329 | | | 11,011 | | | 6,182 | |
+Non-GAAP gross profit | | $ | 508,878 | | | $ | 390,661 | | | $ | 974,580 | | | $ | 759,931 | |
+GAAP gross margin | | 71.8% | | 74.9% | | 71.5% | | 75.4% |
+Non-GAAP gross margin | | 73.1% | | 76.3% | | 73.0% | | 76.7% |
+Reconciliation of operating expenses: | | | | | | | | |
+GAAP sales and marketing | | $ | 276,122 | | | $ | 219,359 | | | $ | 547,722 | | | $ | 433,370 | |
+Less: Stock-based compensation and related employer payroll taxes | | (41,246) | | | (36,818) | | | (84,070) | | | (67,023) | |
+Less: Amortization of acquired intangible assets | | (2,391) | | | (417) | | | (3,641) | | | (805) | |
+| | | | | | | | |
+Less: Acquisition-related and other expenses | | (33) | | | — | | | (33) | | | — | |
+Non-GAAP sales and marketing | | $ | 232,452 | | | $ | 182,124 | | | $ | 459,978 | | | $ | 365,542 | |
+GAAP research and development | | $ | 159,486 | | | $ | 134,557 | | | $ | 310,458 | | | $ | 249,646 | |
+Less: Stock-based compensation and related employer payroll taxes | | (55,435) | | | (50,956) | | | (104,936) | | | (89,225) | |
+| | | | | | | | |
+Non-GAAP research and development | | $ | 104,051 | | | $ | 83,601 | | | $ | 205,522 | | | $ | 160,421 | |
+GAAP general and administrative | | $ | 118,912 | | | $ | 96,987 | | | $ | 213,931 | | | $ | 184,645 | |
+Less: Stock-based compensation and related employer payroll taxes | | (39,601) | | | (40,526) | | | (70,589) | | | (75,041) | |
+Less: Acquisition-related and other expenses | | (2,047) | | | — | | | (2,470) | | | (112) | |
+Less: Lease impairment charges | | — | | | (3,840) | | | — | | | (3,840) | |
+Less: Legal reserve and settlements
+| | (1,000) | | | — | | | (1,000) | | | — | |
+Non-GAAP general and administrative | | $ | 76,264 | | | $ | 52,621 | | | $ | 139,872 | | | $ | 105,652 | |
+GAAP restructuring and other charges | | $ | 150,693 | | | $ | — | | | $ | 150,693 | | | $ | — | |
+Less: Restructuring and other charges | | (150,693) | | | — | | | (150,693) | | | — | |
+Non-GAAP restructuring and other charges | | $ | — | | | $ | — | | | $ | — | | | $ | — | |
+Reconciliation of income (loss) from operations: | | | | | | | | |
+GAAP loss from operations | | $ | (205,696) | | | $ | (67,264) | | | $ | (267,690) | | | $ | (120,511) | |
+Add: Stock-based compensation and related employer payroll taxes | | 140,593 | | | 131,993 | | | 268,050 | | | 237,888 | |
+Add: Amortization of acquired intangible assets | | 7,441 | | | 3,746 | | | 14,652 | | | 6,987 | |
+Add: Acquisition-related and other expenses | | 2,080 | | | — | | | 2,503 | | | 112 | |
+| | | | | | | | |
+Add: Lease impairment charges | | — | | | 3,840 | | | — | | | 3,840 | |
+Add: Legal reserve and settlements
+| | 1,000 | | | — | | | 1,000 | | | — | |
+Add: Restructuring and other charges | | 150,693 | | | — | | | 150,693 | | | — | |
+Non-GAAP income from operations | | $ | 96,111 | | | $ | 72,315 | | | $ | 169,208 | | | $ | 128,316 | |
+GAAP operating margin | | (29.6)% | | (13.1)% | | (20.0)% | | (12.2)% |
+Non-GAAP operating margin | | 13.8% | | 14.1% | | 12.7% | | 12.9% |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+
+
+
+
+
+
+
+
+
+
+CLOUDFLARE, INC.
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES
+(in thousands, except per share amounts)
+(unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+| | 2026 | | 2025 | | 2026 | | 2025 |
+Reconciliation of interest expense: | | | | | | | | |
+GAAP interest expense | | $ | (3,089) | | | $ | (1,524) | | | $ | (5,652) | | | $ | (2,967) | |
+Add: Amortization of debt issuance costs | | 2,439 | | | 1,199 | | | 4,865 | | | 2,189 | |
+Non-GAAP interest expense | | $ | (650) | | | $ | (325) | | | $ | (787) | | | $ | (778) | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Reconciliation of provision for income taxes: | | | | | | | | |
+GAAP provision for income taxes | | $ | 2,041 | | | $ | 3,157 | | | $ | 3,567 | | | $ | 4,852 | |
+Income tax effect of non-GAAP adjustments | | 26,485 | | | 15,275 | | | 47,059 | | | 28,644 | |
+Non-GAAP provision for income taxes | | $ | 28,526 | | | $ | 18,432 | | | $ | 50,626 | | | $ | 33,496 | |
+Reconciliation of net income (loss) and net income (loss) per share: | | | | | | | | |
+GAAP net loss attributable to common stockholders | | $ | (169,981) | | | $ | (50,446) | | | $ | (192,908) | | | $ | (88,900) | |
+Add: Stock-based compensation and related employer payroll taxes | | 140,593 | | | 131,993 | | | 268,050 | | | 237,888 | |
+Add: Amortization of acquired intangible assets | | 7,441 | | | 3,746 | | | 14,652 | | | 6,987 | |
+Add: Acquisition-related and other expenses | | 2,080 | | | — | | | 2,503 | | | 112 | |
+| | | | | | | | |
+Add: Amortization of debt issuance costs | | 2,439 | | | 1,199 | | | 4,865 | | | 2,189 | |
+| | | | | | | | |
+Add: Lease impairment charges | | — | | | 3,840 | | | — | | | 3,840 | |
+Add: Legal reserve and settlements
+| | 1,000 | | | — | | | 1,000 | | | — | |
+Add: Restructuring and other charges | | 150,693 | | | — | | | 150,693 | | | — | |
+Income tax effect of non-GAAP adjustments | | (26,485) | | | (15,275) | | | (47,059) | | | (28,644) | |
+Non-GAAP net income | | $ | 107,780 | | | $ | 75,057 | | | $ | 201,796 | | | $ | 133,472 | |
+| | | | | | | | |
+GAAP net loss per share, basic | | $ | (0.48) | | | $ | (0.15) | | | $ | (0.55) | | | $ | (0.26) | |
+| | | | | | | | |
+GAAP net loss per share, diluted | | $ | (0.48) | | | $ | (0.15) | | | $ | (0.55) | | | $ | (0.26) | |
+Add: Stock-based compensation and related employer payroll taxes | | 0.40 | | | 0.38 | | | 0.76 | | | 0.69 | |
+Add: Amortization of acquired intangible assets | | 0.02 | | | 0.01 | | | 0.04 | | | 0.02 | |
+Add: Acquisition-related and other expenses | | 0.01 | | | — | | | 0.01 | | | — | |
+| | | | | | | | |
+Add: Amortization of debt issuance costs | | 0.01 | | | — | | | 0.01 | | | 0.01 | |
+| | | | | | | | |
+Add: Lease impairment charges | | — | | | 0.01 | | | — | | | 0.01 | |
+Add: Legal reserve and settlements
+| | — | | | — | | | — | | | — | |
+Add: Restructuring and other charges | | 0.43 | | | — | | | 0.43 | | | — | |
+Income tax effect of non-GAAP adjustments
+| | (0.07) | | | (0.04) | | | (0.13) | | | (0.08) | |
+Effect of dilutive shares | | (0.03) | | | — | | | (0.03) | | | (0.02) | |
+Non-GAAP net income per share, diluted (1)
+| | $ | 0.29 | | | $ | 0.21 | | | $ | 0.54 | | | $ | 0.37 | |
+| | | | | | | | |
+Weighted-average shares used in computing net loss per share attributable to common stockholders, basic | | 354,334 | | | 347,489 | | | 353,485 | | | 346,605 | |
+Weighted-average shares used in computing non-GAAP net income per share attributable to common stockholders, diluted | | 373,683 | | | 365,264 | | | 374,672 | | | 363,962 | |
+
+____________
+(1) Totals may not sum due to rounding. Figures are calculated based upon the respective underlying non-rounded data.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+CLOUDFLARE, INC.
+RECONCILIATION OF GAAP TO NON-GAAP FINANCIAL MEASURES
+(in thousands, except per share amounts)
+(unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | | Six Months Ended
+June 30, |
+2026 | | 2025 | | 2026 | | 2025 |
+Free cash flow | | | | | | | |
+Net cash provided by operating activities | $ | 117,564 | | | $ | 99,796 | | | $ | 275,894 | | | $ | 245,580 | |
+Less: Purchases of property and equipment | (49,961) | | | (59,897) | | | (115,192) | | | (145,786) | |
+Less: Capitalized internal-use software | (11,219) | | | (6,619) | | | (20,244) | | | (13,647) | |
+Free cash flow | $ | 56,384 | | | $ | 33,280 | | | $ | 140,458 | | | $ | 86,147 | |
+Net cash provided by (used in) investing activities | $ | 608,174 | | | $ | (793,025) | | | $ | 449,368 | | | $ | (885,463) | |
+Net cash provided by (used in) financing activities | $ | 5,785 | | | $ | 2,007,603 | | | $ | (3,683) | | | $ | 2,011,125 | |
+Net cash provided by operating activities
+(percentage of revenue) | 17 | % | | 19 | % | | 21 | % | | 25 | % |
+Less: Purchases of property and equipment
+(percentage of revenue) | (7) | % | | (12) | % | | (9) | % | | (15) | % |
+Less: Capitalized internal-use software
+(percentage of revenue) | (2) | % | | (1) | % | | (1) | % | | (1) | % |
+Free cash flow margin (1)
+| 8 | % | | 6 | % | | 11 | % | | 9 | % |
+
+
+
+____________
+
+
+(1) Totals may not sum due to rounding. Figures are calculated based upon the respective underlying non-rounded data.
+
+
+
+
+
+
+
+
+
+Explanation of Non-GAAP Financial Measures
+
+
+In addition to our results determined in accordance with generally accepted accounting principles in the United States (U.S. GAAP), we believe the following non-GAAP measures are useful in evaluating our operating performance. We use the following non-GAAP financial information to evaluate our ongoing operations and for internal planning and forecasting purposes. We believe that non-GAAP financial information, when taken collectively, may be helpful to investors because it provides consistency and comparability with past financial performance. However, non-GAAP financial information is presented for supplemental informational purposes only, has limitations as an analytical tool and should not be considered in isolation or as a substitute for financial information presented in accordance with U.S. GAAP. In particular, free cash flow is not a substitute for cash provided by operating activities. Additionally, the utility of free cash flow as a measure of our liquidity is further limited as it does not represent the total increase or decrease in our cash balance for a given period. In addition, other companies, including companies in our industry, may calculate similarly-titled non-GAAP measures differently or may use other measures to evaluate their performance, all of which could reduce the usefulness of our non-GAAP financial measures as tools for comparison. A reconciliation is provided above for each non-GAAP financial measure to the most directly comparable financial measure stated in accordance with U.S. GAAP. Investors are encouraged to review the related U.S. GAAP financial measures and the reconciliation of these non-GAAP financial measures to their most directly comparable U.S. GAAP financial measures, and not to rely on any single financial measure to evaluate our business.
+
+
+Items Excluded from Non-GAAP Measures. We exclude stock-based compensation expense, which is a non-cash expense, from certain of our non-GAAP financial measures because we believe that excluding this item provides meaningful supplemental information regarding operational performance. We exclude employer payroll tax expenses related to stock-based compensation, which is a cash expense, from certain of our non-GAAP financial measures because such expenses are dependent upon the price of our Class A common stock and other factors that are beyond our control and do not correlate to the operation of our business. We exclude amortization of acquired intangible assets, which is a non-cash expense, related to business combinations from certain of our non-GAAP financial measures because such expenses are related to business combinations and have no direct correlation to the operation of our business. We exclude acquisition-related and other expenses from certain of our non-GAAP financial measures because such expenses are related to business combinations and have no direct correlation to the operation of our business. Acquisition-related and other expenses can be cash or non-cash expenses and include third-party transaction costs and compensation expense for key acquired personnel. We exclude lease impairment charges related to real estate leases, which is a non-cash expense, from certain of our non-GAAP financial measures because they are not indicative of our ongoing cost structure and core business performance. We exclude amortization of debt issuance costs, which is a non-cash expense, from certain of our non-GAAP financial measures because such expenses have no direct correlation to the operation of our business. We exclude legal reserve and settlements, which can be cash or non-cash expenses, from certain of our non-GAAP financial measures because they are not indicative of our ongoing cost structure and core business performance. We exclude restructuring and other charges, which can be cash or non-cash expenses, from certain of our non-GAAP financial measures because they are not indicative of our ongoing cost structure and core business performance.
+
+
+Non-GAAP Gross Profit and Non-GAAP Gross Margin. We define non-GAAP gross profit and non-GAAP gross margin as U.S. GAAP gross profit and U.S. GAAP gross margin, respectively, excluding stock-based compensation and related employer payroll taxes and amortization of acquired intangible assets.
+
+
+Non-GAAP Income from Operations and Non-GAAP Operating Margin . We define non-GAAP income from operations and non-GAAP operating margin as U.S. GAAP loss from operations and U.S. GAAP operating margin, respectively, excluding stock-based compensation expense and its related employer payroll taxes, amortization of acquired intangible assets, acquisition-related and other expenses, lease impairment charges, legal reserve and settlements, and restructuring and other charges.
+
+
+Non-GAAP Net Income and Non-GAAP Net Income per Share, Diluted . We define non-GAAP net income as GAAP net loss adjusted for stock-based compensation expense and its related employer payroll taxes, amortization of acquired intangible assets, acquisition-related and other expenses, amortization of issuance costs, lease impairment charges, legal reserve and settlements, restructuring and other charges, and a non-GAAP provision for (benefit from) income taxes. Generally, the difference between our GAAP and non-GAAP income tax expense (benefit) is primarily due to adjustments in stock-based compensation and related employer payroll taxes, amortization of acquired intangibles associated with business combinations, acquisition-related and other expenses, amortization of issuance costs, lease impairment charges, legal reserve and settlements, and restructuring and other charges. We define non-GAAP net income per share, diluted, as non-GAAP net income divided by the weighted-average common shares outstanding, adjusted for dilutive potential shares that were assumed outstanding during period. Currently, potential
+
+
+
+
+
+
+
+
+
+dilutive effect mainly consists of employee equity incentive plans and convertible senior notes. We believe that excluding these items from non-GAAP net income per share, diluted, provides management and investors with greater visibility into the underlying performance of our core business operating results.
+
+
+Free Cash Flow and Free Cash Flow Margin . Free cash flow is a non-GAAP financial measure that we calculate as net cash provided by operating activities less cash used for purchases of property and equipment and capitalized internal-use software. Free cash flow margin is calculated as free cash flow divided by revenue. We believe that free cash flow and free cash flow margin are useful indicators of liquidity that provide information to management and investors about the amount of cash generated from our operations that, after the investments in property and equipment and capitalized internal-use software, can be used for strategic initiatives, including investing in our business, and strengthening our financial position. We believe that historical and future trends in free cash flow and free cash flow margin, even if negative, provide useful information about the amount of cash generated by our operating activities that is available (or not available) to be used for strategic initiatives. For example, if free cash flow is negative, we may need to access cash reserves or other sources of capital to invest in strategic initiatives. One limitation of free cash flow and free cash flow margin is that they do not reflect our future contractual commitments. Additionally, free cash flow does not represent the total increase or decrease in our cash balance for a given period.

--- a/modules/test-fixtures/earnings-filings/ph.txt
+++ b/modules/test-fixtures/earnings-filings/ph.txt
@@ -1,0 +1,694 @@
+EX-99.1
+2
+exhibit991q4fy26.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+Parker Reports Record Fiscal 2026 Fourth Quarter and Full Year Results
+Issues FY27 guidance and raises adjusted segment operating margin target by 300 bps to 30% by FY31
+CLEVELAND, August 6, 2026 -- Parker Hannifin Corporation (NYSE: PH), the global leader in motion and control technologies, today reported results for the quarter and fiscal year ended June 30, 2026, that included the following highlights (compared with the prior year period):
+Fiscal 2026 Fourth Quarter Highlights:
+• Sales increased 9.8% to a record $5.8 billion; organic sales increased 8.0%
+• Net income was $1.1 billion, an increase of 18%, or $1.2 billion adjusted, an increase of 20%
+• EPS increased 19% to $8.54, adjusted EPS increased 21% to a record $9.27
+• Segment operating margin was 26.5%, an increase of 260 bps, or 28.0% adjusted, an increase of 110 bps
+Fiscal 2026 Full Year Highlights:
+• Sales increased 8.3% to a record $21.5 billion; organic sales increased 6.6%
+• Net income was $3.6 billion, an increase of 3%, or $4.1 billion adjusted, an increase of 16%
+• EPS increased 5% to $28.48, adjusted EPS increased 18% to a record $32.31
+• Segment operating margin was 24.5%, an increase of 150 bps, or 27.3% adjusted, an increase of 120 bps
+• Cash flow from operations was a record $4.4 billion, or 20.3% of sales
+• Completed acquisition of Curtis Instruments, Inc. and announced agreements to acquire Filtration Group Corporation and CIRCOR's Commercial and Defense Aerospace Business
+• Returned nearly $2 billion to shareholders, through a combination of share repurchases and dividends
+• Increased the annual dividend 11%, marking 70 consecutive fiscal years of increasing annual dividends per share paid
+“On behalf of the entire leadership team, thank you to our global team members for their outstanding contributions in fiscal year 2026,” said Jenny Parmentier, Chairman and Chief Executive Officer. “We had our safest year ever, continued enhancing our portfolio of interconnected technologies through strategic acquisitions, and demonstrated operational excellence to deliver record results. We also returned value to shareholders with balanced capital deployment through share repurchases and a dividend increase of 11%.
+“We are forecasting fiscal 2027 to be a record year for Parker supported by a broadening recovery in industrial markets and positive organic growth across all market verticals. Our proven ability to execute The Win Strategy™ and successfully integrate accretive acquisitions gives us the confidence to raise our adjusted segment operating margin target by 300 basis points to 30% by fiscal 2031, after surpassing our previous margin target of 27% this year. In addition, we remain committed to achieving 4 to 6% organic growth, 17% free cash flow margin and greater than 10% adjusted earnings per share growth by fiscal 2031. We are proud of what Parker achieved in fiscal 2026, and we are even more excited about the opportunities ahead.”
+This news release contains non-GAAP financial measures. Reconciliations of adjusted numbers and certain non-GAAP financial measures are included in the financial tables of this press release.
+
+
+
+
+
+
+
+Fiscal 2027 Outlook
+The company has issued guidance for the fiscal year ending June 30, 2027 and noted that it excludes the pending acquisitions of Filtration Group Corporation and CIRCOR's Commercial and Defense Aerospace Business. In fiscal 2027, the company expects:
+• Reported sales growth of 5.5% to 8.5%
+• Organic sales growth of 5.5% to 8.5%; previously completed acquisitions of 0.5%, and unfavorable currency of 0.5%
+• Segment operating margin of 24.5% to 24.9%, or 27.5% to 27.9% on an adjusted basis
+• EPS of $30.00 to $31.00, or $34.25 to $35.25 on an adjusted basis
+Fiscal 2026 Fourth Quarter Segment Results
+Diversified Industrial Segment
+| | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | |
+North America Businesses
+| | | | | | | | | | | |
+$ in mm | FY26 Q4 | | FY25 Q4 | | Change
+| | Organic Growth | | | | |
+Sales | $ | 2,221 | | | $ | 2,075 | | | 7.0 | % | | 4.9 | % | | | | |
+| | | | | | | | | | | |
+Segment Operating Income | $ | 606 | | | $ | 513 | | | 18.1 | % | | | | | | |
+Segment Operating Margin | 27.3 | % | | 24.7 | % | | 260 | bps | | | | | | |
+Adjusted Segment Operating Income | $ | 609 | | | $ | 555 | | | 9.7 | % | | | | | | |
+Adjusted Segment Operating Margin | 27.4 | % | | 26.7 | % | | 70 | bps | | | | | | |
+
+• Organic sales growth of 5% as industrial recovery broadens
+• Record adjusted segment operating margin
+• Sales improvement across all market verticals
+| | | | | | | | | | | | | | | | | | | | | | | | | | | |
+International Businesses | | | | | |
+$ in mm
+| FY26 Q4 | | FY25 Q4 | | Change
+| | Organic Growth | | | | |
+Sales
+| $ | 1,634 | | | $ | 1,492 | | | 9.5 | % | | 6.5 | % | | | | |
+| | | | | | | | | | | |
+Segment Operating Income
+| $ | 396 | | | $ | 334 | | | 18.6 | % | | | | | | |
+Segment Operating Margin
+| 24.2 | % | | 22.4 | % | | 180 | bps | | | | | | |
+Adjusted Segment Operating Income | $ | 438 | | | $ | 369 | | | 18.7 | % | | | | | | |
+Adjusted Segment Operating Margin
+| 26.8 | % | | 24.7 | % | | 210 | bps | | | | | | |
+
+• Record sales led by Asia with 16% organic growth
+• Record adjusted segment operating margin
+• Organic growth: 16% APAC, 1% EMEA, (3%) LA
+Aerospace Systems Segment
+| | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | |
+$ in mm
+| FY26 Q4 | | FY25 Q4 | | Change
+| | Organic Growth | | | | |
+Sales
+| $ | 1,900 | | | $ | 1,676 | | | 13.4 | % | | 13.3 | % | | | | |
+| | | | | | | | | | | |
+Segment Operating Income
+| $ | 522 | | | $ | 407 | | | 28.3 | % | | | | | | |
+Segment Operating Margin
+| 27.5 | % | | 24.3 | % | | 320 | bps | | | | | | |
+Adjusted Segment Operating Income | $ | 567 | | | $ | 486 | | | 16.7 | % | | | | | | |
+Adjusted Segment Operating Margin
+| 29.8 | % | | 29.0 | % | | 80 | bps | | | | | | |
+
+• Record sales: double-digit growth in all market segments
+• Record adjusted segment operating margin
+• Backlog increased to record $8.5B
+
+
+
+
+
+
+
+Order Rates
+| | | | | |
+| Q4 FY26 |
+Parker
+| +19% |
+Diversified Industrial Segment - North America Businesses
+| +16% |
+Diversified Industrial Segment - International Businesses
+| +24% |
+Aerospace Systems Segment
+| +18% |
+
+• Backlog increased to a record $12.8 billion, with increases in all segments
+Parmentier added, "As a result of our ongoing portfolio transformation with a higher concentration of aerospace, longer cycle and more resilient end markets, we will harmonize all order rate comparisons to a 12-month rolling calculation starting in fiscal 2027. This method provides a stronger correlation to near-term organic growth rates."
+Order rate comparisons using both methodologies are included below:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Order rates as previously disclosed 1
+| FY25
+| | FY26
+| |
+Q1
+| Q2
+| Q3
+| Q4
+| | Q1
+| Q2
+| Q3
+| Q4
+| |
+Diversified North America
+| (3%)
+| 3%
+| 3%
+| 2%
+| | 3%
+| 7%
+| 7%
+| 16%
+| |
+Diversified International
+| 1%
+| 4%
+| 11%
+| 0%
+| | 6%
+| 6%
+| 6%
+| 24%
+| |
+Aerospace Systems
+| 7%
+| 9%
+| 14%
+| 12%
+| | 15%
+| 14%
+| 14%
+| 18%
+| |
+Parker
+| 1%
+| 5%
+| 9%
+| 5%
+| | 8%
+| 9%
+| 9%
+| 19%
+| |
+
+1. Diversified Industrial order rates are on 3-month average computations; Aerospace order rates are on a rolling 12-month average
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Updated rolling 12- month order rates 2
+| FY25
+| | FY26
+|
+Q1
+| Q2
+| Q3
+| Q4
+| | Q1
+| Q2
+| Q3
+| Q4
+|
+Diversified North America
+| (5%)
+| (3%)
+| 0%
+| 2%
+| | 3%
+| 4%
+| 5%
+| 9%
+|
+Diversified International
+| (5%)
+| (3%)
+| 3%
+| 3%
+| | 4%
+| 5%
+| 4%
+| 10%
+|
+Aerospace Systems
+| 7%
+| 9%
+| 14%
+| 12%
+| | 15%
+| 14%
+| 14%
+| 18%
+|
+Parker
+| (2%)
+| 1%
+| 5%
+| 5%
+| | 7%
+| 8%
+| 8%
+| 12%
+|
+
+2. All order rate comparisons on a rolling 12-month average
+About Parker Hannifin
+Parker Hannifin is a Fortune 250 global leader in motion and control technologies. For more than a century the company has been enabling engineering breakthroughs that lead to a better tomorrow. Learn more at www.parker.com or @parkerhannifin .
+
+
+| | | | | |
+Contacts:
+| |
+Media:
+| Financial Analysts:
+|
+Aidan Gormley
+| Jeff Miller
+|
+216-896-3258
+| 216-896-2708
+|
+aidan.gormley@parker.com
+| jeffrey.miller@parker.com
+|
+
+
+
+Notice of Webcast
+Parker Hannifin's conference call and slide presentation to discuss its fiscal 2026 fourth quarter and full year results are available to all interested parties via live webcast today at 11:00 a.m. ET, at investors.parker.com . A replay of the webcast will be available on the site approximately one hour after the completion of the call and will remain available for one year. To register for e-mail notification of future events please visit investors.parker.com .
+
+
+Note on Orders
+The company reported orders for the quarter ending June 30, 2026, compared with the same quarter a year ago. All comparisons are at constant currency exchange rates, with the prior year quarter restated to the current-year rates, and exclude divestitures. Through fiscal year 2026, Diversified Industrial comparisons have been on 3-month average computations and Aerospace Systems comparisons have been on rolling 12-month average computations. Beginning in fiscal year 2027, all comparisons will be on rolling 12-month average computations.
+
+
+
+
+
+
+
+
+
+Note on Non-GAAP Financial Measures
+This press release contains references to non-GAAP financial information including (a) adjusted net income; (b) adjusted earnings per share; (c) adjusted segment operating margin for Parker and by segment; (d) adjusted segment operating income for Parker and by segment; and (e) organic sales growth. These measures are presented to allow investors and the company to meaningfully evaluate changes in net income, earnings per share and segment operating margins on a comparable basis from period to period. Although these measures are not measures of performance calculated in accordance with GAAP, we believe that they are useful to an investor in evaluating Parker's performance or expected performance for the periods presented. Adjusted results for the current period exclude a reduction of cost of sales related to tariff refunds, which we believe is useful to investors because it reflects a discrete, non-operating item that is not indicative of the Company’s ongoing operations and is not expected to recur. Comparable descriptions of record adjusted results in this release refer only to the period from the first quarter of FY2011 to the periods presented in this release. This period coincides with recast historical financial results provided in association with our FY2014 change in segment reporting. A reconciliation of non-GAAP measures is included in the financial tables of this press release. The non-GAAP metrics included in our 5-year targets for fiscal year 2031 could not be reconciled without unreasonable effort and applicable reconciliations are not included in this press release.
+Forward-Looking Statements
+Forward-looking statements contained in this and other written and oral reports are made based on known events and circumstances at the time of release, and as such, are subject in the future to unforeseen uncertainties and risks. Often but not always, these statements may be identified from the use of forward-looking terminology such as “anticipates,” “believes,” “may,” “should,” “could,” “expects,” “targets,” “is likely,” “will,” or the negative of these terms and similar expressions, and may also include statements regarding future performance, orders, earnings projections, events or developments. Parker cautions readers not to place undue reliance on these statements. It is possible that the future performance may differ materially from expectations, including those based on past performance.
+Among other factors that may affect future performance are: changes in business relationships with and orders by or from major customers, suppliers or distributors, including delays or cancellations in shipments; disputes regarding contract terms, changes in contract costs and revenue estimates for new development programs; changes in product mix; ability to identify acceptable strategic acquisition targets; uncertainties surrounding timing, successful completion or integration of acquisitions and similar transactions, including the pending acquisition of Filtration Group Corporation and CIRCOR International Inc.'s Commercial and Defense Aerospace business and the integration of Curtis Instruments, Inc.; ability to successfully divest businesses planned for divestiture and realize the anticipated benefits of such divestitures; the determination and ability to successfully undertake business realignment activities and the expected costs, including cost savings, thereof; ability to implement successfully business and operating initiatives, including the timing, price and execution of share repurchases and other capital initiatives; availability, cost increases of or other limitations on our access to raw materials, component products and/or commodities if associated costs cannot be recovered in product pricing; ability to manage costs related to insurance and employee retirement and health care benefits; legal and regulatory developments and other government actions, including related to environmental protection, and associated compliance costs; supply chain and labor disruptions, including as a result of tariffs and labor shortages; threats associated with international conflicts, including geopolitical tensions in the Middle East, and cybersecurity risks and risks associated with protecting our intellectual property; uncertainties surrounding the ultimate resolution of outstanding legal proceedings, including the outcome of any appeals; effects on market conditions, including sales and pricing, resulting from global reactions to U.S. trade policies; manufacturing activity, air travel trends, currency exchange rates, difficulties entering new markets and economic conditions such as inflation, deflation, interest rates and credit availability; inability to obtain, or meet conditions imposed for, required governmental and regulatory approvals; changes in the tax laws in the United States and foreign jurisdictions and judicial or regulatory interpretations thereof; and large scale disasters, such as floods, earthquakes, hurricanes, industrial accidents and pandemics. Readers should also consider forward-looking statements in light of risk factors discussed in Parker’s Annual Report on Form 10-K for the fiscal year ended June 30, 2025 and other periodic filings made with the SEC.
+
+
+
+
+###
+
+
+
+
+
+Exhibit 99.1
+PARKER HANNIFIN CORPORATION - JUNE 30, 2026
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+CONSOLIDATED STATEMENTS OF INCOME | | | | | | | | |
+| | | | | | | | |
+| | Three Months Ended | | Twelve Months Ended |
+(Unaudited) | | June 30, | | June 30, |
+(In millions, except per share amounts) | | 2026 | | 2025 | | 2026 | | 2025 |
+Net sales | | $ | 5,755 | | | $ | 5,243 | | | $ | 21,499 | | | $ | 19,850 | |
+Cost of sales | | 3,508 | | | 3,285 | | | 13,397 | | | 12,535 | |
+Selling, general and administrative expenses | | 874 | | | 839 | | | 3,468 | | | 3,255 | |
+Interest expense | | 95 | | | 99 | | | 401 | | | 409 | |
+Other expense (income), net | | (62) | | | (51) | | | (330) | | | (456) | |
+Income before income taxes | | 1,340 | | | 1,071 | | | 4,563 | | | 4,107 | |
+Income taxes | | 248 | | | 148 | | | 914 | | | 575 | |
+Net income | | 1,092 | | | 923 | | | 3,649 | | | 3,532 | |
+Less: Noncontrolling interests | | 1 | | | — | | | 1 | | | 1 | |
+Net income attributable to common shareholders | | $ | 1,091 | | | $ | 923 | | | $ | 3,648 | | | $ | 3,531 | |
+| | | | | | | | |
+Earnings per share attributable to common shareholders: | | | | | | | | |
+Basic | | $ | 8.66 | | | $ | 7.25 | | | $ | 28.89 | | | $ | 27.52 | |
+Diluted | | $ | 8.54 | | | $ | 7.15 | | | $ | 28.48 | | | $ | 27.12 | |
+| | | | | | | | |
+Weighted average shares outstanding: | | | | | | | | |
+Basic | | 126.1 | | 127.2 | | 126.3 | | 128.3 |
+Diluted | | 127.8 | | 129.0 | | 128.1 | | 130.2 |
+| | | | | | | | |
+Cash dividends per common share | | $ | 2.00 | | | $ | 1.80 | | | $ | 7.40 | | | $ | 6.69 | |
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+BUSINESS SEGMENT INFORMATION | | | | | | | | |
+| | | | | | | | |
+| | Three Months Ended | | Twelve Months Ended |
+(Unaudited) | | June 30, | | June 30, |
+(Dollars in millions) | | 2026 | | 2025 | | 2026 | | 2025 |
+Net sales | | | | | | | | |
+Diversified Industrial | | $ | 3,855 | | | $ | 3,567 | | | $ | 14,438 | | | $ | 13,665 | |
+Aerospace Systems | | 1,900 | | | 1,676 | | | 7,061 | | | 6,185 | |
+Total net sales | | $ | 5,755 | | | $ | 5,243 | | | $ | 21,499 | | | $ | 19,850 | |
+Segment operating income | | | | | | | | |
+Diversified Industrial | | $ | 1,002 | | | $ | 847 | | | $ | 3,440 | | | $ | 3,120 | |
+Aerospace Systems | | 522 | | | 407 | | | 1,833 | | | 1,441 | |
+Total segment operating income | | 1,524 | | | 1,254 | | | 5,273 | | | 4,561 | |
+Corporate general and administrative expenses | | 50 | | | 65 | | | 205 | | | 214 | |
+Income before interest expense and other expense (income), net | | 1,474 | | | 1,189 | | | 5,068 | | | 4,347 | |
+Interest expense | | 95 | | | 99 | | | 401 | | | 409 | |
+Other expense (income), net | | 39 | | | 19 | | | 104 | | | (169) | |
+Income before income taxes | | $ | 1,340 | | | $ | 1,071 | | | $ | 4,563 | | | $ | 4,107 | |
+| | | | | | | | |
+|
+| | | | | | | | |
+| | | | | | | | |
+
+
+
+
+
+
+
+
+Exhibit 99.1
+PARKER HANNIFIN CORPORATION - JUNE 30, 2026
+SUPPLEMENTAL FINANCIAL INFORMATION AND NON-GAAP RECONCILIATIONS
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+ADJUSTED SEGMENT OPERATING INCOME AND ORGANIC SALES GROWTH RECONCILIATION |
+| | | | | | | | | | | | | |
+| | Three Months Ended June 30, 2026 | | | Three Months Ended June 30, 2025 |
+| | Diversified Industrial Segment | Aerospace Systems Segment | | | | Diversified Industrial Segment | Aerospace Systems Segment | |
+(Unaudited)
+(Dollars in millions) | | North America | Int'l | Total | Total | | | North America | Int'l | Total | Total |
+Net sales | | $ | 2,221 | | $ | 1,634 | | $ | 3,855 | | $ | 1,900 | | $ | 5,755 | | | | $ | 2,075 | | $ | 1,492 | | $ | 3,567 | | $ | 1,676 | | $ | 5,243 | |
+| | | | | | | | | | | | | |
+Segment operating income | | $ | 606 | | $ | 396 | | $ | 1,002 | | $ | 522 | | $ | 1,524 | | | | $ | 513 | | $ | 334 | | $ | 847 | | $ | 407 | | $ | 1,254 | |
+Adjustments: | | | | | | | | | | | | | |
+Amortization of acquired intangibles | | 49 | | 23 | | 72 | | 76 | | 148 | | | | 41 | | 23 | | 64 | | 75 | | 139 | |
+Business realignment charges | | 2 | | 18 | | 20 | | (1) | | 19 | | | | 2 | | 12 | | 14 | | — | | 14 | |
+Integration costs to achieve | | 5 | | 1 | | 6 | | 1 | | 7 | | | | (1) | | — | | (1) | | 4 | | 3 | |
+| | | | | | | | | | | | | |
+Tariff refunds 1
+| | (53) | | — | | (53) | | (31) | | (84) | | | | — | | — | | — | | — | | — | |
+Adjusted segment operating income | | $ | 609 | | $ | 438 | | $ | 1,047 | | $ | 567 | | $ | 1,614 | | | | $ | 555 | | $ | 369 | | $ | 924 | | $ | 486 | | $ | 1,410 | |
+| | | | | | | | | | | | | |
+Segment operating margin | | 27.3% | 24.2% | 26.0% | 27.5% | 26.5% | | | 24.7% | 22.4% | 23.7% | 24.3% | 23.9% |
+Adjusted segment operating margin | | 27.4% | 26.8% | 27.2% | 29.8% | 28.0% | | | 26.7% | 24.7% | 25.9% | 29.0% | 26.9% |
+| | | | | | | | | | | | | |
+Reported sales growth | | 7.0% | 9.5% | 8.1% | 13.4% | 9.8% | | | | | | | |
+Currency | | 0.3% | 0.5% | 0.4% | 0.1% | 0.3% | | | | | | | |
+| | | | | | | | | | | | | |
+Acquisitions | | 1.8% | 2.5% | 2.1% | —% | 1.5% | | | | | | | |
+Organic sales growth | | 4.9% | 6.5% | 5.6% | 13.3% | 8.0% | | | | | | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | |
+| | Twelve Months Ended June 30, 2026 | | | Twelve Months Ended June 30, 2025 |
+| | Diversified Industrial Segment | Aerospace Systems Segment | | | | Diversified Industrial Segment | Aerospace Systems Segment | |
+(Unaudited)
+(Dollars in millions) | | North America | Int'l | Total | Total | | | North America | Int'l | Total | Total |
+Net sales | | $ | 8,392 | | $ | 6,046 | | $ | 14,438 | | $ | 7,061 | | $ | 21,499 | | | | $ | 8,134 | | $ | 5,531 | | $ | 13,665 | | $ | 6,185 | | $ | 19,850 | |
+| | | | | | | | | | | | | |
+Segment operating income | | $ | 2,041 | | $ | 1,399 | | $ | 3,440 | | $ | 1,833 | | $ | 5,273 | | | | $ | 1,891 | | $ | 1,229 | | $ | 3,120 | | $ | 1,441 | | $ | 4,561 | |
+Adjustments: | | | | | | | | | | | | | |
+Amortization of acquired intangibles | | 188 | | 92 | | 280 | | 304 | | 584 | | | | 165 | | 88 | | 253 | | 300 | | 553 | |
+Business realignment charges | | 9 | | 62 | | 71 | | 1 | | 72 | | | | 15 | | 38 | | 53 | | — | | 53 | |
+Integration costs to achieve | | 15 | | 2 | | 17 | | 3 | | 20 | | | | 2 | | 1 | | 3 | | 19 | | 22 | |
+Acquisition-related expenses | | 6 | | 5 | | 11 | | — | | 11 | | | | — | | — | | — | | — | | — | |
+Tariff refunds 1
+| | (53) | | — | | (53) | | (31) | | (84) | | | | — | | — | | — | | — | | — | |
+Adjusted segment operating income | | $ | 2,206 | | $ | 1,560 | | $ | 3,766 | | $ | 2,110 | | $ | 5,876 | | | | $ | 2,073 | | $ | 1,356 | | $ | 3,429 | | $ | 1,760 | | $ | 5,189 | |
+| | | | | | | | | | | | | |
+Segment operating margin | | 24.3% | 23.1% | 23.8% | 26.0% | 24.5% | | | 23.2% | 22.2% | 22.8% | 23.3% | 23.0% |
+Adjusted segment operating margin | | 26.3% | 25.8% | 26.1% | 29.9% | 27.3% | | | 25.5% | 24.5% | 25.1% | 28.5% | 26.1% |
+| | | | | | | | | | | | | |
+Reported sales growth | | 3.2% | 9.3% | 5.7% | 14.2% | 8.3% | | | | | | | |
+Currency | | 0.4% | 3.4% | 1.7% | 0.8% | 1.2% | | | | | | | |
+Divestitures | | (1.8)% | —% | (1.1)% | —% | (0.7)% | | | | | | | |
+Acquisitions | | 1.5% | 2.0% | 1.7% | —% | 1.2% | | | | | | | |
+Organic sales growth | | 3.1% | 3.9% | 3.4% | 13.4% | 6.6% | | | | | | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+DIVERSIFIED INDUSTRIAL INTERNATIONAL BUSINESSES - ORGANIC SALES GROWTH SUPPLEMENT |
+| | | | | | | | | | |
+| | Three Months Ended June 30, 2026 | | Twelve Months Ended June 30, 2026 |
+(Unaudited) | | EMEA | Asia Pacific | Latin America | Total | | EMEA | Asia Pacific | Latin America | Total |
+Reported sales growth | | 3.0% | 19.6% | 3.0% | 9.5% | | 7.0% | 13.6% | 0.7% | 9.3% |
+Currency | | 0.6% | (0.2)% | 5.6% | 0.5% | | 5.4% | 0.4% | 4.0% | 3.4% |
+Acquisitions | | 1.8% | 3.9% | —% | 2.5% | | 1.5% | 3.0% | —% | 2.0% |
+Organic sales growth | | 0.6% | 15.9% | (2.6)% | 6.5% | | 0.1% | 10.2% | (3.3)% | 3.9% |
+
+
+
+
+
+
+
+Exhibit 99.1
+PARKER HANNIFIN CORPORATION - JUNE 30, 2026
+SUPPLEMENTAL FINANCIAL INFORMATION AND NON-GAAP RECONCILIATIONS
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+ADJUSTED NET INCOME 6 AND ADJUSTED DILUTED EARNINGS PER SHARE RECONCILIATION
+|
+| | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Twelve Months Ended June 30, |
+(Unaudited) | | 2026 | | 2025 | | 2026 | | 2025 |
+(Dollars in millions, except per share amounts) | | Net Income 6
+| Diluted EPS | | Net Income 6
+| Diluted EPS | | Net Income 6
+| Diluted EPS | | Net Income 6
+| Diluted EPS |
+As reported | | $ | 1,091 | | $ | 8.54 | | | $ | 923 | | $ | 7.15 | | | $ | 3,648 | | $ | 28.48 | | | $ | 3,531 | | $ | 27.12 | |
+Adjustments: | | | | | | | | | | | | |
+Amortization of acquired intangibles | | 148 | | 1.16 | | | 139 | | 1.08 | | | 584 | | 4.56 | | | 553 | | 4.25 | |
+Business realignment charges | | 19 | | 0.15 | | | 16 | | 0.12 | | | 72 | | 0.56 | | | 56 | | 0.43 | |
+Integration costs to achieve | | 7 | | 0.05 | | | 3 | | 0.03 | | | 20 | | 0.15 | | | 22 | | 0.17 | |
+Gain on divestitures | | — | | — | | | (2) | | (0.02) | | | — | | — | | | (252) | | (1.94) | |
+Acquisition-related expenses 2
+| | 7 | | 0.05 | | | — | | — | | | 41 | | 0.31 | | | — | | — | |
+Insurance-related charges (recoveries) | | (3) | | (0.02) | | | — | | — | | | (23) | | (0.18) | | | 8 | | 0.06 | |
+Tariff refunds 1
+| | (84) | | (0.65) | | | — | | — | | | (84) | | (0.65) | | | — | | — | |
+Other adjustments 3
+| | 28 | | 0.21 | | | (14) | | (0.10) | | | 28 | | 0.21 | | | (24) | | (0.18) | |
+Tax effect of adjustments 4
+| | (27) | | (0.22) | | | (38) | | (0.30) | | | (147) | | (1.13) | | | (120) | | (0.93) | |
+Discrete tax benefits 5
+| | — | | — | | | (35) | | (0.27) | | | — | | — | | | (215) | | (1.65) | |
+As adjusted | | $ | 1,186 | | $ | 9.27 | | | $ | 992 | | $ | 7.69 | | | $ | 4,139 | | $ | 32.31 | | | $ | 3,559 | | $ | 27.33 | |
+| | | | | | | | | | | | |
+1 In February 2026, the U.S. Supreme Court ruled that tariffs imposed under the International Emergency Economic Powers Act ("IEEPA") on goods imported into the U.S. were unauthorized. During the fourth quarter of fiscal 2026, the Company recognized a reduction to cost of sales of $84 million related to IEEPA tariff refunds received from the U.S. government. The Company has applied for additional refunds under the same program, though for lesser amounts. No receivable has been recorded for these additional refunds as the amount and timing remain uncertain.
+|
+2 Acquisition-related expenses include transaction costs and charges related to the fair value step up of acquired inventory.
+|
+3 Other adjustments include impairment charges and a pension buyout charge for $22 million and $6 million, respectively, in fiscal 2026. Other adjustments in the prior year consist of gains on sales of buildings.
+|
+4 This line item reflects the aggregate tax effect of all non-tax adjustments reflected in the preceding line items of the table. We estimate the tax effect of each adjustment item by applying our overall effective tax rate for continuing operations to the pre-tax amount, unless the nature of the item and/or the tax jurisdiction in which the item has been recorded requires application of a specific tax rate or tax treatment, in which case the tax effect of such item is estimated by applying such specific tax rate or tax treatment.
+|
+5 Discete tax benefits in fiscal 2025 relates to a release of a tax valuation allowance.
+|
+6 Represents net income attributable to common shareholders.
+|
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | |
+| | | | |
+| | | | |
+| | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+
+
+
+
+
+
+
+
+Exhibit 99.1
+PARKER HANNIFIN CORPORATION - JUNE 30, 2026
+
+
+
+| | | | | | | | | | | | | | |
+CONSOLIDATED BALANCE SHEETS | | | | |
+| | | | |
+(Unaudited) | | June 30, | | June 30, |
+(Dollars in millions) | | 2026 | | 2025 |
+Assets | | | | |
+Current assets: | | | | |
+Cash and cash equivalents | | $ | 501 | | | $ | 467 | |
+Trade accounts receivable, net | | 3,170 | | | 2,910 | |
+Non-trade and notes receivable | | 303 | | | 318 | |
+Inventories | | 3,166 | | | 2,839 | |
+Prepaid expenses | | 355 | | | 263 | |
+Other current assets | | 200 | | | 153 | |
+Total current assets | | 7,695 | | | 6,950 | |
+Property, plant and equipment, net | | 3,020 | | | 2,937 | |
+Deferred income taxes | | 238 | | | 270 | |
+Other long-term assets | | 1,535 | | | 1,269 | |
+Intangible assets, net | | 7,280 | | | 7,374 | |
+Goodwill | | 11,109 | | | 10,694 | |
+Total assets | | $ | 30,877 | | | $ | 29,494 | |
+| | | | |
+Liabilities and equity | | | | |
+Current liabilities: | | | | |
+Notes payable and long-term debt payable within one year | | $ | 1,754 | | | $ | 1,791 | |
+Accounts payable, trade | | 2,439 | | | 2,126 | |
+Accrued payrolls and other compensation | | 658 | | | 587 | |
+Other current liabilities | | 1,245 | | | 1,315 | |
+Total current liabilities | | 6,096 | | | 5,819 | |
+Long-term debt | | 6,766 | | | 7,494 | |
+Pensions and other postretirement benefits | | 224 | | | 267 | |
+Deferred income taxes | | 1,630 | | | 1,490 | |
+Other long-term liabilities | | 748 | | | 733 | |
+Shareholders' equity | | 15,404 | | | 13,682 | |
+Noncontrolling interests | | 9 | | | 9 | |
+Total liabilities and equity | | $ | 30,877 | | | $ | 29,494 | |
+| | | | |
+
+
+
+
+
+
+Exhibit 99.1
+PARKER HANNIFIN CORPORATION - JUNE 30, 2026
+
+
+
+| | | | | | | | | | | | | | | | |
+CONSOLIDATED STATEMENTS OF CASH FLOWS | | | | | | |
+| | | | | | |
+| | Twelve Months Ended | | |
+(Unaudited) | | June 30, | | |
+(Dollars in millions) | | 2026 | | 2025 | | |
+Cash flows from operating activities | | | | | | |
+Net income | | $ | 3,649 | | | $ | 3,532 | | | |
+Adjustments to reconcile net income to net cash provided by operating activities: | | | | | | |
+Depreciation | | 353 | | | 354 | | | |
+Amortization | | 584 | | | 553 | | | |
+Stock-based compensation expense | | 179 | | | 159 | | | |
+Deferred income taxes | | (4) | | | (304) | | | |
+Pensions and other postretirement benefits, net | | (68) | | | (152) | | | |
+Gain on sale of businesses | | (9) | | | (253) | | | |
+Other, net | | (24) | | | 40 | | | |
+Changes in assets and liabilities, net of effect of acquisitions and divestitures: | | | | | | |
+Accounts receivable, net | | (114) | | | 6 | | | |
+Inventories | | (272) | | | (94) | | | |
+Other assets | | (71) | | | 15 | | | |
+Accounts payable, trade | | 290 | | | 119 | | | |
+Other liabilities | | 10 | | | (134) | | | |
+Income taxes | | (139) | | | (65) | | | |
+Net cash provided by operating activities | | 4,364 | | | 3,776 | | | |
+Cash flows from investing activities | | | | | | |
+Acquisitions, net of cash acquired | | (1,014) | | | — | | | |
+Capital expenditures | | (459) | | | (435) | | | |
+Proceeds from sale of property, plant and equipment | | 40 | | | 32 | | | |
+Proceeds from sale of businesses | | 16 | | | 623 | | | |
+Other, net | | 27 | | | 4 | | | |
+Net cash (used in) provided by investing activities | | (1,390) | | | 224 | | | |
+Cash flows from financing activities | | | | | | |
+Payments for common shares | | (1,262) | | | (1,766) | | | |
+Proceeds from (payments for) notes payable, net | | (736) | | | (364) | | | |
+Proceeds from long-term borrowings | | 23 | | | 751 | | | |
+Payments for long-term borrowings | | (24) | | | (1,741) | | | |
+Dividends paid | | (936) | | | (861) | | | |
+Other, net | | 1 | | | 4 | | | |
+Net cash used in financing activities | | (2,934) | | | (3,977) | | | |
+Effect of exchange rate changes on cash | | (6) | | | 22 | | | |
+Net increase (decrease) in cash and cash equivalents | | 34 | | | 45 | | | |
+Cash and cash equivalents at beginning of year | | 467 | | | 422 | | | |
+Cash and cash equivalents at end of period | | $ | 501 | | | $ | 467 | | | |
+| | | | | | |
+
+
+
+| | | | | | | | | | | | | | |
+| | | | | | | | |
+|
+| | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+
+
+
+
+
+
+
+
+
+
+Exhibit 99.1
+PARKER HANNIFIN CORPORATION - JUNE 30, 2026
+
+
+
+| | | | | | | | |
+RECONCILIATION OF FORECASTED REPORTED SALES GROWTH TO FORECASTED ORGANIC SALES GROWTH | |
+| | |
+(Unaudited) | | |
+(Amounts in percentages) | | Fiscal Year 2027 |
+Forecasted reported sales growth | | 5.5% to 8.5% |
+Adjustments: | | |
+Currency | | ~0.5% |
+Acquisitions | | ~(0.5%) |
+| | |
+Forecasted organic sales growth | | 5.5% to 8.5% |
+| | |
+RECONCILIATION OF FORECASTED SEGMENT OPERATING MARGIN TO ADJUSTED FORECASTED SEGMENT OPERATING MARGIN |
+| | |
+(Unaudited) | | |
+(Amounts in percentages) | | Fiscal Year 2027 |
+Forecasted segment operating margin | 24.5% to 24.9% |
+Adjustments: | |
+Business realignment charges | ~0.4% |
+| | |
+Amortization of acquired intangibles | | ~2.5% |
+Integration costs to achieve | | ~0.1% |
+| | |
+| | |
+| | |
+Adjusted forecasted segment operating margin | 27.5% to 27.9% |
+| | |
+
+| | | | | | | | | | | | | | |
+| | | | | | | | |
+| | | | | | | |
+RECONCILIATION OF FORECASTED EARNINGS PER DILUTED SHARE TO ADJUSTED FORECASTED EARNINGS PER DILUTED SHARE | | | | | | |
+| | | | | | | | |
+(Unaudited) | | | | | | | | |
+(Amounts in dollars) | | Fiscal Year 2027 | | | | | | |
+Forecasted earnings per diluted share | $30.00 to $31.00 | | | | | | |
+Adjustments: | | | | | | | |
+Business realignment charges | 0.74 | | | | | | |
+| | | | | | | | |
+Amortization of acquired intangibles | | 4.54 | | | | | | |
+| | | | | | | | |
+Integration costs to achieve | | 0.19 | | | | | | |
+Tax effect of adjustments 1
+| | (1.22) | | | | | | |
+| | | | | | | | |
+Adjusted forecasted earnings per diluted share | $34.25 to $35.25 | | | | | | |
+| | | | | | | | |
+1 This line item reflects the aggregate tax effect of all non-tax adjustments reflected in the preceding line items of the table. We estimate the tax effect of each adjustment item by applying our overall effective tax rate for continuing operations to the pre-tax amount, unless the nature of the item and/or the tax jurisdiction in which the item has been recorded requires application of a specific tax rate or tax treatment, in which case the tax effect of such item is estimated by applying such specific tax rate or tax treatment.
+| | | | | | |
+| | | | | | | | |
+Note: Totals may not foot due to rounding
+| | | | | | |

--- a/modules/test-fixtures/earnings-filings/qbts.txt
+++ b/modules/test-fixtures/earnings-filings/qbts.txt
@@ -1,0 +1,373 @@
+EX-99.1
+2
+qbts-20260806xexx991.htm
+EX-99.1
+
+
+
+
+Document
+Exhibit 99.1
+
+D-Wave Reports Second Quarter 2026 Results
+First Half Bookings of $35.5 Million Up over 1,120% Year over Year
+First Half QCaaS Production Revenue Comprised 37.3% of Total QCaaS Revenue
+First Half Remaining Performance Obligations of $40.7 Million Up 668% Year Over Year
+PALO ALTO, Calif. – August 6, 2026 – D-Wave Quantum Inc. (NASDAQ: QBTS) (“D-Wave” or the “Company”), the only dual-platform quantum computing company, providing both annealing and gate-model systems, software, and services, today announced financial results for its second quarter ended June 30, 2026 .
+“This quarter reinforced the strength and breadth of D-Wave’s leadership,” said Dr. Alan Baratz, CEO of D-Wave. “We expanded commercial momentum through stronger bookings and engagements with major global organizations, while achieving important milestones across our dual-platform technology roadmap. The peer-reviewed validation of our dual-rail architecture and recognition by IDC as an industry Leader reflects growing confidence in both our ability to deliver customer value and our approach to building scalable quantum computer systems. D-Wave is translating technical leadership into commercial progress, and we believe that our differentiated technology, expanding customer base and disciplined execution position us to lead as the quantum computing market accelerates.”
+Recent Business and Technical Highlights
+• Bookings for the first six months of 2026 were $35.5 million, a 1,120% year over year increase from bookings of $2.9 million for the first six months of 2025.
+• Named a Leader in the IDC MarketScape: Worldwide Quantum Computing 2026 Vendor Assessment. IDC evaluated quantum computing companies based on their current capabilities and future strategies. D-Wave was one of only two companies named to the “Leaders” category.
+• Provided additional details on the Company’s annealing quantum computing roadmap, which involves packaging and superconducting interconnect technologies to scale the annealing architectures to multi-chip fabrics. We expect this multi-chip approach will allow the next generation Advantage3 TM system to ultimately reach 100,000 qubits by 2031, with an intermediate step of a 20,000 qubit system available in 2029. The Company also announced the design of a new prototype for scalable I/O that would allow quantum processing unit (QPU) scaling with an expectation of reaching a 100,000 qubit system with no more than a 20% increase over the number of I/O lines required for the current 4,500 qubit Advantage2 TM system.
+• Announced a new gate-model quantum computing roadmap, designed to accelerate the development of commercial, fault-tolerant gate model quantum computing, which includes the following key milestones:
+▪ 2026: Delivery of a 17-physical-qubit system that supports logical error rates 2 times lower than physical error rates
+▪ 2027: Completion of a 49-physical-qubit system that can deliver an expected 20-fold error reduction factor over the physical error rate
+▪ 2028: Completion of a 181-physical-qubit system that can deliver an expected 2,000-fold error reduction factor over the physical error rate; representing the scalable blueprint for fault-tolerant architectures
+
+
+
+
+
+
+
+▪ 2030: Completion of a 10-logical qubit system that can support the first fault tolerant algorithms
+▪ 2032: Completion of a 100-logical-qubit system capable of successfully performing more than one million operations that can support initial quantum chemistry and quantum AI applications
+• Announced a major research breakthrough, as published in the peer-reviewed scientific journal Nature, that advances a faster, more practical path to fault tolerant gate-model quantum computing. The research demonstrates a fast, high-fidelity two-qubit entangling gate that preserves the inherent error-correction advantages of D-Wave’s superconducting dual-rail qubit architecture, addressing one of the industry’s most consequential challenges by reducing the immense hardware overhead typically required to detect and correct quantum errors as systems scale.
+• Announced a forthcoming gate-model quantum computing simulator, which is expected to be the first of its kind designed for error-aware programming. Built around D-Wave’s dual-rail technology, we expect the simulator to give developers visibility into errors, so they can design applications and workflows that respond to errors as they occur. D-Wave will offer new quantum development bundles that provide access to both the simulator and gate-model systems.
+• Selected to receive a $1,566,240 grant from the U.S. National Science Foundation (NSF) through the agency’s National Quantum Virtual Laboratory (NQVL) program. This funding will support D-Wave’s gate model efforts as a partner in the ERASE (Erasure Qubits and Dynamic Circuits for Quantum Advantage) project, which is focused on developing foundational technologies for fault-tolerant quantum computing and strengthening U.S. leadership in quantum innovation.
+• Awarded second year funding for the Improved Materials for Superconducting Qubits with Scalable Fabrication (SQFab) project by the Northeast Regional Defense Technology Hub (NORDTECH). The SQFab project is one of four innovative programs selected by the U.S. Department of War (DOW) through NORDTECH that collectively received more than $25 million in funding after achieving key first-year benchmarks.
+• Signed a number of new and renewing customer engagements for both commercial and research applications, including with: one of the world’s largest gambling and entertainment companies; AT&T – one of the world’s largest telecommunications companies; Nasdaq Verafin– a global technology company serving the capital markets and other industries; Oki Electric Industry Co., Ltd. – a leading Japanese technology company focused on info-telecom and infrastructure innovation; Shionogi & Co. Ltd. – a major Japanese pharmaceutical company dedicated to innovative medicines; and Unisys – a global technology solutions company that powers breakthroughs for the world’s leading organizations.
+• Awarded the Great Place to Work Certification TM for 2026. Great Place to Work is regarded as a global authority on workplace culture, employee experience and leadership behaviors proven to help organizations build high-performing workplaces.
+
+
+
+
+
+
+
+
+
+
+Second Quarter 2026 Financial Highlights
+• Revenue: Revenue for the second quarter of 2026 was $3.1 million, essentially flat when compared with the second quarter of 2025 revenue of $3.1 million. 62.4% of second quarter of 2026 revenue was derived from commercial customers compared to 45.1% in the second quarter of 2025. Forbes Global 2000 customers accounted for 47.7% of total revenue in the second quarter of 2026 compared to 20.4% of total revenue in the second quarter of 2025.
+• Bookings 1 : Bookings for the second quarter of 2026 were $2.1 million, an increase of $0.8 million, or 59%, from the second quarter of 2025 Bookings of $1.3 million, with the average Booking size increasing by over 87% on a year over year basis.
+• GAAP Gross Profit: GAAP gross profit for the second quarter of 2026 was $1.7 million, a decrease of $0.3 million, or 14%, from the second quarter of 2025 GAAP gross profit of $2.0 million, with the decrease due primarily to increased personnel costs.
+• GAAP Gross Margin: GAAP gross margin for the second quarter of 2026 was 55.4%, a decrease of 8.4% from the second quarter of 2025 GAAP gross margin of 63.8%.
+• Non-GAAP Gross Profit 2 : Non-GAAP Gross Profit for the second quarter of 2026 was $2.0 million, a decrease of $0.2 million, or 10%, from the second quarter of 2025 Non-GAAP Gross Profit of $2.2 million. The difference between GAAP and Non-GAAP Gross Profit is limited to non-cash stock-based compensation, and depreciation and amortization expenses that are excluded from the Non-GAAP Gross Profit.
+• Non-GAAP Gross Margin 2 : Non-GAAP Gross Margin for the second quarter of 2026 was 64.9%, a decrease of 6.9% from the second quarter of 2025 Non-GAAP Gross Margin of 71.8%. The difference between GAAP and Non-GAAP Gross Margin is limited to non-cash stock-based compensation and depreciation and amortization expenses that are excluded from the Non-GAAP Gross Margin.
+• GAAP Operating Expenses: GAAP operating expenses for the second quarter of 2026 were $55.0 million, an increase of $26.5 million, or 93%, from the second quarter of 2025 GAAP operating expenses of $28.5 million, with the increase driven primarily by increases of $9.7 million in personnel costs, $4.5 million in non-cash stock-based compensation, $4.4 million in non-cash depreciation and amortization, $1.8 million in third party professional services, and $1.0 million in marketing expenses. The increased operating expenses stem from investments to support the Company’s accelerated product development and go-to-market initiatives.
+• Non-GAAP Adjusted Operating Expenses 2 : Non-GAAP Adjusted Operating Expenses for the second quarter of 2026 were $39.1 million, an increase of $16.9 million, or 76%, from the second quarter of 2025 Non-GAAP Adjusted Operating Expenses of $22.2 million, with the difference between GAAP and Non-GAAP Adjusted Operating Expenses being primarily non-cash stock-based compensation expense, depreciation and amortization, and non-recurring or non-operating expenses that are excluded from the Non-GAAP Adjusted Operating Expenses.
+• Net Loss: Net loss for the second quarter of 2026 was $48.0 million, or $0.13 per share, a decrease of $119.3 million, or $0.42 per share, from the second quarter of 2025 net loss of $167.3 million, or $0.55 per share. The decrease was primarily due to a $142.0 million decrease in the amount of non-cash, non-operating charges related to the remeasurement of the Company's warrant liability. All of the Company's remaining publicly traded warrants were redeemed in November 2025.
+• Adjusted EBITDA Loss 2 : Adjusted EBITDA Loss for the second quarter of 2026 was $37.1 million, an increase of $17.1 million, or 85%, from the second quarter of 2025 Adjusted EBITDA Loss of $20.0 million, with the increase due primarily to increased investments to support the Company’s accelerated product development and go-to-market initiatives.
+
+
+
+
+
+
+
+
+Financial Results for the First Half of 2026
+• Revenue: Revenue for the six months ended June 30, 2026 was $5.9 million, a decrease of $12.2 million, or 67%, from revenue of $18.1 million for the six months ended June 30, 2025, which included $13.7 million in revenue recognized from the Company's first sale of an annealing quantum computing system. 67.7% of first half 2026 revenue was derived from commercial customers compared to 16.0% in the first half of 2025. Forbes Global 2000 customers accounted for 48.5% of total first half 2026 revenue compared to 7.5% in the first half of 2025. QCaaS revenue derived from production applications totaled $1.3 million, or 37.3% of total QCaaS revenue, for the first half of 2026 compared with $0.3 million, or 9.8% of total QCaaS revenue, for the first half of 2025.
+• Bookings 1 : Bookings for the six months ended June 30, 2026 were $35.5 million, an increase of $32.6 million, or 1,120%, from Bookings of $2.9 million for the six months ended June 30, 2025 with the average Booking size increasing by over 1,120% on a year over year basis. The first half of 2026 Bookings include a $20 million system sale, the revenue for which will be recognized in subsequent quarters.
+• Remaining Performance Obligations 3 : As of June 30, 2026, the aggregate amount of remaining performance obligations (RPOs) that were unsatisfied or partially unsatisfied related to customer contracts totaled $40.7 million, an increase of $35.4 million, or 668%, from the June 30, 2025 RPO balance of $5.3 million. Approximately 57% of the $40.7 million 2026 second quarter RPO balance is expected to be recognized as revenue in the next 12 months, and 72% is expected to be recognized as revenue in the next two years, with the remainder to be recognized thereafter.
+• Customers: During the six months ended June 30, 2026, D-Wave recognized revenue from over 100 individual customers with over 50% of such customers being commercial enterprises.
+• GAAP Gross Profit: GAAP gross profit for the six months ended June 30, 2026 was $3.5 million, a decrease of $12.4 million, or 78%, from $15.9 million in GAAP gross profit for the six months ended June 30, 2025, with the decrease due primarily to a high margin annealing quantum computer system sale during the six months ended June 30, 2025.
+• GAAP Gross Margin: GAAP gross margin for the six months ended June 30, 2026 was 59.4%, a decrease of 28.2% from the 87.6% GAAP gross margin for the six months ended June 30, 2025, with the decrease due primarily to a high margin annealing quantum computer system sale during the six months ended June 30, 2025.
+• Non-GAAP Gross Profit 2 : Non-GAAP Gross Profit for the six months ended June 30, 2026 was $4.0 million, a decrease of $12.3 million, or 75%, from the Non-GAAP Gross Profit of $16.3 million for the six months ended June 30, 2025. The difference between GAAP and Non-GAAP Gross Profit is limited to non-cash stock-based compensation and depreciation and amortization expenses that are excluded from the Non-GAAP Gross Profit.
+• Non-GAAP Gross Margin 2 : Non-GAAP Gross Margin for the six months ended June 30, 2026 was 67.7%, a decrease of 22.2% from the 89.9% Non-GAAP Gross Margin for the six months ended June 30, 2025. The difference between GAAP and Non-GAAP Gross Margin is limited to non-cash stock-based compensation and depreciation and amortization expenses that are excluded from the Non-GAAP Gross Margin.
+• GAAP Operating Expenses: GAAP operating expenses for the six months ended June 30, 2026 were $111.5 million, an increase of $57.9 million, or 108% from GAAP operating expenses of $53.6 million for the six months ended June 30, 2025, with the increase partially driven by $9.3 million of non-recurring costs related to the acquisition of Quantum Circuits, Inc. ("Quantum Circuits") and increases of $19.0 million in salaries and related personnel costs, 73% of which relate to increases in Sales & Marketing and Research & Development
+personnel; $16.4 million in non-cash stock-based compensation and depreciation and amortization expenses, $3.9 million in fabrication costs and $2.3 million in marketing expenses. These increased operating expenses stem from investments to support the Company’s accelerated product development and go-to-market initiatives, as well as Quantum Circuits expenses incurred subsequent to the January acquisition closing date.
+• Non-GAAP Adjusted Operating Expenses 2 : Non-GAAP Adjusted Operating Expenses for the six months ended June 30, 2026 were $73.9 million, an increase of $31.5 million, or 74%, from Non-GAAP Adjusted Operating Expenses of $42.4 million for the six months ended June 30, 2025, with the difference between GAAP and Non-GAAP Operating Expenses being primarily non-cash stock-based compensation expense, non-cash depreciation and amortization expense, and non-recurring one-time expenses that are excluded from the Non-GAAP Adjusted Operating Expenses.
+• Net Loss: Net loss for the six months ended June 30, 2026 was $66.4 million, or $0.18 per share, a decrease of $106.4 million, or $0.41 per share, compared with the net loss of $172.8 million, or $0.59 per share for the six months ended June 30, 2025, primarily due to a decrease of $138.1 million in the amount of non-cash, non-operating charges related to the remeasurement of the Company's warrant liability, offset by a tax benefit of $28.4 million arising from the Quantum Circuits acquisition.
+• Adjusted EBITDA Loss 2 : Adjusted EBITDA Loss for the six months ended June 30, 2026 was $69.9 million, an increase of $43.8 million from the Adjusted EBITDA Loss of $26.1 million for the six months ended June 30, 2025, with the increase due primarily to increased investments to support the Company’s accelerated product development and go-to-market initiatives.
+__________________
+1 “Bookings” is an operating metric that is defined as customer orders received that are expected to generate net revenues in the future. Year-to-date 2026 Bookings includes $2.3 million in Quantum Circuits bookings that were closed immediately prior to the completion of the acquisition of Quantum Circuits in January 2026. We present the operating metric of Bookings because it reflects customers' demand for our products and services and to assist readers in analyzing our potential performance in future periods.
+2 "Non-GAAP Gross Profit", "Non-GAAP Gross Margin", "Non-GAAP Adjusted Operating Expenses" and "Adjusted EBITDA Loss" are non-GAAP financial measures. Please see the discussion in the section “Non-GAAP Financial Measures” and the reconciliations included at the end of this press release.
+3 Revenue allocated to remaining performance obligations represents the transaction price of noncancellable orders for which service has not been performed, which include deferred revenue and the amounts that will be invoiced and recognized as revenues in future periods from open contracts and excludes unexercised renewals.
+
+
+
+
+
+
+
+
+
+
+Balance Sheet and Liquidity
+As of June 30, 2026, D-Wave’s consolidated cash and marketable investment securities balance totaled $546.2 million, representing a $273.1 million, or 33% decrease from the June 30, 2025 consolidated cash and marketable investment securities balance of $819.3 million with over 90% of the decrease attributable to the cash consideration associated with the January 2026 acquisition of Quantum Circuits.
+
+Earnings Conference Call
+In conjunction with this announcement, D-Wave will host a conference call on Thursday, August 6, 2026, at 8:00 a.m. (Eastern Time), to discuss the Company’s financial results and business outlook. The live dial-in number is 1-833-890-9920 (domestic) or 1-412-564-6463 (international). Participants can use those dial-in numbers or can click this link for instant telephone access to the event. The link will be made active 15 minutes prior to the call’s scheduled start time, and the passcode is 3354042. An on-demand webcast will be available, and a transcript of the conference call will be posted on the D-Wave Investor Relations website after the call. Participating in the call will be Chief Executive Officer Dr. Alan Baratz and Chief Financial Officer John Markovich.
+About D-Wave Quantum Inc.
+D-Wave is a leader in the development and delivery of quantum computing systems, software, and services. It is the world’s first commercial supplier of quantum computers, and the first and only to offer dual-platform quantum computing products and services, spanning both annealing and gate-model quantum computing technologies. D-Wave’s mission is to help customers realize the value of quantum today through enterprise-grade systems available on-premises and via its Leap™ quantum cloud service, which offers 99.9% availability and uptime. More than 100 organizations across commercial, government and research sectors trust D-Wave to address complex computational challenges using quantum computing. Learn more about realizing the value of quantum computing today and how D-Wave is shaping the quantum-driven industrial and societal advancements of tomorrow: ir.dwavequantum.com.
+Non-GAAP Financial Measures
+To supplement the financial information presented in accordance with GAAP, we use non-GAAP measures of certain components of financial performance. Each of Non-GAAP Gross Profit, Non-GAAP Gross Margin, Adjusted EBITDA Loss and Non-GAAP Adjusted Operating Expenses is a financial measure that is not required by or presented in accordance with GAAP. Management believes that each measure provides investors an additional meaningful method to evaluate certain aspects of such results period over period. The Company defines each of its non-GAAP financial measures as follows:
+• Non-GAAP Gross Profit is defined as GAAP gross profit less depreciation and amortization expense and non-cash stock-based compensation expense. We use Non-GAAP Gross Profit to measure, understand and evaluate our core operating performance and trends and to develop short-term and long-term operating plans.
+• Non-GAAP Gross Margin is defined as GAAP gross margin adjusted to exclude depreciation and amortization expense and non-cash stock-based compensation expense. We use Non-GAAP Gross Margin to measure, understand and evaluate our core business performance.
+• Adjusted EBITDA Loss is defined as net loss before interest income, interest expense, depreciation and amortization expense, stock-based compensation, remeasurements of liability-classified warrants, and other non-operating or non-recurring income and expenses. We use Adjusted EBITDA Loss to measure the operating performance of our business, excluding specifically identified items that we do not believe directly reflect our core operations and may not be indicative of our recurring operations.
+• Non-GAAP Adjusted Operating Expenses is defined as operating expenses before depreciation and amortization expense, non-operating or non-recurring expenses and non-cash stock-based compensation expense. We use Non-GAAP Adjusted Operating Expenses to measure our operating expenses, excluding items we do not believe directly reflect our core operations.
+The presentation of non-GAAP financial measures is not meant to be considered in isolation or as a substitute for the financial results prepared in accordance with GAAP, and our presentation of non-GAAP measures may be different from non-GAAP measures used by other companies. For a reconciliation of each of Non-GAAP Gross Profit, Non-GAAP Gross Margin, Adjusted EBITDA Loss and Non-GAAP Adjusted Operating Expenses to its most directly comparable GAAP measure, please refer to the reconciliations below.
+Forward Looking Statements
+Certain statements in this press release are forward-looking, as defined in the Private Securities Litigation Reform Act of 1995, including statements relating to our ability to help customers realize value from quantum computing, development of annealing and gate-model systems, enterprise-scale adoption of quantum computing, our development and commercialization plans, dual-platform roadmap and milestones, expectations regarding our quantum computing simulator, error-corrected gate-model quantum computer, among others. In some cases, you can identify forward-looking statements by the following words: “believe,” “may,” “will,” “could,” “would,” “should,” “expect,” “intend,” “plan,” “anticipate,” “trend,” “estimate,” “predict,” “project,” “potential,” “seem,” “seek,” “future,” “outlook,” “forecast,” “projection,” “continue,” “ongoing,” or the negative of these terms or other comparable terminology, although not all forward-looking statements contain these words. These statements involve risks, uncertainties, and other factors that may cause actual results to differ materially from the information expressed or implied by these forward-looking statements and may not be indicative of future results. These forward-looking statements are subject to a number of risks and uncertainties, including, among others, various factors beyond management’s control, including the risks set forth under the caption “Item 1A. Risk Factors” in Part I of our most recent Annual Report on Form 10-K or any updates discussed under the caption “Item 1A. Risk Factors” in Part II of our Quarterly Reports on Form 10-Q and in our other filings with the Securities and Exchange Commission. Undue reliance should not be placed on the forward-looking statements in this press release in making an investment decision, which are based on information available to us on the date hereof. We undertake no duty to update this information unless required by law.
+Contacts
+Investor Contact:
+ir@dwavesys.com
+Media Contact:
+media@dwavesys.com
+
+
+
+
+
+
+
+
+
+
+
+
+D-Wave Quantum Inc.
+Condensed Consolidated Balance Sheets
+(Unaudited)
+
+
+| | | | | | | | | | | |
+| June 30, | | December 31, |
+(In thousands, except share and per share data) | 2026 | | 2025 |
+Assets | | | |
+Current assets: | | | |
+Cash and cash equivalents | $ | 296,642 | | | $ | 635,347 | |
+Marketable investment securities | 249,573 | | | 249,134 | |
+Trade accounts receivable, net of allowance for credit losses of $1 and $176
+| 2,019 | | | 1,587 | |
+Inventories | 3,488 | | | 2,776 | |
+Prepaid expenses and other current assets | 8,872 | | | 7,388 | |
+Total current assets | 560,594 | | | 896,232 | |
+Property and equipment, net | 22,076 | | | 7,841 | |
+Operating lease right-of-use assets | 12,042 | | | 6,518 | |
+Intangible assets, net | 211,816 | | | 915 | |
+Goodwill | 342,588 | | | — | |
+Other non-current assets, net | 9,314 | | | 4,307 | |
+Total assets | $ | 1,158,430 | | | $ | 915,813 | |
+| | | |
+Liabilities and stockholders' equity | | | |
+Current liabilities: | | | |
+Trade accounts payable | $ | 4,521 | | | $ | 950 | |
+Accrued expenses and other current liabilities | 12,135 | | | 15,838 | |
+Current portion of operating lease liabilities | 1,250 | | | 1,448 | |
+Loans payable, net, current | 146 | | | 134 | |
+Deferred revenue, current | 9,234 | | | 2,778 | |
+Total current liabilities | 27,286 | | | 21,148 | |
+Operating lease liabilities, net of current portion | 11,826 | | | 6,050 | |
+Loans payable, net, non-current | 34,886 | | | 35,825 | |
+Deferred revenue, non-current | 1,322 | | | 560 | |
+Total liabilities | $ | 75,320 | | | $ | 63,583 | |
+| | | |
+Commitments and contingencies
+| | | |
+| | | |
+Stockholders' equity: | | | |
+Common stock, par value $0.0001 per share; 675,000,000 shares authorized at both June 30, 2026 and December 31, 2025; 372,011,420 shares and 358,741,605 shares issued and outstanding as of June 30, 2026 and December 31, 2025, respectively. | 37 | | | 35 | |
+Additional paid-in capital | 2,140,499 | | | 1,843,218 | |
+Accumulated deficit | (1,048,387) | | | (982,002) | |
+Accumulated other comprehensive loss | (9,039) | | | (9,021) | |
+Total stockholders' equity | 1,083,110 | | | 852,230 | |
+Total liabilities and stockholders’ equity | $ | 1,158,430 | | | $ | 915,813 | |
+
+
+
+
+
+
+
+
+
+
+
+D-Wave Quantum Inc.
+Condensed Consolidated Statements of Operations and Comprehensive Loss
+(Unaudited)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+(In thousands, except share and per share data) | 2026 | | 2025 | | 2026 | | 2025 |
+Revenue | $ | 3,076 | | | $ | 3,095 | | | $ | 5,934 | | | $ | 18,096 | |
+Cost of revenue | 1,372 | | | 1,119 | | | 2,412 | | | 2,243 | |
+Total gross profit | 1,704 | | | 1,976 | | | 3,522 | | | 15,853 | |
+Operating expenses: | | | | | | | |
+Research and development | 28,239 | | | 12,694 | | | 54,032 | | | 22,982 | |
+General and administrative | 15,388 | | | 9,151 | | | 35,663 | | | 17,108 | |
+Sales and marketing | 11,355 | | | 6,633 | | | 21,832 | | | 13,556 | |
+Total operating expenses | 54,982 | | | 28,478 | | | 111,527 | | | 53,646 | |
+Loss from operations | (53,278) | | | (26,502) | | | (108,005) | | | (37,793) | |
+Other income (expense), net: | | | | | | | |
+Interest income | 5,028 | | | 4,311 | | | 10,813 | | | 7,410 | |
+Interest expense | (255) | | | (206) | | | (514) | | | (432) | |
+Gain on investment in marketable securities, net | — | | | — | | | 1,880 | | | — | |
+Change in fair value of warrant liabilities | — | | | (142,048) | | | — | | | (138,105) | |
+Other income (expense), net | 485 | | | (2,884) | | | 997 | | | (3,830) | |
+Total other income (expense), net | 5,258 | | | (140,827) | | | 13,176 | | | (134,957) | |
+Loss before income taxes | (48,020) | | | (167,329) | | | (94,829) | | | (172,750) | |
+Income tax benefit (provision), net | (8) | | | — | | | 28,444 | | | — | |
+Net loss | $ | (48,028) | | | $ | (167,329) | | | $ | (66,385) | | | $ | (172,750) | |
+Net loss per share, basic and diluted | $ | (0.13) | | | $ | (0.55) | | | $ | (0.18) | | | $ | (0.59) | |
+Weighted-average shares used in computing net loss per share, basic and diluted | 370,840,115 | | | 302,288,793 | | | 369,165,968 | | | 294,398,419 | |
+| | | | | | | |
+Comprehensive loss: | | | | | | | |
+Net loss | $ | (48,028) | | | $ | (167,329) | | | $ | (66,385) | | | $ | (172,750) | |
+Other comprehensive income (loss), net of tax: | | | | | | | |
+Foreign currency translation adjustment | 140 | | | 787 | | | 158 | | | 1,285 | |
+Unrealized losses on available-for-sale securities | (7) | | | — | | | (160) | | | — | |
+Reclassification adjustment for realized gains (losses) included in net income | (16) | | | — | | | (16) | | | — | |
+Total other comprehensive income (loss), net of tax | 117 | | | 787 | | | (18) | | | 1,285 | |
+Net comprehensive loss | $ | (47,911) | | | $ | (166,542) | | | $ | (66,403) | | | $ | (171,465) | |
+
+
+
+
+
+
+
+
+
+
+
+D-Wave Quantum Inc.
+Condensed Consolidated Statements of Cash Flows
+(Unaudited)
+| | | | | | | | | | | | | |
+| Six Months Ended June 30, |
+(in thousands) | 2026 | | 2025 | | |
+Cash flows from operating activities: | | | | | |
+Net loss | $ | (66,385) | | | $ | (172,750) | | | |
+Adjustments to reconcile net loss to cash used in operating activities: | | | | | |
+Depreciation and amortization | 8,536 | | | 714 | | | |
+Deferred income taxes | (28,365) | | | — | | | |
+Stock-based compensation | 19,132 | | | 10,664 | | | |
+Amortization of operating right-of-use assets | 699 | | | 346 | | | |
+Provision for excess and obsolete inventory | (103) | | | — | | | |
+Non-cash interest income | 1,262 | | | — | | | |
+Non-cash interest expense | 467 | | | 387 | | | |
+Change in fair value of warrant liabilities | — | | | 138,105 | | | |
+Gain on marketable equity securities | (1,880) | | | — | | | |
+Unrealized foreign exchange loss (gain) | (1,740) | | | 1,998 | | | |
+Other noncash items | — | | | 267 | | | |
+Change in operating assets and liabilities: | | | | | |
+Trade accounts receivable | (432) | | | (57) | | | |
+Inventories | (2,605) | | | (762) | | | |
+Prepaid expenses and other current assets | (455) | | | (1,368) | | | |
+Trade accounts payable | (975) | | | 416 | | | |
+Accrued expenses and other current liabilities | (4,371) | | | 2,695 | | | |
+Deferred revenue | 7,218 | | | (13,796) | | | |
+Operating lease liability | (332) | | | (344) | | | |
+Other non-current assets, net | (3,134) | | | (1,080) | | | |
+Net cash used in operating activities | (73,463) | | | (34,565) | | | |
+Cash flows from investing activities: | | | | | |
+Acquisition of business, net of cash acquired | (252,821) | | | — | | | |
+Purchase of property and equipment | (5,521) | | | (1,187) | | | |
+Purchases of marketable debt securities | (149,117) | | | — | | | |
+| | | | | |
+Maturities of marketable debt securities | 147,241 | | | — | | | |
+Proceeds from recovery of previously written-off convertible note | — | | | 959 | | | |
+| | | | | |
+Expenditures for internal-use software | (363) | | | (129) | | | |
+Net cash used in investing activities | (260,581) | | | (357) | | | |
+Cash flows from financing activities: | | | | | |
+Proceeds from the issuance of common stock pursuant to the Lincoln Park Purchase Agreement | — | | | 37,787 | | | |
+Proceeds from the issuance of common stock in at-the-market offerings, net of issuance costs | — | | | 536,741 | | | |
+Proceeds from issuance of common stock upon exercise of warrants | — | | | 99,319 | | | |
+Proceeds from the issuance of common stock upon exercise of stock options | 1,614 | | | 6,860 | | | |
+Proceeds from common stock issued under the Employee Stock Purchase Plan | 724 | | | 291 | | | |
+Payment of tax withheld pursuant to stock-based compensation settlements | (6,885) | | | (5,664) | | | |
+| | | | | |
+Repayments on TPC loan | — | | | (365) | | | |
+| | | | | |
+| | | | | |
+Repayment of the Equipment Financing Term Loan
+| (69) | | | — | | | |
+Payments of equity issuance costs | (203) | | | — | | | |
+Net cash provided by (used in) financing activities | (4,819) | | | 674,969 | | | |
+Effect of exchange rate changes on cash and cash equivalents | 158 | | | 1,285 | | | |
+Net increase (decrease) in cash and cash equivalents | (338,705) | | | 641,332 | | | |
+Cash and cash equivalents at beginning of period | 635,347 | | | 177,980 | | | |
+Cash and cash equivalents at end of period | $ | 296,642 | | | $ | 819,312 | | | |
+
+
+
+
+
+
+
+
+
+D-Wave Quantum Inc.
+Reconciliation of Gross Profit to Non-GAAP Gross Profit
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | Three Months Ended June 30, | | Six Months Ended June 30, |
+(in thousands of U.S. dollars) | | | | | | 2026 | | 2025 | | 2026 | | 2025 |
+Gross Profit | | | | | | $ | 1,704 | | | $ | 1,976 | | | $ | 3,522 | | | $ | 15,853 | |
+Gross Margin | | | | | | 55.4 | % | | 63.8 | % | | 59.4 | % | | 87.6 | % |
+Excluding: | | | | | | | | | | | | |
+Depreciation and Amortization (1) | | | | | | 14 | | | 14 | | | 29 | | | 42 | |
+Stock-based compensation (2) | | | | | | 279 | | | 231 | | | 464 | | | 373 | |
+Non-GAAP Gross Profit | | | | | | $ | 1,997 | | | $ | 2,221 | | | $ | 4,015 | | | $ | 16,268 | |
+Non-GAAP Gross Margin | | | | | | 64.9 | % | | 71.8 | % | | 67.7 | % | | 89.9 | % |
+
+(1) Depreciation and Amortization reflects the Depreciation and Amortization recorded in Cost of Revenue only, which differs from the total Depreciation and Amortization set forth in the Condensed Consolidated Statement of Cash Flows that also includes Depreciation and Amortization recorded in Operating Expenses.
+(2) Stock-based compensation reflects the stock-based compensation recorded in Cost of Revenue only, which differs from the total stock-based compensation set forth in the Condensed Consolidated Statement of Cash Flows that also includes stock-based compensation recorded in Operating Expenses.
+
+D-Wave Quantum Inc.
+Reconciliation of Operating Expenses to Non-GAAP Adjusted Operating Expenses
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | Three Months Ended June 30, | | Six Months Ended June 30, |
+(in thousands of U.S. dollars) | | | | | | 2026 | | 2025 | | 2026 | | 2025 |
+Operating expenses | | | | | | $ | 54,982 | | | $ | 28,478 | | | $ | 111,527 | | | $ | 53,646 | |
+Excluding: | | | | | | | | | | | | |
+Depreciation and Amortization (1) | | | | | | (4,721) | | | (324) | | | (8,508) | | | (672) | |
+Stock-based compensation (2) | | | | | | (10,833) | | | (6,440) | | | (18,668) | | | (10,291) | |
+Other non-operating or non-recurring expenses (3)
+| | | | | | (358) | | | 506 | | | (10,451) | | | (304) | |
+Non-GAAP Adjusted Operating Expenses
+| | | | | | $ | 39,070 | | | $ | 22,220 | | | $ | 73,900 | | | $ | 42,379 | |
+
+(1) Depreciation and Amortization reflects the Depreciation and Amortization recorded in the Operating Expenses only, which differs from the total Depreciation and Amortization set forth in the Condensed Consolidated Statement of Cash Flows that also includes Depreciation and Amortization recorded in Cost of Revenue.
+(2) Stock-based compensation reflects the stock-based compensation recorded in Operating Expenses only, which differs from the total stock-based compensation set forth in the Condensed Consolidated Statement of Cash Flows that also includes stock-based compensation recorded in Cost of Revenue.
+(3) Includes non-recurring costs related to the Quantum Circuits acquisition, as well as legal, consulting, and accounting fees associated with capital markets activities unrelated to the Company’s core operations, and other non-recurring professional fees and credit loss expenses and recoveries.
+
+
+
+
+
+
+
+
+
+
+D-Wave Quantum Inc.
+Reconciliation of Net Loss to Adjusted EBITDA Loss
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | Three Months Ended June 30, | | Six Months Ended June 30, |
+(in thousands of U.S. dollars) | | | | | | 2026 | | 2025 | | 2026 | | 2025 |
+Net loss | | | | | | $ | (48,028) | | | $ | (167,329) | | | $ | (66,385) | | | $ | (172,750) | |
+Excluding: | | | | | | | | | | | | |
+Depreciation and Amortization | | | | | | 4,735 | | | 338 | | | 8,536 | | | 714 | |
+Income tax benefit (provision), net | | | | | | 8 | | | — | | | (28,444) | | | — | |
+Stock-based compensation | | | | | | 11,112 | | | 6,671 | | | 19,132 | | | 10,664 | |
+Interest income | | | | | | (5,028) | | | (4,311) | | | (10,813) | | | (7,410) | |
+Interest expense (1) | | | | | | 255 | | | 206 | | | 514 | | | 432 | |
+Change in fair value of warrant liabilities | | | | | | — | | | 142,048 | | | — | | | 138,105 | |
+Gain on marketable equity securities | | | | | | — | | | — | | | (1,880) | | | — | |
+Other (income) expense, net (2) | | | | | | (485) | | | 2,884 | | | (997) | | | 3,830 | |
+Other non-operating or non-recurring items (3) | | | | | | 358 | | | (506) | | | 10,451 | | | 304 | |
+Adjusted EBITDA Loss | | | | | | $ | (37,073) | | | $ | (19,999) | | | $ | (69,886) | | | $ | (26,111) | |
+| | | | | | | | | | | | |
+
+(1) Interest expense primarily reflects the interest associated with the Equipment Financing Agreement entered into on August 1, 2025, and interest and adjustments to accrued interest on the SIF Loan.
+(2) Other income (expense), net consists primarily of foreign exchange gains and losses.
+(3) Includes non-recurring costs related to the Quantum Circuits acquisition, as well as legal, consulting, and accounting fees associated with capital markets activities unrelated to the Company’s core operations, and other non-recurring professional fees and credit loss expenses and recoveries.

--- a/modules/test-fixtures/earnings-filings/rgti.txt
+++ b/modules/test-fixtures/earnings-filings/rgti.txt
@@ -1,0 +1,1344 @@
+EX-99.1
+2
+rgti-20260806xex99d1.htm
+EX-99.1
+
+
+Exhibit 99.1
+​
+Rigetti Computing Reports Second Quarter 2026 Financial Results
+Growing demand for Rigetti’s quantum systems, progress on the technology roadmap, and strategic U.S. government support
+BERKELEY, Calif., August 6, 2026 -- Rigetti Computing, Inc. (Nasdaq: RGTI) (“Rigetti” or the “Company”), a pioneer in full-stack quantum-classical computing, today announced financial results for the second quarter ended June 30, 2026 and provided an update on recent business and technology milestones.
+Second Quarter 2026 Financial Highlights
+● | Total revenues for the three months ended June 30, 2026 were $5.1 million |
+● | Operating loss for the three months ended June 30, 2026 was $28.1 million |
+● | For the three months ended June 30, 2026: GAAP net loss $52.6 million; non-GAAP net loss $16.0 million |
+● | For the three months ended June 30, 2026: GAAP diluted net loss per share $0.16; non-GAAP diluted net loss per share $0.05 |
+● | As of June 30, 2026, cash, cash equivalents and available-for-sale investments totaled $541.3 million |
+
+“In the second quarter, we continued to execute on our strategy by focusing on our system performance, progressing our core technology roadmap, and broadening on-premises system deployments,” said Dr. Subodh Kulkarni, Rigetti CEO. “Our recently announced expanded collaboration with Hewlett Packard Enterprise Company (HPE) and the Pittsburgh Supercomputing Center to develop a hybrid quantum-classical supercomputer reflects growing demand for our approach and positions Rigetti to deliver differentiated quantum-enhanced high-performance computing (HPC) solutions.”
+​
+“We are seeing broadening engagement across government, academic, and commercial customers, and we believe our open modular approach, superconducting gate-based architecture, and chiplet-based scaling strategy continue to differentiate Rigetti in the market. End users who leverage our systems over the cloud benefit from ease of use and consistent uptime, which we will continue to prioritize as quantum computing R&D progresses,” Dr. Kulkarni continued. “In addition, our recently announced letter of intent with the U.S. Department of Commerce for up to $100 million in potential funding underscores the strategic importance of our platform and could help us accelerate key R&D programs aimed at scaling and advancing superconducting quantum computing.”
+​
+Rigetti ended the second quarter of 2026 with a strong cash position and no debt, providing flexibility to continue investing behind its technology roadmap and customer opportunities.
+​
+Business and Strategic Updates
+​
+Hybrid-Quantum Classical Supercomputer with HPE and PSC
+​
+Rigetti will deliver a 9-qubit Novera™ quantum computing system to the Pittsburgh Supercomputing Center’s new TangleLab testbed, funded by a National Science Foundation grant. The deployment builds on Rigetti’s strategic collaboration with HPE to advance the commercialization of quantum-enabled high-performance computing systems.
+Advancing On-Premises Quantum Computing Systems
+Rigetti is fulfilling recently announced on-premises systems, including Novera-based systems and the Company’s 108-qubit system program for C-DAC in India. The Company also continues to see demand from universities, national laboratories, and research organizations for on-premises quantum computing systems that support direct hardware access, experimentation, and ecosystem development.
+Strategic U.S. Government Letter of Intent
+In May 2026, Rigetti announced that it signed a letter of intent with the U.S. Department of Commerce for an award of up to $100 million in funding over three years to accelerate superconducting quantum computing R&D. The funding is allocated under the CHIPS Research and Development Office Broad Agency Announcement pursuant to the CHIPS Act, and the LOI contemplates that the Department would receive an equity stake in Rigetti consistent with the total amount of the funding. Under the LOI, Rigetti would pursue R&D projects that address major technical challenges in scaling and advancing superconducting quantum computing.
+
+
+Technology Milestones
+Progress on Fidelity, Coherence, and Speed
+Rigetti continued to make progress against the technology milestones that management has identified as most important on the path to quantum advantage, including qubit count, two-qubit gate fidelity, coherence time, and gate speed. Cepheus-1-108Q currently operates at approximately 99.9% median single-qubit gate fidelity, approximately 99.1% median two-qubit gate fidelity, and approximately 60 nanosecond gate speeds. At 9-qubit and 36-qubit level, Rigetti has demonstrated 99.8% and 99.6% median two-qubit gate fidelities, respectively.
+​
+The Company remains focused on improving coherence time, which management has identified as a key factor in raising fidelity further. Rigetti is pursuing chip design, fabrication, materials, and process improvements. These efforts are intended to improve coherence time and support the Company’s goal of continued fidelity improvement as systems scale.
+​
+Roadmap Toward Higher-Qubit Systems
+Rigetti continues to target a path toward systems with approximately 1,000 qubits, approximately 99.9% two-qubit gate fidelity, and gate speeds below 50 nanoseconds over roughly a three-year time horizon. In support of that roadmap, the Company has continued investing in dilution refrigeration capacity and related infrastructure that can support higher-qubit-count systems. Rigetti believes its chiplet-based and open modular architecture provide a practical framework for scaling over time.
+​
+International Expansion and UK Initiative
+Rigetti continues to advance its previously announced plan to invest up to $100 million in the United Kingdom over the next several years to accelerate quantum computing development. The planned investment is intended to support physical system deployments, talent, and facilities in the UK and builds on Rigetti’s existing presence in the country, including its deployed 36-qubit system at the UK’s National Quantum Computing Centre.
+​
+Conference Call and Webcast
+Rigetti will host a conference call today, August 6, 2026, at 5:00 pm ET, or 2:00 pm PT, to discuss its second quarter 2026 financial results.
+You can listen to a live audio webcast of the conference call at https://edge.media-server.com/mmc/p/9pedzvky or the "Events & Presentations" section of the Company's Investor Relations website at https://investors.rigetti.com/ . A replay of the conference call will be available at the same locations following the conclusion of the call for one year.
+To participate in the live call, you must register using the following link: https://register-conf.media-server.com/register/BI6483c92f267f4169a6d27a72dc7c5e58 . Once registered, you will receive dial-in numbers and a unique PIN number. When you dial in, you will input your PIN and be routed into the call. If you register and forget your PIN, or lose the registration confirmation email, simply re-register to receive a new PIN.
+About Rigetti
+Rigetti is a pioneer in full-stack quantum computing. Rigetti quantum computers are based on superconducting qubits, which are widely believed to be the leading qubit modality given their maturity, clear path to scaling, and fast gate speeds. Rigetti quantum computing systems achieve gate speeds of 50-70 nanoseconds, which is about 10,000 times faster than trapped-ion systems and 100x faster than neutral-atom systems.
+Rigetti sells on-premises 9-qubit to 108-qubit quantum computing systems, which support national laboratories and quantum computing centers. Rigetti’s Cepheus 36-qubit to 108-qubit systems are based on the Company’s proprietary chiplet-based technology and include the Company’s control electronics. Rigetti’s 9-qubit Novera QPU supports a broader R&D community with a high-performance, on-premises QPU designed to plug into a customer’s existing cryogenic and control systems.
+The Company operates quantum computers over the cloud through its Rigetti Quantum Cloud Services (QCS) platform, enabling global enterprise, government, and research clients to pursue R&D. The Company’s proprietary quantum-classical infrastructure provides high-performance integration with public and private clouds for practical quantum computing.
+Rigetti developed the industry’s first multi-chip quantum processor for scalable quantum computing systems. Leveraging this proprietary technology, Rigetti deployed the industry’s largest multi-chip quantum computer in 2026 with Cepheus-1-108Q, based on twelve 9-qubit chiplets tiled together . The Company designs and manufactures its chips in-house at Fab-1, the industry’s first dedicated and integrated quantum device manufacturing facility. Learn more at https://www.rigetti.com/ .
+
+
+Contacts
+Rigetti Computing Investor Contact:
+IR@Rigetti.com
+​
+Rigetti Computing Media Contact:
+press@rigetti.com
+​
+Non-GAAP Financial Measures
+To supplement Rigetti’s consolidated financial statements presented in accordance with U.S. generally accepted accounting principles (GAAP), the Company uses certain non-GAAP financial measures, non-GAAP net loss and non-GAAP net loss per share attributable to common stockholders-basic and diluted. The Company believes that providing these non-GAAP financial measures enhances the Company’s and investors’ ability to compare the Company’s past financial performance with its current performance. Non-GAAP net loss is defined as GAAP net income (loss) excluding stock-based compensation expenses, change in fair value of derivative warrant liabilities and change in fair value of earn-out liabilities and non-GAAP net loss per share attributable to common stockholders-basic and diluted is defined as non-GAAP net loss divided by the weighted average shares used to compute net loss per share attributable to common stockholders-basic and diluted. The Company excludes stock-based compensation expenses, change in fair value of derivative warrant liabilities and change in fair value of earn-out liabilities from non-GAAP net loss and non-GAAP net loss per share attributable to common stockholders-basic and diluted, primarily because these are non-cash items that the Company believes are not reflective of ongoing operating results and such items may not be comparable from period to period due to changes in the fair market value of the Company’s common stock, which is influenced by external factors such as the volatility of public markets and the performance of the Company’s peers. These non-GAAP financial measures, which are included in this press release and which may be referred to on the conference call discussing the Company’s second quarter financial results, are provided as supplemental information to the financial measures presented in this press release and discussed on the conference call that are calculated and presented in accordance with GAAP. Non-GAAP financial measures should not be considered a substitute for, or superior to, financial measures determined or calculated in accordance with GAAP. The Company’s definitions of its non-GAAP financial measures may not be comparable to similarly titled measures reported by other companies. For a reconciliation of each non-GAAP financial measure to its most directly comparable GAAP measure, please refer to the reconciliation tables at the end of this press release.
+​
+Cautionary Language and Forward-Looking Statements
+Certain statements in this communication may be considered “forward-looking statements” within the meaning of the federal securities laws, including statements with respect to the Company’s expectations with respect to its future success and performance, including the belief that our open modular approach, superconducting gate-based architecture, and chiplet-based scaling strategy continue to differentiate Rigetti in the market; the potential funding of up to $100 million from our recently announced letter of intent with the U.S. Department of Commerce; the potential that funding from the U.S. Department of Commerce could help us accelerate key R&D programs aimed at scaling and advancing superconducting quantum computing; the potential that Rigetti will deliver a 9-qubit Novera™ quantum computing system to the Pittsburgh Supercomputing Center’s new TangleLab testbed; the intention to improve coherence time and support the Company’s goal of continued fidelity improvement as systems scale; the belief that its chiplet-based and open modular architecture provide a practical framework for scaling over time; the targeting of a path toward systems with approximately 1,000 qubits, approximately 99.9% two-qubit gate fidelity, and gate speeds below 50 nanoseconds over roughly a three-year time horizon; and its planned investment that is intended to support physical system deployments, talent, and facilities in the UK and to build on Rigetti’s existing presence in the UK, including its deployed 36-qubit system at the UK’s National Quantum Computing Centre. These forward-looking statements are based upon estimates and assumptions that, while considered reasonable by the Company and its management, are inherently uncertain. Factors that may cause actual results to differ materially from current expectations include, but are not limited to: Company and the U.S. Department of Commerce’s ability to enter into definitive transaction agreements; the timing of entry into any such definitive transaction agreements; potential impact on the Company, its business and price of its securities with respect to the transactions contemplated by the LOI and definitive transaction agreements; the Company’s issuance of securities to the U.S. Department of Commerce pursuant to the transaction (including dilution to existing stockholders); the Company’s ability to achieve milestones, technological advancements, including with respect to its technology roadmap; Company’s ability to deliver products to customers in time or at all, including actions by customers, such as controls over their facilities and cancelling orders; the ability of the Company to obtain government contracts successfully and in a timely manner and the availability of government funding; the potential of quantum computing; the success of the Company’s partnerships and collaborations; the Company’s ability to accelerate its development of multiple generations of quantum processors; the outcome of any legal proceedings that may be instituted against the Company or others; the ability to maintain relationships with customers and suppliers and attract and retain management and key employees; costs related to operating as a public company; changes in applicable laws or regulations; the possibility that the Company may be adversely affected by other economic, business, or competitive factors; the Company’s estimates of expenses and profitability; the evolution of the markets in which the Company competes; the ability of the Company to implement its strategic initiatives and expansion plans; the expected use of proceeds from the Company’s past and future financings or other capital; the sufficiency of the Company’s cash resources; unfavorable conditions in the Company’s industry, the global economy or global supply chain, including
+
+
+rising inflation and interest rates, deteriorating international trade relations, political turmoil, natural catastrophes, warfare, and terrorist attacks; and other risks and uncertainties set forth in the section entitled “Risk Factors” and “Cautionary Note Regarding Forward-Looking Statements” in the Company’s Annual Report on Form 10-K for the year ended December 31, 2025 and Quarterly Report on Form 10-Q for the quarter ended June 30, 2026 and other documents filed by the Company from time to time with the Securities and Exchange Commission. These filings identify and address other important risks and uncertainties that could cause actual events and results to differ materially from those contained in the forward-looking statements. Forward-looking statements speak only as of the date they are made. Readers are cautioned not to put undue reliance on forward-looking statements, and the Company assumes no obligation and does not intend to update or revise these forward-looking statements other than as required by applicable law. The Company does not give any assurance that it will achieve its expectations.
+
+
+​
+RIGETTI COMPUTING, INC.
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(in thousands, except number of shares and par value)
+(unaudited)
+​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+|
+​
+| ​ ​ ​
+| June 30,
+| ​
+| December 31,
+|
+​
+| ​
+| 2026
+| ​ ​ ​
+| 2025
+|
+Assets
+|
+|
+| ​
+|
+|
+| ​
+|
+Current assets:
+| ​
+|
+| ​
+| ​
+|
+| ​
+|
+Cash and cash equivalents
+| ​
+| $
+| 27,763
+| ​
+| $
+| 44,851
+|
+Available-for-sale investments - short-term
+| ​
+| ​
+| 365,946
+| ​
+| ​
+| 398,660
+|
+Accounts receivable
+| ​
+| ​
+| 3,865
+| ​
+| ​
+| 2,551
+|
+Prepaid expenses
+| ​
+| ​
+| 4,215
+| ​
+| ​
+| 3,186
+|
+Other current assets
+| ​
+| ​
+| 12,601
+| ​
+| ​
+| 5,512
+|
+Total current assets
+| ​
+| ​
+| 414,390
+| ​
+| ​
+| 454,760
+|
+Available-for-sale investments - long-term
+| ​
+| ​
+| 147,586
+| ​
+| ​
+| 146,321
+|
+Property and equipment, net
+| ​
+| ​
+| 75,302
+| ​
+| ​
+| 57,051
+|
+Operating lease right-of-use assets
+| ​
+| ​
+| 6,929
+| ​
+| ​
+| 6,411
+|
+Other assets
+| ​
+| ​
+| 4,026
+| ​
+| ​
+| 2,031
+|
+Total assets
+| ​
+| $
+| 648,233
+| ​
+| $
+| 666,574
+|
+​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Liabilities and Stockholders' Equity
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Current liabilities:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Accounts payable
+| ​
+| $
+| 14,001
+| ​
+| $
+| 3,488
+|
+Accrued expenses and other current liabilities
+| ​
+| ​
+| 6,676
+| ​
+| ​
+| 5,582
+|
+Current derivative warrant liabilities
+| ​
+| ​
+| 78,407
+| ​
+| ​
+| —
+|
+Current portion of deferred revenue
+| ​
+| ​
+| 3,316
+| ​
+| ​
+| 847
+|
+Current portion of operating lease liabilities
+| ​
+| ​
+| 2,657
+| ​
+| ​
+| 2,235
+|
+Total current liabilities
+| ​
+| ​
+| 105,057
+| ​
+| ​
+| 12,152
+|
+Deferred revenue, less current portion
+| ​
+| ​
+| 698
+| ​
+| ​
+| 698
+|
+Operating lease liabilities, less current portion
+| ​
+| ​
+| 5,044
+| ​
+| ​
+| 4,932
+|
+Derivative warrant liabilities
+| ​
+| ​
+| —
+| ​
+| ​
+| 102,593
+|
+Total liabilities
+| ​
+| ​
+| 110,799
+| ​
+| ​
+| 120,375
+|
+Commitments and contingencies
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Stockholders’ equity:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Preferred stock, par value $0.0001 per share, 10,000,000 shares authorized, none outstanding
+| ​
+| ​
+| —
+| ​
+| ​
+| —
+|
+Common stock, par value $0.0001 per share, 1,000,000,000 shares authorized, 333,676,881 shares issued and outstanding at June 30, 2026 and 331,282,895 shares issued and outstanding at December 31, 2025
+| ​
+| ​
+| 33
+| ​
+| ​
+| 33
+|
+Additional paid-in capital
+| ​
+| ​
+| 1,329,607
+| ​
+| ​
+| 1,316,126
+|
+Accumulated other comprehensive (loss) income
+| ​
+| ​
+| (1,752)
+| ​
+| ​
+| 997
+|
+Accumulated deficit
+| ​
+| ​
+| (790,454)
+| ​
+| ​
+| (770,957)
+|
+Total stockholders’ equity
+| ​
+| ​
+| 537,434
+| ​
+| ​
+| 546,199
+|
+Total liabilities and stockholders’ equity
+| ​
+| $
+| 648,233
+| ​
+| $
+| 666,574
+|
+
+​
+​
+
+
+RIGETTI COMPUTING, INC.
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(in thousands, except per share data)
+(unaudited)
+​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+|
+​
+| ​
+| ​
+|
+|
+| ​
+|
+|
+| ​
+|
+​
+| ​
+| Three Months Ended June 30,
+|
+| Six Months Ended June 30,
+|
+​
+| ​ ​ ​
+| 2026
+| ​
+| ​
+| 2025
+| ​ ​ ​
+| 2026
+| ​ ​ ​
+| 2025
+|
+Revenue
+| ​
+| $
+| 5,138
+| ​
+| $
+| 1,801
+| ​
+| $
+| 9,538
+| ​
+| $
+| 3,273
+|
+Cost of revenue
+| ​
+| ​
+| 2,950
+| ​
+| ​
+| 1,235
+| ​
+| ​
+| 5,972
+| ​
+| ​
+| 2,265
+|
+Total gross profit
+| ​
+|
+| 2,188
+| ​
+| ​
+| 566
+| ​
+| ​
+| 3,566
+| ​
+| ​
+| 1,008
+|
+Operating expenses:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Research and development
+| ​
+| ​
+| 20,728
+| ​
+| ​
+| 13,522
+| ​
+| ​
+| 40,685
+| ​
+| ​
+| 28,977
+|
+Selling, general and administrative
+| ​
+| ​
+| 9,522
+| ​
+| ​
+| 6,926
+| ​
+| ​
+| 16,894
+| ​
+| ​
+| 13,545
+|
+Total operating expenses
+| ​
+|
+| 30,250
+| ​
+|
+| 20,448
+| ​
+| ​
+| 57,579
+| ​
+| ​
+| 42,522
+|
+Loss from operations
+| ​
+|
+| (28,062)
+| ​
+|
+| (19,882)
+| ​
+| ​
+| (54,013)
+| ​
+| ​
+| (41,514)
+|
+Other income (expense), net:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Interest income
+| ​
+| ​
+| 5,058
+| ​
+| ​
+| 3,042
+| ​
+| ​
+| 10,421
+| ​
+| ​
+| 5,194
+|
+Change in fair value of derivative warrant liabilities
+| ​
+| ​
+| (29,602)
+| ​
+| ​
+| (20,557)
+| ​
+| ​
+| 24,095
+| ​
+| ​
+| 32,705
+|
+Change in fair value of earn-out liabilities
+| ​
+| ​
+| —
+| ​
+| ​
+| (2,257)
+| ​
+| ​
+| —
+| ​
+| ​
+| 6,580
+|
+Total other income (expense), net
+| ​
+|
+| (24,544)
+| ​
+|
+| (19,772)
+| ​
+| ​
+| 34,516
+| ​
+| ​
+| 44,479
+|
+Net income (loss) before provision for income taxes
+| ​
+|
+| (52,606)
+| ​
+|
+| (39,654)
+| ​
+| ​
+| (19,497)
+| ​
+| ​
+| 2,965
+|
+Provision for income taxes
+| ​
+|
+| —
+| ​
+|
+| —
+| ​
+| ​
+| —
+| ​
+| ​
+| —
+|
+Net income (loss)
+| ​
+| $
+| (52,606)
+| ​
+| $
+| (39,654)
+| ​
+| $
+| (19,497)
+| ​
+| $
+| 2,965
+|
+Net loss available to common stockholders used in diluted loss per share
+| ​
+| $
+| (52,606)
+| ​
+| $
+| (39,654)
+| ​
+| $
+| (43,592)
+| ​
+| $
+| (1,398)
+|
+Net income (loss) per share attributable to common stockholders – basic
+| ​
+| $
+| (0.16)
+| ​
+| $
+| (0.13)
+| ​
+| $
+| (0.06)
+| ​
+| $
+| 0.01
+|
+Net loss per share attributable to common stockholders – diluted
+| ​
+| $
+| (0.16)
+| ​
+| $
+| (0.13)
+| ​
+| $
+| (0.13)
+| ​
+| $
+| (0.00)
+|
+Weighted average shares used to compute net income (loss) per share attributable to common stockholders – basic and diluted
+| ​
+| ​
+| 333,215
+| ​
+| ​
+| 298,254
+| ​
+| ​
+| 332,640
+| ​
+| ​
+| 291,514
+|
+
+​
+​
+​
+​
+​
+
+
+RIGETTI COMPUTING INC.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOW S
+(in thousands)
+(unaudited)
+​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+|
+​
+| ​
+| ​
+|
+​
+|
+| Six Months Ended June 30,
+|
+​
+| ​ ​ ​
+| 2026
+| ​ ​ ​
+| 2025
+|
+Cash flows from operating activities:
+| ​
+| ​
+| ​
+|
+|
+| ​
+|
+Net income (loss)
+| ​
+| $
+| (19,497)
+| ​
+| $
+| 2,965
+|
+Adjustments to reconcile net income (loss) to net cash used in operating activities:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Depreciation and amortization
+| ​
+| ​
+| 5,484
+| ​
+| ​
+| 3,723
+|
+Stock-based compensation
+| ​
+| ​
+| 12,910
+| ​
+| ​
+| 7,728
+|
+Change in fair value of earn-out liabilities
+| ​
+| ​
+| —
+| ​
+| ​
+| (6,580)
+|
+Change in fair value of derivative warrant liabilities
+| ​
+| ​
+| (24,095)
+| ​
+| ​
+| (32,705)
+|
+Accretion of available-for-sale securities
+| ​
+| ​
+| (2,122)
+| ​
+| ​
+| (3,396)
+|
+Non-cash lease expense
+| ​
+| ​
+| 903
+| ​
+| ​
+| 776
+|
+Changes in operating assets and liabilities:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Accounts receivable
+| ​
+| ​
+| (1,314)
+| ​
+| ​
+| 674
+|
+Prepaid expenses, other current assets and other assets
+| ​
+| ​
+| (9,846)
+| ​
+| ​
+| (836)
+|
+Deferred revenue
+| ​
+| ​
+| 2,469
+| ​
+| ​
+| 5
+|
+Accounts payable
+| ​
+| ​
+| 2,649
+| ​
+| ​
+| 618
+|
+Accrued expenses and operating lease liabilities
+| ​
+| ​
+| 466
+| ​
+| ​
+| (2,792)
+|
+Net cash used in operating activities
+| ​
+| ​
+| (31,993)
+| ​
+| ​
+| (29,820)
+|
+Cash flows from investing activities:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Purchases of property and equipment
+| ​
+| ​
+| (16,404)
+| ​
+| ​
+| (8,214)
+|
+Purchases of available-for-sale securities
+| ​
+| ​
+| (189,605)
+| ​
+| ​
+| (438,518)
+|
+Maturities of available-for-sale securities
+| ​
+| ​
+| 221,000
+| ​
+| ​
+| 77,000
+|
+Net cash provided by (used in) investing activities
+| ​
+| ​
+| 14,991
+| ​
+| ​
+| (369,732)
+|
+Cash flows from financing activities:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Proceeds from sale of common stock through At-The-Market (ATM) Offerings
+| ​
+| ​
+| —
+| ​
+| ​
+| 346,719
+|
+Proceeds from sale of common stock from Quanta private placement transaction
+| ​
+| ​
+| —
+| ​
+| ​
+| 35,000
+|
+Payments of offering costs
+| ​
+| ​
+| —
+| ​
+| ​
+| (798)
+|
+Net proceeds from tax withholdings on sell-to-cover equity award transactions
+| ​
+| ​
+| —
+| ​
+| ​
+| 6,272
+|
+Proceeds from issuance of common stock upon exercise of stock options
+| ​
+| ​
+| 381
+| ​
+| ​
+| 1,443
+|
+Proceeds from issuance of common stock upon exercise of warrants
+| ​
+| ​
+| 98
+| ​
+| ​
+| 459
+|
+Net cash provided by financing activities
+| ​
+| ​
+| 479
+| ​
+| ​
+| 389,095
+|
+Effects of exchange rate changes on cash and cash equivalents
+| ​
+| ​
+| (565)
+| ​
+| ​
+| (34)
+|
+Net decrease in cash and cash equivalents
+| ​
+| ​
+| (17,088)
+| ​
+| ​
+| (10,491)
+|
+Cash and cash equivalents – beginning of period
+| ​
+| ​
+| 44,851
+| ​
+| ​
+| 67,674
+|
+Cash and cash equivalents – end of period
+| ​
+| $
+| 27,763
+| ​
+| $
+| 57,183
+|
+Supplemental disclosures of other cash flow information:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Non-cash investing and financing activities:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Purchases of property and equipment recorded in accounts payable
+| ​
+| ​
+| 10,118
+| ​
+| ​
+| 417
+|
+Purchases of property and equipment recorded in accrued expenses
+| ​
+| ​
+| —
+| ​
+| ​
+| 11
+|
+Non-cash addition to operating lease right-of-use asset and liability
+| ​
+| ​
+| 1,421
+| ​
+| ​
+| —
+|
+Reclassification of earn-out liabilities to additional paid-in capital for vesting of Promote Sponsor Vesting Shares
+| ​
+| ​
+| —
+| ​
+| ​
+| 32,946
+|
+Reclassification of derivative liabilities to additional paid-in capital due to exercise of Public Warrants
+| ​
+| ​
+| 92
+| ​
+| ​
+| 274
+|
+Purchases of deferred offering costs in accounts payable
+| ​
+| ​
+| —
+| ​
+| ​
+| 90
+|
+Unrealized (loss) gain on short term investments
+| ​
+| ​
+| (2,176)
+| ​
+| ​
+| 57
+|
+
+​
+
+
+​
+​
+RIGETTI COMPUTING INC.
+Reconciliation of Net Income (Loss) to Non-GAAP Net Loss and Calculation of Non-GAAP Net Loss per share
+attributable to common stockholders -basic and diluted
+(in thousands, except per share data)
+(unaudited)
+​
+​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+| ​
+
+
+|
+​
+| ​
+| Three Months Ended June 30,
+|
+| Six Months Ended June 30,
+|
+​
+| ​ ​ ​
+| 2026
+| ​ ​ ​
+| 2025
+| ​ ​ ​
+| 2026
+| ​ ​ ​
+| 2025
+|
+Net Income (loss) (GAAP Measure)
+| ​
+| $
+| (52,606)
+| ​
+| $
+| (39,654)
+| ​
+| $
+| (19,497)
+| ​
+| $
+| 2,965
+|
+Excluding:
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+| ​
+|
+Stock-based compensation expense
+| ​
+| ​
+| 7,020
+| ​
+| ​
+| 3,554
+| ​
+| ​
+| 12,910
+| ​
+| ​
+| 7,728
+|
+Change in fair value of derivative warrant liabilities
+| ​
+| ​
+| 29,602
+| ​
+| ​
+| 20,557
+| ​
+| ​
+| (24,095)
+| ​
+| ​
+| (32,705)
+|
+Change in fair value of earn-out liabilities
+| ​
+| ​
+| —
+| ​
+| ​
+| 2,257
+| ​
+| ​
+| —
+| ​
+| ​
+| (6,580)
+|
+Non-GAAP Net loss
+| ​
+| $
+| (15,984)
+| ​
+| $
+| (13,286)
+| ​
+| $
+| (30,682)
+| ​
+| $
+| (28,592)
+|
+Net income (loss) per share attributable to common stockholders-basic (GAAP Measure)
+| ​
+| $
+| (0.16)
+| ​
+| $
+| (0.13)
+| ​
+| $
+| (0.06)
+| ​
+| $
+| 0.01
+|
+Net loss per share attributable to common stockholders-diluted (GAAP Measure)
+| ​
+| $
+| (0.16)
+| ​
+| $
+| (0.13)
+| ​
+| $
+| (0.13)
+| ​
+| $
+| (0.00)
+|
+Non-GAAP Net loss per share attributable to common stockholders -basic and diluted
+| ​
+| $
+| (0.05)
+| ​
+| $
+| (0.04)
+| ​
+| $
+| (0.09)
+| ​
+| $
+| (0.10)
+|
+Weighted average shares used to compute net loss per share attributable to common stockholders -basic and diluted
+| ​
+| ​
+| 333,215
+| ​
+| ​
+| 298,254
+| ​
+| ​
+| 332,640
+| ​
+| ​
+| 291,514
+|
+
+​

--- a/modules/test-fixtures/earnings-filings/vst.txt
+++ b/modules/test-fixtures/earnings-filings/vst.txt
@@ -1,0 +1,651 @@
+EX-99.1
+2
+vistra-20260630xearningsre.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+
+
+
+
+
+
+Vistra Reports Second Quarter 2026 Results
+
+
+
+
+Earnings Release Highlights
+• GAAP second quarter 2026 Net Income of $305 million, including an unrealized loss from hedges expected to settle in future years of $472 million.
+• Achieved more than 30% growth in Ongoing Operations Adjusted EBITDA 1 to $1,767 million for the quarter compared to second quarter 2025.
+• Reaffirmed 2026 Ongoing Operations Adjusted EBITDA 1 and Ongoing Operations Adjusted FCFbG 1 guidance ranges of $6.8 billion to $7.6 billion and $3.925 billion to $4.725 billion, respectively. 3
+• Announced Helix Digital Infrastructure alongside KKR, KIA, and NVIDIA with an initial commitment from Vistra of up to $1.0 billion.
+• Received Federal Energy Regulatory Commission approval of the pending Cogentrix Energy acquisition.
+• Earned second consecutive distinction as one of U.S. News & World Report ' s Best Companies to Work For.
+
+IRVING, Texas — Aug. 7, 2026 — Vistra Corp. (NYSE: VST) today reported its second quarter 2026 financial results and other highlights.
+
+
+"The Vistra team delivered another strong quarter, building on our momentum from the start of the year and continuing to execute at a high level," said Jim Burke, president and CEO of Vistra. "I'm incredibly proud of our employees across the company - through their commitment, collaboration, and focus on serving our customers, Vistra delivered a more than 30% year-over-year increase in Ongoing Operations Adjusted EBITDA. 1 From our generation team maintaining a reliable fleet, to our commercial and retail teams navigating dynamic market conditions and delivering solutions for customers, these results reflect the hard work and dedication of our people."
+
+
+"We also announced an important investment to further position Vistra for long-term growth. The formation of Helix Digital Infrastructure, alongside our partners NVIDIA, KKR, and Kuwait Investment Authority, as well as Vistra's role as Helix's preferred power provider, create an exciting opportunity for the company. At the same time, we continued advancing key strategic initiatives, including the pending Cogentrix acquisition, construction of our two Permian Basin natural gas units, and development of solar facilities, including Oak Hill 2 and Pulaski."
+
+
+"Operationally, the Vistra team's preparation and disciplined execution during our annual spring maintenance season set us up for strong, reliable performance during the first half of the summer. During recent periods of extreme heat in Texas and the PJM market, Vistra achieved commercial availability of 97% or greater across our fleet, helping ensure reliable power when our customers and communities needed it most. As we complete the critical summer period and the remainder of the year, we remain focused on safely and reliably operating our fleet, advancing our strategy, and continuing to create solutions and value for our customers, communities, employees, and shareholders."
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 2
+
+
+
+
+
+
+
+
+
+Summary of Financial Results for the Three and Six Months Ended June 30, 2026 and 2025
+(Unaudited) (Millions of Dollars)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Net income | $ | 305 | | | $ | 327 | | | $ | 1,334 | | | $ | 59 | |
+| | | | | | | |
+Ongoing operations Adjusted EBITDA | $ | 1,767 | | | $ | 1,349 | | | $ | 3,261 | | | $ | 2,589 | |
+| | | | | | | |
+Adjusted EBITDA by Segment | | | | | | | |
+Retail | $ | 773 | | | $ | 756 | | | $ | 841 | | | $ | 940 | |
+Texas | $ | 311 | | | $ | 142 | | | $ | 897 | | | $ | 632 | |
+East | $ | 642 | | | $ | 418 | | | $ | 1,443 | | | $ | 932 | |
+West | $ | 68 | | | $ | 49 | | | $ | 124 | | | $ | 111 | |
+| | | | | | | |
+Corporate and Other | $ | (27) | | | $ | (16) | | | $ | (44) | | | $ | (26) | |
+Asset Closure | $ | (23) | | | $ | (17) | | | $ | (42) | | | $ | (41) | |
+
+
+
+
+
+For the quarter ended June 30, 2026, Vistra reported Net Income of $305 million and Ongoing Operations Adjusted EBITDA 1 of $1,767 million. Net Income for the second quarter 2026 decreased $22 million compared to the second quarter 2025, driven primarily by an increase in unrealized mark-to-market losses of $488 million on derivative positions, mostly offset by higher realized prices and capacity revenue, and three months' contribution from the plants acquired from Lotus. Ongoing Operations Adjusted EBITDA for the second quarter 2026 increased by $418 million compared to the second quarter 2025, driven primarily by higher realized energy and capacity prices and three months' contribution from the plants acquired from Lotus.
+
+
+Guidance 3
+| | | | | |
+
+
+($ in millions)
+| Reaffirmed 2026
+Guidance Ranges
+|
+Ongoing Operations Adjusted EBITDA | $6,800 - $7,600
+|
+Ongoing Operations Adjusted FCFbG | $3,925 - $4,725
+|
+
+
+
+
+
+As of Aug. 3, 2026, Vistra had hedged approximately 100% of its expected generation volumes for 2026, approximately 94% for 2027, and approximately 72% for 2028. The company's comprehensive hedging program provides support for the reaffirmed 2026 guidance ranges and the previously announced Ongoing Operations Adjusted EBITDA midpoint opportunity 2 range of $7.4 billion to $7.8 billion for 2027. 3 The ranges exclude any potential benefits from the pending acquisition of Cogentrix and the signed power purchase agreements with Meta, part of which are expected to contribute to our Adjusted EBITDA in 2027.
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 3
+
+
+
+
+
+
+
+Share Repurchase Program
+
+
+As of Aug. 3, 2026:
+• Vistra executed ~$6.5 billion in share repurchases since November 2021.
+• Vistra had ~336 million shares outstanding, representing a ~30% reduction of the amount of the shares outstanding on Nov. 2, 2021.
+• ~$1.2 billion of the share repurchase authorization remained available, which we expect to complete no later than year-end 2027.
+
+
+Liquidity
+As of June 30, 2026, Vistra had total available liquidity of approximately $6,295 million, including cash and cash equivalents of $435 million, $4,408 million of availability under its corporate revolving credit facility, and $1,452 million of availability under its commodity-linked revolving credit facility. Available capacity under the commodity-linked revolving credit facility reflects the borrowing base of $1,452 million and excludes $298 million of commitments under the facility that were not available to be drawn as of June 30, 2026.
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 4
+
+
+
+
+
+
+
+Earnings Webcast
+
+
+Vistra will host a webcast today, Aug. 7, 2026, beginning at 10 a.m. ET (9 a.m. CT) to discuss these results and related matters. The live webcast and the accompanying slides that will be discussed on the call can be accessed via Vistra’s website at www.vistracorp.com under “Investor Relations” and then “Events & Presentations.” Participants can also listen by phone by registering here prior to the start time of the call to receive a conference call dial-in number. A replay of the webcast will be available on Vistra’s website for one year following the live event.
+
+
+About Vistra
+
+
+Vistra (NYSE: VST) is a leading, Fortune 500 integrated retail electricity and power generation company based in Irving, Texas, that provides essential resources to customers, businesses, and communities from California to Maine. Vistra is a leader in transforming the energy landscape, with an unyielding focus on reliability, affordability, and sustainability. The company safely operates a reliable, efficient power generation fleet of natural gas, nuclear, coal, solar, and battery energy storage facilities while taking an innovative, customer-centric approach to its retail business. Learn more at https://www.vistracorp.com.
+
+
+Media
+Meranda Cohn
+214-875-8004
+Media.Relations@vistracorp.com
+
+
+Analysts
+Eric Micek
+214-812-0046
+Investor@vistracorp.com
+
+
+1 Ongoing Operations excludes the Asset Closure segment. Ongoing Operations Adjusted EBITDA and Ongoing Operations Adjusted Free Cash Flow before Growth are non-GAAP financial measures. Any reference to “Ongoing Operations Adjusted FCFbG” is a reference to Ongoing Operations Adjusted Free Cash Flow before Growth. See the “Non-GAAP Reconciliation” tables for further detail. Total segment information may not tie due to rounding.
+
+
+2 Midpoint opportunities are not intended to be guidance and represent only our estimate of potential opportunities for Ongoing Operations Adjusted EBITDA in 2027 based on market curves as of October 31, 2025. Actual results could vary and are subject to a number of risks, uncertainties and factors, including power price market movements and our hedging strategy. We have not provided a quantitative reconciliation of Ongoing Operations Adjusted EBITDA opportunities for 2027 to GAAP net income (loss) because we cannot, without unreasonable effort, calculate certain reconciling items with confidence due to the variability, complexity, and limited visibility of the adjusting items that would be excluded from Ongoing Operations Adjusted EBITDA in such out year periods.
+
+
+3 2026 Ongoing Operations Adjusted EBITDA and Ongoing Operations Adjusted Free Cash Flow before Growth guidance ranges and 2027 Ongoing Operations Adjusted EBITDA Midpoint Opportunity exclude any potential impact from the pending acquisition of Cogentrix and the announced long-term power purchase agreements with Meta.
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 5
+
+
+
+
+
+
+
+About Non-GAAP Financial Measures and Items Affecting Comparability
+
+
+"Adjusted EBITDA" (EBITDA as adjusted for unrealized gains or losses from hedging activities, transition and merger expenses, non-cash compensation expenses, nuclear decommissioning trust income, asset retirement obligation expenses, and certain other items described from time to time in Vistra’s earnings releases), "Adjusted Free Cash Flow before Growth" (or "Adjusted FCFbG") (cash from operating activities excluding changes in margin deposits and working capital and adjusted for maintenance capital expenditures, other net investment activities, and other items described from time to time in Vistra’s earnings releases), "Ongoing Operations Adjusted EBITDA" (adjusted EBITDA less adjusted EBITDA from Asset Closure segment), and "Ongoing Operations Adjusted Free Cash Flow before Growth" or "Ongoing Operations Adjusted FCFbG" (adjusted free cash flow before growth less cash flow from operating activities from Asset Closure segment before growth) are "non-GAAP financial measures." A non-GAAP financial measure is a numerical measure of financial performance that excludes or includes amounts so as to be different than the most directly comparable measure calculated and presented in accordance with GAAP in Vistra’s consolidated statements of operations, comprehensive income, changes in stockholders’ equity and cash flows. Non-GAAP financial measures should not be considered in isolation or as a substitute for the most directly comparable GAAP measures. Vistra’s non-GAAP financial measures may be different from non-GAAP financial measures used by other companies.
+
+
+Vistra uses Adjusted EBITDA as a measure of performance and believes that analysis of its business by external users is enhanced by visibility to both Net Income prepared in accordance with GAAP and Adjusted EBITDA. Vistra uses Adjusted Free Cash Flow before Growth as a measure of liquidity and performance, and believes that analysis of capital available to allocate for debt service, growth, and return of capital to stockholders is supported by disclosure of both cash provided by (used in) operating activities prepared in accordance with GAAP as well as Adjusted Free Cash Flow before Growth. Vistra uses Ongoing Operations Adjusted EBITDA as a measure of performance and Ongoing Operations Adjusted Free Cash Flow before Growth as a measure of liquidity and performance, and Vistra’s management and board of directors have found it informative to view the Asset Closure segment as separate and distinct from Vistra’s ongoing operations. The schedules attached to this earnings release reconcile the non-GAAP financial measures to the most directly comparable financial measures calculated and presented in accordance with U.S. GAAP.
+
+
+Cautionary Note Regarding Forward-Looking Statements
+
+The information presented herein includes forward-looking statements within the meaning of the Private Securities Litigation Reform Act of 1995. These forward-looking statements, which are based on current expectations, estimates and projections about the industry and markets in which Vistra Corp. ("Vistra") operates and beliefs of and assumptions made by Vistra’s management, involve risks and uncertainties, which are difficult to predict and are not guarantees of future performance, that could significantly affect the financial results of Vistra. All statements, other than statements of historical facts, that are presented herein, or in response to questions or otherwise, that address activities, events or developments that may occur in the future, including such matters as activities related to our financial or operational projections, financial condition and cash flows, projected synergy, net debt targets, capital allocation, capital expenditures, liquidity, projected Adjusted EBITDA to free cash flow conversion rate, dividend policy, business strategy, competitive strengths, goals, future acquisitions or dispositions, development or operation of power generation assets, market and industry developments and the growth of our businesses and operations, including potential transactions with large load facilities at our nuclear and natural gas plants (often, but not always, through the use of words or phrases, or the negative variations of those words or other comparable words of a future or forward-looking nature, including, but not limited to: "intends," "plans," "will likely," "unlikely," "believe," "confident," "expect," "seek," "anticipate," "estimate," "continue," "will," "shall," "should," "could," "may," "might," "predict," "project," "forecast," "target," "potential," "goal," "objective," "guidance," "on track" and "outlook"), are forward-looking statements. Readers are cautioned not to place undue reliance on forward-looking statements. Although Vistra believes that in making any such forward-looking statement, Vistra’s expectations are based on reasonable assumptions, any such forward-looking statement involves uncertainties and risks that could cause results to differ materially from those projected in or implied by any such forward-looking statement, including, but not limited to: (i) adverse changes in general economic or market conditions (including changes in interest rates) or changes in political conditions or federal or state laws and regulations; (ii) the ability of Vistra to execute upon its contemplated strategic, capital allocation, performance, and cost-saving initiatives and to successfully integrate acquired businesses, including our ability to close the acquisition of Cogentrix Energy; (iii) actions by credit ratings agencies; (iv) the severity, magnitude and duration of extreme weather events, contingencies and uncertainties relating thereto, most of which are difficult to predict and many of which are beyond our control, and the resulting effects on our results of operations, financial condition and cash flows; and (v) those additional risks and factors discussed in reports filed with the Securities and Exchange Commission by Vistra from time to time, including the uncertainties and risks discussed in the sections entitled "Risk Factors" and "Forward-Looking Statements" in Vistra’s annual report on Form 10-K for the year ended December 31, 2025 and subsequently filed quarterly reports on Form 10-Q.
+
+
+Any forward-looking statement speaks only at the date on which it is made, and except as may be required by law, Vistra will not undertake any obligation to update any forward-looking statement to reflect events or circumstances after the date on which it is made or to reflect the occurrence of unanticipated events. New factors emerge from time to time, and it is not possible to predict all of them; nor can Vistra assess the impact of each such factor or the extent to which any factor, or combination of factors, may cause results to differ materially from those contained in any forward-looking statement.
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 6
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+VISTRA CORP.
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(Unaudited) (Millions of Dollars) |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Operating revenues | $ | 4,017 | | | $ | 4,250 | | | $ | 9,657 | | | $ | 8,183 | |
+Fuel, purchased power costs, and delivery fees | (1,774) | | | (1,974) | | | (4,304) | | | (4,421) | |
+Operating costs | (853) | | | (733) | | | (1,553) | | | (1,426) | |
+Depreciation and amortization | (445) | | | (541) | | | (929) | | | (1,063) | |
+Selling, general, and administrative expenses | (392) | | | (419) | | | (819) | | | (810) | |
+| | | | | | | |
+Impairment of long-lived assets | — | | | (68) | | | — | | | (68) | |
+Operating income | 553 | | | 515 | | | 2,052 | | | 395 | |
+Other income (deductions), net | 186 | | | 191 | | | 162 | | | 186 | |
+| | | | | | | |
+Interest expense and related charges | (312) | | | (303) | | | (575) | | | (622) | |
+| | | | | | | |
+| | | | | | | |
+Net income (loss) before income taxes | 427 | | | 403 | | | 1,639 | | | (41) | |
+Income tax (expense) benefit | (122) | | | (76) | | | (305) | | | 100 | |
+| | | | | | | |
+| | | | | | | |
+Net income attributable to Vistra | $ | 305 | | | $ | 327 | | | $ | 1,334 | | | $ | 59 | |
+Cumulative dividends attributable to preferred stock | (47) | | | (47) | | | (96) | | | (96) | |
+Net income (loss) attributable to Vistra common stock | $ | 258 | | | $ | 280 | | | $ | 1,238 | | | $ | (37) | |
+
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 7
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+VISTRA CORP.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(Unaudited) (Millions of Dollars) |
+| Six Months Ended June 30, |
+| 2026 | | 2025 |
+Cash flows — operating activities: | | | |
+Net income | $ | 1,334 | | | $ | 59 | |
+Adjustments to reconcile net income (loss) to cash provided by operating activities: | | | |
+Depreciation and amortization | 1,363 | | | 1,534 | |
+Deferred income tax expense (benefit), net | 255 | | | (128) | |
+| | | |
+| | | |
+Impairment of long-lived and other assets | — | | | 68 | |
+Unrealized net (gain) loss from mark-to-market valuations of commodities | (251) | | | 551 | |
+Unrealized net (gain) loss from mark-to-market valuations of interest rate swaps | (7) | | | 74 | |
+Unrealized net (gain) loss from nuclear decommissioning trusts | 22 | | | (74) | |
+Asset retirement obligation accretion expense | 63 | | | 66 | |
+| | | |
+| | | |
+Bad debt expense | 86 | | | 87 | |
+Stock-based compensation expense | 67 | | | 46 | |
+Involuntary conversion gain | (48) | | | (80) | |
+Other, net | — | | | 13 | |
+Changes in operating assets and liabilities: | | | |
+Margin deposits, net | (188) | | | (368) | |
+Accrued interest | 61 | | | (5) | |
+Accrued taxes other than income | (100) | | | (56) | |
+Accrued employee incentive | (99) | | | (145) | |
+Other operating assets and liabilities | (336) | | | (471) | |
+Cash provided by operating activities | 2,222 | | | 1,171 | |
+Cash flows — investing activities: | | | |
+Capital expenditures, including nuclear fuel purchases and LTSA prepayments | (1,572) | | | (1,458) | |
+Lotus acquisition purchase price adjustment | 6 | | | — | |
+Proceeds from sales of nuclear decommissioning trust fund securities | 3,036 | | | 3,024 | |
+Investments in nuclear decommissioning trust fund securities | (3,037) | | | (3,035) | |
+Proceeds from sales of environmental allowances | 128 | | | 25 | |
+Purchases of environmental allowances | (201) | | | (392) | |
+Insurance proceeds for recovery of damaged property, plant, and equipment | 234 | | | 173 | |
+Proceeds from sales of property, plant, and equipment, including nuclear fuel | 50 | | | — | |
+Other, net | 77 | | | (8) | |
+Cash used in investing activities | (1,279) | | | (1,671) | |
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 8
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+VISTRA CORP.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(Unaudited) (Millions of Dollars) |
+| Six Months Ended June 30, |
+| 2026 | | 2025 |
+Cash flows — financing activities: | | | |
+Issuances of debt | 6,422 | | | 209 | |
+Repayments/repurchases of debt | (3,859) | | | (757) | |
+Net borrowings (repayments) under accounts receivable financing | (925) | | | 375 | |
+Borrowings under Revolving Credit Facility | 400 | | | — | |
+Repayments under Revolving Credit Facility | (780) | | | — | |
+Borrowings under Commodity-Linked Facility | — | | | 987 | |
+Repayments under Commodity-Linked Facility | (1,420) | | | (126) | |
+| | | |
+| | | |
+| | | |
+Debt issuance costs | (72) | | | — | |
+Stock repurchases | (709) | | | (589) | |
+Dividends paid to common stockholders | (154) | | | (152) | |
+Dividends paid to preferred stockholders | (96) | | | (96) | |
+| | | |
+Tax withholding on stock-based compensation | (69) | | | (50) | |
+Principal payment on forward repurchase obligation | (19) | | | (41) | |
+| | | |
+Other, net | (3) | | | 13 | |
+Cash used in financing activities | (1,284) | | | (227) | |
+Net change in cash, cash equivalents and restricted cash (current and noncurrent) | (341) | | | (727) | |
+Cash, cash equivalents and restricted cash (current and noncurrent) — beginning balance | 822 | | | 1,222 | |
+Cash, cash equivalents and restricted cash (current and noncurrent) — ending balance | $ | 481 | | | $ | 495 | |
+
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 9
+
+
+
+
+
+
+
+VISTRA CORP.
+NON-GAAP RECONCILIATIONS - ADJUSTED EBITDA
+FOR THE THREE MONTHS ENDED JUNE 30, 2026
+(Unaudited) (Millions of Dollars) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Retail | | Texas | | East | | West | | | | Eliminations / Corp and Other | | Ongoing Operations Consolidated | | Asset Closure | | Vistra Corp. Consolidated |
+Net income (loss) | $ | 484 | | | $ | 592 | | | $ | (166) | | | $ | 28 | | | | | $ | (517) | | | $ | 421 | | | $ | (116) | | | $ | 305 | |
+Income tax expense | — | | | — | | | — | | | — | | | | | 122 | | | 122 | | | — | | | 122 | |
+Interest expense and related charges (a) | 10 | | | (10) | | | (24) | | | (4) | | | | | 339 | | | 311 | | | 1 | | | 312 | |
+Depreciation and amortization (b) | 10 | | | 213 | | | 302 | | | 14 | | | | | 18 | | | 557 | | | 3 | | | 560 | |
+EBITDA before Adjustments | 504 | | | 795 | | | 112 | | | 38 | | | | | (38) | | | 1,411 | | | (112) | | | 1,299 | |
+Unrealized net (gain) loss resulting from commodity hedging transactions | 261 | | | (446) | | | 629 | | | 28 | | | | | — | | | 472 | | | — | | | 472 | |
+| | | | | | | | | | | | | | | | | |
+Purchase accounting impacts | 1 | | | — | | | (14) | | | — | | | | | (13) | | | (26) | | | — | | | (26) | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Non-cash compensation expenses | — | | | — | | | — | | | — | | | | | 35 | | | 35 | | | — | | | 35 | |
+Transition and merger expenses | 1 | | | — | | | 2 | | | — | | | | | 12 | | | 15 | | | — | | | 15 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Insurance income (c) | — | | | (48) | | | — | | | — | | | | | — | | | (48) | | | — | | | (48) | |
+Decommissioning-related activities (d) | — | | | 4 | | | (95) | | | 1 | | | | | — | | | (90) | | | 90 | | | — | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Other, net | 6 | | | 6 | | | 8 | | | 1 | | | | | (23) | | | (2) | | | (1) | | | (3) | |
+Adjusted EBITDA | $ | 773 | | | $ | 311 | | | $ | 642 | | | $ | 68 | | | | | $ | (27) | | | $ | 1,767 | | | $ | (23) | | | $ | 1,744 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+
+___________
+(a) Corporate and Other includes $9 million of unrealized mark-to-market net losses on interest rate swaps.
+(b) Includes nuclear fuel amortization of $30 million and $86 million, respectively, in the Texas and East segments.
+(c) Includes involuntary conversion gain recognized from Martin Lake Incident property damage insurance in the Texas segment.
+(d) Includes NDT (income) loss of the PJM nuclear facilities, ARO and environmental remediation expenses, and other expenses associated with the Moss Landing Incident.
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 10
+
+
+
+
+
+
+
+VISTRA CORP.
+NON-GAAP RECONCILIATIONS - ADJUSTED EBITDA
+FOR THE SIX MONTHS ENDED JUNE 30, 2026
+(Unaudited) (Millions of Dollars) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Retail | | Texas | | East | | West | | | | Eliminations / Corp and Other | | Ongoing Operations Consolidated | | Asset Closure | | Vistra Corp. Consolidated |
+Net income (loss) | $ | (240) | | | $ | 2,683 | | | $ | 10 | | | $ | 62 | | | | | $ | (1,045) | | | $ | 1,470 | | | $ | (136) | | | $ | 1,334 | |
+Income tax expense | — | | | — | | | — | | | — | | | | | 305 | | | 305 | | | — | | | 305 | |
+Interest expense and related charges (a) | 23 | | | (24) | | | (46) | | | (7) | | | | | 628 | | | 574 | | | 1 | | | 575 | |
+Depreciation and amortization (b) | 20 | | | 424 | | | 657 | | | 28 | | | | | 36 | | | 1,165 | | | 6 | | | 1,171 | |
+EBITDA before Adjustments | (197) | | | 3,083 | | | 621 | | | 83 | | | | | (76) | | | 3,514 | | | (129) | | | 3,385 | |
+Unrealized net (gain) loss resulting from commodity hedging transactions | 1,026 | | | (2,168) | | | 854 | | | 37 | | | | | — | | | (251) | | | — | | | (251) | |
+| | | | | | | | | | | | | | | | | |
+Purchase accounting impacts | 1 | | | — | | | (15) | | | — | | | | | (13) | | | (27) | | | — | | | (27) | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Non-cash compensation expenses | — | | | — | | | — | | | — | | | | | 67 | | | 67 | | | — | | | 67 | |
+Transition and merger expenses | — | | | — | | | 2 | | | — | | | | | 24 | | | 26 | | | — | | | 26 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Insurance income (c) | — | | | (48) | | | — | | | — | | | | | — | | | (48) | | | (6) | | | (54) | |
+Decommissioning-related activities (d) | — | | | 8 | | | (35) | | | 1 | | | | | — | | | (26) | | | 92 | | | 66 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Other, net | 11 | | | 22 | | | 16 | | | 3 | | | | | (46) | | | 6 | | | 1 | | | 7 | |
+Adjusted EBITDA | $ | 841 | | | $ | 897 | | | $ | 1,443 | | | $ | 124 | | | | | $ | (44) | | | $ | 3,261 | | | $ | (42) | | | $ | 3,219 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+
+___________
+(a) Corporate and Other includes $7 million of unrealized mark-to-market net gains on interest rate swaps.
+(b) Includes nuclear fuel amortization of $66 million and $176 million, respectively, in the Texas and East segments.
+(c) Includes involuntary conversion gain recognized from Martin Lake Incident property damage insurance in Texas segment and revenues from Moss Landing Incident business interruption proceeds in the Asset Closure segment.
+(d) Includes NDT (income) loss of the PJM nuclear facilities, ARO and environmental remediation expenses, and other expenses associated with the Moss Landing Incident.
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 11
+
+
+
+
+
+
+
+VISTRA CORP.
+NON-GAAP RECONCILIATIONS - ADJUSTED EBITDA
+FOR THE THREE MONTHS ENDED JUNE 30, 2025
+(Unaudited) (Millions of Dollars) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Retail | | Texas | | East | | West | | | | Eliminations / Corp and Other | | Ongoing Operations Consolidated | | Asset Closure | | Vistra Corp. Consolidated |
+Net income (loss) | $ | (123) | | | $ | 863 | | | $ | 120 | | | $ | (50) | | | | | $ | (440) | | | $ | 370 | | | $ | (43) | | | $ | 327 | |
+Income tax expense | — | | | — | | | 1 | | | — | | | | | 75 | | | 76 | | | — | | | 76 | |
+Interest expense and related charges (a) | 17 | | | (18) | | | (8) | | | (1) | | | | | 312 | | | 302 | | | 1 | | | 303 | |
+Depreciation and amortization (b) | 24 | | | 197 | | | 412 | | | 16 | | | | | 20 | | | 669 | | | (1) | | | 668 | |
+EBITDA before Adjustments | (82) | | | 1,042 | | | 525 | | | (35) | | | | | (33) | | | 1,417 | | | (43) | | | 1,374 | |
+Unrealized net (gain) loss resulting from commodity hedging transactions | 841 | | | (900) | | | (39) | | | 82 | | | | | — | | | (16) | | | — | | | (16) | |
+| | | | | | | | | | | | | | | | | |
+Purchase accounting impacts | 8 | | | — | | | 9 | | | — | | | | | — | | | 17 | | | — | | | 17 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Non-cash compensation expenses | — | | | — | | | — | | | — | | | | | 25 | | | 25 | | | — | | | 25 | |
+Transition and merger expenses | 5 | | | — | | | — | | | — | | | | | 17 | | | 22 | | | — | | | 22 | |
+Impairment of long-lived assets | — | | | 68 | | | — | | | — | | | | | — | | | 68 | | | — | | | 68 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Insurance income (c) | — | | | (80) | | | — | | | — | | | | | — | | | (80) | | | (21) | | | (101) | |
+Decommissioning-related activities (d) | — | | | 4 | | | (81) | | | — | | | | | — | | | (77) | | | 43 | | | (34) | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+ERP system implementation expenses | 3 | | | 3 | | | 3 | | | — | | | | | — | | | 9 | | | 1 | | | 10 | |
+Other, net (e) | (19) | | | 5 | | | 1 | | | 2 | | | | | (25) | | | (36) | | | 3 | | | (33) | |
+Adjusted EBITDA | $ | 756 | | | $ | 142 | | | $ | 418 | | | $ | 49 | | | | | $ | (16) | | | $ | 1,349 | | | $ | (17) | | | $ | 1,332 | |
+
+___________
+(a) Corporate and Other includes $26 million of unrealized mark-to-market net losses on interest rate swaps.
+(b) Includes nuclear fuel amortization of $30 million and $92 million, respectively, in the Texas and East segments.
+(c) Includes involuntary conversion gain recognized from Martin Lake Incident property damage insurance in the Texas segment and revenues from Moss Landing Incident business interruption proceeds in the Asset Closure segment.
+(d) Includes NDT (income) loss of the PJM nuclear facilities, ARO and environmental remediation expenses, and other expenses associated with the Moss Landing Incident.
+(e) Includes the final application of bill credits to large commercial and industrial customers that curtailed their usage during Winter Storm Uri in the Retail segment.
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 12
+
+
+
+
+
+
+
+VISTRA CORP.
+NON-GAAP RECONCILIATIONS - ADJUSTED EBITDA
+FOR THE SIX MONTHS ENDED JUNE 30, 2025
+(Unaudited) (Millions of Dollars) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Retail | | Texas | | East | | West | | | | Eliminations / Corp and Other | | Ongoing Operations Consolidated | | Asset Closure | | Vistra Corp. Consolidated |
+Net income (loss) | $ | 1,009 | | | $ | 143 | | | $ | (370) | | | $ | 27 | | | | | $ | (639) | | | $ | 170 | | | $ | (111) | | | $ | 59 | |
+Income tax expense (benefit) | — | | | — | | | 1 | | | — | | | | | (101) | | | (100) | | | — | | | (100) | |
+Interest expense and related charges (a) | 35 | | | (32) | | | (20) | | | (2) | | | | | 639 | | | 620 | | | 2 | | | 622 | |
+Depreciation and amortization (b) | 47 | | | 378 | | | 808 | | | 31 | | | | | 39 | | | 1,303 | | | (2) | | | 1,301 | |
+EBITDA before Adjustments | 1,091 | | | 489 | | | 419 | | | 56 | | | | | (62) | | | 1,993 | | | (111) | | | 1,882 | |
+Unrealized net (gain) loss resulting from commodity hedging transactions | (156) | | | 130 | | | 528 | | | 50 | | | | | — | | | 552 | | | (1) | | | 551 | |
+| | | | | | | | | | | | | | | | | |
+Purchase accounting impacts | 8 | | | — | | | 23 | | | — | | | | | — | | | 31 | | | — | | | 31 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Non-cash compensation expenses | — | | | — | | | — | | | — | | | | | 46 | | | 46 | | | — | | | 46 | |
+Transition and merger expenses | 5 | | | — | | | 1 | | | — | | | | | 34 | | | 40 | | | — | | | 40 | |
+Impairment of long-lived assets | — | | | 68 | | | — | | | — | | | | | — | | | 68 | | | — | | | 68 | |
+| | | | | | | | | | | | | | | | | |
+Insurance income (c) | — | | | (80) | | | — | | | — | | | | | — | | | (80) | | | (21) | | | (101) | |
+Decommissioning-related activities (d) | — | | | 9 | | | (46) | | | — | | | | | — | | | (37) | | | 89 | | | 52 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+ERP system implementation expenses | 3 | | | 3 | | | 3 | | | — | | | | | — | | | 9 | | | 1 | | | 10 | |
+Other, net (e) | (11) | | | 13 | | | 4 | | | 5 | | | | | (44) | | | (33) | | | 2 | | | (31) | |
+Adjusted EBITDA | $ | 940 | | | $ | 632 | | | $ | 932 | | | $ | 111 | | | | | $ | (26) | | | $ | 2,589 | | | $ | (41) | | | $ | 2,548 | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+
+___________
+(a) Corporate and Other includes $74 million of unrealized mark-to-market net losses on interest rate swaps.
+(b) Includes nuclear fuel amortization of $61 million and $176 million, respectively, in the Texas and East segments.
+(c) Includes involuntary conversion gain recognized from Martin Lake Incident property damage insurance in the Texas segment and revenues from Moss Landing Incident business interruption proceeds in the Asset Closure segment.
+(d) Includes NDT (income) loss of the PJM nuclear facilities, ARO and environmental remediation expenses, and other expenses associated with the Moss Landing Incident.
+(e) Includes the final application of bill credits to large commercial and industrial customers that curtailed their usage during Winter Storm Uri in the Retail segment.
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 13
+
+
+
+
+
+
+
+VISTRA CORP. - NON-GAAP RECONCILIATIONS 2026 GUIDANCE 1
+(Unaudited) (Millions of Dollars) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Ongoing
+Operations | | Asset
+Closure | | Vistra Corp.
+Consolidated |
+| Low | | High | | Low | | High | | Low | | High |
+Net income (loss) | $ | 3,100 | | | $ | 3,730 | | | $ | (90) | | | $ | (90) | | | $ | 3,010 | | | $ | 3,640 | |
+Income tax expense | 830 | | | 1,000 | | | — | | | — | | | 830 | | | 1,000 | |
+Interest expense and related charges (a) | 1,200 | | | 1,200 | | | — | | | — | | | 1,200 | | | 1,200 | |
+Depreciation and amortization (b) | 2,150 | | | 2,150 | | | — | | | — | | | 2,150 | | | 2,150 | |
+EBITDA before Adjustments | $ | 7,280 | | | $ | 8,080 | | | $ | (90) | | | $ | (90) | | | $ | 7,190 | | | $ | 7,990 | |
+Unrealized net (gain) loss resulting from hedging transactions | (728) | | | (728) | | | — | | | — | | | (728) | | | (728) | |
+Fresh start/purchase accounting impacts | 58 | | | 58 | | | — | | | — | | | 58 | | | 58 | |
+Non-cash compensation expenses | 137 | | | 137 | | | — | | | — | | | 137 | | | 137 | |
+Transition and merger expenses | 29 | | | 29 | | | — | | | — | | | 29 | | | 29 | |
+Decommissioning-related activities (c)
+| 64 | | | 64 | | | 22 | | | 22 | | | 86 | | | 86 | |
+ERP system implementation expenses & other transformational initiatives | 17 | | | 17 | | | — | | | — | | | 17 | | | 17 | |
+Other, net | (57) | | | (57) | | | (12) | | | (12) | | | (69) | | | (69) | |
+Adjusted EBITDA guidance | $ | 6,800 | | | $ | 7,600 | | | $ | (80) | | | $ | (80) | | | $ | 6,720 | | | $ | 7,520 | |
+
+___________
+1 Regulation G Table 2026 Guidance prepared as of November 6, 2025, based on market curves as of October 31, 2025. Guidance excludes any potential benefit from the nuclear production tax credit.
+(a) Includes $60 million interest related to noncontrolling interest repurchase.
+(b) Includes nuclear fuel amortization of $423 million.
+(c) Represents net of all NDT income (loss) of the PJM nuclear facilities, ARO accretion expense for operating assets and ARO remeasurement impacts for operating assets.
+
+
+
+
+
+
+
+
+Vistra – Press Release
+Aug. 7, 2026, Page 14
+
+
+
+
+
+
+
+VISTRA CORP. - NON-GAAP RECONCILIATIONS 2026 GUIDANCE 1
+(Unaudited) (Millions of Dollars) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Ongoing
+Operations | | Asset
+Closure | | Vistra Corp.
+Consolidated |
+| Low | | High | | Low | | High | | Low | | High |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+Adjusted EBITDA guidance | $ | 6,800 | | | $ | 7,600 | | | $ | (80) | | | $ | (80) | | | $ | 6,720 | | | $ | 7,520 | |
+Interest paid, net | (1,125) | | | (1,125) | | | — | | | — | | | (1,125) | | | (1,125) | |
+Tax (paid) / received | (111) | | | (111) | | | — | | | — | | | (111) | | | (111) | |
+Working capital, margin deposits and accrued environmental allowances | 640 | | | 640 | | | — | | | — | | | 640 | | | 640 | |
+Reclamation and remediation | (78) | | | (78) | | | (80) | | | (80) | | | (158) | | | (158) | |
+ERP system implementation expenses & other transformational initiatives | (16) | | | (16) | | | — | | | — | | | (16) | | | (16) | |
+Other changes in other operating assets and liabilities | (112) | | | (112) | | | (5) | | | (5) | | | (117) | | | (117) | |
+Cash provided by operating activities | $ | 5,998 | | | $ | 6,798 | | | $ | (165) | | | $ | (165) | | | $ | 5,833 | | | $ | 6,633 | |
+Capital expenditures including nuclear fuel purchases and LTSA prepayments | (1,536) | | | (1,536) | | | — | | | — | | | (1,536) | | | (1,536) | |
+Other net investing activities | (20) | | | (20) | | | — | | | — | | | (20) | | | (20) | |
+Working capital, margin deposits and accrued environmental allowances | (640) | | | (640) | | | — | | | — | | | (640) | | | (640) | |
+Transition and merger expenses | 41 | | | 41 | | | — | | | — | | | 41 | | | 41 | |
+Interest on noncontrolling interest repurchase obligation | 60 | | | 60 | | | — | | | — | | | 60 | | | 60 | |
+ERP system implementation expenses & other transformational initiatives | 22 | | | 22 | | | — | | | — | | | 22 | | | 22 | |
+Adjusted free cash flow before growth guidance | $ | 3,925 | | | $ | 4,725 | | | $ | (165) | | | $ | (165) | | | $ | 3,760 | | | $ | 4,560 | |
+
+___________
+1 Regulation G Table 2026 Guidance prepared as of November 6, 2025, based on market curves as of October 31, 2025.


### PR DESCRIPTION
## Audit: 4 of 12 carried a wrong figure

| | Was | Correct | Cause |
|---|---|---|---|
| **COP** | `$5.00` / `$5.13` | **`$3.23`** / **`$3.24`** | six-month sentence |
| **DDOG** | Adj EPS `$0.63` | **`$0.65`** | low end of Q3 guidance |
| **INOD** | NI `$7.2M` | **`$14.41M`** | prior-year comparison |
| **VST** | `$7.4B–$7.8B` | **`$6.8B–$7.6B`** | a 2027 range, not guidance |
| HIMX, HWM, QBTS, PH, RGTI, CENX, AAOI, NET | — | already correct | — |

**Howmet was not a bug.** `GAAP EPS $1.33, Adjusted EPS $1.33` looks like a duplicated read; the release's own subtitle says both measures came out equal. Recorded in the corpus so it isn't "fixed" later.

## Causes

- **A hyphen hid the half year.** `six-month 2026 earnings ... or $5.00 per share` — the year-to-date penalty knew only the spaced spelling, so ConocoPhillips' half-year sentence outscored the quarter's.
- **"Diluted" sits on either side of "per".** Datadog captions its measure `non-GAAP net income per diluted share`; no pattern matched that order, which left the Q3 guidance table as the measure's only source, and its low end was posted as the result.
- **A paragraph break made a comparison read as current.** The filing wraps one sentence across lines, so `...period ended June 30, 2026, compared to net income of $7.2 million` stands alone *carrying the reported period's date*. A figure is now demoted where the caption directly follows "compared to" — and that adjacency is load-bearing: accepting any comparison anywhere on the line breaks Beyond Meat and makes the consistency gate fire on a correct filing.
- **A two-column guidance table holds one pipe per row**, so Vistra's rows scored as prose and lost to a sentence quoting a 2027 "midpoint opportunity" range — which the filing's own footnote calls *"not intended to be guidance"*.

## Two omissions recovered

Rigetti's and Axon's reported per-share figures were both stated in a clause that goes on to give the non-GAAP measure. Only the word "adjusted" bounded the reported half of such a clause, so the whole line was discarded and the adjusted figure was posted alone. Two follow-ons fell out of that:

- Merck states its sign beside the value under a combined `loss / earnings per share` caption, which carries no sign of its own — `-$0.54` would otherwise have become `$0.54`.
- Rigetti's share count was being read out of the non-GAAP section's **prose definition** of that caption. A count read from the wrong place is worse than none: the gate then contradicts a correct filing and suppresses it.

## Three figures deliberately still unposted

Howmet's net income and Century's revenue are declared in scales the reader doesn't reach (`$MM`, and a declaration too far above the row); Parker's revenue is a **segment** row under `$ in mm`. Adding those scale spellings without first distinguishing segment tables from consolidated ones would turn three dropped figures into a published wrong one — Parker would report `$2.22B` against an actual `$5.8B`. They are recorded in the corpus as they parse today, with the reason, so the follow-up change has a baseline.

## Verification

Corpus grows to **45 filings**. Every guard mutation-checked — each fails exactly the corpus entry and test written for it. **Two synthetic tests were removed**: reduced from their filings they passed with *and* without their guard, so they implied coverage the corpus was actually providing. **2,476 tests pass**; `audit`, `lint`, `typecheck`, `test:coverage` clean, no thresholds altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)