### PR TITLE
Harden earnings parsing for fiscal and component metrics

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -932,6 +932,54 @@ const filingCorpus: {
     source: "1633978/000162828026055726/lite_ex991xq4fy26.htm",
     ticker: "lite",
   },
+  {
+    // Accounting parentheses close before the unit in both ends of the adjusted EBITDA
+    // range: "($400) million to ($445) million". The unit and sign apply together.
+    company: "Beta Technologies",
+    metrics: [
+      ["gaap_eps", "-$0.64"],
+      ["revenue", "$14.7M"],
+      ["net_income", "-$148.8M"],
+    ],
+    outlook: [
+      ["Revenue", "$42M to $50M"],
+      ["Adj EBITDA", "-$400M to -$445M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1784570/000162828026055933/a2026q2earningsrelease.htm",
+    ticker: "beta",
+  },
+  {
+    // The fiscal quarter number is in the release title, while the year is in the next
+    // highlights heading. The short outlook ends at "Key Financials" before Q4 tables.
+    company: "Amcor",
+    metrics: [
+      ["adjusted_eps", "$1.23"],
+      ["gaap_eps", "$0.83"],
+      ["revenue", "$6.4B"],
+      ["net_income", "$389M"],
+    ],
+    outlook: [
+      ["Adj EPS", "$1.8 to $1.9"],
+    ],
+    quarterLabel: "Q4 2026",
+    source: "1748790/000174879026000020/amcor4q2026ex991-june302026.htm",
+    ticker: "amcr",
+  },
+  {
+    // Product and service revenue are separate components above the consolidated total.
+    // The headline repeats only product sales, which must not outrank the total row.
+    company: "Liquidia",
+    metrics: [
+      ["gaap_eps", "$0.74"],
+      ["revenue", "$171.68M"],
+      ["net_income", "$74.7M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1819576/000110465926094411/tm2622888d1_ex99-1.htm",
+    ticker: "lqda",
+  },
 ];
 
 describe("earnings result filing corpus", () => {
@@ -952,6 +1000,6 @@ describe("earnings result filing corpus", () => {
   }
 
   test("covers every stored fixture", () => {
-    expect(filingCorpus).toHaveLength(60);
+    expect(filingCorpus).toHaveLength(63);
   });
 });

--- a/modules/earnings-results-document.test.ts
+++ b/modules/earnings-results-document.test.ts
@@ -41,6 +41,14 @@ describe("earnings result document text", () => {
     ].join(" "))).toBe("Q2 2026");
   });
 
+  test("joins a fiscal Q4 title to the year in its following highlights heading", () => {
+    expect(getQuarterLabel([
+      "Amcor Reports Strong Fourth Quarter and Full-Year Results",
+      "Highlights - Three Months Ended June 30, 2026",
+      "Highlights - Fiscal Year Ended June 30, 2026",
+    ].join("\n"))).toBe("Q4 2026");
+  });
+
   test("recognizes Swiss francs declared with their ISO code", () => {
     expect(getDocumentCurrencyCode([
       "On Holding AG financial results",

--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -146,6 +146,11 @@ export function getQuarterLabel(text: string): string | undefined {
     return namedPeriodEndedQuarter;
   }
 
+  const quarterAndFullYearHighlightsLabel = getQuarterAndFullYearHighlightsLabel(text);
+  if (undefined !== quarterAndFullYearHighlightsLabel) {
+    return quarterAndFullYearHighlightsLabel;
+  }
+
   // The period the statements cover is stated as the period they ended, and it outranks a
   // written quarter elsewhere in the document: a release for the quarter ended June 30 also
   // says "For the third quarter of 2026, we expect", and that guidance period must not
@@ -170,6 +175,22 @@ export function getQuarterLabel(text: string): string | undefined {
   }
 
   return undefined;
+}
+
+// A fiscal Q4 release can put the quarter number in its title and the year only in the
+// following period heading: "Fourth Quarter and Full-Year Results" followed by
+// "Highlights - Three Months Ended June 30, 2026". The calendar month cannot identify a
+// fiscal quarter, so join those two nearby declarations instead of mapping June to Q2.
+function getQuarterAndFullYearHighlightsLabel(text: string): string | undefined {
+  const quarterAndYearMatch = text.match(
+    /\b(first|second|third|fourth)[\s–—-]+quarter\s+and\s+full[\s–—-]+year\s+results\b[\s\S]{0,500}?\b(?:highlights?\s*[-:]\s*)?(?:three\s+months|fiscal\s+year)\s+ended\s+[A-Z][a-z]+\s+\d{1,2},\s+(20\d{2})\b/i,
+  );
+  if (undefined === quarterAndYearMatch?.[1] || undefined === quarterAndYearMatch[2]) {
+    return undefined;
+  }
+
+  const quarter = getQuarterFromName(quarterAndYearMatch[1]);
+  return quarter ? `${quarter} ${quarterAndYearMatch[2]}` : undefined;
 }
 
 function getNamedQuarterLabelFromPeriodEnded(text: string): string | undefined {

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -110,6 +110,29 @@ export function getMetricCandidateScore({
     score -= 150;
   }
 
+  if ("revenue" === metricKey) {
+    // Biotech statements often list product and service revenue components above an explicit
+    // total. Prefer that total only when the nearby rows establish this component layout:
+    // a generic "Total revenues" can itself be a segment subtotal and must not outrank the
+    // consolidated headline.
+    const precedingRevenueRows = lines
+      .slice(Math.max(0, lineIndex - 16), lineIndex)
+      .join(" ");
+    const metricCaptionText = null === patternMatch
+      ? ""
+      : metricLine.slice(
+        Math.max(0, patternMatch.index - 30),
+        patternMatch.index + patternMatch[0].length,
+      );
+    if (/\btotal\s+revenues?\b/i.test(patternMatch?.[0] ?? "") &&
+        /\b(?:net\s+)?product\s+sales\b/i.test(precedingRevenueRows) &&
+        /\bservice\s+revenues?\b/i.test(precedingRevenueRows)) {
+      score += 100;
+    } else if (/\b(?:net\s+)?product\s+sales\b|\bservice\s+revenues?\b/i.test(metricCaptionText)) {
+      score -= 80;
+    }
+  }
+
   // A company may publish its standard adjusted EPS and then an additional figure that
   // removes a one-off item from that adjusted result. The plain "Adj EPS" label refers to
   // the company-reported non-GAAP measure; an "excluding ..." variant needs a distinct

--- a/modules/earnings-results-metrics.test.ts
+++ b/modules/earnings-results-metrics.test.ts
@@ -2,6 +2,50 @@ import {describe, expect, test} from "vitest";
 import {parseEarningsDocument} from "./earnings-results-format.ts";
 
 describe("earnings result metric selection", () => {
+  test("keeps fiscal-quarter highlights separate from full-year highlights", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <h1>Example Reports Strong Fourth Quarter and Full-Year Results</h1>
+      <h2>Highlights - Three Months Ended June 30, 2026</h2>
+      <p>Net sales $6.4 billion.</p>
+      <p>Net income $389 million.</p>
+      <p>Diluted EPS of $0.83.</p>
+      <p>Adjusted Diluted EPS of $1.23.</p>
+      <h2>Highlights - Fiscal Year Ended June 30, 2026</h2>
+      <p>Net sales $23.5 billion.</p>
+      <p>Net income $1.1 billion.</p>
+      <p>Diluted EPS of $2.38.</p>
+      <p>Adjusted Diluted EPS of $4.02.</p>
+    `);
+
+    expect(parsedDocument.quarterLabel).toBe("Q4 2026");
+    expect(parsedDocument.metrics.map(metric => [metric.key, metric.value])).toEqual([
+      ["adjusted_eps", "$1.23"],
+      ["gaap_eps", "$0.83"],
+      ["revenue", "$6.4B"],
+      ["net_income", "$389M"],
+    ]);
+  });
+
+  test("prefers total revenue over product and service components", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <h1>Example reports second quarter 2026 results</h1>
+      <p>Net product sales were $170.4 million.</p>
+      <table>
+        <tr><td>Net product sales</td><td>$170.382 million</td></tr>
+        <tr><td>Service revenue</td><td>$1.297 million</td></tr>
+        <tr><td>Total revenue</td><td>$171.679 million</td></tr>
+      </table>
+    `);
+
+    expect(parsedDocument.metrics).toEqual([
+      expect.objectContaining({
+        key: "revenue",
+        numericValue: 171_679_000,
+        value: "$171.679M",
+      }),
+    ]);
+  });
+
   test("parses mixed GAAP and footnoted adjusted EPS from an IBKR-style headline", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -212,12 +212,14 @@ function isQuarterSpecificSectionLine(line: string): boolean {
   }
 
   return /^\s*(?:for\s+)?Q[1-4]\s+(?:(?:fiscal\s+year|FY|FYE)\s*)?(?:20\d{2}|\d{2})(?:\s+(?:financial\s+overview|results?(?:\s+summary)?|earnings))?\s*:?$/i.test(line) ||
-    /^\s*(?:for\s+)?(?:the\s+)?(?:first|second|third|fourth)[\s–—-]+quarter(?:\s+(?:of\s+)?(?:(?:fiscal\s+year|FY)\s*)?(?:20\d{2}|\d{2}))?(?:\s+(?:financial\s+overview|results?(?:\s+summary)?|earnings))?\s*:?$/i.test(line);
+    /^\s*(?:for\s+)?(?:the\s+)?(?:first|second|third|fourth)[\s–—-]+quarter(?:\s+(?:of\s+)?(?:(?:fiscal\s+year|FY)\s*)?(?:20\d{2}|\d{2}))?(?:\s+(?:financial\s+overview|results?(?:\s+summary)?|earnings))?\s*:?$/i.test(line) ||
+    /^\s*highlights?\s*[-:]\s*three\s+months\s+ended\s+[A-Z][a-z]+\s+\d{1,2},\s+20\d{2}\s*:?$/i.test(line);
 }
 
 function isQuarterSpecificSectionBoundary(line: string): boolean {
   return /^\s*(?:outlook|guidance|financial\s+outlook|business\s+outlook|use\s+of\s+non-gaap|forward-looking|supplemental\s+financial\s+information)\b/i.test(line) ||
     /^\s*(?:the\s+)?company\s+(?:raises?|updates?|reaffirms?|provides?|issues?)\b.*\b(?:guidance|outlook)\b/i.test(line) ||
+    /^\s*highlights?\s*[-:]\s*(?:fiscal\s+year|twelve\s+months\s+ended)\b/i.test(line) ||
     /^\s*(?:fiscal\s+year|FY|FYE)\s*(?:20\d{2}|\d{2})\b/i.test(line) ||
     /^\s*for\s+fiscal\s+year\s+(?:20\d{2}|\d{2})\s*:?$/i.test(line);
 }

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -81,6 +81,34 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  test("keeps scale words outside accounting parentheses in negative ranges", () => {
+    expect(extractOutlookMetrics([
+      "Financial Outlook",
+      "Adjusted EBITDA to be in the range of ($400) million to ($445) million.",
+    ])).toEqual([
+      {
+        key: "adjusted_ebitda",
+        label: "Adj EBITDA",
+        value: "-$400M to -$445M",
+      },
+    ]);
+  });
+
+  test("stops a short outlook section before key financial results", () => {
+    expect(extractOutlookMetrics([
+      "Outlook - Six Months Ended December 31, 2026",
+      "Adjusted EPS is expected to be $1.80 to $1.90.",
+      "Key Financials",
+      "Net sales | 5,082 | 6,398 | 15,009 | 23,506",
+    ])).toEqual([
+      {
+        key: "adjusted_eps",
+        label: "Adj EPS",
+        value: "$1.8 to $1.9",
+      },
+    ]);
+  });
+
   test("applies an explicit loss caption to an unsigned guidance range", () => {
     expect(extractOutlookMetrics([
       "Business Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -50,7 +50,11 @@ type OutlookSection = {
   revisedColumns: boolean;
 };
 
-const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:C\s*\$|[$€£¥])\s*|(?:(?:USD|CAD|EUR|GBP|JPY|CHF)\s+))?-?\d+(?:,\d{3})*(?:\.\d+)?\s*(?:(?:trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b)?\)?`;
+const moneyUnitPatternSource = String.raw`(?:trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b`;
+// Some releases close accounting parentheses before the scale word — "($400) million" —
+// while others put the scale inside them — "($400 million)". Treat both forms as one
+// token so the scale and negative sign survive range parsing.
+const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:C\s*\$|[$€£¥])\s*|(?:(?:USD|CAD|EUR|GBP|JPY|CHF)\s+))?-?\d+(?:,\d{3})*(?:\.\d+)?\s*\)?\s*(?:${moneyUnitPatternSource})?\)?`;
 const moneyRangePattern = new RegExp(`(${moneyTokenPatternSource})\\s*(?:to|through|-|–|and)\\s*(${moneyTokenPatternSource})`, "gi");
 const singleMoneyPattern = new RegExp(moneyTokenPatternSource, "gi");
 
@@ -310,7 +314,7 @@ function isOutlookSectionEnd(line: string): boolean {
   }
 
   return line.length <= 90 &&
-    /^(?:results|balance\s+sheets?|cash\s+flows?|appendix|contacts?|media|webcast)$/i.test(line);
+    /^(?:results|key\s+financials?|balance\s+sheets?|cash\s+flows?|appendix|contacts?|media|webcast)$/i.test(line);
 }
 
 function isNextSectionHeading(line: string): boolean {
@@ -893,6 +897,12 @@ function parseNumber(value: unknown): number | null {
   }
 
   const normalizedValue = value
+    // A scale outside accounting parentheses carries the same sign as the value inside.
+    // Normalize it before the general parenthetical conversion below.
+    .replace(
+      new RegExp(String.raw`^\(([^)]+)\)\s*(${moneyUnitPatternSource})$`, "i"),
+      "-$1 $2",
+    )
     .replace(/^\((.*)\)$/, "-$1")
     .replace(/C\s*\$/g, "")
     .replace(/[€£¥$]/g, "")

--- a/modules/test-fixtures/earnings-filings/amcr.txt
+++ b/modules/test-fixtures/earnings-filings/amcr.txt
@@ -1,0 +1,823 @@
+EX-99.1
+2
+amcor4q2026ex991-june302026.htm
+EX-99.1
+
+
+
+
+Document
+| | | | | | | | |
+| | Exhibit 99.1 |
+
+|
+
+
+Amcor Reports Strong Fourth Quarter and Full-Year Results
+Highlights - Three Months Ended June 30, 2026
+• Net sales $6.4 billion, up 26% largely driven by Berry acquisition and pass through of higher raw material costs
+• Net income $389 million vs. -$39 million prior-year
+• Adjusted EBITDA $1,045 million vs. $789 million prior-year, up 32%
+• Diluted EPS of $0.83 vs. $-0.10 prior-year
+• Adjusted Diluted EPS of $1.23 vs $1.00 prior-year, up 23%
+Highlights - Fiscal Year Ended June 30, 2026
+• Net sales $23.5 billion, up 57% largely driven by the Berry acquisition
+• Net income $1,106 million vs. $511 million prior-year
+• Adjusted EBITDA $3,673 million vs. $2,186 million prior-year, up 68%
+• Diluted EPS of $2.38 vs. $1.60 prior-year
+• Adjusted Diluted EPS $4.02 vs. $3.56 prior-year, up 13%
+Outlook - Six Months Ended December 31, 2026 ('Transition Period')
+• Adjusted Diluted EPS of $1.80 to $1.90
+Amcor CEO Peter Konieczny said, “We delivered strong operating performance in the fourth quarter despite a challenging macro environment. We drove broad-based volume growth, while effectively managing unprecedented input cost inflation. Synergy realization came in ahead of plan, while performance in our non-core businesses improved substantially.
+Looking ahead, we are encouraged by the momentum we see across the business and the greater potential for growth and continued synergy capture following the transformative acquisition of Berry. As we complete the integration and begin to realize our potential as a global leader in consumer packaging, we remain confident in delivering on our medium and long-term commitments."
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+Key Financials (1)(2)(3)
+| | | | Three Months Ended June 30, | | Twelve Months Ended June 30, | |
+GAAP results | | | | | | 2025 $ million | | 2026 $ million | | 2025 $ million | | 2026 $ million | |
+Net sales | | | | | | 5,082 | | | 6,398 | | | 15,009 | | | 23,506 | | |
+Net income | | | | | | (39) | | | 389 | | | 511 | | | 1,106 | | |
+EPS (diluted, $) | | | | | | (0.10) | | | 0.83 | | | 1.60 | | 2.38 | | |
+| | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Reported ∆% | | Twelve Months Ended June 30, | | Reported ∆% | |
+Adjusted non-GAAP results | | 2025 $ million | | 2026 $ million | | | 2025 $ million | | 2026 $ million | | |
+Net sales | | 5,082 | | | 6,398 | | | 26 | | | 15,009 | | | 23,506 | | | 57 | | |
+EBITDA | | 789 | | | 1,045 | | | 32 | | | 2,186 | | | 3,673 | | | 68 | | |
+EBIT | | 611 | | | 836 | | | 37 | | | 1,723 | | | 2,813 | | | 63 | | |
+Net income | | 408 | | | 570 | | | 40 | | | 1,136 | | | 1,863 | | | 64 | | |
+EPS ($) | | 1.00 | | | 1.23 | | | 23 | | | 3.56 | | | 4.02 | | | 13 | | |
+Free Cash Flow | | 943 | | | 1,396 | | | 48 | | | 926 | | | 1,303 | | | 41 | | |
+
+All amounts referenced throughout this document are in US dollars unless otherwise indicated and numbers may not add up to the totals provided due to rounding.
+(1) Adjusted non-GAAP results exclude items not considered representative of ongoing operations. Further details on non-GAAP measures and reconciliations to GAAP measures can be found under "Presentation of non-GAAP information”.
+(2) All prior year results reflect the Amcor plc group, considered the accounting acquirer in the April 30, 2025 combination between Amcor plc and Berry Global.
+(3) All periods presented in this release have been retroactively adjusted to reflect the 1-for-5 reverse stock split effected on January 14, 2026. Further details can be found under 'Reverse Stock Split'.
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+1
+
+
+
+
+
+
+
+
+
+Financial results
+Three months ended June 30, 2026
+Net sales of $6,398 million were 26% higher than last year on a reported basis, including approximately $962 million of acquired sales net of divestitures, which represents growth of approximately 19%. The pass through of movements in raw material costs had a favorable impact of approximately $280 million, which represents growth of approximately 6%, movements in foreign exchange rates had a favorable impact of approximately 2% and the remaining (1%) year-over-year variation reflects the net impact of volumes and price/mix.
+The Company estimates that volumes were approximately 0.5% higher than estimated combined volumes for the legacy Amcor and legacy Berry businesses in the June quarter last year, excluding non-core and divested businesses. The Company estimates that price/mix had an unfavorable impact of approximately (1%) on comparable prior year net sales, excluding non-core and divested businesses.
+Adjusted EBIT of $836 million was 37% higher than last year on a reported basis, including approximately $96 million of acquired EBIT net of divestitures, which represents growth of approximately 15%. Movements in foreign exchange rates had a favorable impact of approximately 3% and the remaining 19% year-over-year variation mainly reflects synergy benefits from the Berry acquisition of approximately $100 million and strong execution against initiatives to drive cost and productivity benefits, including in the non-core businesses .
+GAAP net interest expense was $150 million and GAAP income tax expense was $97 million. Inclusive of acquisition- related financial benefits of approximately $15 million, adjusted net interest expense was $150 million an d adjusted tax expense was $116 million representing an effective tax rate of 16.8%. Adjusted net interest expense was $36 million higher than the prior year primarily as a result of increased acquisition related net debt.
+Twelve months ended June 30, 2026
+Net sales of $23,506 million were 57% higher than last year on a reported basis, including approximately $7.9 billion of acquired sales net of divestitures, which represents growth of approximately 52%. The pass through of movements in raw material costs had a favorable impact of approximately $240 million, which represents growth of approximately 2%, movements in foreign exchange rates had a favorable impact of approximately 5% and the remaining (2%) year-over-year variation reflects the net impact of volumes and price/mix.
+Adjusted EBIT of $2,813 million was 63% higher than last year on a reported basis, including approximately $842 million of acquired EBIT net of divestitures, which represents growth of approximately 49%. Movements in foreign exchange rates had a favorable impact of approximately 4% and the remaining 10% year-over-year variation mainly reflects synergy benefits from the Berry acquisition of approximately $240 million, partly offset by lower volumes.
+GAAP net interest expense was $610 million and GAAP income tax expense was $181 million. Inclusive of acquisition-related financial benefits of approximately $45 million, adjusted net interest expense was $581 million and adjusted tax expense was $368 million representing an effective tax rate of 16.5%.
+Free cash flow was $1,303 million after funding approximately $290 million of net transaction, restructuring and integration costs. Net debt was $12,897 million at June 30, 2026.
+
+
+Dividend
+The Board declared a quarterly cash dividend of 65.0 cents per share today, compared with 63.75 cents per share, declared as 12.75 cents per share before adjusting for the 1-for-5 reverse stock split effected on January 14, 2026. The dividend will be paid in US dollars to holders of Amcor’s ordinary shares trading on the NYSE. Holders of CDIs trading on the ASX will receive an unfranked dividend of 92.0 Australian cents per share, which reflects the quarterly dividend of 65.0 cents per share converted at an AUD:USD average exchange rate of 0.7043 over the fiv e trading days ended August 10, 2026.
+The ex-dividend date will be September 3, 2026 for holders of CDIs trading on the ASX and September 4, 2026 for holders of shares trading on the NYSE. For all shareholders, the record date will be September 4, 2026 and the payment date will be September 24, 2026.
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+2
+
+
+
+
+
+Outlook
+Amcor will have a six-month reporting period from July 1, 2026, through December 31, 2026 ('Transition Period'), as part of transitioning from a previously announced June 30 to December 31 year-end.
+For the transition period, the Company expects Adjusted EPS of approximately $1.80 to $1.90, and leverage on December 31, 2026 of 3.5x - 3.6x. 1
+
+
+Outlook does not take into account the impact of potential portfolio optimization actions not announced to date. Outlook contemplates a range of factors, including ongoing geopolitical developments, which create a higher degree of uncertainty and additional complexity when estimating future financial results and actual results could vary materially. Reconciliations of projected non-GAAP measures are not included herein because the individual components are not known with certainty as individual financial statements for the periods referenced have not been completed. Refer to page 14 for further information.
+
+
+(1) Leverage calculated as Net Debt divided by LTM Adjusted EBITDA plus share-based compensation.
+
+
+Conference Call
+Amcor is hosting a conference call with investors and analysts to discuss these results on Wednesday August 12, 2026 at 8:00am US Eastern Daylight Time / 10:00pm Australian Eastern Standard Time. Investors are invited to listen to a live webcast of the conference call at our website, www.amcor.com, in the “Investors” section.
+Those wishing to access the call should use the following toll-free numbers, with the Conference ID : 980769865
+• USA: 833 461 5787 (toll free)
+• Australia: 1800 849 752 (toll free)
+• United Kingdom: 0808 196 8935 (toll free)
+• Singapore: 1800 408 1721 (toll free)
+• Hong Kong: 800 938 481 (toll free)
+From all other countries, the call can be accessed by dialing +1 585 542 9983 (toll).
+A replay of the webcast will also be available in the 'Investors" section at www.amcor.com following the call.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+3
+
+
+
+
+
+About Amcor
+Amcor is the global leader in developing and producing responsible consumer packaging and dispensing solutions across a variety of materials for nutrition, health, beauty and wellness categories. Our global product innovation and sustainability expertise enable us to solve packaging challenges around the world every day, producing a range of flexible packaging, rigid packaging, cartons and closures that are more sustainable, functional and appealing for our customers and their consumers. We are guided by our purpose of elevating customers, shaping lives and protecting the future. Supported by a commitment to safety, 75,000 people generate $23 billion in annual sales from operations that span approximately 400 locations in more than 40 countries. NYSE: AMCR; ASX: AMC
+www.amcor.com I LinkedIn I YouTube
+
+
+
+
+
+
+
+
+
+
+Contact Information
+| | | | | | | | | | | | | | |
+Investors | | | | |
+Kate Pearlman | | Damien Bird | | Dustin Stilwell |
+Sr. Vice President, Investor Relations and Treasury | | VP Investor Relations Asia Pacific | | VP Investor Relations North America |
++1 703 585 5353 | | +61 481 900 499 | | +1 812 306 2964 |
+kate.pearlman@amcor.com | | damien.bird@amcor.com | | dustin.stilwell@amcor.com |
+| | | | |
+Media - Australia | | Media - Europe | | Media - North America |
+James Strong | | Ernesto Duran | | Julie Liedtke |
+Managing Director | | Head of Global Communications | | Director, Media Relations |
+Sodali & Co | | Amcor | | Amcor |
++61 448 881 174 | | +41 78 698 69 40 | | +1 847 204 2319 |
+james.strong@sodali.com | | ernesto.duran@amcor.com | | julie.liedtke@amcor.com |
+
+
+
+Amcor plc UK Establishment Address: 83 Tower Road North, Warmley, Bristol, England, BS30 8XP, United Kingdom
+UK Overseas Company Number: BR020803
+Registered Office: 3rd Floor, 44 Esplanade, St Helier, JE4 9WG, Jersey
+Jersey Registered Company Number: 126984, Australian Registered Body Number (ARBN): 630 385 278
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+4
+
+
+
+
+
+Segment information
+Global Flexible Packaging Solutions segment - June 2026 quarter | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Reported ∆% | | Constant
+currency ∆% |
+| 2025 $ million | | 2026 $ million | | |
+Net sales | | 2,994 | | | 3,525 | | | 18 | | | 16 | |
+Adjusted EBIT | | 435 | | | 533 | | | 23 | | 20 | |
+Adjusted EBIT / Sales % | | 14.5 | | | 15.1 | | | | | |
+
+Net sales of $3,525 million were 16% higher than last year on a constant currency basis including approximately $297 million of acquired sales net of divestitures, which represents growth of approximately 10%. The pass through of movements in raw material costs had a favorable impact of approximately $190 million, or 6% on net sales.
+The Company estimates that volumes for the Global Flexible Packaging Solutions segment were approximately 1% higher compared to volumes for the combined legacy Amcor and Berry businesses in the June quarter last year. Market category highlights included higher volumes in pet food and protein, partly offset by lower volumes in healthcare. By region, volumes in developed markets were higher than the prior year led by North America. Emerging markets continued to see volume growth compared with the prior year, led by Asia. The Company estimates that price/mix had an unfavorable impact of approximately (1%) on comparable prior year net sales.
+Adjusted EBIT of $533 million was 20% higher than last year on a constant currency basis, reflecting approximately $31 million of acquired EBIT, net of divestitures which represents growth of approximately 7%. The remaining 13% year-over-year growth mainly reflects synergy realization from the Berry acquisition, favorable cost performance and productivity benefits.
+
+
+Global Flexible Packaging Solutions segment - FY 2026
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Twelve Months Ended June 30, | | Reported ∆% | | Constant
+currency ∆% |
+| 2025 $ million | | 2026 $ million | | |
+Net sales | | 10,066 | | | 12,829 | | | 27 | | | 24 | |
+Adjusted EBIT | | 1,398 | | | 1,789 | | | 28 | | | 26 | |
+Adjusted EBIT / Sales % | | 13.9 | | | 13.9 | | | | | |
+| | | | | | | | |
+
+Net sales of $12,829 million were 24% higher than last year on a constant currency basis including approximately $2.2 billion of acquired sales net of divestitures, which represents growth of approximately 22%. The pass through of movements in raw material costs had a favorable impact of approximately $240 million, or 2% on net sales.
+Adjusted EBIT of $1,7 89 million was 26% higher than last year on a constant currency basis, reflecting approximately $250 million of acquired EBIT, net of divestitures which represents growth of approximately 18%. The remaining 8% year-over-year growth mainly refle cts synergy benefits from the Berry acquisition, favorable cost performance and productivity benefits.
+
+
+Global Rigid Packaging Solutions segment - June 2026 quarter | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Reported ∆% | | Constant
+currency ∆% |
+| 2025 $ million | | 2026 $ million | | |
+Net sales | | 2,088 | | | 2,873 | | | 38 | | | 35 | |
+Adjusted EBIT | | 219 | | | 352 | | | 61 | | | 57 | |
+Adjusted EBIT / Sales % | | 10.5 | | | 12.3 | | | | | |
+
+Net sales of $2,873 million were 35% higher than last year on a constant currency basis, including approximately $665 million of acquired sales, which represents growth of approximately 32%. The pass through of movements in raw material costs had a favorable impact of approximately $90 million, or 4% on net sales, and the remaining (1%) year- over-year variation reflects the impact of volumes and price/mix.
+Excluding non-core businesses, the Company estimates that volumes for the Global Rigid Packaging Solutions segment were approximately 0.5% higher compared with volumes for the combined legacy Amcor and Berry businesses in the June quarter last year. Market category highlights included higher volumes in foodservice and
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+5
+
+
+
+
+
+beauty & wellness, partly offset by lower volumes in liquids. By region, volumes in North America were in line with the prior year, higher than the prior year in Europe and modestly lower across emerging markets, primarily Latin America. The Company estimates that price/mix had an unfavorable impact of approximately (1%) on comparable prior year net sales.
+Adjusted EBIT of $352 million was 57% higher than last year on a constant currency basis, including approximately $52 million of acquired EBIT which represents growth of approximately 24%. The remaining 33% year-over-year variation mainly reflects synergy realization from the Berry acquisition and strong execution against initiatives to drive cost and productivity benefits, including the non-core businesses.
+
+
+Global Rigid Packaging Solutions segment - FY 2026
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Twelve Months Ended June 30, | | Reported ∆% | | Constant
+currency ∆% |
+| 2025 $ million | | 2026 $ million | | |
+Net sales | | 4,943 | | | 10,677 | | | 116 | | | 110 | |
+Adjusted EBIT | | 435 | | | 1,176 | | | 170 | | | 161 | |
+Adjusted EBIT / Sales % | | 8.8 | | | 11.0 | | | | | |
+| | | | | | | | |
+
+Net sales of $10,677 million, were 110% higher than last year on a constant currency basis, including approximately $5.6 billion of acquired sales net of divestitures, which represents growth of approximately 114%, while the remaining (4%) year-over-year variation reflects lower volumes and price/mix. The pass through of movements in raw material costs had no material impact on net sales.
+Adjusted EBIT of $1,176 million was 161% higher than last year on a constant currency basis, including approximately $635 million of acquired EBIT net of divestitures which represents growth of approximately 146%. The remaining 15% year-over-year variation mainly reflects synergy benefits from the Berry acquisition and cost reduction initiatives, partly offset by lower volumes and lower earnings in non-core businesses.
+Adjusted EBIT margins of 11.0% were 220 basis points higher than the prior year reflecting the improved quality of the combined business.
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+6
+
+
+
+
+
+
+U.S. GAAP Condensed Consolidated Statements of Income (Unaudited) | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, | | Twelve Months Ended June 30, |
+($ million, except per share amounts) | | 2025 | 2026 | | 2025 | | 2026 |
+Net sales | | 5,082 | | 6,398 | | | 15,009 | | | 23,506 | |
+Cost of sales | | (4,187) | | (5,061) | | | (12,175) | | | (18,816) | |
+Gross profit | | 895 | | 1,337 | | | 2,834 | | | 4,690 | |
+Selling, general, and administrative expenses | | (408) | | (568) | | | (1,205) | | | (1,931) | |
+Amortization of acquired intangible assets | | (130) | | (147) | | | (246) | | | (558) | |
+Research and development expenses | | (38) | | (42) | | | (120) | | | (170) | |
+Restructuring, transaction and integration expenses, net | | (236) | | (36) | | | (307) | | | (298) | |
+Other income, net | | 4 | | 102 | | | 53 | | | 166 | |
+Operating income | | 87 | | 646 | | | 1,009 | | | 1,899 | |
+Interest expense, net | | (125) | | (150) | | | (347) | | | (610) | |
+Other non-operating income/(loss), net | | (9) | | (11) | | | (12) | | | (7) | |
+Income/loss before income taxes and equity in income/(loss) of affiliated companies | | (47) | | 485 | | | 650 | | | 1,282 | |
+Income tax expense | | 6 | | (97) | | | (135) | | | (181) | |
+Equity in income/(loss) of affiliated companies, net of tax | | 2 | | 1 | | | 3 | | | 5 | |
+Net income/(loss) | | (39) | | 389 | | | 518 | | | 1,106 | |
+Net income attributable to non-controlling interests | | — | | — | | | (7) | | | — | |
+Net income/(loss) attributable to Amcor plc | | (39) | | 389 | | | 511 | | | 1,106 | |
+USD:EUR average FX rate | | 0.8825 | | 0.8614 | | | 0.9203 | | | 0.8574 | |
+| | | | | | | |
+Basic earnings per share attributable to Amcor | | (0.10) | | 0.84 | | | 1.60 | | | 2.39 | |
+Diluted earnings per share attributable to Amcor | | (0.10) | | 0.83 | | | 1.60 | | | 2.38 | |
+Weighted average number of shares outstanding – Basic | | 406.9 | | 463.4 | | | 317.9 | | | 463.2 | |
+Weighted average number of shares outstanding – Diluted | | 408.0 | | 464.6 | | | 318.6 | | | 463.8 | |
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+7
+
+
+
+
+
+
+U.S. GAAP Condensed Consolidated Statements of Cash Flows (Unaudited) | | | | | | | | | | | | | | | | | | | | |
+| | Twelve Months Ended June 30, | |
+($ million) | | | 2025 | | 2026 | |
+Net income | | | 518 | | | 1,106 | | |
+Depreciation, amortization, and impairment | | | 722 | | | 1,479 | | |
+Net gain on disposal of businesses and investments | | | (8) | | | (54) | | |
+Changes in operating assets and liabilities, excluding effect of acquisitions, divestitures, and
+currency | | | (53) | | | (273) | | |
+Other non-cash items | | | 211 | | | (107) | | |
+Net cash provided by operating activities | | | 1,390 | | | 2,151 | | |
+Purchase of property, plant, and equipment and other intangible assets | | | (580) | | | (922) | | |
+Proceeds from sales of property, plant, and equipment and other intangible assets | | | 18 | | | 73 | | |
+Business acquisitions and Investments in affiliated companies, and other | | | (1,653) | | | (17) | | |
+Proceeds from divestitures | | | 113 | | | 272 | | |
+Proceeds from sale of affiliated companies and other investments | | | | | 70 | | |
+Net debt proceeds/(repayments) | | | 1,876 | | | (65) | | |
+Dividends paid | | | (845) | | | (1,195) | | |
+Share buy-back/cancellations | | | — | | | (1) | | |
+Purchase of treasury shares, proceeds from exercise of options and tax withholdings for share-based incentive plans | | | (107) | | | (65) | | |
+| | | | | | |
+Other, including effects of exchange rate on cash and cash equivalents | | | 27 | | | (13) | | |
+Net increase/decrease in cash and cash equivalents | | | 239 | | | 288 | | |
+Cash and cash equivalents at the beginning of the year | | | 588 | | | 827 | | |
+Cash and cash equivalents at the end of the year | | | 827 | | | 1,115 | | |
+
+
+
+
+
+U.S. GAAP Condensed Consolidated Balance Sheets (Unaudited) | | | | | | | | | | | | | | |
+($ million) | | June 30, 2025 | | June 30, 2026 |
+Cash and cash equivalents | | 827 | | | 1,115 | |
+Trade receivables, net | | 3,426 | | | 3,639 | |
+Inventories, net | | 3,471 | | | 3,672 | |
+| | | | |
+| | | | |
+Property, plant and equipment, net | | 8,202 | | | 7,409 | |
+Goodwill and other intangible assets, net | | 18,679 | | | 18,663 | |
+Other assets | | 2,461 | | | 2,597 | |
+Total assets | | 37,066 | | | 37,095 | |
+Trade payables | | 3,490 | | | 4,021 | |
+Short-term debt and current portion of long-term debt | | 257 | | | 150 | |
+Long-term debt, less current portion | | 13,841 | | | 13,862 | |
+| | | | |
+| | | | |
+Accruals and other liabilities | | 7,738 | | | 7,261 | |
+Shareholders' equity | | 11,740 | | | 11,801 | |
+Total liabilities and shareholders' equity | | 37,066 | | | 37,095 | |
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+8
+
+
+
+
+
+
+
+
+Components of Fiscal 2026 Net Sales growth
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30 | | Twelve Months Ended June 30 |
+($ million) | Global Flexible Packaging Solutions | Global Rigid Packaging Solutions | Total | | Global Flexible Packaging Solutions | Global Rigid Packaging Solutions | Total |
+Net sales fiscal year 2026 | 3,525 | | 2,873 | | 6,398 | | | 12,829 | | 10,677 | | 23,506 | |
+Net sales fiscal year 2025 | 2,994 | | 2,088 | | 5,082 | | | 10,066 | | 4,943 | | 15,009 | |
+Reported Growth % | 18 | | 38 | | 26 | | | 27 | | 116 | | 57 | |
+FX % | 2 | | 3 | | 2 | | | 3 | | 6 | | 5 | |
+Constant Currency Growth % | 16 | | 35 | | 24 | | | 24 | | 110 | | 52 | |
+Raw Material Pass Through % | 6 | | 4 | | 6 | | | 2 | | — | | 2 | |
+Items affecting comparability % | 10 | | 32 | | 19 | | | 22 | | 114 | | 52 | |
+| | | | | | | |
+| | | | | | | |
+Organic Growth % | — | | (1) | | (1) | | | — | | (4) | | (2) | |
+Volume % | 1 | | (1) | | — | | | (1) | | (3) | | (2) | |
+Price/Mix % | (1) | | — | | (1) | | | 1 | | (1) | | — | |
+| | | | | | | |
+| | | | | | | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+9
+
+
+
+
+
+
+
+
+
+Reconciliation of Non-GAAP Measures
+Reconciliation of adjusted Earnings before interest, tax, depreciation and amortization (EBITDA), Earnings before interest and tax (EBIT), Net income, Earnings per share (EPS) and Free Cash Flow
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, 2025 | | Three Months Ended June 30, 2026 |
+($ million) | | EBITDA | | EBIT | | Net Income | | EPS (Diluted) | | EBITDA | | EBIT | | Net Income | | EPS (Diluted) |
+Net income attributable to Amcor | | (39) | | | (39) | | | (39) | | | (0.10) | | | 389 | | | 389 | | | 389 | | | 0.83 | |
+Net income attributable to non-controlling interests | | — | | | — | | | | | | | — | | | — | | | | | |
+Tax expense | | (6) | | | (6) | | | | | | | 97 | | | 97 | | | | | |
+Interest expense, net | | 125 | | | 125 | | | | | | | 150 | | | 150 | | | | | |
+Depreciation and amortization | | 309 | | | | | | | | | 367 | | | | | | | |
+EBITDA, EBIT, Net income and EPS | | 389 | | | 80 | | | (39) | | | (0.10) | | | 1,003 | | | 636 | | | 389 | | | 0.83 | |
+Impact of hyperinflation | | 8 | | | 8 | | | 8 | | | 0.02 | | | 6 | | | 6 | | | 6 | | | 0.01 | |
+Restructuring, integration and related expenses, net (1)
+| | 53 | | | 53 | | | 53 | | | 0.13 | | | 24 | | | 36 | | | 36 | | | 0.08 | |
+Transaction costs | | 142 | | | 142 | | | 142 | | | 0.35 | | | — | | | — | | | — | | | — | |
+Merger related compensation | | 41 | | | 41 | | | 41 | | | 0.10 | | | — | | | — | | | — | | | — | |
+| | | | | | | | | | | | | | | | |
+Inventory step-up amortization | | 133 | | | 133 | | | 133 | | | 0.33 | | | — | | | — | | | — | | | — | |
+Other | | 24 | | | 24 | | | 24 | | | 0.06 | | | 12 | | | 12 | | | 12 | | | 0.03 | |
+Amortization of acquired intangibles (2)
+| | | | 130 | | | 130 | | | 0.32 | | | | | 147 | | | 147 | | | 0.32 | |
+Interest expense Berry Transaction | | | | | | 10 | | | 0.02 | | | | | | | — | | | — | |
+Tax effect of above items | | | | | | (94) | | | (0.23) | | | | | | | (20) | | | (0.04) | |
+Adjusted EBITDA, EBIT, Net income and EPS | | 789 | | | 611 | | | 408 | | | 1.00 | | | 1,045 | | | 836 | | | 570 | | | 1.23 | |
+| | | | | | | | | | | | | | | | |
+Reconciliation of adjusted growth to constant currency growth | | | | | | | | |
+% growth - Adjusted EBITDA, EBIT, Net income and EPS | | 32 | | | 37 | | | 40 | | | 23 | |
+% currency impact | | | | | | | | | | 2 | | | 3 | | | 4 | | | 3 | |
+% constant currency growth | | | | | | | | | | 30 | | | 34 | | | 36 | | | 20 | |
+| | | | | | | | |
+% items affecting comparability (3)
+| | | | | | | | | | 18 | | | 15 | | | | | |
+% from all other sources | | | | | | | | | | 12 | | | 19 | | | | | |
+Adjusted EBITDA | | 789 | | | | | | | | | 1,045 | | | | | | | |
+Interest paid, net | | (123) | | | | | | | | | (143) | | | | | | | |
+Income tax paid | | (138) | | | | | | | | | (70) | | | | | | | |
+Purchase of property, plant and equipment and other intangible assets | | (220) | | | | | | | | | (235) | | | | | | | |
+Proceeds from sales of property, plant and equipment and other intangible assets | | 9 | | | | | | | | | 35 | | | | | | | |
+Movement in working capital | | 744 | | | | | | | | | 849 | | | | | | | |
+Other | | (118) | | | | | | | | | (57) | | | | | | | |
+Adjusted Free Cash Flow | | 943 | | | | | | | | | 1,424 | | | | | | | |
+Berry transaction and integration costs | | | | | | | | | | (28) | | | | | | | |
+Free cash flow | | | | | | | | | | 1,396 | | | | | | | |
+
+(1) Three months ended June 30, 2026 primarily reflects restructuring and integration costs incurred in connection with the Berry Global acquisition.
+(2) Amortization of acquired intangible assets from business combinations.
+(3) Reflects the impact of acquired, disposed, and ceased operations.
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+10
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Twelve Months Ended June 30, 2025 | | Twelve Months Ended June 30, 2026 |
+($ million) | | EBITDA | | EBIT | | Net Income | | EPS (Diluted) | | EBITDA | | EBIT | | Net Income | | EPS (Diluted) (1)
+|
+Net income attributable to Amcor | | 511 | | | 511 | | | 511 | | | 1.60 | | | 1,106 | | | 1,106 | | | 1,106 | | | 2.38 | |
+Net income attributable to non-controlling interests | | 7 | | | 7 | | | | | | | — | | | — | | | | | |
+Tax expense | | 135 | | | 135 | | | | | | | 181 | | | 181 | | | | | |
+Interest expense, net | | 347 | | | 347 | | | | | | | 610 | | | 610 | | | | | |
+Depreciation and amortization | | 710 | | | | | | | | | 1,450 | | | | | | | |
+EBITDA, EBIT, Net income and EPS | | 1,710 | | | 1,000 | | | 511 | | | 1.60 | | 3,347 | | | 1,897 | | | 1,106 | | | 2.38 | |
+Impact of hyperinflation | | 16 | | | 16 | | | 16 | | | 0.05 | | | 19 | | | 19 | | | 19 | | | 0.04 | |
+Restructuring, integration and related expenses, net (2)
+| | 97 | | | 97 | | | 97 | | | 0.30 | | | 234 | | | 266 | | | 266 | | | 0.58 | |
+Transaction costs | | 169 | | | 169 | | | 169 | | | 0.53 | | | 32 | | | 32 | | | 32 | | | 0.07 | |
+Merger related compensation | | 41 | | | 41 | | | 41 | | | 0.13 | | | — | | | — | | | — | | | — | |
+Inventory step-up amortization | | 133 | | | 133 | | | 133 | | | 0.42 | | | — | | | — | | | — | | | — | |
+Other | | 21 | | | 21 | | | 21 | | | 0.07 | | | 41 | | | 41 | | | 41 | | | 0.09 | |
+Amortization of acquired intangibles (3)
+| | | | 246 | | | 246 | | | 0.77 | | | | | 558 | | | 558 | | | 1.20 | |
+Interest expense Berry Transaction | | | | | | 15 | | | 0.05 | | | | | | | 29 | | | 0.06 | |
+Tax effect of above items | | | | | | (113) | | | (0.35) | | | | | | | (188) | | | (0.40) | |
+Adjusted EBITDA, EBIT, Net income and EPS | | 2,186 | | | 1,723 | | | 1,136 | | | 3.56 | | | 3,673 | | | 2,813 | | | 1,863 | | | 4.02 | |
+| | | | | | | | | | | | | | | | |
+Reconciliation of adjusted growth to constant currency growth | | | | | | | | |
+% growth - Adjusted EBITDA, EBIT, Net income, and EPS | | | | | | 68 | | | 63 | | | 64 | | | 13 | |
+% currency impact | | | | | | | | | | 4 | | | 4 | | | 5 | | | 3 | |
+% constant currency growth | | | | | | | | | | 64 | | | 59 | | | 59 | | | 10 | |
+| | | | | | | | |
+% items affecting comparability (4)
+| | | | | | | | | | 56 | | | 49 | | | | | |
+% from all other sources | | | | | | | | | | 8 | | | 10 | | | | | |
+Adjusted EBITDA | | 2,186 | | | | | | | | | 3,673 | | | | | | | |
+Interest paid, net | | (290) | | | | | | | | | (549) | | | | | | | |
+Income tax paid | | (286) | | | | | | | | | (451) | | | | | | | |
+Purchase of property, plant and equipment and other intangible assets | | (580) | | | | | | | | | (922) | | | | | | | |
+Proceeds from sales of property, plant and equipment and other intangible assets | | 18 | | | | | | | | | 48 | | | | | | | |
+Movement in working capital | | 34 | | | | | | | | | (50) | | | | | | | |
+Other | | (156) | | | | | | | | | (156) | | | | | | | |
+Adjusted Free Cash Flow | | 926 | | | | | | | | | 1,593 | | | | | | | |
+Berry transaction and integration costs | | | | | | | | | | (290) | | | | | | | |
+Free cash flow | | | | | | | | | | 1,303 | | | | | | | |
+'
+( 1) Calculation of diluted EPS for the twelve months ended June 30, 2026 and 2025, excludes net income attributable to shares to be repurchased under forward contracts of $0 million and $1 million, respectively. Earnings per share amounts are computed independently for each of the quarters presented. The sum of the quarters may not equal the total year amount due to the impact of changes in average quarterly shares outstanding and due to rounding.
+(2) Twelve months ended June 30, 2026 primarily reflects restructuring and integration costs incurred in connection with the Berry Global acquisition.
+(3) Amortization of acquired intangible assets from business combinations.
+(4) Reflects the impact of acquired, disposed, and ceased operations.
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+11
+
+
+
+
+
+Reconciliation of adjusted EBIT by reporting segment
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30, 2025 | | Three Months Ended June 30, 2026 |
+($ million) | | Global Flexible Packaging Solutions | | Global Rigid Packaging Solutions | | Other | | Total | | Global Flexible Packaging Solutions | | Global Rigid Packaging Solutions | | Other | | Total |
+Net income attributable to Amcor | | | | | | | | (39) | | | | | | | | | 389 | |
+Net income attributable to non-controlling interests | | | | | | | | — | | | | | | | | | — | |
+Tax expense | | | | | | | | (6) | | | | | | | | | 97 | |
+Interest expense, net | | | | | | | | 125 | | | | | | | | | 150 | |
+EBIT | | 298 | | | 17 | | | (236) | | | 80 | | | 440 | | | 293 | | | (98) | | | 636 | |
+Impact of hyperinflation | | 1 | | | 7 | | | — | | | 8 | | | — | | | 6 | | | — | | | 6 | |
+Restructuring, integration and related expenses, net (1)
+| | 38 | | | 7 | | | 8 | | | 53 | | | 28 | | | 22 | | | (14) | | | 36 | |
+Transaction costs | | 9 | | | 3 | | | 130 | | | 142 | | | — | | | — | | | — | | | — | |
+Merger related compensation | | — | | | — | | | 41 | | | 41 | | | — | | | — | | | — | | | — | |
+Inventory step-up amortization | | 27 | | | 106 | | | — | | | 133 | | | — | | | — | | | — | | | — | |
+Other | | 1 | | | 12 | | | 11 | | | 24 | | | (10) | | | (41) | | | 63 | | | 12 | |
+Amortization of acquired intangibles (2)
+| | 61 | | | 67 | | | 2 | | | 130 | | | 75 | | | 72 | | | 1 | | | 147 | |
+Adjusted EBIT | | 435 | | | 219 | | | (43) | | | 611 | | | 533 | | | 352 | | | (48) | | | 836 | |
+Adjusted EBIT / sales % | | 14.5 | % | | 10.5 | % | | | | 12.0 | % | | 15.1 | % | | 12.3 | % | | | | 13.1 | % |
+Reconciliation of adjusted growth to constant currency growth | | | | | | | | |
+% growth - Adjusted EBIT | | | | | | | | | | 23 | | | 61 | | | — | | | 37 | |
+% currency impact | | | | | | | | | | 3 | | | 4 | | | — | | | 3 | |
+% constant currency | | | | | | | | | | 20 | | | 57 | | | — | | | 34 | |
+| | | | | | | | |
+% items affecting comparability (3)
+| | | | | | | | | | 7 | | | 24 | | | — | | | 15 | |
+% from all other sources | | | | | | | | | | 13 | | | 33 | | | — | | | 19 | |
+
+(1) Three months ended June 30, 2026 primarily reflects restructuring and integration costs incurred in connection with the Berry Global acquisition.
+(2) Amortization of acquired intangible assets from business combinations.
+(3) Reflects the impact of acquired, disposed, and ceased operations.
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+12
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Twelve Months Ended June 30, 2025 | | Twelve Months Ended June 30, 2026 |
+($ million) | | Global Flexible Packaging Solutions | | Global Rigid Packaging Solutions | | Other | | Total | | Global Flexible Packaging Solutions | | Global Rigid Packaging Solutions | | Other | | Total |
+Net income attributable to Amcor | | | | | | | | 511 | | | | | | | | | 1,106 | |
+Net income attributable to non-controlling interests | | | | | | | | 7 | | | | | | | | | — | |
+Tax expense | | | | | | | | 135 | | | | | | | | | 181 | |
+Interest expense, net | | | | | | | | 347 | | | | | | | | | 610 | |
+EBIT | | 1,113 | | | 229 | | | (342) | | | 1,000 | | | 1,373 | | | 817 | | | (294) | | | 1,897 | |
+Impact of hyperinflation | | 1 | | | 15 | | | — | | | 16 | | | 1 | | | 18 | | | — | | | 19 | |
+Restructuring, integration and related expenses, net (1)
+| | 68 | | | 12 | | | 17 | | | 97 | | | 106 | | | 120 | | | 40 | | | 266 | |
+Transaction costs | | 9 | | | 4 | | | 156 | | | 169 | | | 8 | | | 2 | | | 22 | | | 32 | |
+Merger related compensation | | — | | | — | | | 41 | | | 41 | | | — | | | — | | | — | | | — | |
+Inventory step-up amortization | | 27 | | | 106 | | | — | | | 133 | | | — | | | — | | | — | | | — | |
+Other | | 12 | | | (4) | | | 13 | | | 21 | | | — | | | (35) | | | 76 | | | 41 | |
+Amortization of acquired intangibles (2)
+| | 169 | | | 73 | | | 4 | | | 246 | | | 300 | | | 254 | | | 4 | | | 558 | |
+Adjusted EBIT | | 1,398 | | | 435 | | | (110) | | | 1,723 | | | 1,789 | | | 1,176 | | | (152) | | | 2,813 | |
+Adjusted EBIT / sales % | | 13.9 | % | | 8.8 | % | | | | 11.5 | % | | 13.9 | % | | 11.0 | % | | | | 12.0 | % |
+Reconciliation of adjusted growth to constant currency growth | | | | | | | | |
+% growth - Adjusted EBIT | | | | | | | | | | 28 | | | 170 | | | — | | | 63 | |
+% currency impact | | | | | | | | | | 2 | | | 9 | | | — | | | 4 | |
+% constant currency growth | | | | | | | | | | 26 | | | 161 | | | — | | | 59 | |
+| | | | | | | | |
+% items affecting comparability (3)
+| | | | | | | | | | 18 | | | 146 | | | — | | | 49 | |
+% from all other sources | | | | | | | | | | 8 | | | 15 | | | — | | | 10 | |
+
+(1) Twelve months ended June 30, 2026 primarily reflects restructuring and integration costs incurred in connection with the Berry Global acquisition.
+(2) Amortization of acquired intangible assets from business combinations.
+(3) Reflects the impact of acquired, disposed, and ceased operations.
+
+
+Reconciliation of net debt | | | | | | | | | | | | | | |
+($ million) | | June 30, 2025 | | June 30, 2026 |
+Cash and cash equivalents | | (827) | | | (1,115) | |
+Short-term debt | | 116 | | | 135 | |
+Current portion of long-term debt | | 141 | | | 15 | |
+Long-term debt excluding current portion | | 13,841 | | | 13,862 | |
+Net debt | | 13,271 | | | 12,897 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+13
+
+
+
+
+
+
+Cautionary Statement Regarding Forward-Looking Statements
+Unless otherwise indicated, references to "Amcor," the "Company," "we," "our," and "us" in this document refer to Amcor plc and its consolidated subsidiaries. This document contains certain statements that are "forward-looking statements" within the meaning of the safe harbor provisions of the U.S. Private Securities Litigation Reform Act of 1995. Forward-looking statements are generally identified with words like "believe," "expect," "target," "project," "may," "could," "would," "approximately," "possible," "will," "should," "intend," "plan," "anticipate," "commit," "estimate," "potential," "ambitions," "outlook," or "continue," the negative of these words, other terms of similar meaning, or the use of future dates. Such statements are based on the current expectations of the management of Amcor and are qualified by the inherent risks and uncertainties surrounding future expectations generally. Actual results could differ materially from those currently anticipated due to a number of risks and uncertainties. Neither Amcor nor any of its respective directors, executive officers, or advisors, provide any representation, assurance, or guarantee that the occurrence of the events expressed or implied in any forward-looking statements will actually occur or if any of them do occur, what impact they will have on the business, results of operations or financial condition of Amcor. Should any risks and uncertainties develop into actual events, these developments could have a material adverse effect on Amcor's business. Risks and uncertainties that could cause actual results to differ from expectations include, but are not limited to: changes in consumer demand patterns and customer requirements in numerous industries; risk of loss of key customers, a reduction in their production requirements, or consolidation among key customers; significant competition in the industries and regions in which we operate; risk of integrating acquisitions and achieving the financial and other results and benefits anticipated at the time of acquisition; risk that the strategic review of our portfolio may cause disruptions to our business or may not result in completion of a transaction to restructure or divest non-core businesses or may not create additional value for our shareholders; an inability to expand our current business effectively through either organic growth, including product innovation, investments, or acquisitions; challenging global economic conditions, including impacts from the Middle East conflict; impacts of operating internationally; price fluctuations or shortages in the availability of raw materials, energy and other inputs, which could adversely affect our business; production, supply, and other commercial risks, including those resulting from geopolitical conflicts and counterparty credit risks, which may be exacerbated in times of economic volatility; pandemics, epidemics, or other disease outbreaks; an inability to attract, develop, and retain our skilled workforce and manage key transitions; labor disputes and an inability to renew collective bargaining agreements at acceptable terms; physical impacts of climate change; significant disruption at a key manufacturing facility; cybersecurity risks, which could disrupt our operations or risk of loss of our sensitive business information; failures or disruptions in our information technology systems which could disrupt our operations, compromise customer, employee, supplier, and other data; risk that the use of artificial intelligence could adversely affect our business and financial results; risk that the Company's significant indebtedness may limit its flexibility and increase its borrowing costs; rising interest rates that increase our borrowing costs on our variable rate indebtedness and could have other negative impacts; foreign exchange rate risk; a significant write-down of goodwill and/or other intangible assets; a failure to maintain an effective system of internal control over financial reporting; an inability of our insurance policies, including our use of a captive insurance company, to provide adequate protection against all of the key operational risks we face; an inability to defend our intellectual property rights or intellectual property infringement claims against us; litigation, including product liability claims or litigation related to Environmental, Social, and Governance ("ESG") matters, or regulatory developments; increasing scrutiny and changing expectations from investors, customers, suppliers, and governments with respect to our ESG practices and commitments resulting in additional costs or exposure to additional risks; changing ESG government regulations including climate-related rules; changing environmental, health, and safety laws; changes in tax laws or changes in our geographic mix of earnings; and changes in trade policy, including tariff and custom regulations or failure to comply with such regulations. These risks and uncertainties are supplemented by those identified from time to time in our filings with the Securities and Exchange Commission (the "SEC"), including without limitation, those described under Part I, "Item 1A - Risk Factors" in our Annual Report on Form 10-K for the fiscal year ended June 30, 2025, and as updated by our quarterly reports on Form 10-Q. You can obtain copies of Amcor’s filings with the SEC for free at the SEC’s website (www.sec.gov). Forward-looking statements included herein are made only as of the date hereof and Amcor does not undertake any obligation to update any forward-looking statements, or any other information in this communication, as a result of new information, future developments or otherwise, or to correct any inaccuracies or omissions in them which become apparent, except as expressly required by law. All forward-looking statements in this comm unication are qualified in their entirety by this cautionary statement.
+
+
+Presentation of non-GAAP information
+Included in this release are measures of financial performance that are not calculated in accordance with U.S. GAAP. These measures include adjusted EBITDA and EBITDA (calculated as earnings before interest and tax and depreciation and amortization), adjusted EBIT and EBIT (calculated as earnings before interest and tax), adjusted net income, adjusted earnings per share, adjusted free cash flow, and net debt. In arriving at these non-GAAP measures, we exclude items that either have a non-recurring impact on the income statement or which, in the judgment of our management, are items that, either as a result of their nature or size, could, were they not singled out, potentially cause investors to extrapolate future performance from an improper base. Note that while amortization of acquired intangible assets is excluded from non-GAAP adjusted financial measures, the revenue of the acquired entities and all other expenses unless otherwise stated, are reflected in our non-GAAP financial performance earnings measures. While not all inclusive, examples of these items include: material restructuring programs, including associated costs such as employee severance, pension and related benefits, impairment of property and equipment and other assets, accelerated depreciation, termination payments for contracts and leases, contractual obligations, and any other qualifying costs related to restructuring plans; material sales and earnings from disposed or ceased operations and any associated profit or loss on sale of businesses or subsidiaries; changes in the fair value of economic hedging instruments on commercial paper and contingent purchase consideration; pension settlements; impairments in goodwill and equity method investments; material acquisition compensation and transaction costs such as due diligence expenses, professional and legal fees, financing-related expenses; and integration costs; material purchase accounting adjustments for inventory; amortization of acquired intangible assets from business combination; gains or losses on significant property and divestitures and significant property and other impairments, net of insurance recovery; certain regulatory and legal matters; impacts from highly inflationary accounting; expenses related to the Company's CEO and CFO transition; and impacts related to the Russia-Ukraine conflict and conflict in the Middle East.
+Amcor also evaluates performance on a comparable constant currency basis, which measures financial results assuming constant foreign currency exchange rates used for translation based on the average rates in effect for the comparable prior year period. In order to compute comparable constant currency results, we multiply or divide, as appropriate, current-year U.S. dollar results by the current year average foreign exchange rates and then multiply or divide, as appropriate, those amounts by the prior-year average foreign exchange rates. We then adjust for other items affecting comparability. While not all inclusive, examples of items affecting comparability include the difference between sales or earnings in the current period and the prior period related to disposed, or ceased operations. Comparable constant currency net sales performance also excludes the impact from passing through movements in raw material costs.
+Management has used and uses these measures internally for planning, forecasting and evaluating the performance of the Company’s reporting segments and certain of the measures are used as a component of Amcor’s Board of Directors’ measurement of Amcor’s performance for incentive compensation purposes. Amcor believes that these non-GAAP measures are useful to enable investors to perform comparisons of current and historical performance of the Company. For each of these non-GAAP financial measures, a reconciliation to the most directly comparable U.S. GAAP financial measure has been provided herein. These non-GAAP financial measures should not be construed as an alternative to results determined in accordance with U.S. GAAP. The Company's outlook and guidance do not contemplate the impact of any potential portfolio optimization actions, including acquisitions, divestitures, or other portfolio actions, that have not been publicly announced as of the date of this release. The Company provides guidance on a non-GAAP basis as we are unable to predict with reasonable certainty the ultimate outcome and timing of certain significant for ward-looking items without unreasonable effort. These items include but are not limited to the impact of foreign exchange translation, restructuring program costs, asset impairments, possible gains and losses on the sale of assets, certain tax related events, and difficulty in making accurate forecasts and
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+14
+
+
+
+
+
+projections in connection with the legacy Berry Global business given recency of access to all relevant information. These items are uncertain, depend on various factors, and could have a material impact on U.S. GAAP earnings and cash flow measures for the guidance period.
+Reconciliations of Transition Period projected non-GAAP measures are not included herein because the individual components are not known with certainty as individual financial statements for Transition Period have not been completed.
+
+
+Reverse Stock Split
+On January 14, 2026, the Company filed an amendment to its memorandum of association to effect a 1-for-5 reverse stock split (the “Reverse Split”) of the Company's ordinary shares. The Reverse Split became effective on January 14, 2026 and reduced the number of authorized ordinary shares to 1,800,000,000 and increased the par value of the ordinary shares to $0.05 per share. Accordingly, all share and per share amounts for all prior periods presented in the discussion within this release have been adjusted retroactively, where applicable, to reflect the Reverse Split.
+
+
+Presentation of combined volume performance
+In order to provide the most meaningful comparison of results of volume performance by region and end market for Amcor plc and for each of its reportable segments, the Company has included commentary to reflect Amcor’s estimate of year-over-year volume performance for the three and twelve months ended June 30, 2026 compared with estimated combined volumes for the legacy Amcor and Berry Global businesses for the three and twelve months ended June 30, 2025. The combined volume performance information has been presented for informational purposes and Amcor believes this information reflects the impact of the combination including allocation of volumes across the combined production footprint since May 1, 2025. For the avoidance of doubt, combined volume performance information is not intended to be, and was not, prepared on a basis consistent with pro forma financial information required by Article 11 of Regulation S-X.
+
+
+Dividends
+Amcor has received a waiver from the ASX’s settlement operating rules, which will allow the Company to defer processing conversions between its ordinary share and CDI registers from September 3, 2026 to September 4, 2026 inclusive.
+
+
+
+
+| | | | | | | | | | | |
+| | |
+|
+15

--- a/modules/test-fixtures/earnings-filings/beta.txt
+++ b/modules/test-fixtures/earnings-filings/beta.txt
@@ -1,0 +1,281 @@
+EX-99.1
+2
+a2026q2earningsrelease.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+BETA Technologies, Inc. Announces Second Quarter 2026 Results
+
+
+Delivered strong revenue growth and continued momentum across its commercial, defense and integrated aerospace platform.
+SOUTH BURLINGTON, Vt. – August 12, 2026 – BETA Technologies, Inc. (NYSE: BETA) (“BETA” or the “Company”), an aerospace and defense company, today announced its financial and operating results for the second quarter ended June 30, 2026.
+“This quarter showed that the investments made across the business continue to translate into real-world operations and delivered tangible results,” said Kyle Clark, founder and chief executive officer of BETA. “We became the first company to launch operations under the eVTOL Integration Pilot Program, demonstrated hybrid-electric flight at commercial altitude with GE Aerospace, unveiled the MV250 for defense applications, and continued to grow our backlog. Each of these milestones builds on the same integrated foundation: certification, operational experience, infrastructure, and vertically integration. Progress in one program strengthens the others, accelerating our ability to serve commercial and defense customers as we scale.”
+Business Highlights
+• Unveiled the MV250 Aircraft: Launched BETA’s first hybrid-electric autonomous vertical takeoff and landing aircraft at the Farnborough International Airshow. Built on BETA’s common platform, the MV250 combines autonomous operations with hybrid-electric propulsion developed alongside GE Aerospace, accelerating technologies that will benefit both defense and commercial aircraft maximizing the total addressable market.
+• Achieved World’s First High-Altitude Hybrid-Electric Flight: Collaborated with GE Aerospace, NASA, and Boeing through NASA’s Electrified Powertrain Flight Demonstration program to complete the first hybrid-electric flight above 30,000 feet, reaching the altitudes at which commercial passenger aircraft operate. In addition to supporting flight testing in the U.S., the aircraft was flown by BETA pilots to Farnborough and in the airshow, showing the viability of hybrid-electric propulsion for aviation.
+• Completed Industry’s First eIPP Flights: Launched the first operations under the U.S. Department of Transportation and Federal Aviation Administration’s (“FAA”) eVTOL Integration Pilot Program, with BETA operating its conventional takeoff and landing ALIA aircraft to transport manufactured organs with United Therapeutics utilizing the Company’s existing airport charging network. This milestone reinforces BETA’s leadership in Advanced Air Mobility through proven operational experience and close collaboration with the FAA.
+• Expanded Charging Infrastructure: Grew BETA’s network to 138 charging sites, while announcing the deployment of up to 250 charging sites, including airports and vertiports in California, Texas, Florida, and New York under the America’s Consortium for Electric Skyways (“ACES”) with Archer Aviation and Macquarie Capital. ACES reinforces BETA’s strategy of building the industry’s leading interoperable charging network while generating infrastructure revenue today.
+• Advanced Certification Across BETA’s Common Platform: Reached agreement with the FAA on the H500A’s continued-rotation compliance approach, completed durability and lightning-strike teardowns with strong results and substantially completed software requirements-based testing, with formal FAA testing underway. For the CX300, BETA closed the Requirements Definition phase, receiving FAA acceptance of the aircraft’s complete set of compliance requirements and creating meaningful carryover to the A250 program.
+1
+
+
+
+
+
+• Strengthened Commercial Backlog: Following successful cargo flight demonstrations completed across Scotland, Loganair signed a term sheet for five CX300 aircraft, with options for five additional aircraft. The order demonstrates BETA’s strategy of proving aircraft performance through real-world operations that convert directly into commercial demand.
+Financial Highlights
+• Q2 Revenues of $14.7 million
+• Q2 Net loss of ($148.8) million
+• Q2 Adjusted EBITDA of ($109.8) million
+Second Quarter 2026 Key Financial Metrics
+(in thousands)
+| | | | | | | | | |
+| Three Months Ended
+June 30, |
+| 2026 | | 2025 |
+Revenues | $ | 14,658 | | | $ | 5,966 | |
+Cost of revenues | 6,637 | | | 1,190 | |
+Gross margin | 8,021 | | | 4,776 | |
+Research and development | 122,365 | | | 58,035 | |
+General and administrative | 43,774 | | | 26,061 | |
+Total operating expenses | 166,139 | | | 84,096 | |
+Loss from operations | (158,118) | | | (79,320) | |
+Net loss
+| (148,753) | | | (80,416) | |
+Adjusted EBITDA (1)
+| (109,810) | | | (68,394) | |
+Capital expenditures (2)
+| 41,113 | | | 6,025 | |
+Cash and cash equivalents
+| 1,479,470 | | | 174,531 | |
+
+(1) In addition to results determined in accordance with U.S. generally accepted accounting principles (“GAAP”), this press release contains financial measures that are not calculated and presented in accordance with GAAP. See “Non-GAAP Financial Measures” for definitions of these non-GAAP financial measures. A reconciliation of the non-GAAP measures to their related GAAP measures can be found in the supplemental tables later in this press release.
+(2) Represents purchases of property and equipment.
+Revenues for the quarter ended June 30, 2026 were $14.7 million, compared to $6.0 million for the quarter ended June 30, 2025. Product revenues and service revenues were $3.3 million and $11.4 million, respectively.
+Operating expenses for the quarter ended June 30, 2026 were $166.1 million, including research and development expenses of $122.4 million. Non-cash warrant expense related to the collaborative arrangement with GE Aerospace of $5.7 million and in-process research and development (“IPR&D”) expense of $16.1 million related to an acquisition, were both embedded in research and development expenses in the quarter. Investments in research and development enable our certification programs and the further advancement of our enabling technologies.
+Net loss and Adjusted EBITDA for the quarter ended June 30, 2026 were ($148.8) million and ($109.8) million, respectively.
+Capital expenditures for the quarter ended June 30, 2026 were $41.1 million, compared to $6.0 million for the quarter ended June 30, 2025. Cash and cash equivalents totaled $1,479.5 million as of June 30, 2026,
+2
+
+
+
+
+
+compared to $174.5 million as of June 30, 2025, as a result of successful private financings and the proceeds from our IPO.
+Financial Outlook
+BETA increases our full year 2026 revenues to be in the range o f $42 million to $50 million and updates full year 2026 Adjusted EBITDA to be in the range of ($400) million to ($445) million.
+BETA has not reconciled our forward-looking Adjusted EBITDA guidance because certain items that impact this non-GAAP metric are uncertain or out of BETA’s control and cannot be reasonably predicted. In particular, stock-based compensation expense is impacted by the future fair market value of BETA’s Class A common stock, BETA’s future hiring needs, and other factors, all of which are difficult to predict, subject to frequent change, or not within BETA’s control. The actual amount of these expenses during 2026 could materially affect BETA’s future GAAP financial results. Accordingly, a reconciliation of this forward-looking non-GAAP metric is not available without unreasonable effort.
+Webcast and Conference Call Details
+BETA will host a live webcast and conference call at 8:30 am ET today to discuss the quarter’s financial and operating results. A link to the live webcast and supporting materials can be accessed on the Company’s Investor Relations website and a replay webcast will be available following the call. Participants may also join the conference call by registering on our Investors Relations website.
+Investors should note that BETA may use our website (investors.beta.team) and BETA’s company account on Instagram and LinkedIn as a means of disclosing information and for complying with BETA’s disclosure obligations under Regulation FD. The information BETA provides through these channels may be deemed material. Investors should monitor these channels in addition to reviewing BETA’s press releases, SEC filings, and public conference calls.
+About BETA Technologies, Inc.
+BETA (NYSE: BETA) is an aerospace and defense company designing, manufacturing and selling high-performance electric aircraft, advanced electric propulsion systems, components and charging systems to top operators worldwide. BETA has built and flown its family of ALIA aircraft, consisting of both conventional fixed-wing electric aircraft (the “ALIA CTOL”) and electric vertical takeoff and landing aircraft (the “ALIA VTOL”), more than 190,000 nautical miles, including multiple trips across the United States. BETA is deploying a network of charging infrastructure to enable the growing industry with more than 130 sites across the United States and internationally. BETA’s intentional approach to developing the enabling technologies necessary to electrify aviation unlocks lucrative aftermarket revenue opportunity over the life of each aircraft. These highly scalable enabling technologies allow BETA to serve a customer base across cargo and logistics, defense, passenger and medical end markets and unlock cost-effective and safe missions. Visit www.beta.team for more information about BETA and its products.
+Contacts
+Media:
+Nat Bol, external communications
+press@beta.team
+3
+
+
+
+
+
+Investor Relations:
+Devon Rothman, head of investor relations and FP&A
+investors@beta.team
+4
+
+
+
+
+
+Forward Looking Statements
+This press release and the accompanying earnings call contain forward-looking statements within the meaning of federal securities laws. Forward-looking statements are neither historical facts nor assurances of future performance. Instead, they are based only on our current beliefs, expectations and assumptions regarding the future of our business, future plans and strategies, projections, anticipated events and trends, the economy and other future conditions. Forward-looking statements can be identified by words such as: “anticipate,” “intend,” plan,” “goal,” “seek,” “believe,” “project,” “estimate,” “expect,” “strategy,” “future,” “likely,” “may,” “should,” “will” and similar references to future periods. Examples of forward-looking statements include, among others, statements we make regarding our future financial and operating performance, including our outlook and guidance; our regulatory outlook, progress and timing; our business strategy, plan, objectives, and goals; capital needs and the growth of our operations, manufacturing capabilities, and supporting infrastructure for aircraft development and deployment; plans and anticipated benefits with respect to our collaborations with third parties, and projected demand for our aircraft, other products, and services.
+Because forward-looking statements relate to the future, they are subject to inherent uncertainties, risks and changes in circumstances that are difficult to predict and many of which are outside of our control. Our actual results and financial condition may differ materially from those indicated in the forward-looking statements. Therefore, you should not rely on any of these forward-looking statements. Important factors that could cause our actual results and financial condition to differ materially from those indicated in the forward-looking statements include, among others, factors described throughout the “Risk Factors” and “Management’s Discussion and Analysis of Financial Condition and Results of Operations” sections of our Annual Report on Form 10-K for the year ended December 31, 2025 filed with the Securities and Exchange Commission (the “SEC”) on March 9, 2026, as such descriptions may be updated or amended by the factors that will be included in the future reports we file with the SEC. Moreover, we operate in a very competitive and rapidly changing environment, and new risks and uncertainties may emerge that could have an impact on the forward-looking statements contained in this press release and the accompanying earnings call.
+Any forward-looking statement made by us in this press release and the accompanying earnings call is based only on information currently available to us and speaks only as of the date on which it is made. We undertake no obligation to publicly update any forward-looking statement whether as a result of new information, future developments or otherwise.
+Non-GAAP Financial Measures
+In addition to traditional financial metrics, we use EBITDA and Adjusted EBITDA to help us evaluate our business.
+We define EBITDA as net loss adjusted for interest income, interest expense, provision for income taxes, and depreciation and amortization. We define Adjusted EBITDA as EBITDA adjusted for stock-based compensation, warrant expense, acquisition-related expense, loss on disposal of property and equipment, and IPO costs.
+We believe that these non-GAAP measures provide useful information to investors because they allow for greater transparency into what measures we use in operating our business and measuring our performance and enable comparison of financial trends and results between periods where items may vary independent of business performance. These non-GAAP measures are presented for supplemental informational purposes and should not be considered as substitutes for or superior to financial information presented in accordance with GAAP. The principal limitation of these non-GAAP financial measures is that they
+5
+
+
+
+
+
+exclude certain expenses that are required by GAAP to be recorded in our financial statements and they are subject to inherent limitations as they reflect the exercise of judgment by our management about which expenses are excluded or included in determining these non-GAAP financial measures. Further, non-GAAP financial measures are not standardized. It may not be possible to compare these financial measures with other companies’ non-GAAP financial measures having the same or similar names. Investors are encouraged to review the related GAAP financial measures and the reconciliation of these non-GAAP financial measures to their most directly comparable GAAP financial measures. In addition, investors are encouraged to review our consolidated financial statements included in our filings with the SEC in their entirety and not rely solely on any single financial measure.
+We caution readers that our definitions of these non-GAAP financial measures may not be calculated in the same manner as similar measures used by other companies. Reconciliations of the non-GAAP financial measures to their most comparable GAAP financial measures are included in the supplemental tables attached to this press release.
+
+
+6
+
+
+
+
+
+
+BETA Technologies, Inc.
+Condensed Consolidated Statements of Operations
+(in thousands, except per share amounts)
+| | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | Six Months Ended
+June 30, |
+| 2026 | | 2025 | 2026 | 2025 |
+Revenues: | | | | | |
+Product
+| $ | 3,280 | | | $ | 2,544 | | $ | 4,243 | | $ | 5,032 | |
+Service
+| 11,378 | | | 3,422 | | 20,548 | | 10,533 | |
+| 14,658 | | | 5,966 | | 24,791 | | 15,565 | |
+Cost of revenues: | | | | | |
+Product
+| 1,661 | | | 62 | | 2,257 | | 595 | |
+Service
+| 4,976 | | | 1,128 | | 8,681 | | 2,333 | |
+| 6,637 | | | 1,190 | | 10,938 | | 2,928 | |
+Gross margin:
+| | | | | |
+Product
+| 1,619 | | | 2,482 | | 1,986 | | 4,437 | |
+Service
+| 6,402 | | | 2,294 | | 11,867 | | 8,200 | |
+| 8,021 | | | 4,776 | | 13,853 | | 12,637 | |
+Operating expenses:
+| | | | | |
+Research and development
+| 122,365 | | | 58,035 | | 214,104 | | 115,899 | |
+General and administrative
+| 43,774 | | | 26,061 | | 90,824 | | 54,075 | |
+Total operating expenses
+| 166,139 | | | 84,096 | | 304,928 | | 169,974 | |
+Loss from operations
+| (158,118) | | | (79,320) | | (291,075) | | (157,337) | |
+Other (income) expense:
+| | | | | |
+Interest income
+| (13,293) | | | (2,023) | | (27,774) | | (4,720) | |
+Interest expense
+| 3,661 | | | 2,890 | | 7,278 | | 5,750 | |
+| | | | | |
+Total other (income) expense
+| (9,632) | | | 867 | | (20,496) | | 1,030 | |
+Loss before income taxes
+| (148,486) | | | (80,187) | | (270,579) | | (158,367) | |
+Provision for income taxes
+| 267 | | | 229 | | 483 | | 327 | |
+Net loss
+| (148,753) | | | (80,416) | | (271,062) | | (158,694) | |
+Convertible preferred stock paid-in-kind dividend
+| — | | | 12,376 | | - | | 24,540 | |
+Net loss attributable to common stockholders
+| $ | (148,753) | | | $ | (92,792) | | $ | (271,062) | | $ | (183,234) | |
+Net loss per share attributable to common stockholders, basic and diluted | $ | (0.64) | | | $ | (2.02) | | $ | (1.17) | | $ | (4.01) | |
+
+7
+
+
+
+
+
+
+BETA Technologies, Inc.
+Condensed Consolidated Balance Sheets
+(in thousands)
+| | | | | | | | | |
+| June 30, 2026 | | December 31, 2025 |
+Assets
+| | | |
+Current assets:
+| | | |
+Cash and cash equivalents
+| $ | 1,479,470 | | | $ | 1,710,227 | |
+Accounts receivable
+| 3,609 | | | 5,747 | |
+Prepaid expenses and other current assets
+| 20,545 | | | 23,494 | |
+Total current assets
+| 1,503,624 | | | 1,739,468 | |
+Property and equipment, net
+| 402,753 | | | 348,540 | |
+Operating lease right-of-use assets
+| 20,675 | | | 16,417 | |
+Other assets
+| 6,400 | | | 1,840 | |
+Total assets
+| $ | 1,933,452 | | | $ | 2,106,265 | |
+Liabilities and stockholders’ equity
+| | | |
+Current liabilities:
+| | | |
+Accounts payable
+| $ | 22,808 | | | $ | 24,503 | |
+Accrued expenses | 43,606 | | | 35,109 | |
+Payroll liabilities | 16,344 | | | 3,334 | |
+Deferred revenue
+| 7,015 | | | 3,704 | |
+Operating lease liabilities
+| 1,859 | | | 1,551 | |
+Notes payable
+| 8,547 | | | 5,711 | |
+Other current liabilities
+| 3,728 | | | 2,483 | |
+Total current liabilities
+| 103,907 | | | 76,395 | |
+Deferred revenue, non-current
+| 14,879 | | | 12,550 | |
+Operating lease liabilities, non-current
+| 20,885 | | | 16,838 | |
+Notes payable, non-current
+| 175,405 | | | 179,799 | |
+Other liabilities
+| 3,199 | | | 2,847 | |
+Total liabilities
+| 318,275 | | | 288,429 | |
+Total stockholders’ equity (1)
+| 1,615,177 | | | 1,817,836 | |
+Total liabilities and stockholders’ equity
+| $ | 1,933,452 | | | $ | 2,106,265 | |
+
+(1) Includes all components of stockholders’ equity, as presented in the Company’s Quarterly Report on Form 10-Q for the three months ended June 30, 2026.
+8
+
+
+
+
+
+
+BETA Technologies, Inc.
+Non-GAAP EBITDA and Adjusted EBITDA Reconciliation
+(in thousands)
+| | | | | | | | | | | | | | | | | |
+| Three Months Ended
+June 30, | Six Months Ended
+June 30, |
+| 2026 | | 2025 | 2026 | 2025 |
+Net loss | $ | (148,753) | | | $ | (80,416) | | $ | (271,062) | | $ | (158,694) | |
+Increase (decrease) as adjusted for: | | | | | |
+Interest income | (13,293) | | | (2,023) | | (27,774) | | (4,720) | |
+Interest expense | 3,661 | | | 2,890 | | 7,278 | | 5,750 | |
+Provision for income taxes | 267 | | | 229 | | 483 | | 327 | |
+Depreciation and amortization | 6,322 | | | 5,399 | | 12,473 | | 10,520 | |
+EBITDA | $ | (151,796) | | | $ | (73,921) | | $ | (278,602) | | $ | (146,817) | |
+| | | | | |
+Stock-based compensation | 14,674 | | | 4,307 | | 38,090 | | 11,614 | |
+Warrant expense | 5,697 | | | — | | 11,331 | | — | |
+Acquisition-related expense (1)
+| 16,147 | | | — | | 16,147 | | — | |
+Loss on disposal of property and equipment | 5,411 | | | 670 | | 5,742 | | 1,541 | |
+IPO costs (2)
+| 57 | | | 550 | | 236 | | 550 | |
+Adjusted EBITDA | $ | (109,810) | | | $ | (68,394) | | $ | (207,056) | | $ | (133,112) | |
+
+(1) Includes acquired IPR&D expense of $15.0 million and direct transaction costs of $1.1 million.
+(2) Represents accounting and advisory expenses incurred in connection with becoming and operating as a public company.
+9

--- a/modules/test-fixtures/earnings-filings/lqda.txt
+++ b/modules/test-fixtures/earnings-filings/lqda.txt
@@ -1,0 +1,854 @@
+EX-99.1
+2
+tm2622888d1_ex99-1.htm
+EXHIBIT 99.1
+
+
+
+
+
+
+
+
+
+
+Exhibit 99.1
+
+
+
+
+
+Liquidia Corporation Reports Second Quarter
+2026 Financial Results
+
+
+
+
+
+
+| &middot; | YUTREPIA&reg;
+(treprostinil) inhalation powder net product sales of approximately $170.4 million in the
+second quarter of 2026, up 31% from the first quarter of 2026 |
+
+
+
+
+
+
+| &middot; | Approximately 5,900 unique
+patient prescriptions and more than 5,000 patients treated between launch in June 2025
+and July 31, 2026 |
+
+
+
+
+
+
+| &middot; | Recorded fourth consecutive
+quarter of increasing profitability, with net income of $74.7 million, adjusted EBITDA of
+$96.3 million and an increase in cash and cash equivalents of $61.4 million compared to the
+first quarter of 2026 |
+
+
+
+
+
+
+| &middot; | Progressing 10 clinical
+studies supporting YUTREPIA and L606 across known and new indications for inhaled treprostinil |
+
+
+
+
+
+MORRISVILLE,
+N.C., August 12, 2026 &ndash; Liquidia Corporation (NASDAQ: LQDA), a biopharmaceutical company driven by science
+and compassion to revolutionize care for patients with challenging respiratory and vascular diseases, today reported financial results
+for the second quarter ended June 30, 2026. The company will also host a webcast at 8:30 a.m. ET on August 12, 2026, to
+discuss its financial results and provide a corporate update.
+
+
+
+
+
+Dr. Roger Jeffs, Liquidia&rsquo;s Chief
+Executive Officer, said: &ldquo;We are pleased by the sustained adoption of YUTREPIA as the inhaled prostacyclin of choice. The inhaled
+category has grown almost 40% since launch, and YUTREPIA has captured an ever-increasing share of that growth. We are building on that
+momentum by strengthening the clinical evidence for YUTREPIA in PAH and PH-ILD patients transitioning from other therapies, and advancing
+studies in new indications that may broaden its impact. Having reset the bar for tolerability and dose flexibility with YUTREPIA, we
+are excited to have begun site activation and enrollment in Re-Spire, our pivotal study for L606, which we believe can raise that bar
+even further, beyond any therapy currently available or in development.&rdquo;
+
+
+
+
+
+YUTREPIA Commercial Launch Highlights
+(as of July 31, 2026)
+
+
+
+
+
+
+| &middot; | Received approximately
+5,900 unique patient prescriptions since launch in June 2025 |
+
+
+
+
+
+
+| &middot; | Started more than 5,000
+patients on treatment since launch in June 2025 |
+
+
+
+
+
+
+| &middot; | Prescription-to-start conversion
+remained strong above the 85% level as previously reported |
+
+
+
+
+
+
+| &middot; | Increased total number
+of prescribers to more than 1,100 since launch, of which more than 30% have prescribed YUTREPIA
+to at least 5 patients |
+
+
+
+
+
+Second Quarter 2026 Financial Results
+
+
+
+
+
+YUTREPIA sales led to the company&rsquo;s fourth consecutive quarter
+of increasing profitability with net income of $74.7 million and positive non-GAAP adjusted EBITDA of $96.3 million in the second
+quarter of 2026.
+
+
+
+
+
+Cash and
+cash equivalents totaled $284.2 million as of June 30, 2026, compared to $190.7 million as of December 31,
+2025.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Product
+sales, net, were $170.4 million for the three months ended June 30, 2026, compared to $6.5 million for the three months
+ended June 30, 2025. We began shipping YUTREPIA to our customers in the United States in June 2025, following receipt of full
+FDA approval for YUTREPIA on May 23, 2025. The increase of $163.9 million was due to higher volume of YUTREPIA sales.
+
+
+
+
+
+Service
+revenue, net, was $1.3 million for the three months ended June 30, 2026, compared to $2.3 million for the three months
+ended June 30, 2025. Service revenue, net was related to the promotion agreement with Sandoz, Inc. pursuant
+to which we share profits from the sale of Treprostinil Injection in the United States. The decrease of $1.0 million was primarily
+due to the impact of unfavorable gross-to-net adjustments.
+
+
+
+
+
+Cost of
+product sales was $10.8 million for the three months ended June 30, 2026, compared to $0.2 million for the three months
+ended June 30, 2025. Cost of product sales is related to sales of YUTREPIA. The increase of $10.6 million was primarily due to higher
+volume of YUTREPIA sales.
+
+
+
+
+
+Research
+and development expenses were $17.2 million for the three months ended June 30, 2026, compared to $6.0 million for the
+three months ended June 30, 2025. The increase of $11.2 million or 185% was primarily due to a $7.0 million increase in expenses
+for our L606 program, a $2.0 million increase in expenses related to our YUTREPIA research and development activities, a $0.9 million
+increase in personnel expenses driven by higher headcount, and a $1.0 million L606 development milestone recognized during the second
+quarter of 2026.
+
+
+
+
+
+Selling,
+general and administrative expenses were $57.4 million for the three months ended June 30, 2026, compared to $38.8 million
+for the three months ended June 30, 2025. The increase of $18.6 million or 48% was primarily due to a $10.0 million increase in
+personnel expenses and a $3.1 million increase in stock-based compensation driven by higher headcount, and an $8.6 million increase in
+commercial and consulting expenses to support the commercialization of YUTREPIA. These increases were partially offset by a $5.5 million
+decrease in legal fees related to our ongoing YUTREPIA-related litigation.
+
+
+
+
+
+Total
+other expenses, net was $3.8 million for the three months ended June 30, 2026, compared to $4.1 million for the three
+months ended June 30, 2025. The decrease of $0.3 million was primarily attributable to higher money market balances offset by higher
+borrowings under our revenue interest financing agreement with HealthCare Royalty Partners IV, L.P.
+
+
+
+
+
+Income
+tax expense was $7.0 million for the three months ended June 30, 2026. We did not recognize any income tax expense during
+the three months ended June 30, 2025.
+
+
+
+
+
+Net income
+for the three months ended June 30, 2026, was $74.7 million, or $0.84 per basic and $0.74 per diluted share, as compared
+to a net loss of $41.6 million, or $0.49 per basic and diluted share, for the three months ended June 30, 2025.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Webcast Information
+
+
+
+
+
+Liquidia
+will host a live webcast at 8:30 a.m. Eastern Time on August 12, 2026, to discuss the second quarter 2026 financial
+results and corporate update. The webcast will be available on Liquidia&rsquo;s website at https://liquidia.com/investors/events-and-presentations .
+A rebroadcast of the event will be available and archived for a period of one year at the same location.
+
+
+
+
+
+About
+YUTREPIA&reg; (treprostinil) Inhalation Powder
+
+
+
+
+
+YUTREPIA is an inhaled dry-powder formulation of treprostinil delivered
+through a convenient, low-effort, palm-sized device. YUTREPIA is indicated for the treatment of PAH and PH-ILD to improve exercise ability.
+YUTREPIA was designed using Liquidia&rsquo;s PRINT&reg; technology, which enables the development of drug particles that are precise
+and uniform in size, shape and composition, and that are engineered for enhanced deposition in the lung following oral inhalation. YUTREPIA
+was previously referred to as LIQ861 in investigational studies.
+
+
+
+
+
+
+
+About L606 (liposomal treprostinil inhalation suspension)
+
+
+
+
+
+L606 is an investigational, extended-release
+formulation of treprostinil administered twice-daily with a next-generation nebulizer. The L606 suspension uses a proprietary liposomal
+formulation to encapsulate treprostinil which can be released slowly at a controlled rate into the lung, enhancing drug exposure over
+an extended period of time. L606 is currently being evaluated in an open-label study in the United States for treatment of
+PAH and PH-ILD and is the subject of Re-Spire, a global pivotal placebo-controlled efficacy study for the treatment of PH-ILD.
+
+
+
+
+
+About Treprostinil Injection
+
+
+
+
+
+Treprostinil Injection is the first-to-file,
+fully substitutable generic treprostinil for parenteral administration. Treprostinil Injection contains the same active ingredient, same
+strengths, same dosage form and same inactive ingredients as Remodulin&reg; (treprostinil) and is offered to patients and physicians
+with the same level of service and support, but at a lower price than the branded drug. Liquidia PAH promotes the appropriate use of
+Treprostinil Injection for the treatment of PAH in the United States in partnership with its commercial partner, Sandoz, who holds the
+Abbreviated New Drug Application (ANDA) with the FDA.
+
+
+
+
+
+About
+Pulmonary Arterial Hypertension (PAH)
+
+
+
+
+
+PAH is a rare, chronic, progressive disease
+caused by hardening and narrowing of the pulmonary arteries that can lead to right heart failure and eventually death. Currently, an
+estimated 45,000 patients are diagnosed and treated in the United States. There is currently no cure for PAH, so the goals
+of existing treatments are to alleviate symptoms, maintain or improve functional class, delay disease progression and improve quality
+of life.
+
+
+
+
+
+About
+Pulmonary Hypertension Associated with Interstitial Lung Disease (PH-ILD)
+
+
+
+
+
+PH-ILD includes a diverse collection of up
+to 150 different pulmonary diseases, including interstitial pulmonary fibrosis, chronic hypersensitivity pneumonitis, connective tissue
+disease-related ILD, and chronic pulmonary fibrosis with emphysema (CPFE) among others. Any level of PH in ILD patients is associated
+with poor 3-year survival. A current estimate of PH-ILD prevalence in the United States is greater than 60,000 patients, though
+actual prevalence in many of these underlying ILD diseases is not yet known due to factors including underdiagnosis and lack of approved
+treatments until March 2021 when inhaled treprostinil was first approved for this indication.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+About Liquidia
+Corporation
+
+
+
+
+
+Liquidia Corporation is a biopharmaceutical company driven by science
+and compassion to revolutionize care for patients with challenging respiratory and vascular diseases through precise, innovative therapies
+and applications of its proprietary PRINT&reg; technology. PRINT enabled the development of YUTREPIA&reg; (treprostinil) inhalation powder
+for the treatment of PAH and PH-ILD. The company is also developing L606, an investigational extended-release formulation of treprostinil
+administered twice-daily with a next-generation nebulizer, and currently markets generic Treprostinil Injection for the treatment of
+PAH. To learn more about Liquidia, please visit www.liquidia.com .
+
+
+
+
+
+Abbreviations
+
+
+
+
+
+1. PAH: pulmonary arterial hypertension. 2. PH-ILD: pulmonary hypertension
+associated with interstitial lung disease.
+
+
+
+
+
+Remodulin&reg;
+is a registered mark of United Therapeutics Corporation.
+
+
+
+
+
+Cautionary
+Statements Regarding Forward-Looking Statements
+
+
+
+
+
+This press release may include forward-looking
+statements within the meaning of the Private Securities Litigation Reform Act of 1995. All statements contained in this press release
+other than statements of historical facts, including statements regarding our future results of operations and financial position, our
+strategic and financial initiatives, our business strategy and plans and our objectives for future operations, are forward-looking statements.
+
+
+
+
+
+Forward-looking statements, including statements
+regarding clinical trials, clinical studies and other clinical work (including the funding therefor, anticipated patient enrollment,
+safety data, study data, trial outcomes, timing or associated costs), regulatory applications and related submission contents and timelines,
+the timelines or outcomes related to patent litigation with United Therapeutics in the U.S. District Court for the District of Delaware
+and U.S. District Court for the Middle District of North Carolina, or other litigation between Liquidia and United Therapeutics or others,
+including rehearings or appeals of decisions in any such proceedings, the issuance of patents by the USPTO and our ability to execute
+on our strategic or financial initiatives, our estimates regarding future expenses, capital requirements and needs for additional financing,
+and potential revenue and profitability of YUTREPIA involve significant risks and uncertainties and actual results could differ materially
+from those expressed or implied herein. Our ability to maintain YUTREPIA&rsquo;s approval and to continue commercialization of YUTREPIA
+remain subject to ongoing litigation in which United Therapeutics is seeking injunctive relief, which could block our ability to continue
+to sell YUTREPIA for one or both of PAH and PH-ILD. The words &ldquo;anticipate,&rdquo; &ldquo;believe,&rdquo; &ldquo;continue,&rdquo;
+&ldquo;could,&rdquo; &ldquo;estimate,&rdquo; &ldquo;expect,&rdquo; &ldquo;intend,&rdquo; &ldquo;may,&rdquo; &ldquo;plan,&rdquo; &ldquo;potential,&rdquo;
+&ldquo;predict,&rdquo; &ldquo;project,&rdquo; &ldquo;should,&rdquo; &ldquo;target,&rdquo; &ldquo;would,&rdquo; and similar expressions
+are intended to identify forward-looking statements. We have based these forward-looking statements largely on our current expectations
+and projections about future events and financial trends that we believe may affect our financial condition, results of operations, business
+strategy, short-term and long-term business operations and objectives and financial needs. These forward-looking statements are subject
+to a number of risks discussed in our filings with the SEC, as well as a number of uncertainties and assumptions. Moreover, we operate
+in a very competitive and rapidly changing environment and our industry has inherent risks. New risks emerge from time to time. It is
+not possible for our management to predict all risks, nor can we assess the impact of all factors on our business or the extent to which
+any factor, or combination of factors, may cause actual results to differ materially from those contained in any forward-looking statements
+we may make. In light of these risks, uncertainties and assumptions, the future events discussed in this press release may not occur
+and actual results could differ materially and adversely from those anticipated or implied in the forward-looking statements. Nothing
+in this press release should be regarded as a representation by any person that these goals will be achieved, and we undertake no duty
+to update our goals or to update or alter any forward-looking statements, whether as a result of new information, future events or otherwise.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Use of Non-GAAP Financial Information
+
+
+
+
+
+This press release and the accompanying tables
+include U.S. Generally Accepted Accounting Principles (GAAP) and non-GAAP financial measures. For a description of such non-GAAP financial
+measures, including the reasons for using such measures, and reconciliations of such non-GAAP financial measures to the most directly
+comparable financial measures prepared in accordance with GAAP, please see the section entitled &ldquo;About Non-GAAP Financial Information&rdquo;
+below.
+
+
+
+
+
+Contact Information
+
+
+
+
+
+Investors:
+
+
+Jason Adair
+
+Chief Business Officer
+
+919.328.4350
+
+Jason.adair@liquidia.com
+
+
+
+
+
+Media:
+
+media@liquidia.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liquidia Corporation
+
+Select Consolidated Balance Sheet Data
+
+(in thousands)
+
+
+
+
+
+
+
+| |
+June 30, | | |
+December 31, | |
+
+
+| |
+2026 | | |
+2025 | |
+
+
+Cash and cash equivalents | |
+$ | 284,181 | | |
+$ | 190,680 | |
+
+
+Total assets | |
+$ | 521,918 | | |
+$ | 327,934 | |
+
+
+Total liabilities | |
+$ | 326,804 | | |
+$ | 283,186 | |
+
+
+Accumulated deficit | |
+$ | (498,729 | ) | |
+$ | (626,313 | ) |
+
+
+Total stockholders&rsquo; equity | |
+$ | 195,114 | | |
+$ | 44,748 | |
+
+
+
+
+
+
+Liquidia Corporation
+
+Consolidated Statements of Operations and Comprehensive Income (Loss)
+
+(unaudited)
+
+
+(in thousands, except share and per share amounts)
+
+
+
+
+
+
+
+| |
+Three Months
+Ended June 30, | |
+
+
+| |
+2026 | | |
+2025 | |
+
+
+Revenues: | |
+| | |
+| |
+
+
+Product sales, net | |
+$ | 170,382 | | |
+$ | 6,517 | |
+
+
+Service revenue,
+net | |
+| 1,297 | | |
+| 2,320 | |
+
+
+Total revenue | |
+| 171,679 | | |
+| 8,837 | |
+
+
+Costs and expenses: | |
+| | | |
+| | |
+
+
+Cost of product sales | |
+| 10,759 | | |
+| 205 | |
+
+
+Cost of service revenue | |
+| 791 | | |
+| 1,292 | |
+
+
+Research and development | |
+| 17,184 | | |
+| 6,021 | |
+
+
+Selling,
+general and administrative | |
+| 57,428 | | |
+| 38,824 | |
+
+
+Total costs and expenses | |
+| 86,162 | | |
+| 46,342 | |
+
+
+Income (loss) from operations | |
+| 85,517 | | |
+| (37,505 | ) |
+
+
+Other income (expense): | |
+| | | |
+| | |
+
+
+Interest income | |
+| 2,476 | | |
+| 1,584 | |
+
+
+Interest
+expense | |
+| (6,296 | ) | |
+| (5,658 | ) |
+
+
+Total other
+expense, net | |
+| (3,820 | ) | |
+| (4,074 | ) |
+
+
+Income (loss) before income taxes | |
+| 81,697 | | |
+| (41,579 | ) |
+
+
+Income tax
+expense | |
+| 6,975 | | |
+| &mdash; | |
+
+
+Net income (loss) and comprehensive
+income (loss) | |
+$ | 74,722 | | |
+$ | (41,579 | ) |
+
+
+Net income (loss) per common share,
+basic | |
+$ | 0.84 | | |
+$ | (0.49 | ) |
+
+
+Net income (loss) per common share,
+diluted | |
+$ | 0.74 | | |
+$ | (0.49 | ) |
+
+
+Weighted average common shares outstanding, basic | |
+| 88,887,744 | | |
+| 85,588,108 | |
+
+
+Weighted average common shares outstanding, diluted | |
+| 101,397,028 | | |
+| 85,588,108 | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+About Non-GAAP Financial Information
+
+
+
+
+
+To supplement our financial results presented in accordance with U.S.
+Generally Accepted Accounting Principles (GAAP), this press release includes certain non-GAAP financial measures, such as Adjusted EBITDA.
+We believe the use of such non-GAAP financial measures provides investors with additional insight into our operational performance. While
+we compute non-GAAP financial measures using a consistent method from quarter to quarter and year to year, we may consider whether other
+significant items that arise in the future should be excluded from our non-GAAP financial measures.
+
+
+
+
+
+Adjusted EBITDA is a non-GAAP measure that represents net
+income for the period before the impact of interest income, interest expense, other income and expense, income taxes, depreciation and
+amortization, and certain items that impact comparison of the performance of our business either period-over-period or with other businesses.
+
+
+
+
+
+Adjusted EBITDA should not be considered in isolation or as a substitute
+to net income or any other measure of financial performance calculated and presented in accordance with GAAP. Our calculation of
+Adjusted EBITDA may not be comparable to similarly titled measures of other companies because other companies may not calculate them
+in the same manner as we calculate these measures.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+For a reconciliation
+of such non-GAAP financial measures to the most directly comparable financial measures prepared in accordance with GAAP, please see the
+table titled &ldquo; Reconciliation of Non-GAAP Financial Information&rdquo; below.
+
+
+
+
+
+Liquidia Corporation
+
+
+Reconciliation
+of Non- GAAP Financial Information
+
+
+Reconciliation of Net Income (Loss) to Adjusted EBITDA
+
+
+(unaudited)
+
+(in thousands)
+
+
+
+
+
+
+
+| |
+Three Months Ended | |
+
+
+| |
+June 30, | |
+
+
+| |
+2026 | |
+
+
+Net income | |
+$ | 74,722 | |
+
+
+Interest expense, net | |
+| 3,820 | |
+
+
+Income tax expense | |
+| 6,975 | |
+
+
+Depreciation and amortization | |
+| 400 | |
+
+
+EBITDA | |
+$ | 85,917 | |
+
+
+Stock-based compensation | |
+| 10,370 | |
+
+
+Adjusted EBITDA | |
+$ | 96,287 | |


### PR DESCRIPTION
## Summary

- parse accounting-negative outlook ranges whose scale follows the closing parenthesis
- keep fiscal-quarter highlights separate from annual results and stop outlook extraction at key financials
- prefer consolidated revenue totals over product and service components
- add full SEC fixtures for BETA, AMCR, and LQDA

## Verification

- npm audit --audit-level=high
- npm run lint
- npm run test:coverage
- npm run typecheck
- mutation checks for each new selection rule