### PR TITLE
Recover calendar alerts across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Calendar reminder assets are matched against the current day and sent at `08:30 
   roleIdReference: "hblwrk_role_special_alerts_ID"
 ```
 
+Calendar result follow-ups reconcile at startup and every 30 minutes from `08:00` through `23:30 Europe/Berlin` on weekdays. The reconciliation reloads configured reminder events from the previous 24 hours, reconstructs release polling after a restart, follows provider event IDs when release times change, and recovers results published while the bot is offline. Aggressive polling continues for 15 minutes after each scheduled release; periodic reconciliation handles later provider updates within the recovery window. Recent bot-authored Discord messages act as the delivery record, so restarts suppress duplicate updates without a database or writable filesystem. If message history is unavailable, the bot favours delivering a validated result and logs the degraded duplicate protection.
+
 Earnings reminders use same-day ticker heads-ups at `08:00 Europe/Berlin` on weekdays:
 
 ```yaml

--- a/modules/calendar-reminder-follow-ups.test.ts
+++ b/modules/calendar-reminder-follow-ups.test.ts
@@ -1,0 +1,380 @@
+import moment from "moment-timezone";
+import type Schedule from "node-schedule";
+import {describe, expect, test, vi} from "vitest";
+import {CalendarReminderAsset} from "./assets.ts";
+import {createCalendarReminderFollowUpCoordinator} from "./calendar-reminder-follow-ups.ts";
+import {CalendarEvent} from "./calendar.ts";
+import {buildCalendarReminderEmbed, getCalendarReminderContent} from "./timer-reminders.ts";
+
+type ScheduledInvocation = {
+  callback: () => void | Promise<void>;
+  rule: Date | Schedule.RecurrenceRule;
+};
+
+function createCalendarEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  const event = new CalendarEvent();
+  event.actualValue = "";
+  event.country = "🇺🇸";
+  event.date = "2026-08-12";
+  event.forecastValue = "2.7%";
+  event.name = "CPI y/y";
+  event.previousValue = "3.5%";
+  event.sourceEventId = "cpi-yy";
+  event.time = "14:30";
+  Object.assign(event, overrides);
+  return event;
+}
+
+function createReminderAsset(overrides: Partial<CalendarReminderAsset> = {}): CalendarReminderAsset {
+  const asset = new CalendarReminderAsset();
+  asset.countryFlags = ["🇺🇸"];
+  asset.eventNameSubstrings = ["cpi"];
+  asset.name = "us-cpi";
+  asset.roleId = "alerts-role";
+  Object.assign(asset, overrides);
+  return asset;
+}
+
+function createHistoryMessage(event: CalendarEvent, options: {legacyFooter?: boolean} = {}) {
+  const embed = buildCalendarReminderEmbed("update", [event]).data;
+  const footerText = true === options.legacyFooter
+    ? `🕒 ${event.time}`
+    : embed.footer?.text;
+  return {
+    author: {id: "bot-user"},
+    content: getCalendarReminderContent("alerts-role", "update"),
+    createdAt: new Date("2026-08-12T12:31:00.000Z"),
+    embeds: [{
+      footer: {text: footerText},
+      title: embed.title,
+    }],
+  };
+}
+
+function createFixture({
+  assets = [createReminderAsset()],
+  events = [],
+  now = "2026-08-12T13:00:00+02:00",
+}: {
+  assets?: CalendarReminderAsset[];
+  events?: CalendarEvent[];
+  now?: string;
+} = {}) {
+  let currentTime = moment.parseZone(now).tz("Europe/Berlin");
+  const scheduledInvocations: ScheduledInvocation[] = [];
+  const send = vi.fn().mockResolvedValue({id: "sent-message"});
+  const fetchHistory = vi.fn().mockResolvedValue(new Map());
+  const getCalendarEventsResult = vi.fn().mockResolvedValue({
+    events,
+    status: "ok" as const,
+  });
+  const getCalendarOfficialSummary = vi.fn().mockResolvedValue(undefined);
+  const logger = {log: vi.fn()};
+  const channel = {
+    messages: {fetch: fetchHistory},
+    send,
+  };
+  const client = {
+    channels: {
+      cache: {
+        get: vi.fn(() => channel),
+      },
+    },
+    user: {id: "bot-user"},
+  };
+  const coordinator = createCalendarReminderFollowUpCoordinator({
+    assets,
+    channelId: "macro-channel",
+    client,
+    dependencies: {
+      getCalendarEventsResultFn: getCalendarEventsResult,
+      getCalendarOfficialSummaryFn: getCalendarOfficialSummary,
+      nowFn: () => currentTime.clone(),
+      scheduleJobFn: (rule, callback) => {
+        scheduledInvocations.push({callback, rule});
+        return {cancel: vi.fn()} as unknown as Schedule.Job;
+      },
+    },
+    logger,
+  });
+
+  return {
+    coordinator,
+    fetchHistory,
+    getCalendarEventsResult,
+    getCalendarOfficialSummary,
+    logger,
+    scheduledInvocations,
+    send,
+    setNow: (nextNow: string) => {
+      currentTime = moment.parseZone(nextNow).tz("Europe/Berlin");
+    },
+  };
+}
+
+function getDateInvocations(coordinatorFixture: ReturnType<typeof createFixture>): ScheduledInvocation[] {
+  return coordinatorFixture.scheduledInvocations.filter(invocation => invocation.rule instanceof Date);
+}
+
+async function runInvocation(invocation: ScheduledInvocation | undefined) {
+  if (undefined === invocation) {
+    throw new Error("Expected a scheduled invocation.");
+  }
+
+  await invocation.callback();
+}
+
+describe("calendar reminder follow-up coordinator", () => {
+  test("reconstructs every remaining release poll after a restart before the release", async () => {
+    const event = createCalendarEvent();
+    const fixture = createFixture({
+      events: [event],
+      now: "2026-08-12T13:59:00+02:00",
+    });
+
+    await fixture.coordinator.reconcile("startup");
+
+    expect(getDateInvocations(fixture).map(invocation => (invocation.rule as Date).toISOString())).toEqual([
+      "2026-08-12T12:30:05.000Z",
+      "2026-08-12T12:30:10.000Z",
+      "2026-08-12T12:30:20.000Z",
+      "2026-08-12T12:30:30.000Z",
+      "2026-08-12T12:31:00.000Z",
+      "2026-08-12T12:32:00.000Z",
+      "2026-08-12T12:33:00.000Z",
+      "2026-08-12T12:35:00.000Z",
+      "2026-08-12T12:40:00.000Z",
+      "2026-08-12T12:45:00.000Z",
+    ]);
+    expect(fixture.send).not.toHaveBeenCalled();
+  });
+
+  test("recovers a released numeric event after the immediate polling window", async () => {
+    const releasedEvent = createCalendarEvent({actualValue: "3.4%"});
+    const fixture = createFixture({
+      events: [releasedEvent],
+      now: "2026-08-12T16:00:00+02:00",
+    });
+
+    await fixture.coordinator.reconcile("startup");
+    await fixture.coordinator.reconcile("periodic");
+
+    expect(fixture.fetchHistory).toHaveBeenCalledTimes(1);
+    expect(fixture.send).toHaveBeenCalledTimes(1);
+    expect(fixture.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "<@&alerts-role> Update",
+    }));
+  });
+
+  test("uses Discord history as the delivery record across restarts", async () => {
+    const releasedEvent = createCalendarEvent({actualValue: "3.4%"});
+    const fixture = createFixture({
+      events: [releasedEvent],
+      now: "2026-08-12T14:32:00+02:00",
+    });
+    fixture.fetchHistory.mockResolvedValueOnce(new Map([
+      ["existing", createHistoryMessage(releasedEvent)],
+    ]));
+
+    await fixture.coordinator.reconcile("startup");
+
+    expect(fixture.send).not.toHaveBeenCalled();
+    expect(fixture.logger.log).toHaveBeenCalledWith("info", expect.objectContaining({
+      state: "already-posted",
+    }));
+  });
+
+  test("recognizes legacy updates without a date in the footer", async () => {
+    const releasedEvent = createCalendarEvent({actualValue: "3.4%"});
+    const fixture = createFixture({
+      events: [releasedEvent],
+      now: "2026-08-12T14:32:00+02:00",
+    });
+    fixture.fetchHistory.mockResolvedValueOnce(new Map([
+      ["existing", createHistoryMessage(releasedEvent, {legacyFooter: true})],
+    ]));
+
+    await fixture.coordinator.reconcile("startup");
+
+    expect(fixture.send).not.toHaveBeenCalled();
+  });
+
+  test("posts when history is unavailable instead of silently dropping a release", async () => {
+    const releasedEvent = createCalendarEvent({actualValue: "3.4%"});
+    const fixture = createFixture({
+      events: [releasedEvent],
+      now: "2026-08-12T14:32:00+02:00",
+    });
+    fixture.fetchHistory.mockRejectedValueOnce(new Error("missing permission"));
+
+    await fixture.coordinator.reconcile("startup");
+
+    expect(fixture.send).toHaveBeenCalledTimes(1);
+    expect(fixture.logger.log).toHaveBeenCalledWith("warn", expect.stringContaining("message history"));
+  });
+
+  test("does not duplicate an ambiguously failed send that appears in history", async () => {
+    const releasedEvent = createCalendarEvent({actualValue: "3.4%"});
+    const fixture = createFixture({
+      events: [releasedEvent],
+      now: "2026-08-12T14:32:00+02:00",
+    });
+    fixture.fetchHistory
+      .mockResolvedValueOnce(new Map())
+      .mockResolvedValueOnce(new Map([
+        ["accepted", createHistoryMessage(releasedEvent)],
+      ]));
+    fixture.send.mockRejectedValueOnce(new Error("response lost"));
+
+    await fixture.coordinator.reconcile("startup");
+    await fixture.coordinator.reconcile("periodic");
+
+    expect(fixture.send).toHaveBeenCalledTimes(1);
+    expect(fixture.logger.log).toHaveBeenCalledWith("info", expect.objectContaining({
+      state: "already-posted",
+    }));
+  });
+
+  test("tracks a provider event id when the release is rescheduled", async () => {
+    const originalEvent = createCalendarEvent();
+    const rescheduledEvent = createCalendarEvent({time: "15:00"});
+    const fixture = createFixture({now: "2026-08-12T13:00:00+02:00"});
+    fixture.getCalendarEventsResult.mockResolvedValue({
+      events: [rescheduledEvent],
+      status: "ok",
+    });
+    fixture.coordinator.scheduleGroups([{
+      asset: createReminderAsset(),
+      events: [originalEvent],
+    }]);
+    fixture.setNow("2026-08-12T14:30:05+02:00");
+
+    await runInvocation(getDateInvocations(fixture)[0]);
+
+    const scheduledTimes = getDateInvocations(fixture).map(invocation => (invocation.rule as Date).toISOString());
+    expect(scheduledTimes).toContain("2026-08-12T13:00:05.000Z");
+    expect(fixture.send).not.toHaveBeenCalled();
+    expect(fixture.logger.log).toHaveBeenCalledWith("info", expect.objectContaining({
+      state: "rescheduled",
+    }));
+  });
+
+  test("recovers text-only releases through the same generic path", async () => {
+    const fomcEvent = createCalendarEvent({
+      forecastValue: "",
+      name: "FOMC Statement",
+      previousValue: "",
+      sourceEventId: "fomc-statement",
+      time: "20:00",
+    });
+    const fixture = createFixture({
+      assets: [createReminderAsset({
+        eventNameSubstrings: ["fomc statement"],
+        name: "us-fomc",
+      })],
+      events: [fomcEvent],
+      now: "2026-08-12T20:30:00+02:00",
+    });
+    fixture.getCalendarOfficialSummary.mockResolvedValueOnce({
+      name: "Federal Reserve",
+      summaryMarkdown: "The statement keeps policy unchanged.",
+      url: "https://www.federalreserve.gov/example",
+    });
+
+    await fixture.coordinator.reconcile("periodic");
+
+    expect(fixture.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: "<@&alerts-role> Update",
+    }));
+  });
+
+  test("retries unresolved releases on later reconciliation", async () => {
+    const pendingEvent = createCalendarEvent();
+    const releasedEvent = createCalendarEvent({actualValue: "3.4%"});
+    const fixture = createFixture({
+      events: [pendingEvent],
+      now: "2026-08-12T15:30:00+02:00",
+    });
+
+    await fixture.coordinator.reconcile("startup");
+    fixture.getCalendarEventsResult.mockResolvedValue({
+      events: [releasedEvent],
+      status: "ok",
+    });
+    await fixture.coordinator.reconcile("periodic");
+
+    expect(fixture.send).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles multiple configured release types without event-specific code", async () => {
+    const cpiEvent = createCalendarEvent({actualValue: "3.4%"});
+    const ppiEvent = createCalendarEvent({
+      actualValue: "2.1%",
+      name: "PPI y/y",
+      sourceEventId: "ppi-yy",
+    });
+    const fixture = createFixture({
+      assets: [
+        createReminderAsset(),
+        createReminderAsset({
+          eventNameSubstrings: ["ppi"],
+          name: "us-ppi",
+        }),
+      ],
+      events: [cpiEvent, ppiEvent],
+      now: "2026-08-12T15:00:00+02:00",
+    });
+
+    await fixture.coordinator.reconcile("startup");
+
+    expect(fixture.fetchHistory).toHaveBeenCalledTimes(1);
+    expect(fixture.send).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not post events outside the bounded recovery horizon", async () => {
+    const oldEvent = createCalendarEvent({
+      actualValue: "3.4%",
+      date: "2026-08-11",
+    });
+    const fixture = createFixture({
+      events: [oldEvent],
+      now: "2026-08-12T15:00:01+02:00",
+    });
+
+    await fixture.coordinator.reconcile("startup");
+
+    expect(fixture.fetchHistory).not.toHaveBeenCalled();
+    expect(fixture.send).not.toHaveBeenCalled();
+    expect(fixture.logger.log).toHaveBeenCalledWith("info", expect.objectContaining({
+      state: "expired",
+    }));
+  });
+
+  test("keeps calendar load failures retryable", async () => {
+    const fixture = createFixture();
+    fixture.getCalendarEventsResult.mockResolvedValueOnce({
+      events: [],
+      status: "error",
+    });
+
+    await fixture.coordinator.reconcile("periodic");
+
+    expect(fixture.send).not.toHaveBeenCalled();
+    expect(fixture.logger.log).toHaveBeenCalledWith("warn", expect.objectContaining({
+      state: "calendar-load-error",
+    }));
+  });
+
+  test("starts a storage-free periodic reconciliation job", () => {
+    const fixture = createFixture();
+
+    fixture.coordinator.start();
+
+    const recurrence = fixture.scheduledInvocations.find(invocation => false === (invocation.rule instanceof Date));
+    expect(recurrence?.rule).toEqual(expect.objectContaining({
+      hour: expect.objectContaining({start: 8, end: 23}),
+      minute: [0, 30],
+      tz: "Europe/Berlin",
+    }));
+  });
+});

--- a/modules/calendar-reminder-follow-ups.ts
+++ b/modules/calendar-reminder-follow-ups.ts
@@ -1,0 +1,657 @@
+import moment from "moment-timezone";
+import Schedule from "node-schedule";
+import {type CalendarReminderAsset} from "./assets.ts";
+import {
+  getCalendarEventDateTime,
+  getCalendarEventsResult,
+  type CalendarEvent,
+} from "./calendar.ts";
+import {
+  getCalendarOfficialSummary,
+  type CalendarOfficialSummary,
+} from "./calendar-economic-summary.ts";
+import {
+  buildCalendarReminderEmbed,
+  type CalendarReminderGroup,
+  getAllowedRoleMentions,
+  getCalendarReminderContent,
+  getMatchedCalendarReminderEventGroups,
+  getNormalizedRoleId,
+  hasCalendarReminderActualValues,
+  hasCalendarReminderClearMetrics,
+} from "./timer-reminders.ts";
+
+type Logger = {
+  log: (level: string, message: unknown) => void;
+};
+
+type CalendarReminderClient = {
+  channels?: {
+    cache?: {
+      get?: (channelId: string) => unknown;
+    };
+    fetch?: (channelId: string) => Promise<unknown> | unknown;
+  };
+  user?: {
+    id?: string | undefined;
+  } | null | undefined;
+};
+
+type SendableChannel = {
+  send: (payload: unknown) => Promise<unknown> | unknown;
+};
+
+type FetchableMessageManager = {
+  fetch: (options: {limit: number}) => Promise<unknown> | unknown;
+};
+
+type MessageHistorySnapshot = {
+  available: boolean;
+  messages: unknown[];
+};
+
+type CalendarReminderFollowUpDependencies = {
+  getCalendarEventsResultFn?: typeof getCalendarEventsResult | undefined;
+  getCalendarOfficialSummaryFn?: typeof getCalendarOfficialSummary | undefined;
+  nowFn?: (() => moment.Moment) | undefined;
+  scheduleJobFn?: ((rule: Date | Schedule.RecurrenceRule, callback: () => void | Promise<void>) => Schedule.Job) | undefined;
+};
+
+export type CalendarReminderFollowUpCoordinator = {
+  reconcile: (source?: string) => Promise<void>;
+  scheduleGroups: (groups: CalendarReminderGroup[]) => void;
+  start: () => void;
+};
+
+const calendarReminderAnnouncementSource = "calendar-reminder";
+const europeBerlinTimezone = "Europe/Berlin";
+const historyFetchLimit = 100;
+const recoveryLookbackHours = 24;
+const recoveryRefreshMinutes = [0, 30];
+const recoveryRefreshHours = new Schedule.Range(8, 23);
+const berlinWeekdays = new Schedule.Range(1, 5);
+const followUpDelaySeconds = [5, 10, 20, 30, 60, 120, 180, 300, 600, 900];
+
+export function createCalendarReminderFollowUpCoordinator({
+  assets,
+  channelId,
+  client,
+  dependencies = {},
+  logger,
+}: {
+  assets: CalendarReminderAsset[];
+  channelId: string;
+  client: CalendarReminderClient;
+  dependencies?: CalendarReminderFollowUpDependencies | undefined;
+  logger: Logger;
+}): CalendarReminderFollowUpCoordinator {
+  const getCalendarEventsResultFn = dependencies.getCalendarEventsResultFn ?? getCalendarEventsResult;
+  const getCalendarOfficialSummaryFn = dependencies.getCalendarOfficialSummaryFn ?? getCalendarOfficialSummary;
+  const nowFn = dependencies.nowFn ?? (() => moment().tz(europeBerlinTimezone));
+  const scheduleJobFn = dependencies.scheduleJobFn ?? ((rule, callback) => Schedule.scheduleJob(rule, callback));
+  const inFlightKeys = new Set<string>();
+  const sentKeys = new Set<string>();
+  const uncertainDeliveryKeys = new Set<string>();
+  const scheduledAttemptKeys = new Set<string>();
+  let reconciliationInFlight = false;
+  let started = false;
+
+  function scheduleGroups(groups: CalendarReminderGroup[]) {
+    for (const group of groups) {
+      scheduleGroup(group);
+    }
+  }
+
+  function scheduleGroup(group: CalendarReminderGroup) {
+    const groupKey = getCalendarReminderGroupKey(group);
+    if (true === sentKeys.has(groupKey)) {
+      return;
+    }
+
+    const primaryEvent = group.events[0];
+    if (undefined === primaryEvent) {
+      return;
+    }
+
+    const releaseDateTime = getCalendarEventDateTime(primaryEvent);
+    if (false === releaseDateTime.isValid()) {
+      logFollowUpState("invalid-event-time", group, "warn");
+      return;
+    }
+
+    const now = nowFn();
+    let scheduledCount = 0;
+    for (const delaySeconds of followUpDelaySeconds) {
+      const scheduledDateTime = releaseDateTime.clone().add(delaySeconds, "seconds");
+      if (true === scheduledDateTime.isSameOrBefore(now)) {
+        continue;
+      }
+
+      const attemptKey = `${groupKey}|${scheduledDateTime.valueOf()}`;
+      if (true === scheduledAttemptKeys.has(attemptKey)) {
+        continue;
+      }
+
+      scheduledAttemptKeys.add(attemptKey);
+      scheduledCount++;
+      scheduleJobFn(scheduledDateTime.toDate(), async () => {
+        scheduledAttemptKeys.delete(attemptKey);
+        await refreshAndAttemptGroup(group, groupKey, "scheduled").catch(error => {
+          logger.log("error", {
+            source: calendarReminderAnnouncementSource,
+            state: "scheduled-follow-up-error",
+            message: `Calendar reminder follow-up failed: ${error}`,
+          });
+        });
+      });
+    }
+
+    if (0 < scheduledCount) {
+      logFollowUpState("scheduled", group, "info");
+    }
+  }
+
+  async function reconcile(source = "manual") {
+    if (0 === assets.length || true === reconciliationInFlight) {
+      return;
+    }
+
+    reconciliationInFlight = true;
+    try {
+      const now = nowFn();
+      const oldestDateTime = now.clone().subtract(recoveryLookbackHours, "hours");
+      const startDate = oldestDateTime.clone().startOf("day");
+      const endDate = now.clone().startOf("day");
+      const rangeDays = Math.max(0, endDate.diff(startDate, "days"));
+      const result = await getCalendarEventsResultFn(startDate.format("YYYY-MM-DD"), rangeDays);
+      if ("error" === result.status) {
+        logger.log("warn", {
+          source: calendarReminderAnnouncementSource,
+          recoverySource: source,
+          state: "calendar-load-error",
+          message: "Calendar reminder reconciliation could not load calendar events.",
+        });
+        return;
+      }
+
+      const groups = getMatchedCalendarReminderEventGroups(assets, result.events);
+      let historySnapshotPromise: Promise<MessageHistorySnapshot> | undefined;
+      const getHistorySnapshot = () => {
+        historySnapshotPromise ??= fetchMessageHistory(client, channelId, logger);
+        return historySnapshotPromise;
+      };
+
+      for (const group of groups) {
+        const primaryEvent = group.events[0];
+        if (undefined === primaryEvent) {
+          continue;
+        }
+
+        const releaseDateTime = getCalendarEventDateTime(primaryEvent);
+        if (false === releaseDateTime.isValid()) {
+          logFollowUpState("invalid-event-time", group, "warn", source);
+          continue;
+        }
+
+        if (true === releaseDateTime.isAfter(now)) {
+          scheduleGroup(group);
+          continue;
+        }
+
+        if (true === releaseDateTime.isBefore(oldestDateTime)) {
+          logFollowUpState("expired", group, "info", source);
+          continue;
+        }
+
+        const couldPost = true === hasCalendarReminderActualValues(group.events) ||
+          false === hasCalendarReminderClearMetrics(group.events);
+        await attemptFreshGroup(group, getCalendarReminderGroupKey(group), {
+          checkHistory: couldPost,
+          getHistorySnapshot,
+          source,
+        });
+        scheduleGroup(group);
+      }
+
+      logger.log("info", {
+        source: calendarReminderAnnouncementSource,
+        recoverySource: source,
+        state: "reconciled",
+        matchedGroupCount: groups.length,
+      });
+    } catch (error) {
+      logger.log("error", {
+        source: calendarReminderAnnouncementSource,
+        recoverySource: source,
+        state: "reconciliation-error",
+        message: `Calendar reminder reconciliation failed: ${error}`,
+      });
+    } finally {
+      reconciliationInFlight = false;
+    }
+  }
+
+  function start() {
+    if (true === started || 0 === assets.length) {
+      return;
+    }
+
+    started = true;
+    const recoveryRule = new Schedule.RecurrenceRule();
+    recoveryRule.hour = recoveryRefreshHours;
+    recoveryRule.minute = recoveryRefreshMinutes;
+    recoveryRule.dayOfWeek = [berlinWeekdays];
+    recoveryRule.tz = europeBerlinTimezone;
+    scheduleJobFn(recoveryRule, () => reconcile("periodic"));
+    if ("test" !== process.env["NODE_ENV"]) {
+      void reconcile("startup").catch(error => {
+        logger.log("error", {
+          source: calendarReminderAnnouncementSource,
+          state: "startup-recovery-error",
+          message: `Calendar reminder startup recovery failed: ${error}`,
+        });
+      });
+    }
+  }
+
+  async function refreshAndAttemptGroup(
+    originalGroup: CalendarReminderGroup,
+    groupKey: string,
+    source: string,
+  ): Promise<boolean> {
+    if (true === sentKeys.has(groupKey) || true === inFlightKeys.has(groupKey)) {
+      return false;
+    }
+
+    inFlightKeys.add(groupKey);
+    try {
+      const primaryEvent = originalGroup.events[0];
+      if (undefined === primaryEvent) {
+        return false;
+      }
+
+      const now = nowFn();
+      const originalDateTime = getCalendarEventDateTime(primaryEvent);
+      const startDate = moment.min(
+        originalDateTime.clone(),
+        now.clone().subtract(recoveryLookbackHours, "hours"),
+      ).startOf("day");
+      const endDate = moment.max(originalDateTime.clone(), now.clone()).startOf("day");
+      const rangeDays = Math.max(0, endDate.diff(startDate, "days"));
+      const result = await getCalendarEventsResultFn(startDate.format("YYYY-MM-DD"), rangeDays);
+      if ("error" === result.status) {
+        logFollowUpState("calendar-load-error", originalGroup, "warn", source);
+        return false;
+      }
+
+      const refreshedGroup = findRefreshedGroup(originalGroup, result.events);
+      if (undefined === refreshedGroup) {
+        logFollowUpState("event-not-found", originalGroup, "warn", source);
+        return false;
+      }
+
+      const refreshedDateTime = getCalendarEventDateTime(refreshedGroup.events[0]!);
+      const releaseTimeChanged = refreshedDateTime.valueOf() !== originalDateTime.valueOf();
+      if (true === releaseTimeChanged && true === refreshedDateTime.isAfter(now)) {
+        scheduleGroup(refreshedGroup);
+        logFollowUpState("rescheduled", refreshedGroup, "info", source);
+        return false;
+      }
+
+      const checkHistory = true === uncertainDeliveryKeys.has(groupKey);
+      return attemptFreshGroupWhileClaimed(refreshedGroup, groupKey, {
+        checkHistory,
+        getHistorySnapshot: () => fetchMessageHistory(client, channelId, logger),
+        source,
+      });
+    } finally {
+      inFlightKeys.delete(groupKey);
+    }
+  }
+
+  async function attemptFreshGroup(
+    group: CalendarReminderGroup,
+    groupKey: string,
+    options: {
+      checkHistory: boolean;
+      getHistorySnapshot: () => Promise<MessageHistorySnapshot>;
+      source: string;
+    },
+  ): Promise<boolean> {
+    if (true === sentKeys.has(groupKey) || true === inFlightKeys.has(groupKey)) {
+      return false;
+    }
+
+    inFlightKeys.add(groupKey);
+    try {
+      return attemptFreshGroupWhileClaimed(group, groupKey, options);
+    } finally {
+      inFlightKeys.delete(groupKey);
+    }
+  }
+
+  async function attemptFreshGroupWhileClaimed(
+    group: CalendarReminderGroup,
+    groupKey: string,
+    options: {
+      checkHistory: boolean;
+      getHistorySnapshot: () => Promise<MessageHistorySnapshot>;
+      source: string;
+    },
+  ): Promise<boolean> {
+    if (true === options.checkHistory) {
+      const historySnapshot = await options.getHistorySnapshot();
+      if (true === hasMatchingHistoryMessage(historySnapshot, group, client.user?.id)) {
+        markGroupSent(group, groupKey);
+        logFollowUpState("already-posted", group, "info", options.source);
+        return true;
+      }
+    }
+
+    const roleId = getNormalizedRoleId(group.asset.roleId);
+    if (!roleId) {
+      return false;
+    }
+
+    if (true === hasCalendarReminderActualValues(group.events)) {
+      const sent = await sendPayload({
+        content: getCalendarReminderContent(roleId, "update"),
+        embeds: [buildCalendarReminderEmbed("update", group.events)],
+        allowedMentions: getAllowedRoleMentions(roleId),
+      }, groupKey);
+      if (true === sent) {
+        markGroupSent(group, groupKey);
+        logFollowUpState("posted", group, "info", options.source);
+      }
+      return sent;
+    }
+
+    if (true === hasCalendarReminderClearMetrics(group.events)) {
+      return false;
+    }
+
+    const officialSummary: CalendarOfficialSummary | undefined = await getCalendarOfficialSummaryFn(group.events, {logger});
+    if (undefined === officialSummary) {
+      return false;
+    }
+
+    const sent = await sendPayload({
+      content: getCalendarReminderContent(roleId, "summary"),
+      embeds: [buildCalendarReminderEmbed("summary", group.events, {
+        sourceName: officialSummary.name,
+        summaryMarkdown: officialSummary.summaryMarkdown,
+      })],
+      allowedMentions: getAllowedRoleMentions(roleId),
+    }, groupKey);
+    if (true === sent) {
+      markGroupSent(group, groupKey);
+      logFollowUpState("posted", group, "info", options.source);
+    }
+    return sent;
+  }
+
+  async function sendPayload(payload: unknown, groupKey: string): Promise<boolean> {
+    const channel = await fetchChannel(client, channelId, logger);
+    if (false === isSendableChannel(channel)) {
+      uncertainDeliveryKeys.add(groupKey);
+      logger.log("error", `Skipping ${calendarReminderAnnouncementSource} announcement: channel ${channelId} not found or not send-capable.`);
+      return false;
+    }
+
+    try {
+      await Promise.resolve(channel.send(payload));
+      uncertainDeliveryKeys.delete(groupKey);
+      return true;
+    } catch (error) {
+      uncertainDeliveryKeys.add(groupKey);
+      logger.log("error", `Error sending ${calendarReminderAnnouncementSource} announcement: ${error}`);
+      return false;
+    }
+  }
+
+  function markGroupSent(group: CalendarReminderGroup, groupKey: string) {
+    sentKeys.add(groupKey);
+    sentKeys.add(getCalendarReminderGroupKey(group));
+    uncertainDeliveryKeys.delete(groupKey);
+  }
+
+  function logFollowUpState(
+    state: string,
+    group: CalendarReminderGroup,
+    level: "info" | "warn",
+    recoverySource?: string,
+  ) {
+    const primaryEvent = group.events[0];
+    logger.log(level, {
+      source: calendarReminderAnnouncementSource,
+      ...(undefined !== recoverySource ? {recoverySource} : {}),
+      state,
+      asset: group.asset.name,
+      eventDate: primaryEvent?.date,
+      eventTime: primaryEvent?.time,
+      eventNames: group.events.map(event => event.name),
+    });
+  }
+
+  return {
+    reconcile,
+    scheduleGroups,
+    start,
+  };
+}
+
+function getCalendarReminderGroupKey(group: CalendarReminderGroup): string {
+  const assetName = group.asset.name?.trim() || "calendar-reminder";
+  const roleId = getNormalizedRoleId(group.asset.roleId) ?? "missing-role";
+  const sourceEventIds = getSourceEventIds(group.events);
+  if (0 < sourceEventIds.length) {
+    return `${assetName}|${roleId}|source:${sourceEventIds.join(",")}`;
+  }
+
+  const primaryEvent = group.events[0];
+  if (undefined === primaryEvent) {
+    return `${assetName}|${roleId}|missing-event`;
+  }
+
+  return `${assetName}|${roleId}|${primaryEvent.date}|${primaryEvent.time}|${primaryEvent.country}`;
+}
+
+function findRefreshedGroup(
+  originalGroup: CalendarReminderGroup,
+  calendarEvents: CalendarEvent[],
+): CalendarReminderGroup | undefined {
+  const candidates = getMatchedCalendarReminderEventGroups([originalGroup.asset], calendarEvents);
+  const originalSourceIds = new Set(getSourceEventIds(originalGroup.events));
+  if (0 < originalSourceIds.size) {
+    const matchedBySourceId = candidates
+      .map(candidate => ({
+        candidate,
+        overlap: getSourceEventIds(candidate.events).filter(sourceId => originalSourceIds.has(sourceId)).length,
+      }))
+      .filter(match => 0 < match.overlap)
+      .sort((left, right) => right.overlap - left.overlap)[0];
+    if (undefined !== matchedBySourceId) {
+      return matchedBySourceId.candidate;
+    }
+  }
+
+  const originalPrimaryEvent = originalGroup.events[0];
+  if (undefined === originalPrimaryEvent) {
+    return undefined;
+  }
+
+  return candidates.find(candidate => {
+    const candidatePrimaryEvent = candidate.events[0];
+    return candidatePrimaryEvent?.date === originalPrimaryEvent.date &&
+      candidatePrimaryEvent.time === originalPrimaryEvent.time &&
+      candidatePrimaryEvent.country === originalPrimaryEvent.country;
+  });
+}
+
+function getSourceEventIds(events: CalendarEvent[]): string[] {
+  return [...new Set(events
+    .map(event => event.sourceEventId?.trim())
+    .filter((sourceEventId): sourceEventId is string => Boolean(sourceEventId)))]
+    .sort();
+}
+
+async function fetchMessageHistory(
+  client: CalendarReminderClient,
+  channelId: string,
+  logger: Logger,
+): Promise<MessageHistorySnapshot> {
+  const channel = await fetchChannel(client, channelId, logger);
+  const messages = getMessageManager(channel);
+  if (undefined === messages) {
+    logger.log("warn", `Could not recover calendar reminder announcements: channel ${channelId} message history is not fetchable.`);
+    return {available: false, messages: []};
+  }
+
+  const fetchedMessages = await Promise.resolve(messages.fetch({limit: historyFetchLimit})).catch(error => {
+    logger.log("warn", `Could not recover calendar reminder announcements from message history: ${error}`);
+    return undefined;
+  });
+  if (undefined === fetchedMessages) {
+    return {available: false, messages: []};
+  }
+
+  return {
+    available: true,
+    messages: getCollectionValues(fetchedMessages),
+  };
+}
+
+function hasMatchingHistoryMessage(
+  historySnapshot: MessageHistorySnapshot,
+  group: CalendarReminderGroup,
+  botUserId: string | undefined,
+): boolean {
+  if (false === historySnapshot.available) {
+    return false;
+  }
+
+  const roleId = getNormalizedRoleId(group.asset.roleId);
+  const primaryEvent = group.events[0];
+  if (!roleId || undefined === primaryEvent) {
+    return false;
+  }
+
+  const expectedContent = getCalendarReminderContent(roleId, "update");
+  const expectedTitle = buildCalendarReminderEmbed("update", group.events).data.title;
+  const expectedTime = `🕒 ${primaryEvent.time}`;
+  const expectedDate = `📅 ${primaryEvent.date}`;
+
+  return historySnapshot.messages.some(message => {
+    if (false === isRecord(message)) {
+      return false;
+    }
+
+    const author = isRecord(message["author"]) ? message["author"] : undefined;
+    if (undefined !== botUserId && author?.["id"] !== botUserId) {
+      return false;
+    }
+
+    if (message["content"] !== expectedContent) {
+      return false;
+    }
+
+    const embed = getFirstEmbed(message["embeds"]);
+    if (undefined === embed || embed.title !== expectedTitle || false === embed.footerText.includes(expectedTime)) {
+      return false;
+    }
+
+    if (true === embed.footerText.includes(expectedDate)) {
+      return true;
+    }
+
+    return isMessageFromBerlinDate(message, primaryEvent.date);
+  });
+}
+
+function getFirstEmbed(value: unknown): {footerText: string; title: string | undefined} | undefined {
+  if (false === Array.isArray(value)) {
+    return undefined;
+  }
+
+  const firstEmbed: unknown = (value as unknown[])[0];
+  if (false === isRecord(firstEmbed)) {
+    return undefined;
+  }
+
+  const data = isRecord(firstEmbed["data"]) ? firstEmbed["data"] : firstEmbed;
+  const footer = isRecord(data["footer"]) ? data["footer"] : undefined;
+  return {
+    footerText: "string" === typeof footer?.["text"] ? footer["text"] : "",
+    title: "string" === typeof data["title"] ? data["title"] : undefined,
+  };
+}
+
+function isMessageFromBerlinDate(message: Record<string, unknown>, expectedDate: string): boolean {
+  const createdAt = message["createdAt"];
+  if (createdAt instanceof Date) {
+    return moment(createdAt).tz(europeBerlinTimezone).format("YYYY-MM-DD") === expectedDate;
+  }
+
+  const createdTimestamp = message["createdTimestamp"];
+  return "number" === typeof createdTimestamp &&
+    moment(createdTimestamp).tz(europeBerlinTimezone).format("YYYY-MM-DD") === expectedDate;
+}
+
+async function fetchChannel(
+  client: CalendarReminderClient,
+  channelId: string,
+  logger: Logger,
+): Promise<unknown> {
+  const cachedChannel = client.channels?.cache?.get?.(channelId);
+  if (undefined !== cachedChannel) {
+    return cachedChannel;
+  }
+
+  const fetchChannelFn = client.channels?.fetch;
+  if ("function" !== typeof fetchChannelFn) {
+    return undefined;
+  }
+
+  return Promise.resolve(fetchChannelFn(channelId)).catch(error => {
+    logger.log("warn", `Could not fetch calendar reminder channel ${channelId}: ${error}`);
+    return undefined;
+  });
+}
+
+function getMessageManager(channel: unknown): FetchableMessageManager | undefined {
+  if (false === isRecord(channel) || false === isRecord(channel["messages"])) {
+    return undefined;
+  }
+
+  const messages = channel["messages"];
+  const fetch = messages["fetch"];
+  if ("function" !== typeof fetch) {
+    return undefined;
+  }
+
+  const fetchFn = fetch as (this: unknown, options: {limit: number}) => Promise<unknown> | unknown;
+  return {
+    fetch: options => fetchFn.call(messages, options),
+  };
+}
+
+function getCollectionValues(collection: unknown): unknown[] {
+  if (false === isRecord(collection)) {
+    return [];
+  }
+
+  const values = collection["values"];
+  if ("function" !== typeof values) {
+    return [];
+  }
+
+  return [...Reflect.apply(values, collection, []) as Iterable<unknown>];
+}
+
+function isSendableChannel(channel: unknown): channel is SendableChannel {
+  return true === isRecord(channel) && "function" === typeof channel["send"];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return "object" === typeof value && null !== value;
+}

--- a/modules/test-utils/timers.ts
+++ b/modules/test-utils/timers.ts
@@ -244,6 +244,7 @@ function getEarningsReminderJob(): RecurringScheduledJob {
 
 export function resetTimerMocks() {
   vi.useFakeTimers();
+  vi.stubEnv("NODE_ENV", "test");
   vi.setSystemTime(new Date("2025-02-18T10:00:00-05:00"));
   vi.clearAllMocks();
   scheduledJobs.length = 0;
@@ -305,6 +306,7 @@ export function resetTimerMocks() {
 
 export function restoreTimerMocks() {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 }
 
 export {

--- a/modules/timer-reminders.test.ts
+++ b/modules/timer-reminders.test.ts
@@ -92,7 +92,7 @@ describe("timer-reminders", () => {
     expect(getCalendarReminderContent("role-1", "reminder")).toBe("<@&role-1> Heute wichtig");
     expect(reminderEmbed.data.title).toBe("🇺🇸 ISM Manufacturing PMI");
     expect(reminderEmbed.data.description).toBe("**ISM Manufacturing PMI**\n**ISM Manufacturing PMI Final**");
-    expect(reminderEmbed.data.footer?.text).toBe("🕒 14:30");
+    expect(reminderEmbed.data.footer?.text).toBe("🕒 14:30 · 📅 2026-05-04");
     expect(reminderEmbed.data.color).toBe(0x0099ff);
 
     const emptyEmbed = buildCalendarReminderEmbed("reminder", []);
@@ -125,7 +125,7 @@ describe("timer-reminders", () => {
     expect(getCalendarReminderContent("role-1", "update")).toBe("<@&role-1> Update");
     expect(updateEmbed.data.title).toBe("🇺🇸 Consumer Price Index (CPI) y/y");
     expect(updateEmbed.data.description).toBe("**Consumer Price Index (CPI) y/y** — `3.4%` ▲ exp. `3.2%` · prev. `3.1%`");
-    expect(updateEmbed.data.footer?.text).toBe("🕒 14:30");
+    expect(updateEmbed.data.footer?.text).toBe("🕒 14:30 · 📅 2026-05-04");
   });
 
   test("renders forecast-only and actual-only embed lines", () => {
@@ -162,7 +162,7 @@ describe("timer-reminders", () => {
     expect(getCalendarReminderContent("role-1", "summary")).toBe("<@&role-1> Update");
     expect(summaryEmbed.data.title).toBe("🇺🇸 FOMC Statement");
     expect(summaryEmbed.data.description).toBe("**FOMC Statement**\n\nPolicy remains data dependent.");
-    expect(summaryEmbed.data.footer?.text).toBe("🕒 14:30 · Quelle: Federal Reserve");
+    expect(summaryEmbed.data.footer?.text).toBe("🕒 14:30 · 📅 2026-05-04 · Quelle: Federal Reserve");
   });
 
   test("matches earnings reminder tickers, removes duplicates and formats by time bucket", () => {

--- a/modules/timer-reminders.ts
+++ b/modules/timer-reminders.ts
@@ -7,6 +7,10 @@ import {type CalendarEvent} from "./calendar.ts";
 import {type EarningsEvent} from "./earnings.ts";
 
 export type CalendarReminderKind = "reminder" | "update" | "summary";
+export type CalendarReminderGroup = {
+  asset: CalendarReminderAsset;
+  events: CalendarEvent[];
+};
 
 // Neutral embed accent — macro data has no inherent good/bad direction
 // (a hotter CPI print is not "good"), so do not colour by beat/miss.
@@ -296,6 +300,11 @@ export function buildCalendarReminderEmbed(
     footerParts.push(`🕒 ${time}`);
   }
 
+  const date = getCalendarEventDisplayValue(primaryEvent?.date);
+  if ("" !== date) {
+    footerParts.push(`📅 ${date}`);
+  }
+
   const sourceName = options.sourceName?.trim() ?? "";
   if ("summary" === kind && "" !== sourceName) {
     footerParts.push(`Quelle: ${sourceName}`);
@@ -311,8 +320,8 @@ export function buildCalendarReminderEmbed(
 export function getMatchedCalendarReminderEventGroups(
   calendarReminderAssets: CalendarReminderAsset[],
   calendarEvents: CalendarEvent[],
-): {asset: CalendarReminderAsset; events: CalendarEvent[]}[] {
-  const groupedReminderEvents = new Map<string, {asset: CalendarReminderAsset; events: CalendarEvent[]}>();
+): CalendarReminderGroup[] {
+  const groupedReminderEvents = new Map<string, CalendarReminderGroup>();
 
   for (const calendarReminderAsset of calendarReminderAssets) {
     const roleId = getNormalizedRoleId(calendarReminderAsset.roleId);

--- a/modules/timers-other.test.ts
+++ b/modules/timers-other.test.ts
@@ -8,6 +8,7 @@ import {
   createClientWithChannel,
   getAssetByNameMock,
   getCalendarEventsMock,
+  getCalendarEventsResultMock,
   getCalendarOfficialSummaryMock,
   getCalendarMessagesMock,
   getEarningsMessagesMock,
@@ -219,13 +220,12 @@ describe("timers: other announcements", () => {
     expect(reminder.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
     expect(reminder.embeds[0]!.data.title).toBe("🇺🇸 Consumer Price Index (CPI)");
     expect(reminder.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI)**");
-    expect(reminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
+    expect(reminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30 · 📅 2025-02-19");
   });
 
   test("startOtherTimers keeps the agenda in the trading calendar thread but posts macro alerts to the main channel", async () => {
     const {client, parentSend, threadSend, mainSend} = createClientWithThreadAndMainChannel("trading-calendar-thread", "main-channel-id");
-    getCalendarEventsMock
-      .mockResolvedValueOnce([
+    getCalendarEventsMock.mockResolvedValueOnce([
         {
           date: "2025-02-19",
           time: "14:30",
@@ -234,8 +234,10 @@ describe("timers: other announcements", () => {
           name: "Consumer Price Index (CPI) y/y",
           previousValue: "3.1%",
         },
-      ])
-      .mockResolvedValueOnce([
+      ]);
+    getCalendarEventsResultMock.mockResolvedValueOnce({
+      status: "ok",
+      events: [
         {
           actualValue: "3.4%",
           date: "2025-02-19",
@@ -245,7 +247,8 @@ describe("timers: other announcements", () => {
           name: "Consumer Price Index (CPI) y/y",
           previousValue: "3.1%",
         },
-      ]);
+      ],
+    });
 
     startOtherTimers(client, "channel-id", [], [], [createCalendarReminderAsset({
       name: "us-cpi-1h",
@@ -278,7 +281,7 @@ describe("timers: other announcements", () => {
     expect(releaseUpdate.content).toBe("<@&role-123> Update");
     expect(releaseUpdate.embeds[0]!.data.title).toBe("🇺🇸 Consumer Price Index (CPI) y/y");
     expect(releaseUpdate.embeds[0]!.data.description).toBe("**Consumer Price Index (CPI) y/y** — `3.4%` ▲ exp. `3.2%` · prev. `3.1%`");
-    expect(releaseUpdate.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
+    expect(releaseUpdate.embeds[0]!.data.footer?.text).toBe("🕒 14:30 · 📅 2025-02-19");
   });
 
   test("startOtherTimers bundles same-minute calendar reminder matches into one reminder", async () => {
@@ -319,13 +322,12 @@ describe("timers: other announcements", () => {
     expect(bundledReminder.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
     expect(bundledReminder.embeds[0]!.data.title).toBe("🇺🇸 CPI y/y");
     expect(bundledReminder.embeds[0]!.data.description).toBe("**CPI y/y**\n**Core CPI y/y**\n**CPI m/m**");
-    expect(bundledReminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
+    expect(bundledReminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30 · 📅 2025-02-19");
   });
 
   test("startOtherTimers posts calendar actuals after the release when they become available", async () => {
     const {client, send} = createClientWithChannel();
-    getCalendarEventsMock
-      .mockResolvedValueOnce([
+    getCalendarEventsMock.mockResolvedValueOnce([
         {
           date: "2025-02-19",
           time: "14:30",
@@ -334,8 +336,10 @@ describe("timers: other announcements", () => {
           name: "Consumer Price Index (CPI) y/y",
           previousValue: "3.1%",
         },
-      ])
-      .mockResolvedValueOnce([
+      ]);
+    getCalendarEventsResultMock.mockResolvedValueOnce({
+      status: "ok",
+      events: [
         {
           actualValue: "3.4%",
           date: "2025-02-19",
@@ -345,7 +349,8 @@ describe("timers: other announcements", () => {
           name: "Consumer Price Index (CPI) y/y",
           previousValue: "3.1%",
         },
-      ]);
+      ],
+    });
 
     startOtherTimers(client, "channel-id", [], [], [createCalendarReminderAsset({
       name: "us-cpi-1h",
@@ -394,12 +399,11 @@ describe("timers: other announcements", () => {
         previousValue: "3.1%",
       },
     ];
-    let resolveFollowUpFetch: (events: unknown[]) => void = () => undefined;
-    const pendingFollowUpFetch = new Promise<unknown[]>(resolve => {
+    let resolveFollowUpFetch: (result: {events: unknown[]; status: "ok"}) => void = () => undefined;
+    const pendingFollowUpFetch = new Promise<{events: unknown[]; status: "ok"}>(resolve => {
       resolveFollowUpFetch = resolve;
     });
-    getCalendarEventsMock
-      .mockResolvedValueOnce([
+    getCalendarEventsMock.mockResolvedValueOnce([
         {
           date: "2025-02-19",
           time: "14:30",
@@ -408,9 +412,10 @@ describe("timers: other announcements", () => {
           name: "Consumer Price Index (CPI) y/y",
           previousValue: "3.1%",
         },
-      ])
+      ]);
+    getCalendarEventsResultMock
       .mockReturnValueOnce(pendingFollowUpFetch)
-      .mockResolvedValue(releasedEvents);
+      .mockResolvedValue({events: releasedEvents, status: "ok"});
 
     startOtherTimers(client, "channel-id", [], [], [createCalendarReminderAsset({
       name: "us-cpi-1h",
@@ -427,7 +432,7 @@ describe("timers: other announcements", () => {
     // A second follow-up fires while the first is mid-flight; it must skip, not duplicate.
     await followUpJobs[1]!.callback();
     // Let the first follow-up complete and post the single update.
-    resolveFollowUpFetch(releasedEvents);
+    resolveFollowUpFetch({events: releasedEvents, status: "ok"});
     await firstFollowUp;
 
     // 1 agenda + 1 morning reminder + exactly 1 release update (no duplicate).
@@ -447,6 +452,15 @@ describe("timers: other announcements", () => {
         name: "FOMC Statement",
       },
     ]);
+    getCalendarEventsResultMock.mockResolvedValue({
+      status: "ok",
+      events: [{
+        date: "2025-02-19",
+        time: "20:00",
+        country: "🇺🇸",
+        name: "FOMC Statement",
+      }],
+    });
     getCalendarOfficialSummaryMock.mockResolvedValueOnce({
       name: "Federal Reserve",
       summaryMarkdown: "The Fed emphasized inflation and labor-market risks.",
@@ -478,7 +492,7 @@ describe("timers: other announcements", () => {
     expect(summaryUpdate.allowedMentions).toEqual({parse: [], roles: ["role-123"]});
     expect(summaryUpdate.embeds[0]!.data.title).toBe("🇺🇸 FOMC Statement");
     expect(summaryUpdate.embeds[0]!.data.description).toBe("**FOMC Statement**\n\nThe Fed emphasized inflation and labor-market risks.");
-    expect(summaryUpdate.embeds[0]!.data.footer?.text).toBe("🕒 20:00 · Quelle: Federal Reserve");
+    expect(summaryUpdate.embeds[0]!.data.footer?.text).toBe("🕒 20:00 · 📅 2025-02-19 · Quelle: Federal Reserve");
   });
 
   test("startOtherTimers skips calendar reminder assets with wrong country or invalid config", async () => {
@@ -565,12 +579,12 @@ describe("timers: other announcements", () => {
     expect(gdpReminder.content).toBe("<@&role-123> Heute wichtig");
     expect(gdpReminder.embeds[0]!.data.title).toBe("🇺🇸 GDP q/q");
     expect(gdpReminder.embeds[0]!.data.description).toBe("**GDP q/q**");
-    expect(gdpReminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30");
+    expect(gdpReminder.embeds[0]!.data.footer?.text).toBe("🕒 14:30 · 📅 2025-02-19");
     const fomcReminder = getReminderPayload(send, 2);
     expect(fomcReminder.content).toBe("<@&role-123> Heute wichtig");
     expect(fomcReminder.embeds[0]!.data.title).toBe("🇺🇸 FOMC Statement");
     expect(fomcReminder.embeds[0]!.data.description).toBe("**FOMC Statement**");
-    expect(fomcReminder.embeds[0]!.data.footer?.text).toBe("🕒 20:00");
+    expect(fomcReminder.embeds[0]!.data.footer?.text).toBe("🕒 20:00 · 📅 2025-02-19");
   });
 
   test("startOtherTimers skips Friday announcement when asset is unavailable", async () => {

--- a/modules/timers.ts
+++ b/modules/timers.ts
@@ -10,13 +10,12 @@ import {
 import {
   CALENDAR_MAX_MESSAGE_LENGTH,
   CALENDAR_MAX_MESSAGES_TIMER,
-  getCalendarEventDateTime,
   getCalendarEvents,
   getCalendarMessages,
   type CalendarEvent,
   type CalendarMessageBatch,
 } from "./calendar.ts";
-import {getCalendarOfficialSummary} from "./calendar-economic-summary.ts";
+import {createCalendarReminderFollowUpCoordinator} from "./calendar-reminder-follow-ups.ts";
 import {
   EARNINGS_MAX_MESSAGE_LENGTH,
   EARNINGS_MAX_MESSAGES_TIMER,
@@ -43,8 +42,6 @@ import {
   getMatchedCalendarReminderEventGroups,
   getMatchedEarningsReminderEvents,
   getNormalizedRoleId,
-  hasCalendarReminderActualValues,
-  hasCalendarReminderClearMetrics,
 } from "./timer-reminders.ts";
 
 const logger = getLogger();
@@ -59,7 +56,6 @@ type FileAnnouncementAsset = {
 const calendarReminderAnnouncementSource = "calendar-reminder";
 const earningsReminderSource = "earnings-reminder";
 const calendarMessageDelayMs = 500;
-const calendarReminderFollowUpDelaySeconds = [5, 10, 20, 30, 60, 120, 180, 300, 600, 900];
 const usEasternTimezone = "US/Eastern";
 const dailyEarningsHeadline = "**Earnings**";
 const weeklyEarningsHeadline = "💸 **Earnings der nächsten Handelswoche**";
@@ -82,6 +78,9 @@ type TimerClient = {
     };
     fetch?: (channelId: string) => Promise<unknown> | unknown;
   };
+  user?: {
+    id?: string | undefined;
+  } | null | undefined;
 };
 type NyseSentimentPollMessage = {
   channel?: {
@@ -113,10 +112,6 @@ type EarningsAnnouncementConfig = {
   headlinePlacement?: "merged" | "standalone";
   source: string;
   when: "all" | "before_open" | "during_session" | "after_close" | string;
-};
-type CalendarReminderGroup = {
-  asset: CalendarReminderAsset;
-  events: CalendarEvent[];
 };
 const nyseSentimentPollAnswers = [
   {emoji: "🟢", text: "Risk-on"},
@@ -885,6 +880,13 @@ export function startOtherTimers(
   // summaries) post to the main channel for visibility; the daily/weekly
   // calendar agenda batches stay in the optional trading-calendar thread.
   const resolvedMacroAlertChannelID = macroAlertChannelID ?? channelID;
+  const calendarFollowUps = createCalendarReminderFollowUpCoordinator({
+    assets: calendarReminderAssets,
+    channelId: resolvedMacroAlertChannelID,
+    client,
+    logger,
+  });
+  calendarFollowUps.start();
   const ruleFriday = createRecurrenceRule({
     hour: 8,
     minute: 0,
@@ -1088,7 +1090,7 @@ export function startOtherTimers(
         calendarReminderAnnouncementSource,
       );
     }
-    scheduleCalendarReminderFollowUpJobs(client, resolvedMacroAlertChannelID, matchedReminderGroups);
+    calendarFollowUps.scheduleGroups(matchedReminderGroups);
   });
 
   const ruleEventsWeekly = createRecurrenceRule({
@@ -1135,133 +1137,6 @@ function dedupeCalendarEvents(calendarEvents: CalendarEvent[]): CalendarEvent[] 
   }
 
   return dedupedEvents;
-}
-
-function scheduleCalendarReminderFollowUpJobs(
-  client: TimerClient,
-  macroAlertChannelID: string,
-  matchedReminderGroups: CalendarReminderGroup[],
-) {
-  const sentFollowUpKeys = new Set<string>();
-  // Follow-up jobs fire at staggered delays; once actuals are out, two jobs can
-  // overlap because sendCalendarReminderFollowUp awaits a network fetch. Claim the
-  // key synchronously (before any await) so an overlapping job skips instead of
-  // posting a duplicate. Released on failure so a later job can still retry.
-  const inFlightFollowUpKeys = new Set<string>();
-
-  for (const matchedReminderGroup of matchedReminderGroups) {
-    if (false === shouldScheduleCalendarReminderFollowUp(matchedReminderGroup)) {
-      continue;
-    }
-
-    const primaryEvent = matchedReminderGroup.events[0];
-    if (undefined === primaryEvent) {
-      continue;
-    }
-
-    const eventDateTime = getCalendarEventDateTime(primaryEvent);
-    if (false === eventDateTime.isValid()) {
-      continue;
-    }
-
-    const followUpKey = getCalendarReminderFollowUpKey(matchedReminderGroup);
-    for (const delaySeconds of calendarReminderFollowUpDelaySeconds) {
-      const scheduledDateTime = eventDateTime.clone().add(delaySeconds, "seconds");
-      if (true === scheduledDateTime.isSameOrBefore(moment())) {
-        continue;
-      }
-
-      Schedule.scheduleJob(scheduledDateTime.toDate(), async () => {
-        if (true === sentFollowUpKeys.has(followUpKey) || true === inFlightFollowUpKeys.has(followUpKey)) {
-          return;
-        }
-
-        inFlightFollowUpKeys.add(followUpKey);
-        try {
-          const sent = await sendCalendarReminderFollowUp(client, macroAlertChannelID, matchedReminderGroup);
-          if (true === sent) {
-            sentFollowUpKeys.add(followUpKey);
-          }
-        } finally {
-          inFlightFollowUpKeys.delete(followUpKey);
-        }
-      });
-    }
-  }
-}
-
-function shouldScheduleCalendarReminderFollowUp(matchedReminderGroup: CalendarReminderGroup): boolean {
-  return false === hasCalendarReminderActualValues(matchedReminderGroup.events);
-}
-
-function getCalendarReminderFollowUpKey(matchedReminderGroup: CalendarReminderGroup): string {
-  const primaryEvent = matchedReminderGroup.events[0];
-  const roleId = getNormalizedRoleId(matchedReminderGroup.asset.roleId) ?? "missing-role";
-  const assetName = matchedReminderGroup.asset.name?.trim() || "calendar-reminder";
-  if (undefined === primaryEvent) {
-    return `${assetName}|${roleId}|missing-event`;
-  }
-
-  return `${assetName}|${roleId}|${primaryEvent.date}|${primaryEvent.time}|${primaryEvent.country}`;
-}
-
-async function sendCalendarReminderFollowUp(
-  client: TimerClient,
-  macroAlertChannelID: string,
-  matchedReminderGroup: CalendarReminderGroup,
-): Promise<boolean> {
-  const roleId = getNormalizedRoleId(matchedReminderGroup.asset.roleId);
-  const primaryEvent = matchedReminderGroup.events[0];
-  if (!roleId || undefined === primaryEvent) {
-    return false;
-  }
-
-  const refreshedEvents = await getCalendarEvents(primaryEvent.date, 0);
-  const refreshedReminderGroup = findMatchingCalendarReminderGroup(matchedReminderGroup, refreshedEvents);
-  const calendarEvents = refreshedReminderGroup?.events ?? matchedReminderGroup.events;
-
-  if (true === hasCalendarReminderActualValues(calendarEvents)) {
-    await sendToChannel(
-      getSendableChannel(client, macroAlertChannelID, calendarReminderAnnouncementSource),
-      {
-        content: getCalendarReminderContent(roleId, "update"),
-        embeds: [buildCalendarReminderEmbed("update", calendarEvents)],
-        allowedMentions: getAllowedRoleMentions(roleId),
-      },
-      calendarReminderAnnouncementSource,
-    );
-    return true;
-  }
-
-  if (false === hasCalendarReminderClearMetrics(calendarEvents)) {
-    const officialSummary = await getCalendarOfficialSummary(calendarEvents, {logger});
-    if (undefined !== officialSummary) {
-      await sendToChannel(
-        getSendableChannel(client, macroAlertChannelID, calendarReminderAnnouncementSource),
-        {
-          content: getCalendarReminderContent(roleId, "summary"),
-          embeds: [buildCalendarReminderEmbed("summary", calendarEvents, {
-            sourceName: officialSummary.name,
-            summaryMarkdown: officialSummary.summaryMarkdown,
-          })],
-          allowedMentions: getAllowedRoleMentions(roleId),
-        },
-        calendarReminderAnnouncementSource,
-      );
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function findMatchingCalendarReminderGroup(
-  matchedReminderGroup: CalendarReminderGroup,
-  calendarEvents: CalendarEvent[],
-): CalendarReminderGroup | undefined {
-  const followUpKey = getCalendarReminderFollowUpKey(matchedReminderGroup);
-  return getMatchedCalendarReminderEventGroups([matchedReminderGroup.asset], calendarEvents)
-    .find(candidate => getCalendarReminderFollowUpKey(candidate) === followUpKey);
 }
 
 function prependHeadlineToFirstMessage(


### PR DESCRIPTION
## Summary
- reconcile configured calendar alerts at startup and every 30 minutes
- recover releases after redeploys without persistent storage by using provider event IDs and Discord message history
- handle delayed data, reschedules, text-only releases, ambiguous sends, and overlapping retries

## Verification
- npm audit --audit-level=high
- npm run lint
- npm run test:coverage
- npm run typecheck