### PR TITLE
Fix nanoid audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3583,9 +3583,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Updates the transitive nanoid lockfile entry from 3.3.16 to 3.3.18 to resolve GHSA-2v37-7h3g-55p8. No manifest or application code changes.\n\nVerified under Node 24:\n- npm audit: 0 vulnerabilities\n- lint\n- coverage suite\n- production and test typechecks