### PR TITLE
Fix text-only whatis responses

### DIFF
--- a/modules/slash-commands-interact-media.ts
+++ b/modules/slash-commands-interact-media.ts
@@ -121,8 +121,8 @@ async function handleWhatisCommand(
         {name: asset.title, value: asset.text},
       );
 
-      if (true === Object.prototype.hasOwnProperty.call(asset, "_fileName")) {
-        if (!asset?.fileContent || !asset.fileName) {
+      if (asset.fileName) {
+        if (!asset.fileContent) {
           logger.log(
             "warn",
             `Whatis asset ${asset.name} is temporarily unavailable.`,

--- a/modules/slash-commands.interact.test.ts
+++ b/modules/slash-commands.interact.test.ts
@@ -794,6 +794,33 @@ describe("interactSlashCommands", () => {
     });
   });
 
+  test("replies to text-only whatis assets with an embed", async () => {
+    const {client, getHandler} = createEventClient();
+    interactSlashCommands(client, [], [], [
+      createImageAsset({
+        name: "whatis_faq",
+        title: "FAQ",
+        text: "Answer",
+        fileName: "",
+      }),
+    ], []);
+
+    const handler = getHandler("interactionCreate");
+    const interaction = createChatInputInteraction("whatis");
+    interaction.options.getString.mockImplementation(name => name === "search" ? "whatis_faq" : null);
+
+    await handler(interaction);
+
+    const payload = getReplyPayload(interaction);
+    expect(payload.files).toBeUndefined();
+    expect(payload.embeds?.[0]?.toJSON()).toEqual({
+      fields: [{
+        name: "FAQ",
+        value: "Answer",
+      }],
+    });
+  });
+
   test("handles whatis unavailable responses when reply itself fails", async () => {
     const {client, getHandler} = createEventClient();
     interactSlashCommands(client, [], [], [

--- a/modules/trigger-response.test.ts
+++ b/modules/trigger-response.test.ts
@@ -319,13 +319,12 @@ describe("addTriggerResponses", () => {
   test("replies with whatis embed-only when no attachment exists", async () => {
     const {client, getHandler} = createEventClient();
 
-    addTriggerResponses(client, [], [], [
-      {
-        name: "whatis_faq",
-        title: "FAQ",
-        text: "Answer",
-      },
-    ]);
+    const whatIsAsset = new ImageAsset();
+    whatIsAsset.name = "whatis_faq";
+    whatIsAsset.title = "FAQ";
+    whatIsAsset.text = "Answer";
+
+    addTriggerResponses(client, [], [], [whatIsAsset]);
 
     const handler = getHandler("messageCreate");
     const message = createMessage("!whatis faq");

--- a/modules/trigger-response.ts
+++ b/modules/trigger-response.ts
@@ -288,8 +288,8 @@ export function addTriggerResponses(
             {name: asset.title, value: asset.text},
           );
 
-          if (true === Object.prototype.hasOwnProperty.call(asset, "_fileName")) {
-            if (!asset?.fileContent || !asset.fileName) {
+          if (asset.fileName) {
+            if (!asset.fileContent) {
               logger.log(
                 "warn",
                 `Whatis asset ${asset.name} is temporarily unavailable.`,


### PR DESCRIPTION
## Summary
- treat whatis entries without filenames as text-only embeds
- preserve unavailable handling for configured attachments without downloaded content
- cover slash and legacy handlers with production-shaped ImageAsset tests

## Validation
- npm audit --audit-level=high
- npm run lint
- npm run test:coverage
- npm run typecheck