### PR TITLE
Fix earnings parsing across six filings

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -1002,6 +1002,123 @@ const filingCorpus: {
     source: "864749/000086474926000106/a2026q2-8kex991_00version.htm",
     ticker: "trmb",
   },
+  {
+    // Summary-table money units occupy their own SEC cells, and the actual non-GAAP EPS is
+    // introduced as the per-share equivalent of non-GAAP net income. Guidance spans Q1 and FY.
+    company: "Cisco Systems",
+    metrics: [
+      ["adjusted_eps", "$1.22"],
+      ["gaap_eps", "$0.97"],
+      ["revenue", "$17.3B"],
+      ["net_income", "$3.9B"],
+    ],
+    outlook: [
+      ["Q1 Revenue", "$18B to $18.2B"],
+      ["FY2027 Revenue", "$72.2B to $73.4B"],
+      ["Q1 Adj EPS", "$1.32 to $1.34"],
+      ["FY2027 Adj EPS", "$5.05 to $5.11"],
+      ["Q1 EPS", "$1.08 to $1.1"],
+      ["FY2027 EPS", "$4 to $4.06"],
+    ],
+    quarterLabel: "Q4 2026",
+    source: "858877/000085887726000106/exhibit991pressrelease-q4f.htm",
+    ticker: "csco",
+  },
+  {
+    // Core revenue is a non-GAAP operating measure, not the generic top-line result. The
+    // outlook publishes both Q3 and FY core measures, including parenthesized margin ranges.
+    company: "Cerebras Systems",
+    metrics: [
+      ["gaap_eps", "-$2.98"],
+      ["revenue", "$180.1M"],
+      ["net_income", "-$450.53M"],
+    ],
+    outlook: [
+      ["Q3 Core revenue", "$214M to $216M"],
+      ["FY2026 Core revenue", "$880M to $890M"],
+      ["Q3 Core gross margin", "38% to 40%"],
+      ["FY2026 Core gross margin", "41% to 43%"],
+      ["Q3 Core operating margin", "-25% to -23%"],
+      ["FY2026 Core operating margin", "-19% to -17%"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "2021728/000162828026056186/cbrsannouncesfinancialresu.htm",
+    ticker: "cbrs",
+  },
+  {
+    // The headline calls $1.19 "GAAP net income" per diluted share after mentioning scaled
+    // revenue. Aggregate net income is $240.5M, and the Q1 expense range wraps onto two lines.
+    company: "Coherent",
+    metrics: [
+      ["adjusted_eps", "$1.74"],
+      ["gaap_eps", "$1.19"],
+      ["revenue", "$2.05B"],
+      ["net_income", "$240.5M"],
+    ],
+    outlook: [
+      ["Revenue", "$2.2B to $2.4B"],
+      ["Adj EPS", "$1.85 to $2.05"],
+      ["Gross margin", "39.5% to 41.5%"],
+      ["Operating expenses", "$400M to $420M"],
+      ["Tax rate", "18% to 20%"],
+    ],
+    quarterLabel: "Q4 2026",
+    source: "820318/000119312526346860/d128030dex991.htm",
+    ticker: "cohr",
+  },
+  {
+    // The only quantified outlook is embedded in an ordinary cash-runway paragraph rather
+    // than under a guidance heading, and it states operating expense on two distinct bases.
+    company: "Allogene Therapeutics",
+    metrics: [
+      ["gaap_eps", "-$0.13"],
+      ["revenue", "$4.64M"],
+      ["net_income", "-$42.7M"],
+    ],
+    outlook: [
+      ["GAAP operating expenses", "$225M"],
+      ["Operating expenses", "$165M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1737287/000162828026056198/allo-20260630xexx991q226.htm",
+    ticker: "allo",
+  },
+  {
+    // The first value column is Q3 guidance and the following two are historical results.
+    // Captions and values are split across lines, with one parenthesis enclosing each range.
+    company: "Enovix",
+    metrics: [
+      ["adjusted_eps", "-$0.13"],
+      ["gaap_eps", "-$0.20"],
+      ["revenue", "$9M"],
+      ["net_income", "-$43.06M"],
+    ],
+    outlook: [
+      ["Revenue", "$9M to $10M"],
+      ["Adj EPS", "-$0.13 to -$0.17"],
+      ["Adj operating income", "-$29M to -$32M"],
+      ["Capex", "$8M to $12M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "1828318/000182831826000055/envx8k-q22026x8122026ex991.htm",
+    ticker: "envx",
+  },
+  {
+    // The annual revenue figure is carried on the same bullet as its outlook heading, so
+    // skipping the heading also skips the only quantified guidance in the release.
+    company: "Infleqtion",
+    metrics: [
+      ["gaap_eps", "-$0.12"],
+      ["revenue", "$12.6M"],
+      ["net_income", "-$25.47M"],
+    ],
+    outlook: [
+      ["Revenue", "$43M"],
+    ],
+    quarterLabel: "Q2 2026",
+    source: "2007825/000162828026056222/infq-20260630xex991.htm",
+    ticker: "infq",
+  },
 ];
 
 describe("earnings result filing corpus", () => {
@@ -1022,6 +1139,6 @@ describe("earnings result filing corpus", () => {
   }
 
   test("covers every stored fixture", () => {
-    expect(filingCorpus).toHaveLength(64);
+    expect(filingCorpus).toHaveLength(70);
   });
 });

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -131,6 +131,15 @@ export function getMetricCandidateScore({
     } else if (/\b(?:net\s+)?product\s+sales\b|\bservice\s+revenues?\b/i.test(metricCaptionText)) {
       score -= 80;
     }
+
+    // Some companies publish a bespoke "Core revenue" measure alongside the
+    // consolidated GAAP total. Generic Revenue is the filed GAAP total; a core
+    // measure remains useful only when it is explicitly labelled as such.
+    if (/\bgaap\s+total\s+revenues?\b/i.test(metricLine)) {
+      score += 100;
+    } else if (/\bcore\s+(?:total\s+)?revenues?\b/i.test(metricCaptionText)) {
+      score -= 100;
+    }
   }
 
   // A company may publish its standard adjusted EPS and then an additional figure that

--- a/modules/earnings-results-metrics.test.ts
+++ b/modules/earnings-results-metrics.test.ts
@@ -338,6 +338,50 @@ describe("earnings result metric selection", () => {
     ]);
   });
 
+  test("does not let unrelated revenue scale turn per-share net income into an aggregate", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <h1>Example reports fourth quarter 2026 results</h1>
+      <p>In Q4 2026, revenue was $2.05 billion and GAAP net income was $1.19 per diluted share.</p>
+      <p>CONDENSED CONSOLIDATED STATEMENTS OF EARNINGS</p>
+      <p>(in millions, except per-share data)</p>
+      <table><tr><td>Net earnings attributable to Example</td><td>$</td><td>240.5</td></tr></table>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "net_income", value: "$240.5M"}),
+    ]));
+    expect(parsedDocument.metrics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "net_income", value: "$1.19"}),
+    ]));
+  });
+
+  test("prefers GAAP total revenue over a quarter-specific core measure", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <h1>Example reports second quarter 2026 results</h1>
+      <p>In Q2 2026, Core revenue more than doubled to $210 million.</p>
+      <p>CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS</p>
+      <p>(in thousands)</p>
+      <table><tr><td>GAAP Total revenue</td><td>$</td><td>180,100</td></tr></table>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "revenue", value: "$180.1M"}),
+    ]));
+  });
+
+  test("reads per-share value introduced by non-GAAP net income", () => {
+    const parsedDocument = parseEarningsDocument(`
+      <h1>Example reports fourth quarter 2026 results</h1>
+      <p>For the fourth quarter, non-GAAP net income was $4.9 billion, or $1.22 per diluted share.</p>
+      <h2>Guidance</h2>
+      <p>Non-GAAP EPS is expected to be $1.32 to $1.34.</p>
+    `);
+
+    expect(parsedDocument.metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({key: "adjusted_eps", value: "$1.22"}),
+    ]));
+  });
+
   test("uses Amazon quarterly EPS and consolidated sales instead of YTD and run-rate values", () => {
     const parsedDocument = parseEarningsDocument(`
       <html>

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -47,6 +47,9 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
     key: "adjusted_eps",
     label: "Adj EPS",
     patterns: [
+      // Some releases state non-GAAP net income and then introduce its per-share
+      // equivalent with "or", without ever spelling out EPS as a caption.
+      /\b(?:reported|for)\s+(?:the\s+)?(?:q[1-4]|first|second|third|fourth)[\s–—-]+quarter\b(?:(?![.!?]\s)[^!?\n]){0,360}?\bnon-gaap\s+(?:net\s+)?(?:income|earnings|loss)\b(?:(?![.!?]\s)[^!?\n]){0,180}?\bor\s+(?<metricValue>\(?-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share\b/i,
       /\badjusted\b(?:(?![.!?]\s)[^!?\n]){0,180}?(?<metricValue>-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share(?:\s*[-–—]\s*diluted)?\b/i,
       /\bnon-gaap\s+(?:net\s+)?(?:income|earnings|loss)\s+for\s+(?:the\s+)?(?:q[1-4]|(?:first|second|third|fourth)[\s–—-]+quarter)\b(?:(?![.!?]\s)[^!?\n]){0,180}?(?<metricValue>-?(?:[$€£¥]\s*)?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+per\s+(?:common\s+)?(?:diluted\s+)?share(?:\s*[-–—]\s*diluted)?\b/i,
       /\badjusted\s+(?:\d{1,2}\s+)?(?:continuing(?:\s+operations?)?\s+)?(?:diluted\s+)?(?:earnings\s+per\s+(?:common\s+)?share|eps)\b/i,
@@ -230,8 +233,20 @@ function isQuarterSpecificSectionBoundary(line: string): boolean {
 export function isPerShareOnlyNetIncomeLine(line: string): boolean {
   const hasCombinedAggregateLabel =
     /\bnet\s+income\b.*\band\b.*\bnet\s+income\s+per\s+(?:common\s+|diluted\s+)?share\b/i.test(line);
+  if (true === hasCombinedAggregateLabel) {
+    return false;
+  }
+
+  // A headline can mention scaled revenue and then say "GAAP net income of
+  // $1.19 per diluted share". The unrelated revenue scale must not make that
+  // per-share statement look like an aggregate net-income figure.
+  const hasPerShareNetIncome = /\bnet\s+(?:income|earnings)\b[^.!?]{0,80}\b(?:of\s+)?\(?-?[$€£¥]?\s*\d+(?:\.\d+)?\)?\s+per\s+(?:common\s+)?(?:diluted\s+)?share\b/i.test(line);
+  const hasAggregateNetIncome = /\bnet\s+(?:income|earnings)\b[^.!?]{0,80}\(?-?[$€£¥]?\s*\d+(?:\.\d+)?\)?\s+(?:trillion|billion|million|thousand)s?\b/i.test(line);
+  if (true === hasPerShareNetIncome && false === hasAggregateNetIncome) {
+    return true;
+  }
+
   return /\bper\s+(?:common\s+|diluted\s+)?share\b/i.test(line) &&
-    false === hasCombinedAggregateLabel &&
     false === /\b(?:trillion|billion|million|thousand)s?\b/i.test(line);
 }
 

--- a/modules/earnings-results-money.test.ts
+++ b/modules/earnings-results-money.test.ts
@@ -5,6 +5,7 @@ import {
   findNumericValue,
   formatEps,
   formatUsdCompact,
+  getExplicitMoneyScale,
   parseNumber,
 } from "./earnings-results-money.ts";
 import {type EarningsEvent} from "./earnings.ts";
@@ -535,5 +536,12 @@ describe("earnings result money parsing", () => {
     test("still skips a bare year in a column header", () => {
       expect(findNumericValue(" 2026 | 2025", scanOptions)).toBeNull();
     });
+  });
+
+  test("keeps an explicit money scale across SEC table separators", () => {
+    const row = "Revenue | | $ | 17.3 | billion |";
+    const valueEndIndex = row.indexOf("17.3") + "17.3".length;
+
+    expect(getExplicitMoneyScale(row, valueEndIndex)).toBe(1_000_000_000);
   });
 });

--- a/modules/earnings-results-money.ts
+++ b/modules/earnings-results-money.ts
@@ -341,7 +341,10 @@ export function getCurrencyCodeFromText(
 
 export function getExplicitMoneyScale(text: string, valueEndIndex: number): number | null {
   const afterValue = text.slice(valueEndIndex, valueEndIndex + 24);
-  const unitMatch = afterValue.match(/^\s*(trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands|[kmbt])\b/i);
+  // SEC tables preserve empty cell separators between a number and its unit
+  // ("$ | 17.3 | billion"). Those separators are presentation, not a break in
+  // the value, so retain the explicit scale across them.
+  const unitMatch = afterValue.match(/^[\s|]*(trillion|trillions|tn|billion|billions|bn|million|millions|mm|thousand|thousands|[kmbt])\b/i);
   const unit = unitMatch?.[1]?.toLowerCase();
   if (!unit) {
     return null;

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -566,6 +566,99 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  test("keeps core guidance separated across quarter and full-year sections", () => {
+    expect(extractOutlookMetrics([
+      "Third Quarter 2026 Financial Outlook",
+      "Core Non-GAAP Financial Outlook:",
+      "Core revenue of approximately $214 to $216 million",
+      "Core gross margin in the range of 38% - 40%",
+      "Core operating margins in the range of (25%) to (23%)",
+      "Full Year 2026 Financial Outlook",
+      "Core Non-GAAP Financial Outlook has been raised for all metrics:",
+      "Core revenue of $880 to $890 million",
+      "Core gross margin in the range of 41% - 43%",
+      "Core operating margins in the range of (19%) to (17%)",
+    ])).toEqual([
+      {key: "core_revenue", label: "Core revenue", periodLabel: "Q3", value: "$214M to $216M"},
+      {key: "core_revenue", label: "Core revenue", periodLabel: "FY2026", value: "$880M to $890M"},
+      {key: "core_gross_margin", label: "Core gross margin", periodLabel: "Q3", value: "38% to 40%"},
+      {key: "core_gross_margin", label: "Core gross margin", periodLabel: "FY2026", value: "41% to 43%"},
+      {key: "core_operating_margin", label: "Core operating margin", periodLabel: "Q3", value: "-25% to -23%"},
+      {key: "core_operating_margin", label: "Core operating margin", periodLabel: "FY2026", value: "-19% to -17%"},
+    ]);
+  });
+
+  test("reads only the guidance column of a results comparison table", () => {
+    expect(extractOutlookMetrics([
+      "Financial Outlook",
+      "(unaudited, in millions, except per share data)",
+      "| | Q3 2026 Guidance (1)",
+      "| | Q3 2025 Results | | Q2 2026 Results |",
+      "Revenue | | $9.0 - 10.0 | | $8.0 | | $9.0 |",
+      "Non-GAAP loss from operations",
+      "| | ($29.0 - 32.0) | | ($29.8) | | ($28.8) |",
+      "Non-GAAP net loss per share",
+      "| | ($0.13 - 0.17) | | ($0.14) | | ($0.13) |",
+      "Capital expenditures",
+      "| | $8.0 - 12.0 | | $3.0 | | $9.6 |",
+    ])).toEqual([
+      {key: "revenue", label: "Revenue", value: "$9M to $10M"},
+      {key: "adjusted_eps", label: "Adj EPS", value: "-$0.13 to -$0.17"},
+      {key: "adjusted_operating_income", label: "Adj operating income", value: "-$29M to -$32M"},
+      {key: "capex", label: "Capex", value: "$8M to $12M"},
+    ]);
+  });
+
+  test("extracts quantified guidance embedded in prose without a section heading", () => {
+    expect(extractOutlookMetrics([
+      "Based on its cash position, the company projects its runway into 2029. Guidance for operating expense in 2026 is expected to be approximately $165 million. GAAP operating expenses are expected to be approximately $225 million.",
+      "Conference Call",
+    ])).toEqual([
+      {key: "gaap_operating_expenses", label: "GAAP operating expenses", value: "$225M"},
+      {key: "operating_expenses", label: "Operating expenses", value: "$165M"},
+    ]);
+  });
+
+  test("keeps the metric on an inline annual outlook heading", () => {
+    expect(extractOutlookMetrics([
+      "2026 Outlook: Raised full-year revenue outlook to approximately $43 million and reiterated the target of 30 logical qubits in 2026",
+      "Second Quarter and Recent Business Highlights",
+    ])).toEqual([
+      {key: "revenue", label: "Revenue", value: "$43M"},
+    ]);
+  });
+
+  test("joins a wrapped range and preserves a postfix non-GAAP EPS basis", () => {
+    expect(extractOutlookMetrics([
+      "Business Outlook",
+      "Revenue between $2.2 billion and $2.4 billion.",
+      "EPS between $1.85 and $2.05 on a non-GAAP basis.",
+      "Total operating expenses are expected to be between $400 million and",
+      "$420 million on a non-GAAP basis.",
+    ])).toEqual([
+      {key: "revenue", label: "Revenue", value: "$2.2B to $2.4B"},
+      {key: "adjusted_eps", label: "Adj EPS", value: "$1.85 to $2.05"},
+      {key: "operating_expenses", label: "Operating expenses", value: "$400M to $420M"},
+    ]);
+  });
+
+  test("inherits mixed periods from standalone SEC table captions", () => {
+    expect(extractOutlookMetrics([
+      "Guidance",
+      "Q1 FY 2027 | | |",
+      "Revenue | | $18.0 billion - $18.2 billion |",
+      "Non-GAAP EPS | | $1.32 - $1.34 |",
+      "FY 2027 | | |",
+      "Revenue | | $72.2 billion - $73.4 billion |",
+      "Non-GAAP EPS | | $5.05 - $5.11 |",
+    ])).toEqual([
+      {key: "revenue", label: "Revenue", periodLabel: "Q1", value: "$18B to $18.2B"},
+      {key: "revenue", label: "Revenue", periodLabel: "FY2027", value: "$72.2B to $73.4B"},
+      {key: "adjusted_eps", label: "Adj EPS", periodLabel: "Q1", value: "$1.32 to $1.34"},
+      {key: "adjusted_eps", label: "Adj EPS", periodLabel: "FY2027", value: "$5.05 to $5.11"},
+    ]);
+  });
+
   test("limits outlook scanning and ignores unusable fallback values", () => {
     const lines = [
       "Business Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -48,6 +48,10 @@ type OutlookSection = {
   // guidance, so they are read rather than dismissed as a comparison table, and the updated
   // column is the one that now applies.
   revisedColumns: boolean;
+  // A comparison table can put guidance in its first value column and historical results
+  // after it. Those rows are safe to read, but only the first populated financial cell is
+  // forward-looking.
+  guidanceFirstColumns: boolean;
 };
 
 const moneyUnitPatternSource = String.raw`(?:trillions?|billions?|millions?|thousands?|tn|bn|mm|[tbmk])\b`;
@@ -69,6 +73,7 @@ const adjustedEpsDefinition: OutlookMetricDefinition = {
     /\badjusted\s+(?:diluted\s+)?eps\b/i,
     /\badjusted\s+(?:diluted\s+)?(?:earnings|net\s+income)\s+per\s+(?:common\s+)?(?:diluted\s+)?share\b/i,
     /\bnon-gaap\s+(?:diluted\s+)?(?:eps|(?:earnings|net\s+income)\s+per\s+(?:common\s+)?(?:diluted\s+)?share)\b/i,
+    /\bnon-gaap\s+net\s+loss\s+per\s+(?:common\s+)?(?:diluted\s+)?share\b/i,
   ],
   valueType: "eps",
 };
@@ -120,13 +125,30 @@ const outlookMetricDefinitions: OutlookMetricDefinition[] = [
   {
     key: "operating_margin",
     label: "Operating margin",
-    patterns: [/\boperating\s+margin\b/i],
+    patterns: [/\boperating\s+margins?\b/i],
     valueType: "percent",
   },
   {
     key: "operating_income",
     label: "Operating income",
     patterns: [/\boperating\s+income\b/i],
+    valueType: "money",
+  },
+  {
+    key: "adjusted_operating_income",
+    label: "Adj operating income",
+    patterns: [
+      /\bnon-gaap\s+(?:operating\s+loss|loss\s+from\s+operations)\b/i,
+      /\badjusted\s+operating\s+loss\b/i,
+    ],
+    valueType: "money",
+  },
+  {
+    key: "gaap_operating_expenses",
+    label: "GAAP operating expenses",
+    patterns: [
+      /\bguidance\s+for\s+operating\s+expenses?\b.{0,260}\bgaap\s+operating\s+expenses?\b/i,
+    ],
     valueType: "money",
   },
   {
@@ -178,6 +200,7 @@ export function extractOutlookMetrics(
       section.revisedColumns,
       section.moneyUnit,
       section.nonGaapMeasures,
+      section.guidanceFirstColumns,
     );
     for (const metric of definitionMetrics) {
       const identity = `${metric.periodLabel ?? ""}:${metric.key}`;
@@ -204,10 +227,21 @@ function getOutlookSection(lines: string[]): OutlookSection {
       collecting = true;
       heading = line;
       mixedPeriods = isMixedPeriodOutlookHeading(line);
+      // An inline heading such as "2026 Outlook: revenue ..." carries the only metric
+      // value and therefore belongs to the section body.
+      if (true === hasInlineOutlookMetricValue(line)) {
+        sectionLines.push(line);
+      }
       continue;
     }
 
     if (false === collecting) {
+      if (false === isInlineOutlookMetricLine(line)) {
+        continue;
+      }
+
+      collecting = true;
+      sectionLines.push(line);
       continue;
     }
 
@@ -222,13 +256,42 @@ function getOutlookSection(lines: string[]): OutlookSection {
   }
 
   return {
+    guidanceFirstColumns: hasGuidanceFirstColumnHeader(sectionLines),
     heading,
     moneyUnit: getSectionMoneyUnit(sectionLines),
     lines: sectionLines,
-    mixedPeriods: mixedPeriods || hasMixedOutlookPeriods(sectionLines),
+    mixedPeriods: mixedPeriods ||
+      hasMixedOutlookPeriods(sectionLines) ||
+      hasMixedOutlookPeriods([
+        heading ?? "",
+        ...getStructuredOutlookPeriodLines(sectionLines),
+      ]),
     nonGaapMeasures: hasNonGaapGuidanceBasis(sectionLines),
     revisedColumns: sectionLines.some(line => hasRevisedColumnHeader(line)),
   };
+}
+
+function getStructuredOutlookPeriodLines(lines: string[]): string[] {
+  return lines.filter(line =>
+    true === isStandaloneOutlookPeriodCaption(line) ||
+    (false === isDefinitionalLine(line) &&
+      true === hasInlineOutlookMetricValue(line) &&
+      /\b(?:expects?|expected|guidance|outlook|forecast|projected|raises?|raised)\b/i.test(line)));
+}
+
+function hasInlineOutlookMetricValue(line: string): boolean {
+  const content = line.slice(Math.max(0, line.indexOf(":") + 1));
+  return /\b(?:revenues?|net\s+sales|eps|earnings\s+per\s+share|gross(?:\s+profit)?\s+margin|operating\s+(?:margin|income|loss|expenses?)|capex|capital\s+expenditures?|tax\s+rate)\b/i.test(content) &&
+    /[$€£¥]|\b(?:USD|CAD|EUR|GBP|JPY|CHF)\b|\d+(?:\.\d+)?\s*%/i.test(content);
+}
+
+function isInlineOutlookMetricLine(line: string): boolean {
+  const isGuidanceSentence = /\bguidance\s+for\b/i.test(line) &&
+    /\b(?:expects?|expected|forecast|projected)\b/i.test(line);
+  const isInlineOutlookHeading = /\b(?:20\d{2}|fy\s*\d{2})\s+outlook\s*:/i.test(line) &&
+    /\b(?:raises?|raised|updates?|provides?|expects?|reiterates?|reaffirms?)\b/i.test(line);
+  return (isGuidanceSentence || isInlineOutlookHeading) &&
+    true === hasInlineOutlookMetricValue(line);
 }
 
 // Only a sentence declaring what the guidance *is* counts. The boilerplate footnote that a
@@ -262,6 +325,21 @@ function hasRevisedColumnHeader(line: string): boolean {
   return /\bprior\b/i.test(line) &&
     /\bupdated\b/i.test(line) &&
     false === /\d/.test(line);
+}
+
+function hasGuidanceFirstColumnHeader(lines: string[]): boolean {
+  for (const [lineIndex, line] of lines.entries()) {
+    if (false === /\bguidance\b/i.test(line)) {
+      continue;
+    }
+
+    const headerText = lines.slice(lineIndex, lineIndex + 3).join(" ");
+    if (/\bresults?\b/i.test(headerText) && /\bq[1-4]\b/i.test(headerText)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function hasMixedOutlookPeriods(lines: string[]): boolean {
@@ -308,9 +386,14 @@ function isOutlookSectionEnd(line: string): boolean {
     return true;
   }
 
+  if (line.length <= 90 && /\b(?:business|financial)\s+highlights?\s*$/i.test(line)) {
+    return true;
+  }
+
   if (line.length <= 140 &&
       /^\s*(?:use\s+of\s+)?(?:non-gaap|reconciliation)\b/i.test(line) &&
-      false === /\d|\|/.test(line)) {
+      false === /\d|\|/.test(line) &&
+      false === /\b(?:eps|earnings\s+per\s+share|net\s+loss\s+per\s+share|operating\s+(?:income|loss)|loss\s+from\s+operations|gross(?:\s+profit)?\s+margin)\b/i.test(line)) {
     return true;
   }
 
@@ -340,10 +423,11 @@ function extractOutlookMetricsForDefinition(
   revisedColumns: boolean,
   sectionMoneyUnit: string | undefined,
   nonGaapMeasures: boolean,
+  guidanceFirstColumns: boolean,
 ): EarningsOutlookMetric[] {
   const bestCandidateByPeriod = new Map<string, OutlookMetricCandidate>();
   for (const [lineIndex, line] of lines.entries()) {
-    if (false === revisedColumns && true === isNoisyOutlookLine(line)) {
+    if (false === revisedColumns && false === guidanceFirstColumns && true === isNoisyOutlookLine(line)) {
       continue;
     }
 
@@ -361,9 +445,12 @@ function extractOutlookMetricsForDefinition(
 
       // A guidance table can carry its caption on one line and its cells on the next
       // ("Earnings per Share" / "| | | $35.50 to $37.00 | $35.50 to $36.50 |").
-      const valueLine = true === revisedColumns && false === /\d/.test(line)
-        ? `${line} ${lines[lineIndex + 1] ?? ""}`
-        : line;
+      const valueLine = getOutlookMetricValueLine(
+        lines,
+        lineIndex,
+        revisedColumns,
+        guidanceFirstColumns,
+      );
       const value = extractOutlookValue(
         valueLine,
         pattern,
@@ -372,13 +459,14 @@ function extractOutlookMetricsForDefinition(
         documentCurrencyCode,
         revisedColumns,
         sectionMoneyUnit,
+        guidanceFirstColumns,
       );
       if (null === value) {
         continue;
       }
 
       const periodLabel = true === includePeriodLabel
-        ? getOutlookPeriodLabel(lines, lineIndex)
+        ? getOutlookPeriodLabel(lines, lineIndex, sectionHeading)
         : undefined;
       if (true === includePeriodLabel && undefined === periodLabel) {
         continue;
@@ -389,11 +477,16 @@ function extractOutlookMetricsForDefinition(
       // stays intelligible. Revenue is never relabelled — the sentence that declares the
       // basis names revenue as the GAAP item.
       const isAdjustedBySectionBasis = "eps" === definition.key &&
-        true === nonGaapMeasures &&
+        (true === nonGaapMeasures || /\bnon-gaap\b/i.test(valueLine)) &&
         false === hasStandaloneGaapTerm(line);
+      const coreIdentity = getCoreOutlookIdentity(definition, line);
       const metric: EarningsOutlookMetric = {
-        key: isAdjustedBySectionBasis ? adjustedEpsDefinition.key : definition.key,
-        label: isAdjustedBySectionBasis ? adjustedEpsDefinition.label : definition.label,
+        key: isAdjustedBySectionBasis
+          ? adjustedEpsDefinition.key
+          : coreIdentity?.key ?? definition.key,
+        label: isAdjustedBySectionBasis
+          ? adjustedEpsDefinition.label
+          : coreIdentity?.label ?? definition.label,
         value,
       };
       Object.defineProperty(metric, "sourceSnippet", {
@@ -430,7 +523,49 @@ function extractOutlookMetricsForDefinition(
   return [...bestCandidateByPeriod.values()].map(candidate => candidate.metric);
 }
 
-function getOutlookPeriodLabel(lines: string[], lineIndex: number): string | undefined {
+function getOutlookMetricValueLine(
+  lines: string[],
+  lineIndex: number,
+  revisedColumns: boolean,
+  guidanceFirstColumns: boolean,
+): string {
+  const line = lines[lineIndex] ?? "";
+  const nextLine = lines[lineIndex + 1] ?? "";
+  const needsTableValueContinuation = (true === revisedColumns || true === guidanceFirstColumns) &&
+    false === /[$€£¥]|\d+\.\d+|\d+\s*%/.test(line) &&
+    /[$€£¥]|\d+\.\d+|\d+\s*%/.test(nextLine);
+  const needsWrappedRangeContinuation = /\b(?:between|range)\b/i.test(line) &&
+    /(?:\band|\bto|[-–—])\s*$/.test(line.trim()) &&
+    /^\s*(?:[$€£¥]|\(?-?\d)/.test(nextLine);
+  return true === needsTableValueContinuation || true === needsWrappedRangeContinuation
+    ? `${line} ${nextLine}`
+    : line;
+}
+
+function getCoreOutlookIdentity(
+  definition: OutlookMetricDefinition,
+  line: string,
+): {key: string; label: string;} | undefined {
+  if (false === /\bcore\b/i.test(line)) {
+    return undefined;
+  }
+
+  const labelByKey = new Map<string, string>([
+    ["revenue", "Core revenue"],
+    ["gross_margin", "Core gross margin"],
+    ["operating_margin", "Core operating margin"],
+  ]);
+  const label = labelByKey.get(definition.key);
+  return undefined === label
+    ? undefined
+    : {key: `core_${definition.key}`, label};
+}
+
+function getOutlookPeriodLabel(
+  lines: string[],
+  lineIndex: number,
+  sectionHeading?: string,
+): string | undefined {
   const directPeriodLabel = getLineOutlookPeriodLabel(lines[lineIndex] ?? "");
   if (undefined !== directPeriodLabel) {
     return directPeriodLabel;
@@ -441,14 +576,32 @@ function getOutlookPeriodLabel(lines: string[], lineIndex: number): string | und
   // one row's period onto the next otherwise-unlabelled row.
   for (let index = lineIndex - 1; index >= 0 && index >= lineIndex - 4; index--) {
     const contextLine = lines[index] ?? "";
-    if (false === /^\s*for\s+the\s+(?:(?:first|second|third|fourth)\s+quarter|full[\s–—-]+year)\b[^:]{0,40}\b(?:we|the\s+company)\s+expect\s*:\s*$/i.test(contextLine)) {
+    const inheritedPeriodLabel = getLineOutlookPeriodLabel(contextLine);
+    if (undefined === inheritedPeriodLabel ||
+        false === isStandaloneOutlookPeriodCaption(contextLine)) {
       continue;
     }
 
-    return getLineOutlookPeriodLabel(contextLine);
+    return inheritedPeriodLabel;
   }
 
-  return undefined;
+  // A period-specific "Financial Outlook" heading governs the first bullet group even when
+  // a later full-year caption makes the section mixed. Keep this fallback narrow: a generic
+  // period heading can sit above historical and target prose whose rows do not inherit it.
+  return /^\s*(?:q[1-4]|(?:first|second|third|fourth)[\s–—-]+quarter)\b.*\bfinancial\s+outlook\b/i
+    .test(sectionHeading ?? "")
+    ? getLineOutlookPeriodLabel(sectionHeading ?? "")
+    : undefined;
+}
+
+function isStandaloneOutlookPeriodCaption(line: string): boolean {
+  if (/[$€£¥]|\d+(?:\.\d+)?\s*%/.test(line)) {
+    return false;
+  }
+
+  return /^\s*for\s+the\s+(?:(?:first|second|third|fourth)\s+quarter|full[\s–—-]+year)\b[^:]{0,40}\b(?:we|the\s+company)\s+expect\s*:\s*$/i.test(line) ||
+    /^\s*(?:q[1-4](?:\s+(?:fy\s*)?20\d{2})?|(?:first|second|third|fourth)[\s–—-]+quarter(?:\s+(?:of\s+)?(?:fiscal\s+year\s+)?20\d{2})?|(?:full[\s–—-]+year|fiscal(?:\s+year)?|fy)\s*(?:20\d{2}|\d{2}))(?:\s+financial\s+(?:outlook|guidance))?(?:\s*[|:])*\s*$/i.test(line) ||
+    true === isOutlookHeading(line);
 }
 
 function getLineOutlookPeriodLabel(line: string): string | undefined {
@@ -548,10 +701,16 @@ function extractOutlookValue(
   documentCurrencyCode: string,
   revisedColumns = false,
   sectionMoneyUnit?: string,
+  guidanceFirstColumns = false,
 ): string | null {
   pattern.lastIndex = 0;
   const patternMatch = pattern.exec(line);
-  for (const rawValueText of getOutlookValueSegments(line, patternMatch, revisedColumns)) {
+  for (const rawValueText of getOutlookValueSegments(
+    line,
+    patternMatch,
+    revisedColumns,
+    guidanceFirstColumns,
+  )) {
     const valueText = normalizeOutlookValueText(rawValueText);
     if ("" === valueText) {
       continue;
@@ -603,6 +762,7 @@ function getOutlookValueSegments(
   line: string,
   patternMatch: RegExpExecArray | null,
   revisedColumns: boolean,
+  guidanceFirstColumns: boolean,
 ): string[] {
   if (null === patternMatch) {
     return [line];
@@ -615,6 +775,15 @@ function getOutlookValueSegments(
     const populatedCells = cells.filter(cell => /\d/.test(cell)).reverse();
     if (0 < populatedCells.length) {
       return populatedCells;
+    }
+  }
+
+  if (true === guidanceFirstColumns) {
+    const cells = line.slice(patternMatch.index + patternMatch[0].length).split("|");
+    const guidanceCell = cells.find(cell =>
+      /[$€£¥]|\b(?:USD|CAD|EUR|GBP|JPY|CHF)\b|\d+\.\d+|\d+\s*%/i.test(cell));
+    if (undefined !== guidanceCell) {
+      return [guidanceCell];
     }
   }
 
@@ -655,6 +824,13 @@ function getPreviousOutlookValueSegment(line: string, metricStartIndex: number):
 
 function normalizeOutlookValueText(value: string): string {
   return value
+    // A table can wrap one accounting parenthesis around a complete range,
+    // "($29.0 - 32.0)". Both endpoints are losses, so make each sign explicit
+    // before the normal range parser sees them.
+    .replace(
+      /\(\s*((?:(?:C\s*\$|[$€£¥])\s*)?\d+(?:,\d{3})*(?:\.\d+)?)\s*(?:to|through|-|–|—)\s*((?:(?:C\s*\$|[$€£¥])\s*)?\d+(?:,\d{3})*(?:\.\d+)?)\s*\)/gi,
+      "($1) to ($2)",
+    )
     .replace(/^[\s:|,-]+/, "")
     .replace(/\b(?:is|are|was|were|to\s+be|of|at|approximately|about|around|roughly|expected|expects|expect|guidance|outlook|projected|forecast|in\s+the\s+range\s+of|between)\b/gi, " ")
     .replace(/\bto\s+(?:grow|increase|range)\b/gi, " ")
@@ -748,9 +924,11 @@ function getOutlookRangeValue(
       return null;
     }
 
-    const percentRangeMatch = value.match(/(-?\d+(?:\.\d+)?)\s*%\s*(?:to|through|-|–|and)\s*(-?\d+(?:\.\d+)?)\s*%/i);
-    return undefined !== percentRangeMatch?.[1] && undefined !== percentRangeMatch[2]
-      ? `${formatPercent(Number.parseFloat(percentRangeMatch[1]))} to ${formatPercent(Number.parseFloat(percentRangeMatch[2]))}`
+    const percentRangeMatch = value.match(/(\(?-?\d+(?:\.\d+)?\s*%\)?)\s*(?:to|through|-|–|and)\s*(\(?-?\d+(?:\.\d+)?\s*%\)?)/i);
+    const firstPercentValue = parseNumber(percentRangeMatch?.[1]);
+    const secondPercentValue = parseNumber(percentRangeMatch?.[2]);
+    return null !== firstPercentValue && null !== secondPercentValue
+      ? `${formatPercent(firstPercentValue)} to ${formatPercent(secondPercentValue)}`
       : null;
   }
 
@@ -798,8 +976,15 @@ function getSingleOutlookValue(
   sectionMoneyUnit?: string,
 ): string | null {
   if ("percent" === valueType) {
-    const percentMatch = value.match(/-?\d+(?:\.\d+)?\s*%/);
-    return percentMatch ? percentMatch[0].replace(/\s+/g, "") : null;
+    const percentMatch = value.match(/\(?-?\d+(?:\.\d+)?\s*%\)?/);
+    const percentValue = parseNumber(percentMatch?.[0]);
+    if (null === percentValue || null === percentMatch) {
+      return null;
+    }
+
+    return percentMatch[0].trim().startsWith("(")
+      ? formatPercent(percentValue)
+      : percentMatch[0].replace(/\s+/g, "");
   }
 
   if ("eps" === valueType) {
@@ -835,9 +1020,11 @@ function getEpsPercentOutlookValue(value: string): string | null {
 }
 
 function getPercentRangeOutlookValue(value: string): string | null {
-  const percentRangeMatch = value.match(/(-?\d+(?:\.\d+)?)\s*%\s*(?:to|through|-|–|and)\s*(-?\d+(?:\.\d+)?)\s*%/i);
-  return undefined !== percentRangeMatch?.[1] && undefined !== percentRangeMatch[2]
-    ? `${formatPercent(Number.parseFloat(percentRangeMatch[1]))} to ${formatPercent(Number.parseFloat(percentRangeMatch[2]))}`
+  const percentRangeMatch = value.match(/(\(?-?\d+(?:\.\d+)?\s*%\)?)\s*(?:to|through|-|–|and)\s*(\(?-?\d+(?:\.\d+)?\s*%\)?)/i);
+  const firstPercentValue = parseNumber(percentRangeMatch?.[1]);
+  const secondPercentValue = parseNumber(percentRangeMatch?.[2]);
+  return null !== firstPercentValue && null !== secondPercentValue
+    ? `${formatPercent(firstPercentValue)} to ${formatPercent(secondPercentValue)}`
     : null;
 }
 
@@ -900,7 +1087,7 @@ function parseNumber(value: unknown): number | null {
     return null;
   }
 
-  const normalizedValue = value
+  const normalizedValue = value.trim()
     // A scale outside accounting parentheses carries the same sign as the value inside.
     // Normalize it before the general parenthetical conversion below.
     .replace(

--- a/modules/test-fixtures/earnings-filings/allo.txt
+++ b/modules/test-fixtures/earnings-filings/allo.txt
@@ -1,0 +1,165 @@
+EX-99.1
+2
+allo-20260630xexx991q226.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+
+
+Exhibit 99.1
+
+
+
+Allogene Therapeutics Reports Second Quarter 2026 Financial Results and Business Update
+• Pivotal Phase 2 ALPHA3 Program in 1L Large B-cell Lymphoma (LBCL):
+◦ Recent Interim Futility Analysis Supports Cemacabtagene Ansegedleucel’s (Cema-Cel) Potential as an Outpatient, MRD-Guided 1L Consolidation Therapy
+◦ Strong Execution and Increased Investigator Interest Accelerated 2026 Site Activation Target by Six Months; Approximately 100 Sites Now Expected by Year-End, Further Supporting Enrollment
+◦ Next Update Anticipated in Mid-2027, with Trial Enrollment Expected to Be Completed by Year-End 2027
+◦ Following Review of the Interim Futility Analysis, FDA Granted RMAT and Fast Track Designations for Cema-Cel Underscoring MRD Positivity as an Unmet Need in LBCL
+• Phase 1 RESOLUTION Trial in Autoimmune Disease:
+◦ Brisk Enrollment Continues Across ALLO-329 Dose Escalation and Lymphodepletion Optimization Cohorts
+◦ Clinical Data Update Expected Q4 2026
+• Ended the Second Quarter of 2026 with $423.6 Million in Cash, Cash Equivalents and Investments
+• Conference Call and Webcast Scheduled for Today at 2:00 PM PT/5:00 PM ET
+
+
+SOUTH SAN FRANCISCO, Calif., August 12, 2026 – Allogene Therapeutics, Inc. (Nasdaq: ALLO), a clinical-stage biotechnology company pioneering the development of allogeneic CAR T (AlloCAR T) products for cancer and autoimmune disease, today provided corporate updates and reported financial results for the quarter ended June 30, 2026.
+
+
+“When we reset our strategy in 2024, we started with the patient and focused on where the distinct attributes of allogeneic CAR T could create a clinical advantage,” said Zachary Roberts, M.D., Ph.D., President and Chief Executive Officer of Allogene. “ALPHA3 is the clearest expression of that strategy: identifying patients at high risk of relapse, treating before disease returns clinically, and enabling CAR T delivery where patients already receive care. We took the same patient-first approach with ALLO-329, recognizing early that chemotherapy-based lymphodepletion and treatment interruptions associated with leukapheresis in autologous therapy could create meaningful burdens for patients with autoimmune disease. Together, these programs demonstrate that the value of allogeneic CAR T extends well beyond off-the-shelf availability, offering the flexibility to address clinical and practical barriers other approaches cannot. We believe the scale of that opportunity will become increasingly apparent as our programs continue to advance.”
+
+
+Cema-Cel: Pivotal Phase 2 ALPHA3 1L Consolidation Trial in LBCL
+Cemacabtagene ansegedleucel (cema-cel) is being evaluated in ALPHA3, the first pivotal, randomized Phase 2 trial in LBCL designed to assess whether MRD-guided treatment following first-line therapy can delay or prevent clinical relapse.
+
+
+In July, the U.S. Food and Drug Administration granted Regenerative Medicine Advanced Therapy (RMAT) and Fast Track designations for cema-cel as 1L consolidation therapy for patients with high-risk LBCL following review of the interim futility analysis. At the protocol-defined data cutoff, triggered when the 24th patient enrolled in the ongoing study arms completed the Day 45 MRD assessment, 58.3% (7/12) of patients in the cema-cel arm achieved MRD negativity, with the majority clearing MRD by the first post-treatment assessment, compared to 16.7% (2/12) in the observation arm. This represents a 41.6% absolute difference in MRD clearance between the two arms. Published literature and cross-study benchmarks suggest that MRD clearance differences of 25-30% may lead to clinically meaningful improvement at study completion.
+
+
+Cema-cel was well-tolerated as of the data cutoff with no treatment-related serious adverse events. There were no cases of cytokine release syndrome (CRS), immune effector cell-associated neurotoxicity syndrome (ICANS), graft-versus-host disease (GvHD) or high-grade infections. No tocilizumab or steroids were administered for toxicity prophylaxis or treatment, and no patients were hospitalized for treatment-related adverse events. This profile compares favorably with the broader CAR T experience, where hospitalization for toxicity management remains common.
+
+
+Most patients were treated and followed entirely in the outpatient setting. Community cancer centers accounted for approximately one-third of screening activity and cema-cel infusions, including sites with limited or no prior CAR T experience. These findings support ALPHA3’s potential to bring CAR T earlier in the course of disease and closer to where patients receive care.
+
+
+The Company achieved its 2026 goal of activating more than 80 sites approximately six months ahead of schedule, driven by strong execution and increased investigator interest following the interim futility analysis. The Company now expects
+
+
+
+
+
+
+
+
+
+approximately 100 sites to be active by year-end, with the significant majority in the United States and additional sites in Canada, Australia and South Korea. This expansion is expected to support enrollment momentum, broaden access to the trial, and provide more sites with hands-on experience administering cema-cel ahead of a potential commercial launch.
+
+
+ALPHA3 is expected to randomize approximately 220 MRD+ patients to either cema-cel consolidation or close observation, with enrollment anticipated to be completed by year-end 2027. The next program update tied to the interim event-free survival (EFS) analysis is expected in mid-2027.
+
+
+ALLO-329: Purpose-Built Allogeneic CAR T for Autoimmune Disease
+ALLO-329 is a next-generation, dual-targeting anti-CD19/CD70 AlloCAR T product incorporating the Company’s proprietary Dagger® technology. The product was designed to address allogeneic rejection by targeting activated CD70-positive host T cells, with the goal of supporting CAR T-cell expansion while reducing or eliminating the need for conventional chemotherapy-based lymphodepletion.
+
+
+The ongoing Phase 1 RESOLUTION trial is a dose-escalation study evaluating cell dose of ALLO-329 and the role played by Dagger with and without lymphodepletion across multiple autoimmune indications, including systemic lupus erythematosus, scleroderma, and inflammatory myositis.
+
+
+Enrollment continues at a brisk pace across cohorts, dose levels and lymphodepletion strategies. The Company remains on track to provide a clinical and translational update in the fourth quarter of 2026.
+
+
+2026 Second Quarter Financial Results
+• Research and development expenses were $30.7 million for the second quarter of 2026, which includes $2.1 million of non-cash stock-based compensation expense.
+• General and administrative expenses were $20.8 million for the second quarter of 2026, which includes $10.3 million of non-cash stock-based compensation expense.
+• Net loss for the second quarter of 2026 was $42.7 million, or $0.13 per share, including non-cash stock-based compensation expense of $12.4 million.
+• The Company had $423.6 million in cash, cash equivalents, and investments as of June 30, 2026.
+
+
+Based on its cash, cash equivalents, and investments as of June 30, 2026, the Company currently projects its cash runway into 2029. Guidance for operating expense in 2026 is expected to be approximately $165 million. GAAP Operating Expenses are expected to be approximately $225 million, including estimated non-cash stock-based compensation expense of approximately $35 million. These estimates exclude any impact from potential business development activities.
+
+
+Conference Call and Webcast Details
+Allogene will host a live conference call and webcast today at 2:00 p.m. PT/5:00 p.m. ET to discuss financial results and provide a business update. If you would like the option to ask a question on the conference call, please use this link to register. Upon registering for the conference call, you will receive a personal PIN to access the call, which will identify you as the participant and allow you the option to ask a question. The listen-only webcast will be made available on the Company's website at www.allogene.com under the Investors tab in the News and Events section. Following the live audio webcast, a replay will be available on the Company's website for approximately 30 days.
+
+
+About Allogene Therapeutics
+Allogene Therapeutics, with headquarters in South San Francisco, is a clinical-stage biotechnology company pioneering the development of allogeneic chimeric antigen receptor T cell (AlloCAR T) products for cancer and autoimmune disease. Led by cell therapy veterans applying proven CAR T experience, Allogene is developing a pipeline of off-the-shelf CAR T cell product candidates with the goal of delivering readily available cell therapy on-demand, more reliably, and at greater scale to more patients. For more information, please visit www.allogene.com, and follow Allogene Therapeutics on X and LinkedIn.
+
+
+Cautionary Note on Forward-Looking Statements
+This press release contains forward-looking statements within the meaning of the Private Securities Litigation Reform Act of 1995. Forward-looking statements are based on management’s current expectations and assumptions and involve risks and uncertainties that could cause actual results to differ materially from those expressed or implied by such statements. In some cases, forward-looking statements may be identified by words such as “expect,” “believe,” “aim,” “plan,” “intend,” “seek,” “estimate,” “target,” “potential,” “may,” “could,” “will,” “would,” “should,” “anticipate,” “support,” “designed to,” “working to” and similar expressions. Forward-looking statements in this press release include, but are not limited to, statements regarding the timing, design, conduct, and results of Allogene’s clinical trials and analyses (including the interim futility analysis and MRD clearance outcomes from the Phase 2 ALPHA3 trial of cema-cel and updates from the Phase 1 RESOLUTION trial of ALLO-329); the extent to which additional clinical trial sites may support enrollment momentum, broaden access to the ALPHA3 trial, or provide more sites with hands-on experience administering cema-cel ahead of a potential commercial launch; the rate and pace of enrollment in the RESOLUTION trial; the potential benefits and regulatory
+
+
+
+
+
+
+
+
+
+implications of the RMAT and Fast Track designations for cema-cel; the potential clinical benefits, safety, tolerability, durability, and efficacy of Allogene’s product candidates; the potential for MRD-guided first-line consolidation to improve outcomes in LBCL; the extent to which published literature, cross-study benchmarks, and observed or potential MRD clearance differences of 25-30% may translate into clinically meaningful improvement at study completion; the potential value and advantages of allogeneic CAR T, including its ability to address clinical and practical barriers presented by other therapies; the potential to deliver allogeneic CAR T therapy in outpatient and community care settings and expand access across academic and community care settings and the extent to which interim data and analysis is supportive thereof; the potential to reduce or eliminate conventional lymphodepletion; expectations regarding clinical trial execution and operational performance; and expectations regarding Allogene’s financial position, cash runway, and 2026 operating outlook. Actual results may differ materially from those indicated by these forward-looking statements as a result of various important factors, including, but not limited to, risks and uncertainties inherent in clinical development (including that interim or early data may not be predictive of later or final results or clinical outcomes), patient enrollment and trial execution risks, uncertainties related to MRD testing and its clinical significance and whether observed differences in MRD clearance will translate into clinically meaningful benefit, the occurrence of adverse safety events, regulatory risks and uncertainties, manufacturing and CMC risks, reliance on third parties and licensors, competitive developments, intellectual property and contractual risks, and financial risks, including the need for additional capital. These and other risks and uncertainties are described more fully in Allogene’s filings with the Securities and Exchange Commission (SEC), including under the heading “Risk Factors” in its Quarterly Report on Form 10-Q for the quarter ended June 30, 2026, being filed with the SEC today. All forward-looking statements in this press release speak only as of the date of this press release, and Allogene undertakes no obligation to update or revise any forward-looking statements, whether as a result of new information, future events, or otherwise, except as required by law.
+
+
+Dagger® is a trademark of Allogene Therapeutics, Inc.
+
+
+Allogene’s investigational AlloCAR T oncology products utilize Cellectis technologies. Cemacabtagene ansegedleucel (cema-cel) was developed based on an exclusive license granted by Cellectis to Servier. Servier has granted Allogene exclusive rights to cema-cel in the U.S., all EU Member States and the United Kingdom. The anti-CD70 AlloCAR T program is licensed exclusively from Cellectis by Allogene and Allogene holds global development and commercial rights to this AlloCAR T program. ALLO-329 (CD19/CD70) in autoimmune disease uses CRISPR gene-editing technology.
+
+
+
+
+
+
+
+
+
+
+
+
+ALLOGENE THERAPEUTICS, INC.
+SELECTED FINANCIAL DATA
+(unaudited; in thousands, except share and per share data)
+
+STATEMENTS OF OPERATIONS | | | | | | | | | | | |
+| Three Months Ended June 30, |
+| 2026 | | 2025 |
+Collaboration revenue - related party | $ | 4,640 | | | $ | — | |
+Operating expenses: | | | |
+Research and development | $ | 30,721 | | | $ | 40,156 | |
+General and administrative | 20,839 | | | 14,281 | |
+Impairment of long-lived assets | — | | | 2,382 | |
+Total operating expenses | 51,560 | | | 56,819 | |
+Loss from operations | (46,920) | | | (56,819) | |
+Other income (expenses), net: | | | |
+Interest and other income, net | 4,647 | | | 6,187 | |
+Interest expense | (343) | | | (268) | |
+Other income (expenses), net | (61) | | | (43) | |
+Total other income (expenses), net | 4,243 | | | 5,876 | |
+Net loss | $ | (42,677) | | | $ | (50,943) | |
+Net loss per share, basic and diluted | $ | (0.13) | | | $ | (0.23) | |
+Weighted-average number of shares used in computing net loss per share, basic and diluted | 328,930,269 | | | 218,929,548 | |
+
+
+
+
+SELECTED BALANCE SHEET DATA | | | | | | | | | | | |
+| As of June 30, 2026 | | As of December 31, 2025 |
+Cash, cash equivalents and investments | $ | 423,590 | | | $ | 258,253 | |
+Total assets | 550,091 | | | 415,905 | |
+Total liabilities | 113,916 | | | 123,363 | |
+Total stockholders’ equity | 436,175 | | | 292,542 | |
+
+
+
+
+
+Allogene Media/Investor Contact:
+Christine Cassiano
+EVP, Chief Corporate Affairs & Brand Strategy Officer
+Christine.Cassiano@allogene.com\n

--- a/modules/test-fixtures/earnings-filings/cbrs.txt
+++ b/modules/test-fixtures/earnings-filings/cbrs.txt
@@ -1,0 +1,2492 @@
+EX-99.1
+2
+cbrsannouncesfinancialresu.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Cerebras Systems Fast Inference Cloud Business Nearly Quadruples in Second Quarter 2026
+• GAAP cloud revenue grew 281%, core cloud revenue grew 287% from a year ago
+• 600 MW of data center capacity now under contract
+• Manufacturing capacity to scale more than 10x in 2026
+• OpenAI launch partner for frontier model GPT-5.6 Sol
+• Partnerships with AMD and AWS establish Cerebras as the leader in disaggregated inference
+SUNNYVALE, Calif. — August 12, 2026 — Cerebras Systems (NASDAQ: CBRS), maker of the world’s fastest AI infrastructure, today announced financial results for the second quarter ended June 30, 2026.
+“This was an outstanding quarter for Cerebras. Core revenue more than doubled to $210 million, and our cloud business nearly quadrupled year-over-year,” said Andrew Feldman, Cerebras co-founder and CEO. “Speed changes what AI can do. It makes AI more useful, more productive, and opens entirely new markets. As a result, the demand for fast inference is enormous and Cerebras is scaling to meet it, securing more data center capacity, expanding manufacturing, and growing with customers and partners including OpenAI, AWS, AMD, and CrowdStrike.”
+“Our quarterly results exceeded our guidance across all core business metrics. The market has responded strongly to the value of fast inference. We significantly improved core gross and operating margins compared to a year ago,” said Bob Komin, Chief Financial Officer of Cerebras. “We have made rapid progress in key areas required to deliver exceptional growth against our remaining performance obligations of $25.4 billion, and plan to more than triple revenue in 2027.”
+Q2 2026 Financial Highlights
+Core Financial Results are all non-GAAP metrics (and exclude the impacts of non-cash amortization of customer warrants and stock-based compensation, data center pass-through revenues and costs, and certain other items):
+• Record GAAP cloud and other services revenue of $126.0 million, up 281% year-over-year; Record core cloud and other services revenue of $127.7 million, up 287% year-over-year.
+• GAAP total revenue of $180.1 million, up 74% year-over-year; Core total revenue of $209.9 million, up 103% year-over-year.
+• GAAP gross margin of 14%; Core gross margin of 41%, an improvement of approximately 940 basis points from Q2’25.
+• GAAP operating margin of (265%); Core operating margin of (16%), an improvement of approximately 2,600 basis points from Q2’25.
+• Strong liquidity with cash, cash equivalents, restricted cash, and short-term investments of $8.6 billion and debt capacity of $850 million.
+
+
+
+
+
+
+
+Business Highlights: General
+• Successfully raised $6.4 billion in gross proceeds through our IPO and closed a revolving credit facility for up to $850 million to accelerate the pace of our data center acquisitions.
+• $25.4 billion in remaining performance obligations as of June 30, 2026.
+Business Highlights: Capacity
+• Data Center Capacity Expansion: Increased data center capacity, live and under contract for delivery by the end of 2027 to more than 600 MW. Increased pipeline of data center opportunities to gigawatts.
+• Manufacturing Capacity Expansion: New factory lines added at contract manufacturers Flex, Sanmina, and Rocket EMS. Manufacturing capacity to increase more than 10x in 2026.
+• Supply Chain Capacity Expansion: Secured TSMC wafer supply needed for continued growth. Well positioned with other component vendors to meet the rapid growth forecasted in 2027 and beyond.
+• Supply Chain Advantages: Through our wafer-scale architecture, we avoid many of the components that are currently in short supply. We do not use HBM memory, CoWoS packaging or 3nm fabrication technology, all of which are currently supply limited.
+Business Highlights: Capabilities
+• Enabled support for OpenAI GPT-5.6 Sol at 750 tokens per second.
+• Stood up pioneering disaggregated inference solutions with AMD to deliver Cerebras speed while increasing throughput by up to 5x, which will be in production in Q4 2026.
+• Deepened our partnership with AWS and expect to bring Cerebras’s disaggregated inference and the same 5x throughput benefits to Amazon Bedrock in the first quarter of 2027.
+Business Highlights: Customers
+• Signed new cloud capacity agreements with leading AI coding companies including Cognition and Lovable.
+• Cerebras fast inference serves as the foundation for agentic flows in industries ranging from finance to life sciences with customers including Block, Figma, AlphaSense, and GSK.
+• Pioneered a new segment of the security market with CrowdStrike. Cerebras fast inference enables inline security using LLMs for a large portion of enterprise traffic.
+Third Quarter 2026 Financial Outlook
+Core Non-GAAP Financial Outlook:
+• Core revenue of approximately $214 to $216 million
+• Core gross margin in the range of 38% - 40%
+• Core operating margins in the range of (25%) to (23%)
+
+
+
+
+
+
+
+Full Year 2026 Financial Outlook
+Core Non-GAAP Financial Outlook has been raised for all metrics:
+• Core revenue of $880 to $890 million
+• Core gross margin in the range of 41% - 43%
+• Core operating margins in the range of (19%) to (17%)
+Earnings Webcast and Conference Call
+Cerebras Systems will host a conference call to review its financial results for the second quarter of 2026 and to discuss our financial outlook today at 2 p.m. PT (5 p.m. ET). Interested parties may join the conference call via the webcast and can be accessed at the Cerebras website at https://investors.cerebras.ai/. The webcast will be recorded and available for replay on the same website following the conclusion of the conference call.
+About Cerebras Systems
+Cerebras Systems (NASDAQ: CBRS) builds the world’s fastest AI infrastructure. The Cerebras team of pioneering computer architects, computer scientists, AI researchers, and engineers of all types came together to make AI blisteringly fast through innovation and invention. Cerebras believes that when AI is fast, it will change the world. Leading global corporations, research institutes, and governments choose Cerebras to run their AI workloads. Cerebras solutions are available on premises and in the cloud.
+Investor Relations
+Sean Dorsey
+investors@cerebras.ai
+Media Relations
+Kriselle Laran
+pr@cerebras.ai
+
+
+
+
+
+
+
+
+Forward-Looking Statements
+This press release contains “forward-looking statements” within the meaning of applicable securities laws. All statements other than statements of historical fact could be deemed to be forward-looking, including, but not limited to, statements regarding Cerebras’s expectations regarding growth in its revenue, customer demand, outlook for Q3, full year 2026 and 2027, the timing, execution and anticipated benefits of customer and partner arrangements, deployments and capacity expansion initiatives, ability to secure and deliver increased data center capacity, maintain and increase manufacturing capacity and supply chain capacity, realize remaining performance obligations, provide disaggregated inference architecture with industry leading speed and increasing throughput, growing with customers and partners such as AMD and AWS, winning new customers and partners, and expanding into new industries and markets, and any assumptions relating to the foregoing. The words “may,” “will,” “shall,” “should,” “expects,” “plans,” “anticipates,” “could,” “intends,” “target,” “projects,” “contemplates,” “believes,” “estimates,” “predicts,” “potential,” “objective,” or “continue,” or the negative of these words or other similar terms or expressions that concern our expectations, strategy, plans, or intentions are intended to identify forward-looking statements, although not all forward-looking statements contain these identifying words. These forward-looking statements are subject to a number of risks and uncertainties, many of which involve factors or circumstances that are beyond Cerebras’s control. These risks and uncertainties include, but are not limited to: Cerebras’s ability to sustain and manage its growth, access borrowings and other sources of capital on acceptable terms, and deploy available capital to support growth; its history of net losses and ability to achieve and maintain profitability; its limited operating history at its current scale and ability to accurately forecast revenue and appropriately budget and manage expenses; its dependence on a limited number of significant customers, including OpenAI, Group 42 Holding Ltd, Mohamed bin Zayed University of Artificial Intelligence, and AWS, and the potential impact of any reduction in demand from, material adverse development in its relationships with, or failure to meet its obligations to, such customers, including under its Master Relationship Agreement with OpenAI; the timing, execution and expected benefits of its strategic customer, partner and financing arrangements; its historical reliance on sales of hardware systems and the early-stage, rapidly evolving market for its cloud-based offerings and AI infrastructure; its ability to secure sufficient data center capacity and capital to support its cloud-based offerings; its ability to launch new offerings and add new product capabilities; and its ability to compete effectively in the rapidly evolving and competitive market for AI computing solutions.
+Cerebras’s actual results could differ materially from those stated or implied in forward-looking statements due to a number of factors. Accordingly, undue reliance should not be placed on such statements. These forward-looking statements are made as of the date they were first issued and are based on information available to Cerebras together with Cerebras’s expectations, estimates, forecasts, projections, beliefs, and assumptions as of such date. These forward-looking statements should not be relied upon as representing Cerebras’s views as of any date subsequent to the date of this press release. Past performance is not necessarily indicative of future results. Cerebras undertakes no intention or obligation to update or revise any forward-looking statements, whether as a result of new information, future events, or otherwise, except as required by law.
+
+
+
+
+
+
+
+Further information on potential risks that could affect actual results is included in Cerebras’s most recent filings with the Securities and Exchange Commission (the “SEC”), including in Cerebras’s most recent Quarterly Report on Form 10-Q, copies of which may be obtained by visiting Cerebras’s Investor Relations website at investors.cerebras.ai or the SEC’s website at www.sec.gov.
+
+
+
+
+
+
+
+
+CEREBRAS SYSTEMS INC.
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(unaudited)
+(in thousands, except per share amounts)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30,
+| | Six Months Ended June 30,
+|
+| 2026
+|
+| 2025
+| | 2026
+|
+| 2025
+|
+Revenue
+| | | | | | | |
+Hardware
+| $
+| 54,119
+|
+| | $
+| 70,295
+|
+| | $
+| 164,712
+|
+| | $
+| 139,969
+|
+|
+Cloud and other services
+| 125,991
+|
+| | 33,027
+|
+| | 208,804
+|
+| | 62,865
+|
+|
+Total revenue
+| 180,110
+|
+| | 103,322
+|
+| | 373,516
+|
+|
+| 202,834
+|
+|
+Cost of revenue
+| | | | | | | |
+Hardware
+| 53,141
+|
+| | 46,649
+|
+| | 118,072
+|
+| | 95,059
+|
+|
+Cloud and other services
+| 101,410
+|
+| | 24,574
+|
+| | 143,709
+|
+| | 34,072
+|
+|
+Total cost of revenue
+| 154,551
+|
+| | 71,223
+|
+| | 261,781
+|
+| | 129,131
+|
+|
+Gross profit
+| 25,559
+|
+| | 32,099
+|
+| | 111,735
+|
+| | 73,703
+|
+|
+Operating expenses
+| | | | | | | |
+Research and development
+| 320,151
+|
+| | 60,768
+|
+| | 395,646
+|
+| | 113,519
+|
+|
+Sales and marketing
+| 86,969
+|
+| | 18,228
+|
+| | 101,670
+|
+| | 28,554
+|
+|
+General and administrative
+| 95,672
+|
+| | 10,285
+|
+| | 106,689
+|
+| | 17,282
+|
+|
+Total operating expenses
+| 502,792
+|
+| | 89,281
+|
+| | 604,005
+|
+| | 159,355
+|
+|
+Loss from operations
+| (477,233)
+|
+| | (57,182)
+|
+| | (492,270)
+|
+| | (85,652)
+|
+|
+Other income, net
+| 26,979
+|
+| | 368,358
+|
+| | 29,507
+|
+| | 374,644
+|
+|
+Income (loss) before income taxes
+| (450,254)
+|
+| | 311,176
+|
+| | (462,763)
+|
+| | 288,992
+|
+|
+Income tax expense
+| 274
+|
+| | 1,664
+|
+| | 1,771
+|
+| | 3,347
+|
+|
+Net income (loss)
+| $
+| (450,528)
+|
+| | $
+| 309,512
+|
+| | $
+| (464,534)
+|
+| | $
+| 285,645
+|
+|
+
+|
+| |
+| | | | |
+Net income (loss) attributable to common shareholders
+|
+|
+|
+|
+|
+|
+|
+|
+Basic
+| $
+| (450,528)
+|
+|
+| $
+| 120,318
+|
+|
+| $
+| (464,534)
+|
+|
+| $
+| 110,580
+|
+|
+Diluted
+| $
+| (450,528)
+|
+|
+| $
+| 309,512
+|
+|
+| $
+| (464,534)
+|
+|
+| $
+| 285,645
+|
+|
+Net income (loss) per share attributable to common shareholders
+|
+|
+|
+|
+|
+|
+|
+|
+Basic
+| $
+| (2.98)
+|
+|
+| $
+| 2.28
+|
+|
+| $
+| (4.34)
+|
+|
+| $
+| 2.11
+|
+|
+Diluted
+| $
+| (2.98)
+|
+|
+| $
+| 1.91
+|
+|
+| $
+| (4.34)
+|
+|
+| $
+| 1.76
+|
+|
+Weighted average shares outstanding
+|
+|
+|
+|
+|
+|
+|
+|
+Basic
+| 150,968
+|
+|
+| 52,720
+|
+|
+| 107,132
+|
+|
+| 52,363
+|
+|
+Diluted
+| 150,968
+|
+|
+| 161,822
+|
+|
+| 107,132
+|
+|
+| 162,276
+|
+|
+
+
+
+
+
+
+
+
+
+
+CEREBRAS SYSTEMS INC.
+CONDENSED CONSOLIDATED STATEMENTS OF COMPREHENSIVE INCOME (LOSS)
+(unaudited)
+(in thousands)
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30,
+| | Six Months Ended June 30,
+|
+| 2026
+| | 2025
+| | 2026
+| | 2025
+|
+Net income (loss)
+| $
+| (450,528)
+|
+| | $
+| 309,512
+|
+| | $
+| (464,534)
+|
+| | $
+| 285,645
+|
+|
+Change in foreign currency translation adjustments, net of tax
+| (274)
+|
+| | 732
+|
+| | 638
+|
+| | 912
+|
+|
+Available-for-sale investments:
+|
+| |
+| |
+| |
+|
+Change in net unrealized gain (loss) on debt securities, net of tax
+| 2,645
+|
+| | (735)
+|
+| | 3,828
+|
+| | (807)
+|
+|
+Comprehensive income (loss)
+| $
+| (448,157)
+|
+| | $
+| 309,509
+|
+| | $
+| (460,068)
+|
+| | $
+| 285,750
+|
+|
+
+
+
+
+
+
+
+
+
+
+
+
+
+CEREBRAS SYSTEMS INC.
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(unaudited)
+(in thousands)
+
+| | | | | | | | | | | |
+| June 30, 2026
+| | December 31, 2025
+|
+ASSETS
+| | | |
+Current assets:
+| | | |
+Cash and cash equivalents
+| $
+| 6,742,157
+|
+|
+| $
+| 701,706
+|
+|
+Restricted cash
+| 684,680
+|
+|
+| 228,672
+|
+|
+Investments
+| 1,179,390
+|
+|
+| 406,531
+|
+|
+Accounts receivable, net
+| 123,361
+|
+|
+| 50,423
+|
+|
+Inventories
+| 32,666
+|
+|
+| 63,626
+|
+|
+Customer warrants
+| 167,762
+|
+|
+| 60,906
+|
+|
+Prepaid expenses and other current assets
+| 191,698
+|
+|
+| 31,782
+|
+|
+Total current assets
+| 9,121,714
+|
+|
+| 1,543,646
+|
+|
+Property and equipment, net
+| 986,808
+|
+|
+| 437,396
+|
+|
+Customer warrants, net of current portion
+| 960,635
+|
+|
+| 91,447
+|
+|
+Operating lease right-of-use assets
+| 528,275
+|
+|
+| 248,950
+|
+|
+Other non-current assets
+| 30,440
+|
+|
+| 4,598
+|
+|
+Total assets
+| $
+| 11,627,872
+|
+|
+| $
+| 2,326,037
+|
+|
+| | | |
+LIABILITIES, REDEEMABLE CONVERTIBLE PREFERRED STOCK, AND STOCKHOLDERS’ EQUITY (DEFICIT)
+| | | |
+Current liabilities:
+| | | |
+Accounts payable
+| $
+| 88,313
+|
+|
+| $
+| 48,630
+|
+|
+Deferred revenue
+| 173,735
+|
+|
+| 131,049
+|
+|
+Operating lease liability
+| 88,422
+|
+|
+| 45,865
+|
+|
+Customer deposits
+| 242,672
+|
+|
+| 354,460
+|
+|
+Working capital loan
+| 736,036
+|
+|
+| —
+|
+|
+Accrued and other current liabilities
+| 236,910
+|
+|
+| 139,536
+|
+|
+Total current liabilities
+| 1,566,088
+|
+|
+| 719,540
+|
+|
+Deferred revenue, net of current portion
+| 244,529
+|
+|
+| 35,847
+|
+|
+Operating lease liability, net of current portion
+| 480,405
+|
+|
+| 215,957
+|
+|
+Working capital loan, net of current portion
+| 182,208
+|
+|
+| —
+|
+|
+Total liabilities
+| 2,473,230
+|
+|
+| 971,344
+|
+|
+| | | |
+Redeemable convertible preferred stock
+| —
+|
+|
+| 1,933,348
+|
+|
+Stockholders’ equity (deficit)
+| | | |
+Class A common stock
+| 1
+|
+|
+| 1
+|
+Class B common stock
+| 1
+|
+|
+| —
+|
+|
+Class N common stock
+| —
+|
+|
+| —
+|
+|
+Treasury stock
+| (21,456)
+|
+|
+| (21,456)
+|
+|
+Additional paid-in capital
+| 10,540,193
+|
+|
+| 346,829
+|
+|
+Accumulated other comprehensive income
+| 5,767
+|
+|
+| 1,301
+|
+|
+Accumulated deficit
+| (1,369,864)
+|
+|
+| (905,330)
+|
+|
+Total stockholders’ equity (deficit)
+| 9,154,642
+|
+|
+| (578,655)
+|
+|
+Total liabilities, redeemable convertible preferred stock, and stockholders’ equity (deficit)
+| $
+| 11,627,872
+|
+|
+| $
+| 2,326,037
+|
+|
+
+
+
+
+
+
+
+
+
+CEREBRAS SYSTEMS INC.
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(unaudited)
+(in thousands) | | | | | | | | | | | |
+
+
+| Six Months Ended June 30,
+|
+
+
+| 2026
+| | 2025
+|
+Cash flows from operating activities:
+| | | |
+Net income (loss)
+| $
+| (464,534)
+|
+| | $
+| 285,645
+|
+|
+Adjustments to reconcile net income (loss) to net cash flows used in operating activities:
+| | | |
+Stock-based compensation
+| 386,601
+|
+| | 22,435
+|
+|
+Amortization of customer warrants
+| 46,315
+|
+| | —
+|
+|
+Depreciation and amortization
+| 42,551
+|
+| | 9,315
+|
+|
+Non-cash lease expense
+| 39,104
+|
+| | 5,872
+|
+|
+Non-cash interest expense
+| 38,602
+|
+| | —
+|
+|
+Provision for product warranties
+| 8,430
+|
+| | 9,000
+|
+|
+Extinguishment of forward contract liability
+| —
+|
+|
+| (363,336)
+|
+|
+Other
+| (2,110)
+|
+| | (835)
+|
+|
+Changes in operating assets and liabilities:
+| | | |
+Accounts receivable
+| (72,938)
+|
+| | 125,508
+|
+|
+Inventories
+| 31,116
+|
+| | 74,929
+|
+|
+Prepaid expenses and other assets
+| (182,311)
+|
+| | (3,003)
+|
+|
+Accounts payable
+| 565
+|
+| | 6,314
+|
+|
+Deferred revenue
+| 126,440
+|
+| | 16,525
+|
+|
+Customer deposits
+| (111,788)
+|
+| | (320,558)
+|
+|
+Other liabilities
+| 66,469
+|
+| | 8,346
+|
+|
+Net cash flows used in operating activities
+| $
+| (47,488)
+|
+| | $
+| (123,843)
+|
+|
+Cash flows from investing activities:
+| | | |
+Purchases of property and equipment
+| $
+| (548,873)
+|
+| | $
+| (185,094)
+|
+|
+Purchases of investments
+| (1,275,515)
+|
+| | (20,175)
+|
+|
+Maturities and sales of investments
+| 514,455
+|
+| | 117,973
+|
+|
+Net cash flows used in investing activities
+| $
+| (1,309,933)
+|
+| | $
+| (87,296)
+|
+|
+Cash flows from financing activities:
+| | | |
+Proceeds from initial public offering, net of underwriting discounts and commissions
+| $
+| 6,232,511
+|
+| | $
+| —
+|
+|
+Proceeds from sale of shares of Series H redeemable convertible preferred stock
+| 1,014,249
+|
+| | —
+|
+|
+Costs incurred in connection with the sale of shares of Series H redeemable convertible preferred stock
+| (218)
+|
+|
+| —
+|
+|
+Proceeds from Working Capital Loan
+| 1,004,571
+|
+| | —
+|
+|
+Proceeds from exercise of stock options
+| 20,221
+|
+| | 5,176
+|
+|
+Proceeds from issuance of shares of Class N common stock
+| 15,036
+|
+|
+| —
+|
+|
+Fees paid for revolving credit facility
+| (3,801)
+|
+|
+| —
+|
+|
+Repurchases of early exercised stock options
+| —
+|
+|
+| (28)
+|
+|
+Tax withholding from tender offer and initial public offering
+| (416,660)
+|
+| | —
+|
+|
+Payments of deferred offering costs and other financing activities
+| (12,667)
+|
+| | —
+|
+|
+Net cash flows provided by financing activities
+| $
+| 7,853,242
+|
+| | $
+| 5,148
+|
+|
+Effect of exchange rate on cash
+| 638
+|
+| | 912
+|
+|
+Increase (decrease) in cash, cash equivalents, and restricted cash
+| $
+| 6,496,459
+|
+| | $
+| (205,079)
+|
+|
+Cash, cash equivalents, and restricted cash beginning of period
+| 930,378
+|
+| | 581,965
+|
+|
+Cash, cash equivalents, and restricted cash end of period
+| $
+| 7,426,837
+|
+| | $
+| 376,886
+|
+|
+
+
+
+
+
+
+
+
+
+CEREBRAS SYSTEMS INC.
+RECONCILIATION OF GAAP TO NON-GAAP MEASURES
+(unaudited)
+(in thousands)
+
+Reconciliation of GAAP Revenue to Core Revenue:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+| Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+GAAP revenue
+| | $
+| 180,110
+|
+|
+| $
+| 54,119
+|
+|
+| $
+| 125,991
+|
+|
+| $
+| 103,322
+|
+|
+| $
+| 70,295
+|
+|
+| $
+| 33,027
+|
+|
+Less: Pass-through revenue
+| | (14,503)
+|
+|
+| —
+|
+|
+| (14,503)
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Amortization of customer warrant assets
+| | 44,262
+|
+|
+| 28,022
+|
+|
+| 16,240
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Core revenue
+| | $
+| 209,869
+|
+|
+| $
+| 82,141
+|
+|
+| $
+| 127,728
+|
+|
+| $
+| 103,322
+|
+|
+| $
+| 70,295
+|
+|
+| $
+| 33,027
+|
+|
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Six Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+| Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+GAAP revenue
+| | $
+| 373,516
+|
+|
+| $
+| 164,712
+|
+|
+| $
+| 208,804
+|
+|
+| $
+| 202,834
+|
+|
+| $
+| 139,969
+|
+|
+| $
+| 62,865
+|
+|
+Less: Pass-through revenue
+| | (18,614)
+|
+|
+| —
+|
+|
+| (18,614)
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Amortization of customer warrant assets
+| | 46,315
+|
+|
+| 28,991
+|
+|
+| 17,324
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Core revenue
+| | $
+| 401,217
+|
+|
+| $
+| 193,703
+|
+|
+| $
+| 207,514
+|
+|
+| $
+| 202,834
+|
+|
+| $
+| 139,969
+|
+|
+| $
+| 62,865
+|
+|
+
+Reconciliation of GAAP Gross Profit to Core Gross Profit:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+| Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+GAAP gross profit
+| | $
+| 25,559
+|
+|
+| $
+| 978
+|
+|
+| $
+| 24,581
+|
+|
+| $
+| 32,099
+|
+|
+| $
+| 23,646
+|
+|
+| $
+| 8,453
+|
+|
+Less: Pass-through revenue
+| | (14,503)
+|
+|
+| —
+|
+|
+| (14,503)
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Pass-through costs
+| | 14,075
+|
+|
+| —
+|
+|
+| 14,075
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Amortization of customer warrant assets
+| | 44,262
+|
+|
+| 28,022
+|
+|
+| 16,240
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Stock-based compensation expense
+| | 15,353
+|
+|
+| 2,760
+|
+|
+| 12,593
+|
+|
+| 187
+|
+|
+| 47
+|
+|
+| 140
+|
+|
+Add: Employer payroll tax related to stock-based compensation from IPO
+| | 471
+|
+|
+| 118
+|
+|
+| 353
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Core gross profit
+| | $
+| 85,217
+|
+|
+| $
+| 31,878
+|
+|
+| $
+| 53,339
+|
+|
+| $
+| 32,286
+|
+|
+| $
+| 23,693
+|
+|
+| $
+| 8,593
+|
+|
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Six Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+| Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+GAAP gross profit
+| | $
+| 111,735
+|
+|
+| $
+| 46,640
+|
+|
+| $
+| 65,095
+|
+|
+| $
+| 73,703
+|
+|
+| $
+| 44,910
+|
+|
+| $
+| 28,793
+|
+|
+Less: Pass-through revenue
+| | (18,614)
+|
+|
+| —
+|
+|
+| (18,614)
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Pass-through costs
+| | 18,065
+|
+|
+| —
+|
+|
+| 18,065
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Amortization of customer warrant assets
+| | 46,315
+|
+|
+| 28,991
+|
+|
+| 17,324
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Add: Stock-based compensation expense
+| | 16,303
+|
+|
+| 2,998
+|
+|
+| 13,305
+|
+|
+| 513
+|
+|
+| 129
+|
+|
+| 384
+|
+|
+Add: Employer payroll tax related to stock-based compensation from IPO
+| | 471
+|
+|
+| 118
+|
+|
+| 353
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Core gross profit
+| | $
+| 174,275
+|
+|
+| $
+| 78,747
+|
+|
+| $
+| 95,528
+|
+|
+| $
+| 74,216
+|
+|
+| $
+| 45,039
+|
+|
+| $
+| 29,177
+|
+|
+
+Reconciliation of GAAP Gross Margin to Core Gross Margin:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+| Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+GAAP gross margin
+| | 14.2
+| %
+|
+| 1.8
+| %
+|
+| 19.5
+| %
+|
+| 31.1
+| %
+|
+| 33.6
+| %
+|
+| 25.6
+| %
+|
+Non-GAAP adjustments
+| | 26.4
+|
+|
+| 37.0
+|
+|
+| 22.2
+|
+|
+| 0.2
+|
+|
+| 0.1
+|
+|
+| 0.4
+|
+|
+Core gross margin
+| | 40.6
+| %
+|
+| 38.8
+| %
+|
+| 41.8
+| %
+|
+| 31.2
+| %
+|
+| 33.7
+| %
+|
+| 26.0
+| %
+|
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Six Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+| Total
+|
+| Hardware
+|
+| Cloud and Other Services
+|
+GAAP gross margin
+| | 29.9
+| %
+|
+| 28.3
+| %
+|
+| 31.2
+| %
+|
+| 36.3
+| %
+|
+| 32.1
+| %
+|
+| 45.8
+| %
+|
+Non-GAAP adjustments
+| | 13.5
+|
+|
+| 12.3
+|
+|
+| 14.9
+|
+|
+| 0.3
+|
+|
+| 0.1
+|
+|
+| 0.6
+|
+|
+Core gross margin
+| | 43.4
+| %
+|
+| 40.7
+| %
+|
+| 46.0
+| %
+|
+| 36.6
+| %
+|
+| 32.2
+| %
+|
+| 46.4
+| %
+|
+
+Reconciliation of GAAP Operating Expenses to Core Operating Expenses:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Three Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Research and Development
+|
+| Sales and Marketing
+|
+| General and Administrative
+|
+| Total
+|
+| Research and Development
+|
+| Sales and Marketing
+|
+| General and Administrative
+|
+GAAP operating expenses
+| | $
+| 502,792
+|
+|
+| $
+| 320,151
+|
+|
+| $
+| 86,969
+|
+|
+| $
+| 95,672
+|
+|
+| $
+| 89,281
+|
+|
+| $
+| 60,768
+|
+|
+| $
+| 18,228
+|
+|
+| $
+| 10,285
+|
+|
+Less: Stock-based compensation expense
+| | (361,655)
+|
+|
+| (222,147)
+|
+|
+| (71,055)
+|
+|
+| (68,453)
+|
+|
+| (13,094)
+|
+|
+| (9,301)
+|
+|
+| (1,533)
+|
+|
+| (2,260)
+|
+|
+Less: Employer payroll tax related to stock-based compensation from IPO
+| | (22,307)
+|
+|
+| (16,491)
+|
+|
+| (3,907)
+|
+|
+| (1,909)
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Core operating expenses
+| | $
+| 118,830
+|
+|
+| $
+| 81,513
+|
+|
+| $
+| 12,007
+|
+|
+| $
+| 25,310
+|
+|
+| $
+| 76,187
+|
+|
+| $
+| 51,467
+|
+|
+| $
+| 16,695
+|
+|
+| $
+| 8,025
+|
+|
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Six Months Ended June 30,
+|
+| | 2026
+|
+| 2025
+|
+| | Total
+|
+| Research and Development
+|
+| Sales and Marketing
+|
+| General and Administrative
+|
+| Total
+|
+| Research and Development
+|
+| Sales and Marketing
+|
+| General and Administrative
+|
+GAAP operating expenses
+| | $
+| 604,005
+|
+|
+| $
+| 395,646
+|
+|
+| $
+| 101,670
+|
+|
+| $
+| 106,689
+|
+|
+| $
+| 159,355
+|
+|
+| $
+| 113,519
+|
+|
+| $
+| 28,554
+|
+|
+| $
+| 17,282
+|
+|
+Less: Stock-based compensation expense
+| | (370,298)
+|
+|
+| (227,846)
+|
+|
+| (72,847)
+|
+|
+| (69,605)
+|
+|
+| (21,922)
+|
+|
+| (15,013)
+|
+|
+| (3,482)
+|
+|
+| (3,427)
+|
+|
+Less: Employer payroll tax related to stock-based compensation from IPO
+| | (22,307)
+|
+|
+| (16,491)
+|
+|
+| (3,907)
+|
+|
+| (1,909)
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+| —
+|
+|
+Core operating expenses
+| | $
+| 211,400
+|
+|
+| $
+| 151,309
+|
+|
+| $
+| 24,916
+|
+|
+| $
+| 35,175
+|
+|
+| $
+| 137,433
+|
+|
+| $
+| 98,506
+|
+|
+| $
+| 25,072
+|
+|
+| $
+| 13,855
+|
+|
+
+Reconciliation of GAAP Loss from Operations to Core Operating Loss:
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30,
+|
+| Six Months Ended June 30,
+|
+| 2026
+|
+| 2025
+|
+| 2026
+|
+| 2025
+|
+GAAP loss from operations
+| $
+| (477,233)
+|
+|
+| $
+| (57,182)
+|
+|
+| $
+| (492,270)
+|
+|
+| $
+| (85,652)
+|
+|
+Less: Pass-through revenue
+| (14,503)
+|
+|
+| —
+|
+|
+| (18,614)
+|
+|
+| —
+|
+|
+Add: Stock-based compensation expense
+| 377,008
+|
+|
+| 13,281
+|
+|
+| 386,601
+|
+|
+| 22,435
+|
+|
+Add: Pass-through costs
+| 14,075
+|
+|
+| —
+|
+|
+| 18,065
+|
+|
+| —
+|
+|
+Add: Amortization of customer warrant assets
+| 44,262
+|
+|
+| —
+|
+|
+| 46,315
+|
+|
+| —
+|
+|
+Add: Employer payroll tax related to stock-based compensation from IPO
+| 22,778
+|
+|
+| —
+|
+|
+| 22,778
+|
+|
+| —
+|
+|
+Core operating loss
+| $
+| (33,613)
+|
+|
+| $
+| (43,901)
+|
+|
+| $
+| (37,125)
+|
+|
+| $
+| (63,217)
+|
+|
+
+Reconciliation of GAAP Operating Margin to Core Operating Margin:
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30,
+|
+| Six Months Ended June 30,
+|
+| 2026
+|
+| 2025
+|
+| 2026
+|
+| 2025
+|
+GAAP operating margin
+| (265
+| %)
+|
+| (55
+| %)
+|
+| (132
+| %)
+|
+| (42
+| %)
+|
+Non-GAAP adjustments
+| (249)
+|
+|
+| (13)
+|
+|
+| (123)
+|
+|
+| (11)
+|
+|
+Core operating margin
+| (16
+| %)
+|
+| (42
+| %)
+|
+| (9
+| %)
+|
+| (31
+| %)
+|
+
+Reconciliation of GAAP Loss from Operations to Adjusted EBITDA:
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30,
+|
+| Six Months Ended June 30,
+|
+| 2026
+|
+| 2025
+|
+| 2026
+|
+| 2025
+|
+GAAP loss from operations
+| $
+| (477,233)
+|
+|
+| $
+| (57,182)
+|
+|
+| $
+| (492,270)
+|
+|
+| $
+| (85,652)
+|
+|
+Add: Depreciation and amortization
+| 24,377
+|
+|
+| 5,600
+|
+|
+| 42,551
+|
+|
+| 9,315
+|
+|
+Add: Stock-based compensation
+| 377,008
+|
+|
+| 13,281
+|
+|
+| 386,601
+|
+|
+| 22,435
+|
+|
+Add: Employer payroll tax related to stock-based compensation from IPO
+| 22,778
+|
+|
+| —
+|
+|
+| 22,778
+|
+|
+| —
+|
+|
+Adjusted EBITDA
+| $
+| (53,070)
+|
+|
+| $
+| (38,301)
+|
+|
+| $
+| (40,340)
+|
+|
+| $
+| (53,902)
+|
+|
+
+
+
+
+
+
+
+
+
+
+
+
+Reconciliation of GAAP Net Income (Loss) to Core Net Loss:
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30,
+|
+| Six Months Ended June 30,
+|
+| 2026
+|
+| 2025
+|
+| 2026
+|
+| 2025
+|
+GAAP net income (loss)
+| $
+| (450,528)
+|
+|
+| $
+| 309,512
+|
+|
+| $
+| (464,534)
+|
+|
+| $
+| 285,645
+|
+|
+Less: Pass-through revenue
+| (14,503)
+|
+|
+| —
+|
+|
+| (18,614)
+|
+|
+| —
+|
+|
+Less: Change in fair value (extinguishment) of forward contract liability
+| —
+|
+|
+| (363,336)
+|
+|
+| —
+|
+|
+| (363,336)
+|
+|
+Add: Stock-based compensation expense
+| 377,008
+|
+|
+| 13,281
+|
+|
+| 386,601
+|
+|
+| 22,435
+|
+|
+Add: Pass-through costs
+| 14,075
+|
+|
+| —
+|
+|
+| 18,065
+|
+|
+| —
+|
+|
+Add: Amortization of customer warrant assets
+| 44,262
+|
+|
+| —
+|
+|
+| 46,315
+|
+|
+| —
+|
+|
+Add: Employer payroll tax related to stock-based compensation from IPO
+| 22,778
+|
+|
+| —
+|
+|
+| 22,778
+|
+|
+| —
+|
+|
+Core net loss
+| $
+| (6,908)
+|
+|
+| $
+| (40,543)
+|
+|
+| $
+| (9,389)
+|
+|
+| $
+| (55,256)
+|
+|
+
+
+
+
+
+
+
+
+
+Discussion of Non-GAAP Financial Measures
+Use of non-GAAP financial measures
+We use certain non-GAAP financial measures to supplement the performance measures in our consolidated financial statements, which are presented in accordance with GAAP. These non-GAAP financial measures include core total revenue, core hardware revenue, core cloud and other services revenue, core gross profit, core hardware gross profit, core cloud and other services gross profit, core gross margin, core hardware gross margin, core cloud and other services gross margin, core operating loss, core operating margin, core net loss, and adjusted earnings before interest, income tax, depreciation and amortization (“Adjusted EBITDA”). We use these non-GAAP financial measures for financial and operational decision-making and as a means to assist us in evaluating period-to-period comparisons.
+Reconciliations of each of these non-GAAP financial measures to their most directly comparable GAAP measures for this quarter and prior periods are included in the tables below or elsewhere in the materials accompanying this press release.
+Usefulness of non-GAAP financial measures to investors
+By excluding certain items that may not be indicative of our recurring operating results from our core technology and service offerings and stock-based compensation from grants of equity awards, we believe that the non-GAAP metrics described below provide meaningful supplemental information regarding our performance. Accordingly, we believe these non-GAAP financial measures are useful to investors and others because they allow additional information with respect to financial measures used by management in its financial and operational decision-making and may be useful to our institutional investors and the analyst community to help them analyze the health of our business. Disclosure of these non-GAAP financial measures also facilitates the comparisons of Cerebras’s operating performance with the performance of other companies in the same industry that supplement their GAAP results with non-GAAP financial measures that may be calculated in a manner comparable to their core operations.
+Economic substance of and material limitations associated with non-GAAP financial measures used by Cerebras
+Core revenue, core hardware revenue, core cloud and other services revenue, core gross profit, core hardware gross profit, core cloud and other services gross profit, core gross margin, core hardware gross margin, core cloud and other services gross margin, core operating loss, core operating margin, Adjusted EBITDA and core net loss are adjusted, as applicable, to: (i) exclude non-cash stock-based compensation; (ii) exclude pass-through revenues and costs that are not part of our core technology and services offering; and (iii) add back non-cash amortization from customer warrants that is recorded as a reduction in revenues; (iv) exclude from core net loss the effect of the change in fair value (extinguishment) of the forward contract liability; and (v) present employer payroll tax related to stock-based compensation from IPO as an offset to the stock-based compensation adjustment in calculating core net loss. Non-GAAP adjusted EBITDA excludes the impacts of depreciation and amortization and stock-based compensation.
+
+
+
+
+
+
+
+Core gross margin, core hardware margin, and core cloud and other services margin represent core gross profit, core hardware gross profit, and core cloud and other services gross profit, respectively, expressed as a percentage of their corresponding core revenue.
+More specifically, Cerebras makes the adjustments described above for the following reasons:
+• Stock-based compensation expense consists of equity awards granted based on the estimated fair value of those awards at the grant date. Although stock-based compensation is a key incentive offered to employees, Cerebras excludes these charges for the purpose of calculating these non-GAAP measures, primarily because they are non-cash expenses, and the Company’s internal benchmarking analyses evidence that many industry participants and peers present non-GAAP financial measures excluding stock-based compensation expense.
+• Amortization of customer warrants consists of equity granted to customers and recorded as contra-revenue. We exclude the impact of amortization of customer warrant assets recorded as contra‑revenue from our non‑GAAP results because it represents a non‑cash, valuation‑driven adjustment associated with equity instruments issued to customers.The amount and timing of this amortization may be influenced by factors outside our operational performance, including the timing of customer capacity deployment decisions and product delivery schedules, which are at the discretion of the customer. This adjustment does not reflect the underlying economics of our core revenue‑generating activities, including pricing, volume, or cost of delivering our products and services, and therefore may not be indicative of our ongoing operating performance.
+• Pass-through revenue and associated pass-through cost of revenue relate to non-recurring data center start-up and recurring data center costs that are incurred on behalf of specific customers. We exclude pass‑through revenue and the associated pass-through cost of revenue from our non‑GAAP financial measures because such amounts are incurred on behalf of specific customers and do not reflect the underlying economics of our core hardware technology and services offerings and generally generate fixed minimal gross margins. These pass-through revenues and costs are dependent on the pace of customer data center build-outs, deployment schedules, and customer deployment choices and approval of associated billings. Accordingly, these amounts may fluctuate significantly between reporting periods and can obscure comparisons of our operating performance results and trends in our core business.
+• The change in fair value (extinguishment) of the forward contract liability reflects the impact recognized in connection with the forward contract liability. We exclude this item from core net loss because it arose from the forward contract liability rather than from the operating performance of our core technology and services offerings.
+• Employer payroll tax related to stock-based compensation from IPO is presented as an adjustment in calculating core net loss. This treatment presents the employer payroll tax separately from the non-cash stock-based compensation excluded from core net loss.
+
+
+
+
+
+
+
+There are a number of limitations related to the use of non-GAAP financial measures, and these non-GAAP measures should be considered in addition to, not as a substitute for or in isolation from, our financial results prepared in accordance with GAAP. Other companies, including companies in our industry, may calculate these non-GAAP financial measures differently or not at all, which reduces their usefulness as comparative measures. No reconciliation is provided with respect to certain forward-looking non-GAAP financial measures as the GAAP measures are not accessible on a forward-looking basis. We cannot reliably predict all necessary components or their impact to reconcile such financial measures without unreasonable effort. The events necessitating a non-GAAP adjustment are inherently unpredictable and may have a significant impact on our future GAAP financial results. Cerebras compensates for these limitations on the use of non-GAAP financial measures by relying primarily on its GAAP results and using non-GAAP financial measures only as a supplement. Cerebras also provides a reconciliation of each non-GAAP financial measure to its most directly comparable GAAP financial measure for this quarter and prior periods within this press release, and Cerebras encourages investors to review those reconciliations carefully.\n

--- a/modules/test-fixtures/earnings-filings/cohr.txt
+++ b/modules/test-fixtures/earnings-filings/cohr.txt
@@ -1,0 +1,7459 @@
+EX-99.1
+2
+d128030dex991.htm
+EX-99.1
+
+
+EX-99.1
+
+
+
+
+Exhibit 99.1
+
+
+
+
+
+
+
+
+|
+
+|
+|
+
+|
+|
+
+|
+|
+
+
+
+
+
+
+
+
+|
+|
+|
+|
+Coherent Corp.
+375 Saxonburg Blvd.
+
+Saxonburg, PA 16056-9499
+|
+
+PRESS RELEASE
+
+COHERENT CORP. REPORTS FOURTH QUARTER AND FULL YEAR FISCAL 2026 RESULTS
+
+
+
+
+|
+ |
+|
+Q4 REVENUE OF $2.05B, INCREASED 34% Y/Y AND 42% Y/Y ON A PRO FORMA BASIS
+|
+
+
+
+
+
+|
+ |
+|
+Q4 GAAP GROSS MARGIN OF 38.5%, INCREASED 277 bps Y/Y; Q4 NON-GAAP
+GROSS MARGIN OF 40.2%, INCREASED 215 bps Y/Y
+|
+
+
+
+
+|
+ |
+|
+Q4 GAAP EPS OF $1.19, INCREASED $2.02 Y/Y; Q4 NON-GAAP EPS OF $1.74,
+INCREASED $0.74 Y/Y
+|
+SAXONBURG, Pa., August 12, 2026 – Coherent Corp. (NYSE: COHR)
+(“Coherent,” “We,” or the “Company”), a global leader in photonics, announced financial results today for its fiscal fourth quarter and full year fiscal 2026 ended June 30, 2026.
+
+Revenue for the fourth quarter of fiscal 2026 was $2.05 billion, with GAAP gross margin of 38.5% and GAAP net income of $1.19 per diluted share. On a non-GAAP basis, gross margin was 40.2% with net income per diluted share of $1.74.
+“Fiscal 2026 was an
+outstanding year for Coherent, with record revenue, significant margin expansion, and non-GAAP EPS growth that was more than twice the rate of revenue growth,” said Jim Anderson, CEO. “We enter
+fiscal 2027 with exceptional customer demand, expanding production capacity, and multiple new growth platforms beginning to ramp. As AI datacenter architectures increasingly transition from copper to optical connectivity, we believe Coherent’s
+broad photonic technology portfolio and manufacturing scale uniquely position us to deliver accelerating growth and capitalize on this multi-year opportunity.”
+
+Sherri Luther, CFO, said, “Strong operational execution across our business drove meaningful gross margin expansion and converted our top-line revenue growth into robust GAAP and non-GAAP EPS growth. As we enter fiscal 2027, we remain disciplined in our capital allocation, prioritizing investments to expand
+manufacturing capacity so we can efficiently fulfill the ongoing acceleration in customer demand.”
+
+
+1
+
+
+
+
+
+
+
+
+
+
+
+
+
+Selected Fourth Quarter and Full Year 2026 Financial Results and Comparisons (in millions, except percentages and per share data)
+
+Table 1
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+|
+|
+GAAP Financial Results (unaudited) |
+|
+
+
+|
+|
+Q4 FY26 |
+|
+|
+Q3 FY26 |
+|
+|
+Q4 FY25 |
+|
+|
+Q/Q |
+|
+|
+Y/Y |
+|
+|
+FY 2026 |
+|
+|
+FY 2025 |
+|
+|
+FY/FY |
+|
+
+
+
+
+Revenues
+|
+|
+$ |
+2,046 |
+|
+|
+$ |
+1,806 |
+|
+|
+$ |
+1,529 |
+|
+|
+|
+13.3 |
+% |
+|
+|
+33.8 |
+% |
+|
+$ |
+7,118 |
+|
+|
+$ |
+5,810 |
+|
+|
+|
+22.5 |
+% |
+
+
+Gross Margin %
+|
+|
+|
+38.5 |
+% |
+|
+|
+37.7 |
+% |
+|
+|
+35.7 |
+% |
+|
+|
+82 |
+bps |
+|
+|
+277 |
+bps |
+|
+|
+37.5 |
+% |
+|
+|
+35.2 |
+% |
+|
+|
+233 |
+bps |
+
+
+R&D Expense %
+|
+|
+|
+10.6 |
+% |
+|
+|
+10.3 |
+% |
+|
+|
+10.2 |
+% |
+|
+|
+28 |
+bps |
+|
+|
+40 |
+bps |
+|
+|
+10.2 |
+% |
+|
+|
+10.0 |
+% |
+|
+|
+14 |
+bps |
+
+
+SG&A Expense %
+|
+|
+|
+13.0 |
+% |
+|
+|
+14.8 |
+% |
+|
+|
+16.0 |
+% |
+|
+|
+(180 |
+) bps |
+|
+|
+(302 |
+) bps |
+|
+|
+14.7 |
+% |
+|
+|
+15.9 |
+% |
+|
+|
+(127 |
+) bps |
+
+
+Operating Expenses
+|
+|
+$ |
+533 |
+|
+|
+$ |
+479 |
+|
+|
+$ |
+540 |
+|
+|
+|
+11.2 |
+% |
+|
+|
+(1.3 |
+)% |
+|
+$ |
+1,771 |
+|
+|
+$ |
+1,753 |
+|
+|
+|
+1.0 |
+% |
+
+
+Operating Income (1)
+|
+|
+$ |
+254 |
+|
+|
+$ |
+201 |
+|
+|
+$ |
+6 |
+|
+|
+|
+26.5 |
+% |
+|
+|
+4063.9 |
+% |
+|
+$ |
+898 |
+|
+|
+$ |
+290 |
+|
+|
+|
+209.7 |
+% |
+
+
+Operating Margin
+|
+|
+|
+12.4 |
+% |
+|
+|
+11.1 |
+% |
+|
+|
+0.4 |
+% |
+|
+|
+130 |
+bps |
+|
+|
+1,202 |
+bps |
+|
+|
+12.6 |
+% |
+|
+|
+5.0 |
+% |
+|
+|
+762 |
+bps |
+
+
+Net Earnings Attributable to Coherent Corp.
+|
+|
+$ |
+241 |
+|
+|
+$ |
+191 |
+|
+|
+$ |
+(96 |
+) |
+|
+|
+25.8 |
+% |
+|
+|
+(351.6 |
+)% |
+|
+$ |
+805 |
+|
+|
+$ |
+49 |
+|
+|
+|
+1530.8 |
+% |
+
+
+Diluted Earnings (Loss) Per Share
+|
+|
+$ |
+1.19 |
+|
+|
+$ |
+0.97 |
+|
+|
+$ |
+(0.83 |
+) |
+|
+$ |
+0.22 |
+|
+|
+$ |
+2.02 |
+|
+|
+$ |
+4.12 |
+|
+|
+$ |
+(0.52 |
+) |
+|
+$ |
+4.64 |
+|
+
+
+
+
+
+(1) |
+Operating Income is defined as earnings (loss) before income taxes, interest expense, and other expense or
+income, net.
+|
+
+
+
+Selected Fourth Quarter and Full Year 2026 Financial Results and Comparisons (in millions, except percentages and per share data)
+
+Table 1, continued
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+|
+|
+Non-GAAP Financial Results (unaudited) (1)(2) |
+|
+
+
+|
+|
+Q4 FY26 |
+|
+|
+Q3 FY26 |
+|
+|
+Q4 FY25 |
+|
+|
+Q/Q |
+|
+|
+Y/Y |
+|
+|
+FY 2026 |
+|
+|
+FY 2025 |
+|
+|
+FY/FY |
+|
+
+
+
+
+Revenues
+|
+|
+$ |
+2,046 |
+|
+|
+$ |
+1,806 |
+|
+|
+$ |
+1,529 |
+|
+|
+|
+13.3 |
+% |
+|
+|
+33.8 |
+% |
+|
+$ |
+7,118 |
+|
+|
+$ |
+5,810 |
+|
+|
+|
+22.5 |
+% |
+
+
+Gross Margin %
+|
+|
+|
+40.2 |
+% |
+|
+|
+39.6 |
+% |
+|
+|
+38.1 |
+% |
+|
+|
+66 |
+bps |
+|
+|
+215 |
+bps |
+|
+|
+39.4 |
+% |
+|
+|
+37.9 |
+% |
+|
+|
+152 |
+bps |
+
+
+R&D Expense %
+|
+|
+|
+10.2 |
+% |
+|
+|
+9.9 |
+% |
+|
+|
+9.8 |
+% |
+|
+|
+30 |
+bps |
+|
+|
+39 |
+bps |
+|
+|
+9.7 |
+% |
+|
+|
+9.5 |
+% |
+|
+|
+20 |
+bps |
+
+
+SG&A Expense %
+|
+|
+|
+8.2 |
+% |
+|
+|
+9.4 |
+% |
+|
+|
+10.3 |
+% |
+|
+|
+(116 |
+) bps |
+|
+|
+(205 |
+) bps |
+|
+|
+9.2 |
+% |
+|
+|
+10.5 |
+% |
+|
+|
+(130 |
+) bps |
+
+
+Operating Expenses
+|
+|
+$ |
+377 |
+|
+|
+$ |
+348 |
+|
+|
+$ |
+307 |
+|
+|
+|
+8.2 |
+% |
+|
+|
+22.7 |
+% |
+|
+$ |
+1,350 |
+|
+|
+$ |
+1,165 |
+|
+|
+|
+15.8 |
+% |
+
+
+Operating Income
+|
+|
+$ |
+446 |
+|
+|
+$ |
+366 |
+|
+|
+$ |
+275 |
+|
+|
+|
+21.8 |
+% |
+|
+|
+62.1 |
+% |
+|
+$ |
+1,457 |
+|
+|
+$ |
+1,037 |
+|
+|
+|
+40.5 |
+% |
+
+
+Operating Margin
+|
+|
+|
+21.8 |
+% |
+|
+|
+20.3 |
+% |
+|
+|
+18.0 |
+% |
+|
+|
+152 |
+bps |
+|
+|
+381 |
+bps |
+|
+|
+20.5 |
+% |
+|
+|
+17.8 |
+% |
+|
+|
+262 |
+bps |
+
+
+Net Earnings Attributable to Coherent Corp.
+|
+|
+$ |
+351 |
+|
+|
+$ |
+276 |
+|
+|
+$ |
+192 |
+|
+|
+|
+27.2 |
+% |
+|
+|
+82.7 |
+% |
+|
+$ |
+1,097 |
+|
+|
+$ |
+693 |
+|
+|
+|
+58.3 |
+% |
+
+
+Diluted Earnings Per Share
+|
+|
+$ |
+1.74 |
+|
+|
+$ |
+1.41 |
+|
+|
+$ |
+1.00 |
+|
+|
+$ |
+0.33 |
+|
+|
+$ |
+0.74 |
+|
+|
+$ |
+5.61 |
+|
+|
+$ |
+3.53 |
+|
+|
+$ |
+2.08 |
+|
+
+
+
+
+
+(1) |
+During the second fiscal quarter of 2025, the Company refined its methodology to report non-GAAP measures. The change does not impact the Company’s financial position, cash flows, or GAAP consolidated results of operations. Prior period non-GAAP financial
+measures presented in this press release have been recast to conform to the current presentation.
+|
+
+
+
+(2) |
+The Company has disclosed financial measurements in this earnings release that present financial information
+that are considered to be non-GAAP financial measures. These measurements are not a substitute for GAAP measurements, although the Company’s management uses these measurements as an aid in monitoring the
+Company’s on-going financial performance. The non-GAAP net earnings attributable to Coherent Corp., the non-GAAP diluted
+earnings per share, the non-GAAP operating income, the non-GAAP gross margin, the non-GAAP research and development, the non-GAAP selling, general and administrative expenses, the non-GAAP operating expenses, the non-GAAP interest and other (income)
+expense, and the non-GAAP income taxes, measure earnings and operating income (loss), respectively, excluding non-recurring or unusual items that are considered by
+management to be outside the Company’s standard operation and excluding certain non-cash items. There are limitations associated with the use of non-GAAP financial
+measures, including that such measures may not be entirely
+|
+
+
+2
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|
+
+comparable to similarly titled measures used by other companies, due to potential differences among calculation methodologies. Thus, there can be no assurance whether (i) items excluded from
+the non-GAAP financial measures will occur in the future or (ii) there will be cash costs associated with items excluded from the non-GAAP financial measures. The
+Company compensates for these limitations by using these non-GAAP financial measures as supplements to GAAP financial measures and by providing the reconciliations of the
+non-GAAP financial measures to their most comparable GAAP financial measures. Investors should consider adjusted measures in addition to, and not as a substitute for, or superior to, financial performance
+measures prepared in accordance with GAAP. All non-GAAP amounts exclude certain adjustments for share-based compensation, acquired intangible amortization expense, restructuring charges (recoveries),
+impairments of assets held-for-sale, gains on sale of business, integration and site consolidation expenses, integration transaction expenses, and various one-time adjustments. See Table 6 for the Reconciliation of GAAP Measures to Non-GAAP Measures. |
+
+Business Outlook – First Quarter Fiscal 2027 (1)
+
+
+
+
+
+|
+ |
+|
+Revenue for the first quarter of fiscal 2027 is expected to be between $2.2 billion and $2.4 billion.
+
+|
+
+
+
+
+|
+ |
+|
+Gross margin percentage for the first quarter of fiscal 2027 is expected to be between 39.5% and 41.5% on a non-GAAP basis.
+|
+
+
+
+
+|
+ |
+|
+Total operating expenses for the first quarter of fiscal 2027 are expected to be between $400 million and
+$420 million on a non-GAAP basis.
+|
+
+
+
+
+|
+ |
+|
+Tax rate for the first quarter of fiscal 2027 is expected to be between 18% and 20% on a non-GAAP basis.
+|
+
+
+
+
+|
+ |
+|
+EPS for the first quarter of fiscal 2027 is expected to be between $1.85 and $2.05 on a non-GAAP basis.
+|
+
+
+
+
+(1) |
+The Company has not provided a quantitative reconciliation of forward-looking
+non-GAAP gross margin percentage, non-GAAP operating expenses, non-GAAP tax rate and
+non-GAAP earnings per share, because we cannot, without unreasonable efforts, forecast certain items required to develop comparable GAAP measures. These items include, without limitation, restructuring
+charges, integration, site consolidation and other expenses, foreign exchange gains (losses), and share based compensation expense. The variability of these items could significantly impact our future GAAP financial results and we believe that the
+inclusion of any such reconciliations would imply a degree or precision that could be confusing or misleading to investors.
+|
+Investor
+Conference Call / Webcast Details
+Coherent will review the Company’s financial results for its fourth quarter and full year fiscal 2026 and
+business outlook on Wednesday, August 12, at 4:30 p.m. ET. A live webcast and replay of the conference call will be available on the Investor Relations section of the Company’s website at coherent.com/company/investor-relations .
+The Company’s financial guidance will be limited to the comments on its public quarterly earnings call and the public business outlook statements contained in this press release.
+
+Additional Information and Where to Find It
+In
+connection with the conference call described above, the Company intends to file an investor presentation as an exhibit to a Current Report on Form 8-K filed with the Securities and Exchange Commission
+(“SEC”) and to post the investor presentation on the Company’s website at coherent.com/company/investor-relations/investor-presentations after market close on August 12, 2026. We also may, from time to time, post other
+important information for investors on our website at coherent.com/company/investor-relations . We intend to use our website as a means of disclosing material, non-public information and for complying
+with our disclosure obligations under Regulation FD. Accordingly, investors should review the Investor Relations page of our website referenced above, in addition to following the Company’s press releases, SEC filings, and public conference
+calls, presentations, and webcasts. Investors and security holders are
+
+
+3
+
+
+
+
+
+
+
+
+
+
+
+
+able to obtain free copies of these documents through the Company’s website referenced above. Copies of the documents filed by the Company with the SEC may be obtained free of charge on the
+Company’s website at coherent.com/company/investor-relations/sec-filings . The information contained on, or that may be accessed through, the Company’s website is not incorporated by
+reference into, and is not part of, this release.
+Forward-Looking Statements
+
+This press release contains statements, estimates, and projections that constitute “forward-looking statements” as defined under U.S. federal
+securities laws – including our estimates and projections for our business outlook for the first quarter of fiscal 2027, each of which is made pursuant to the safe harbor provisions of the U.S. Private Securities Litigation Reform Act of 1995
+and relate to the Company’s performance on a going-forward basis. The forward-looking statements are subject to certain risks and uncertainties that could cause the Company’s actual results to differ materially from its historical
+experience and our present expectations or projections.
+The Company believes that all forward-looking statements made by it herein have a reasonable
+basis, but there can be no assurance that management’s expectations, beliefs, or projections as expressed in the forward-looking statements will actually occur or prove to be correct. In addition to general industry and global economic
+conditions, factors that could cause actual results to differ materially from those discussed in the forward-looking statements herein include but are not limited to: (i) the failure of any one or more of the assumptions stated herein to prove
+to be correct; (ii) changes in demand in the Company’s end markets along with the Company’s ability to respond to such market changes; (iii) our failure to accurately estimate customer demand and future sales and/or
+fluctuations in purchasing patterns of customers and end users; (iv) the ability of the Company to retain and hire key employees; (v) the terms of the Company’s indebtedness and ability to service such debt; (vi) the timely
+release of new products and acceptance of such new products by the market; (vii) the introduction of new products by competitors and other competitive responses; (viii) the risks to realizing the benefits of investments in R&D and
+commercialization of innovations; (ix) the risks that the Company’s stock price will not trade in line with industrial technology leaders; (x) the impact of international conflict and economic volatility in either domestic or foreign
+markets, including risks related to the impact of trade protection measures, such as import tariffs by the United States or retaliatory actions taken by other countries; and/or (xi) the risks relating to forward-looking statements and other
+“Risk Factors” identified from time to time in our filings with the SEC, including our Annual Report on Form 10-K for the fiscal year ended June 30, 2025, and our subsequently filed Quarterly
+Reports on Form 10-Q and Annual Report on Form 10-K for the fiscal year ended June 30, 2026, which filings are available from the SEC. You should not place undue
+reliance on forward-looking statements, which speak only as of the date they are made. The Company disclaims any obligation to update information contained in these forward-looking statements, whether as a
+result of new information, future events or developments, or otherwise.
+
+
+4
+
+
+
+
+
+
+
+
+
+
+
+About Coherent
+
+Coherent is the global photonics leader. We harness photons to drive innovation. Industry leaders in the datacenter, communications, and industrial markets
+rely on Coherent’s world-leading technology to fuel their own innovation and growth.
+Founded in 1971 and operating in more than 20 countries,
+Coherent brings the industry’s broadest, deepest technology stack; unmatched supply chain resilience; and global scale to help its customers solve their toughest technology challenges. For more information, please visit us at
+coherent.com .
+Contact:
+Paul Silverstein
+
+Senior VP, Investor Relations
+investor.relations@coherent.com
+
+# # #
+
+
+5
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 2
+
+Coherent Corp. and Subsidiaries
+
+Condensed Consolidated Statements of Earnings (Loss)*
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+
+|
+|
+THREE MONTHS ENDED |
+|
+
+
+$ Millions, except per share amounts (unaudited)
+|
+|
+Jun 30, 2026 |
+|
+|
+Mar 31, 2026 |
+|
+|
+Jun 30, 2025 |
+|
+
+
+Revenues
+|
+|
+$ |
+2,045.5 |
+|
+|
+$ |
+1,805.6 |
+|
+|
+$ |
+1,529.4 |
+|
+
+
+Costs, Expenses & Other Expense (Income)
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Cost of goods sold
+|
+|
+|
+1,258.5 |
+|
+|
+|
+1,125.7 |
+|
+|
+|
+983.3 |
+|
+
+
+Research and development
+|
+|
+|
+216.4 |
+|
+|
+|
+186.0 |
+|
+|
+|
+155.7 |
+|
+
+
+Selling, general and administrative
+|
+|
+|
+266.4 |
+|
+|
+|
+267.6 |
+|
+|
+|
+245.4 |
+|
+
+
+Restructuring charges
+|
+|
+|
+6.1 |
+|
+|
+|
+34.4 |
+|
+|
+|
+53.9 |
+|
+
+
+Impairment of assets
+held-for-sale
+|
+|
+|
+44.3 |
+|
+|
+|
+—  |
+|
+|
+|
+85.0 |
+|
+
+
+Gain on sale of business
+|
+|
+|
+—  |
+|
+|
+|
+(8.9 |
+) |
+|
+|
+—  |
+|
+
+
+Interest expense
+|
+|
+|
+41.1 |
+|
+|
+|
+44.6 |
+|
+|
+|
+55.0 |
+|
+
+
+Other expense (income), net
+|
+|
+|
+(65.6 |
+) |
+|
+|
+(28.1 |
+) |
+|
+|
+14.4 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Costs, Expenses, & Other Expense
+|
+|
+|
+1,767.0 |
+|
+|
+|
+1,621.3 |
+|
+|
+|
+1,592.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Earnings (Loss) Before Income Taxes
+|
+|
+|
+278.5 |
+|
+|
+|
+184.3 |
+|
+|
+|
+(63.4 |
+) |
+
+
+Income Taxes
+|
+|
+|
+42.3 |
+|
+|
+|
+2.7 |
+|
+|
+|
+34.7 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net Earnings (Loss)
+|
+|
+|
+236.2 |
+|
+|
+|
+181.7 |
+|
+|
+|
+(98.1 |
+) |
+
+
+Net Loss Attributable to Noncontrolling Interests
+|
+|
+|
+(4.3 |
+) |
+|
+|
+(9.7 |
+) |
+|
+|
+(2.5 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net Earnings (Loss) Attributable to Coherent Corp.
+|
+|
+|
+240.5 |
+|
+|
+|
+191.4 |
+|
+|
+|
+(95.6 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Less: Dividends on Preferred Stock
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+33.1 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net Earnings (Loss) Available to the Common Shareholders
+|
+|
+$ |
+240.5 |
+|
+|
+$ |
+191.4 |
+|
+|
+$ |
+(128.8 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Basic Earnings (Loss) Per Share
+|
+|
+$ |
+1.23 |
+|
+|
+$ |
+1.01 |
+|
+|
+$ |
+(0.83 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted Earnings (Loss) Per Share
+|
+|
+$ |
+1.19 |
+|
+|
+$ |
+0.97 |
+|
+|
+$ |
+(0.83 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Average Shares Outstanding - Basic
+|
+|
+|
+195.7 |
+|
+|
+|
+190.2 |
+|
+|
+|
+155.5 |
+|
+
+
+Average Shares Outstanding - Diluted
+|
+|
+|
+202.2 |
+|
+|
+|
+196.4 |
+|
+|
+|
+155.5 |
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+6
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 2
+Coherent Corp. and Subsidiaries
+
+Condensed Consolidated Statements of Earnings*
+
+(Continued)
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+
+|
+|
+YEAR ENDED |
+|
+
+
+$ Millions, except per share amounts (unaudited)
+|
+|
+Jun 30, 2026 |
+|
+|
+Jun 30, 2025 |
+|
+
+
+Revenues
+|
+|
+$ |
+7,118.2 |
+|
+|
+$ |
+5,810.1 |
+|
+
+
+Costs, Expenses & Other Expense (Income)
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Cost of goods sold
+|
+|
+|
+4,449.1 |
+|
+|
+|
+3,766.8 |
+|
+
+
+Research and development
+|
+|
+|
+723.0 |
+|
+|
+|
+581.9 |
+|
+
+
+Selling, general and administrative
+|
+|
+|
+1,044.6 |
+|
+|
+|
+926.5 |
+|
+
+
+Restructuring charges
+|
+|
+|
+63.4 |
+|
+|
+|
+160.1 |
+|
+
+
+Impairment of assets
+held-for-sale
+|
+|
+|
+64.4 |
+|
+|
+|
+85.0 |
+|
+
+
+Gain on sale of business
+|
+|
+|
+(124.1 |
+) |
+|
+|
+—  |
+|
+
+
+Interest expense
+|
+|
+|
+190.3 |
+|
+|
+|
+243.3 |
+|
+
+
+Other expense (income), net
+|
+|
+|
+(140.1 |
+) |
+|
+|
+(47.6 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Costs, Expenses, & Other Expense
+|
+|
+|
+6,270.4 |
+|
+|
+|
+5,715.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Earnings Before Income Taxes
+|
+|
+|
+847.7 |
+|
+|
+|
+94.2 |
+|
+
+
+Income Taxes
+|
+|
+|
+60.8 |
+|
+|
+|
+64.1 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net Earnings
+|
+|
+|
+786.9 |
+|
+|
+|
+30.1 |
+|
+
+
+Net Loss Attributable to Noncontrolling Interests
+|
+|
+|
+(18.1 |
+) |
+|
+|
+(19.3 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net Earnings Attributable to Coherent Corp.
+|
+|
+|
+805.0 |
+|
+|
+|
+49.4 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Less: Dividends on Preferred Stock
+|
+|
+|
+35.1 |
+|
+|
+|
+129.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net Earnings (Loss) Available to the Common Shareholders
+|
+|
+$ |
+769.9 |
+|
+|
+$ |
+(80.6 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Basic Earnings (Loss) Per Share
+|
+|
+$ |
+4.34 |
+|
+|
+$ |
+(0.52 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted Earnings (Loss) Per Share
+|
+|
+$ |
+4.12 |
+|
+|
+$ |
+(0.52 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Average Shares Outstanding - Basic
+|
+|
+|
+177.3 |
+|
+|
+|
+154.8 |
+|
+
+
+Average Shares Outstanding - Diluted
+|
+|
+|
+195.4 |
+|
+|
+|
+154.8 |
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+7
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 3
+Coherent Corp. and Subsidiaries
+
+Condensed Consolidated Balance Sheets*
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+
+$ Millions (unaudited)
+|
+|
+Jun 30, 2026 |
+|
+|
+Jun 30, 2025 |
+|
+
+
+Assets
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Current Assets
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Cash and cash equivalents
+|
+|
+$ |
+1,162.0 |
+|
+|
+$ |
+909.2 |
+|
+
+
+Restricted cash, current
+|
+|
+|
+35.2 |
+|
+|
+|
+8.9 |
+|
+
+
+Short-term investments
+|
+|
+|
+825.0 |
+|
+|
+|
+—  |
+|
+
+
+Accounts receivable
+|
+|
+|
+1,343.3 |
+|
+|
+|
+964.1 |
+|
+
+
+Inventories
+|
+|
+|
+2,581.0 |
+|
+|
+|
+1,437.6 |
+|
+
+
+Prepaid and refundable income taxes
+|
+|
+|
+78.9 |
+|
+|
+|
+55.8 |
+|
+
+
+Prepaid and other current assets
+|
+|
+|
+900.1 |
+|
+|
+|
+551.6 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Current Assets
+|
+|
+|
+6,925.5 |
+|
+|
+|
+3,927.2 |
+|
+
+
+Property, plant & equipment, net
+|
+|
+|
+2,999.3 |
+|
+|
+|
+1,877.5 |
+|
+
+
+Goodwill
+|
+|
+|
+4,375.6 |
+|
+|
+|
+4,471.1 |
+|
+
+
+Other intangible assets, net
+|
+|
+|
+2,884.5 |
+|
+|
+|
+3,204.7 |
+|
+
+
+Deferred income taxes
+|
+|
+|
+69.4 |
+|
+|
+|
+53.4 |
+|
+
+
+Restricted cash, non-current
+|
+|
+|
+571.2 |
+|
+|
+|
+714.8 |
+|
+
+
+Other assets
+|
+|
+|
+474.3 |
+|
+|
+|
+662.2 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Assets
+|
+|
+$ |
+18,299.9 |
+|
+|
+$ |
+14,910.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Liabilities, Mezzanine Equity and Equity
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Current Liabilities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Current portion of long-term debt
+|
+|
+$ |
+7.9 |
+|
+|
+$ |
+188.3 |
+|
+
+
+Accounts payable
+|
+|
+|
+1,905.4 |
+|
+|
+|
+847.0 |
+|
+
+
+Operating lease current liabilities
+|
+|
+|
+61.4 |
+|
+|
+|
+41.6 |
+|
+
+
+Accruals and other current liabilities
+|
+|
+|
+879.3 |
+|
+|
+|
+718.0 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Current Liabilities
+|
+|
+|
+2,853.9 |
+|
+|
+|
+1,794.8 |
+|
+
+
+Long-term debt
+|
+|
+|
+3,214.3 |
+|
+|
+|
+3,498.6 |
+|
+
+
+Deferred income taxes
+|
+|
+|
+540.6 |
+|
+|
+|
+711.7 |
+|
+
+
+Operating lease liabilities
+|
+|
+|
+254.8 |
+|
+|
+|
+165.2 |
+|
+
+
+Other liabilities
+|
+|
+|
+198.0 |
+|
+|
+|
+259.3 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Liabilities
+|
+|
+|
+7,061.7 |
+|
+|
+|
+6,429.7 |
+|
+
+
+Total Mezzanine Equity
+|
+|
+|
+—  |
+|
+|
+|
+2,483.3 |
+|
+
+
+Total Coherent Corp. Shareholders’ Equity
+|
+|
+|
+10,903.5 |
+|
+|
+|
+5,644.5 |
+|
+
+
+Noncontrolling interests
+|
+|
+|
+334.7 |
+|
+|
+|
+353.5 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Equity
+|
+|
+|
+11,238.2 |
+|
+|
+|
+5,998.0 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total Liabilities, Mezzanine Equity and Equity
+|
+|
+$ |
+18,299.9 |
+|
+|
+$ |
+14,910.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+8
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 4
+Coherent Corp. and Subsidiaries
+
+Condensed Consolidated Statements of Cash Flows*
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+
+|
+|
+YEAR ENDED |
+|
+
+
+$ Millions (unaudited)
+|
+|
+Jun 30, 2026 |
+|
+|
+Jun 30, 2025 |
+|
+
+
+Cash Flows from Operating Activities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Net cash provided by operating activities
+|
+|
+$ |
+79.5 |
+|
+|
+$ |
+633.6 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash Flows from Investing Activities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Additions to property, plant & equipment
+|
+|
+|
+(1,102.9 |
+) |
+|
+|
+(440.8 |
+) |
+
+
+Purchases of intangible assets
+|
+|
+|
+(7.2 |
+) |
+|
+|
+—  |
+|
+
+
+Proceeds from the sale of business
+|
+|
+|
+437.0 |
+|
+|
+|
+27.0 |
+|
+
+
+Proceeds from sale of equity investment
+|
+|
+|
+89.4 |
+|
+|
+|
+—  |
+|
+
+
+Purchases of short-term investments
+|
+|
+|
+(1,025.0 |
+) |
+|
+|
+—  |
+|
+
+
+Proceeds from sales/maturities of short-term investments
+|
+|
+|
+200.0 |
+|
+|
+|
+—  |
+|
+
+
+Other investing activities
+|
+|
+|
+(5.0 |
+) |
+|
+|
+(0.4 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net cash used in investing activities
+|
+|
+|
+(1,413.7 |
+) |
+|
+|
+(414.2 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash Flows from Financing Activities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Proceeds from borrowings of Term A Facility
+|
+|
+|
+1,250.0 |
+|
+|
+|
+—  |
+|
+
+
+Proceeds from borrowings of Term B Facility
+|
+|
+|
+3.3 |
+|
+|
+|
+—  |
+|
+
+
+Proceeds from borrowings of revolving credit facilities
+|
+|
+|
+640.1 |
+|
+|
+|
+53.7 |
+|
+
+
+Proceeds from borrowings of other credit facilities
+|
+|
+|
+28.0 |
+|
+|
+|
+—  |
+|
+
+
+Proceeds from issuance of common shares
+|
+|
+|
+1,998.6 |
+|
+|
+|
+—  |
+|
+
+
+Payments on existing debt
+|
+|
+|
+(1,723.4 |
+) |
+|
+|
+(437.0 |
+) |
+
+
+Payments on borrowings under revolving credit facilities
+|
+|
+|
+(676.2 |
+) |
+|
+|
+(51.7 |
+) |
+
+
+Debt issuance costs
+|
+|
+|
+(9.1 |
+) |
+|
+|
+—  |
+|
+
+
+Proceeds from exercises of stock options and purchases under employee stock purchase plan
+|
+
+|
+|
+53.8 |
+|
+|
+|
+49.6 |
+|
+
+
+Payments in satisfaction of employees’ minimum tax obligations
+|
+|
+|
+(77.4 |
+) |
+|
+|
+(54.0 |
+) |
+
+
+Payment of dividends
+|
+|
+|
+(11.4 |
+) |
+|
+|
+(11.4 |
+) |
+
+
+Other financing activities
+|
+|
+|
+1.0 |
+|
+|
+|
+(0.9 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net cash provided by (used in) financing activities
+|
+|
+|
+1,477.1 |
+|
+|
+|
+(451.7 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Effect of exchange rate changes on cash and cash equivalents
+|
+|
+|
+(7.4 |
+) |
+|
+|
+75.6 |
+|
+
+
+Net increase (decrease) in cash and cash equivalents
+|
+|
+|
+135.5 |
+|
+|
+|
+(156.8 |
+) |
+
+
+Cash, Cash Equivalents, and Restricted Cash at Beginning of Period
+|
+|
+|
+1,632.9 |
+|
+|
+|
+1,789.7 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash, Cash Equivalents, and Restricted Cash at End of Period
+|
+|
+$ |
+1,768.4 |
+|
+|
+$ |
+1,632.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+9
+
+
+
+
+
+
+
+
+
+
+
+Table 5
+
+Segment Revenues*
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+
+|
+|
+THREE MONTHS ENDED |
+|
+|
+YEAR ENDED |
+|
+
+
+$ Millions (unaudited)
+|
+|
+Jun 30,
+2026 |
+|
+|
+Mar 31,
+2026 |
+|
+|
+Jun 30,
+2025 |
+|
+|
+Jun 30,
+2026 |
+|
+|
+Jun 30,
+2025 |
+|
+
+
+Revenues:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Datacenter & Communications
+|
+|
+$ |
+1,615.0 |
+|
+|
+$ |
+1,361.6 |
+|
+|
+$ |
+1,018.3 |
+|
+|
+$ |
+5,274.6 |
+|
+|
+$ |
+3,755.2 |
+|
+
+
+Industrial
+|
+|
+|
+430.5 |
+|
+|
+|
+444.0 |
+|
+|
+|
+511.1 |
+|
+|
+|
+1,843.6 |
+|
+|
+|
+2,054.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Consolidated
+|
+|
+$ |
+2,045.5 |
+|
+|
+$ |
+1,805.6 |
+|
+|
+$ |
+1,529.4 |
+|
+|
+$ |
+7,118.2 |
+|
+|
+$ |
+5,810.1 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+10
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 6
+Reconciliation of GAAP Measures to Non-GAAP Measures*
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+
+|
+|
+THREE MONTHS ENDED |
+|
+|
+YEAR ENDED |
+|
+
+
+$ Millions, except per share amounts (unaudited)
+|
+|
+Jun 30,
+2026 |
+|
+|
+Mar 31,
+2026 |
+|
+|
+Jun 30,
+2025 |
+|
+|
+Jun 30,
+2026 |
+|
+|
+Jun 30,
+2025 (1) |
+|
+
+
+Gross margin on GAAP basis
+|
+|
+$ |
+787.1 |
+|
+|
+$ |
+679.9 |
+|
+|
+$ |
+546.1 |
+|
+|
+$ |
+2,669.0 |
+|
+|
+$ |
+2,043.3 |
+|
+
+
+Share-based compensation
+|
+|
+|
+7.4 |
+|
+|
+|
+6.4 |
+|
+|
+|
+5.8 |
+|
+|
+|
+26.0 |
+|
+|
+|
+22.5 |
+|
+
+
+Amortization of acquired intangibles
+|
+|
+|
+27.8 |
+|
+|
+|
+27.9 |
+|
+|
+|
+30.6 |
+|
+|
+|
+111.2 |
+|
+|
+|
+135.1 |
+|
+
+
+Integration, site consolidation and
+other (2)
+|
+|
+|
+0.3 |
+|
+|
+|
+—  |
+|
+|
+|
+(0.4 |
+) |
+|
+|
+0.3 |
+|
+|
+|
+1.3 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Gross margin on non-GAAP basis
+|
+|
+$ |
+822.6 |
+|
+|
+$ |
+714.2 |
+|
+|
+$ |
+582.2 |
+|
+|
+$ |
+2,806.5 |
+|
+|
+$ |
+2,202.3 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Research & development on GAAP basis
+|
+|
+$ |
+216.4 |
+|
+|
+$ |
+186.0 |
+|
+|
+$ |
+155.7 |
+|
+|
+$ |
+723.0 |
+|
+|
+$ |
+581.9 |
+|
+
+
+Share-based compensation
+|
+|
+|
+(8.0 |
+) |
+|
+|
+(7.4 |
+) |
+|
+|
+(5.9 |
+) |
+|
+|
+(28.9 |
+) |
+|
+|
+(22.2 |
+) |
+
+
+Amortization of acquired intangibles
+|
+|
+|
+(0.2 |
+) |
+|
+|
+(0.2 |
+) |
+|
+|
+(0.2 |
+) |
+|
+|
+(0.8 |
+) |
+|
+|
+(5.3 |
+) |
+
+
+Integration, site consolidation and
+other (2)
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+0.1 |
+|
+|
+|
+—  |
+|
+|
+|
+(0.2 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Research & development on non-GAAP
+basis
+|
+|
+$ |
+208.3 |
+|
+|
+$ |
+178.4 |
+|
+|
+$ |
+149.7 |
+|
+|
+$ |
+693.3 |
+|
+|
+$ |
+554.3 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Selling, general and administrative on GAAP basis
+|
+|
+$ |
+266.4 |
+|
+|
+$ |
+267.6 |
+|
+|
+$ |
+245.4 |
+|
+|
+$ |
+1,044.6 |
+|
+|
+$ |
+926.5 |
+|
+
+
+Share-based compensation
+|
+|
+|
+(38.5 |
+) |
+|
+|
+(36.8 |
+) |
+|
+|
+(32.6 |
+) |
+|
+|
+(138.9 |
+) |
+|
+|
+(116.3 |
+) |
+
+
+Amortization of acquired intangibles
+|
+|
+|
+(41.8 |
+) |
+|
+|
+(42.4 |
+) |
+|
+|
+(41.2 |
+) |
+|
+|
+(168.3 |
+) |
+|
+|
+(162.4 |
+) |
+
+
+Financing fees (3)
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+(1.1 |
+) |
+|
+|
+—  |
+|
+
+
+Integration, site consolidation and
+other (2)
+|
+|
+|
+(17.4 |
+) |
+|
+|
+(18.9 |
+) |
+|
+|
+(14.4 |
+) |
+|
+|
+(79.9 |
+) |
+|
+|
+(36.7 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Selling, general and administrative on non-GAAP
+basis
+|
+|
+$ |
+168.5 |
+|
+|
+$ |
+169.7 |
+|
+|
+$ |
+157.3 |
+|
+|
+$ |
+656.3 |
+|
+|
+$ |
+611.0 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Restructuring charges on GAAP basis
+|
+|
+$ |
+6.1 |
+|
+|
+$ |
+34.4 |
+|
+|
+$ |
+53.9 |
+|
+|
+$ |
+63.4 |
+|
+|
+$ |
+160.1 |
+|
+
+
+Restructuring charges (4)
+|
+|
+|
+(6.1 |
+) |
+|
+|
+(34.4 |
+) |
+|
+|
+(53.9 |
+) |
+|
+|
+(63.4 |
+) |
+|
+|
+(160.1 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Restructuring charges on non-GAAP basis
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Impairment of assets
+held-for-sale on GAAP basis
+|
+|
+$ |
+44.3 |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+85.0 |
+|
+|
+$ |
+64.4 |
+|
+|
+$ |
+85.0 |
+|
+
+
+Impairment of assets
+held-for-sale (5)
+|
+|
+|
+(44.3 |
+) |
+|
+|
+—  |
+|
+|
+|
+(85.0 |
+) |
+|
+|
+(64.4 |
+) |
+|
+|
+(85.0 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Impairment of assets
+held-for-sale on non-GAAP basis
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Gain on sale of business on GAAP basis
+|
+|
+$ |
+—  |
+|
+|
+$ |
+(8.9 |
+) |
+|
+$ |
+—  |
+|
+|
+$ |
+(124.1 |
+) |
+|
+$ |
+—  |
+|
+
+
+Gain on sale of business (6)
+|
+|
+|
+—  |
+|
+|
+|
+8.9 |
+|
+|
+|
+—  |
+|
+|
+|
+124.1 |
+|
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Gain on sale of business on non-GAAP basis
+|
+
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Operating income on GAAP basis
+|
+|
+$ |
+253.9 |
+|
+|
+$ |
+200.8 |
+|
+|
+$ |
+6.1 |
+|
+|
+$ |
+897.9 |
+|
+|
+$ |
+289.9 |
+|
+
+
+Share-based compensation
+|
+|
+|
+53.9 |
+|
+|
+|
+50.6 |
+|
+|
+|
+44.3 |
+|
+|
+|
+193.8 |
+|
+|
+|
+161.0 |
+|
+
+
+Amortization of acquired intangibles
+|
+|
+|
+69.8 |
+|
+|
+|
+70.5 |
+|
+|
+|
+72.0 |
+|
+|
+|
+280.3 |
+|
+|
+|
+302.8 |
+|
+
+
+Restructuring charges (4)
+|
+|
+|
+6.1 |
+|
+|
+|
+34.4 |
+|
+|
+|
+53.9 |
+|
+|
+|
+63.4 |
+|
+|
+|
+160.1 |
+|
+
+
+Impairment of assets
+held-for-sale (5)
+|
+|
+|
+44.3 |
+|
+|
+|
+—  |
+|
+|
+|
+85.0 |
+|
+|
+|
+64.4 |
+|
+|
+|
+85.0 |
+|
+
+
+Gain on sale of business (6)
+|
+|
+|
+—  |
+|
+|
+|
+(8.9 |
+) |
+|
+|
+—  |
+|
+|
+|
+(124.1 |
+) |
+|
+|
+—  |
+|
+
+
+Financing fees (3)
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+1.1 |
+|
+|
+|
+—  |
+|
+
+
+Integration, site consolidation and
+other (2)
+|
+|
+|
+17.7 |
+|
+|
+|
+18.9 |
+|
+|
+|
+13.8 |
+|
+|
+|
+80.2 |
+|
+|
+|
+38.2 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Operating income on non-GAAP basis
+|
+|
+$ |
+445.8 |
+|
+|
+$ |
+366.1 |
+|
+|
+$ |
+275.1 |
+|
+|
+$ |
+1,456.9 |
+|
+|
+$ |
+1,036.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+
+
+11
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 6
+Reconciliation of GAAP Measures to Non-GAAP Measures*
+(Continued)
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+
+|
+|
+THREE MONTHS ENDED |
+|
+|
+YEAR ENDED |
+|
+
+
+$ Millions, except per share amounts (unaudited)
+|
+|
+Jun 30,
+2026 |
+|
+|
+Mar 31,
+2026 |
+|
+|
+Jun 30,
+2025 |
+|
+|
+Jun 30,
+2026 |
+|
+|
+Jun 30,
+2025 (1) |
+|
+
+
+Interest and other (income) expense, net on GAAP basis
+|
+|
+$ |
+(24.6 |
+) |
+|
+$ |
+16.5 |
+|
+|
+$ |
+69.5 |
+|
+|
+$ |
+50.1 |
+|
+|
+$ |
+195.7 |
+|
+
+
+Foreign currency exchange gains (losses), net
+|
+|
+|
+3.8 |
+|
+|
+|
+(0.9 |
+) |
+|
+|
+(37.0 |
+) |
+|
+|
+6.1 |
+|
+|
+|
+(28.4 |
+) |
+
+
+Gain on sale of investment (7)
+|
+|
+|
+38.4 |
+|
+|
+|
+14.1 |
+|
+|
+|
+—  |
+|
+|
+|
+74.0 |
+|
+|
+|
+—  |
+|
+
+
+Financing fees (3)
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+(12.1 |
+) |
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Interest and other (income) expense, net on non-GAAP
+basis
+|
+|
+$ |
+17.6 |
+|
+|
+$ |
+29.7 |
+|
+|
+$ |
+32.5 |
+|
+|
+$ |
+118.1 |
+|
+|
+$ |
+167.3 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Income taxes on GAAP basis
+|
+|
+$ |
+42.3 |
+|
+|
+$ |
+2.7 |
+|
+|
+$ |
+34.7 |
+|
+|
+$ |
+60.8 |
+|
+|
+$ |
+64.1 |
+|
+
+
+Tax impact of non-GAAP measures (8)
+|
+|
+|
+39.1 |
+|
+|
+|
+61.3 |
+|
+|
+|
+18.1 |
+|
+|
+|
+193.6 |
+|
+|
+|
+119.9 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Income taxes on non-GAAP basis
+|
+|
+$ |
+81.4 |
+|
+|
+$ |
+63.9 |
+|
+|
+$ |
+52.8 |
+|
+|
+$ |
+254.4 |
+|
+|
+$ |
+184.0 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net earnings attributable to Coherent Corp. on GAAP basis
+|
+|
+$ |
+240.5 |
+|
+|
+$ |
+191.4 |
+|
+|
+$ |
+(95.6 |
+) |
+|
+$ |
+805.0 |
+|
+|
+$ |
+49.4 |
+|
+
+
+Share-based compensation
+|
+|
+|
+53.9 |
+|
+|
+|
+50.6 |
+|
+|
+|
+44.3 |
+|
+|
+|
+193.8 |
+|
+|
+|
+161.0 |
+|
+
+
+Amortization of acquired intangibles
+|
+|
+|
+69.8 |
+|
+|
+|
+70.5 |
+|
+|
+|
+72.0 |
+|
+|
+|
+280.3 |
+|
+|
+|
+302.8 |
+|
+
+
+Foreign currency exchange gains
+|
+|
+|
+(3.8 |
+) |
+|
+|
+0.9 |
+|
+|
+|
+37.0 |
+|
+|
+|
+(6.1 |
+) |
+|
+|
+28.4 |
+|
+
+
+Restructuring charges (4)
+|
+|
+|
+6.1 |
+|
+|
+|
+34.4 |
+|
+|
+|
+53.9 |
+|
+|
+|
+63.4 |
+|
+|
+|
+160.1 |
+|
+
+
+Impairment of assets
+held-for-sale (5)
+|
+|
+|
+44.3 |
+|
+|
+|
+—  |
+|
+|
+|
+85.0 |
+|
+|
+|
+64.4 |
+|
+|
+|
+85.0 |
+|
+
+
+Gain on sale of business (6)
+|
+|
+|
+—  |
+|
+|
+|
+(8.9 |
+) |
+|
+|
+—  |
+|
+|
+|
+(124.1 |
+) |
+|
+|
+—  |
+|
+
+
+Integration, site consolidation and
+other (2)
+|
+|
+|
+17.7 |
+|
+|
+|
+18.9 |
+|
+|
+|
+13.8 |
+|
+|
+|
+80.2 |
+|
+|
+|
+38.2 |
+|
+
+
+Gain on sale of investment (7)
+|
+|
+|
+(38.4 |
+) |
+|
+|
+(14.1 |
+) |
+|
+|
+—  |
+|
+|
+|
+(74.0 |
+) |
+|
+|
+—  |
+|
+
+
+Financing fees (3)
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+13.2 |
+|
+|
+|
+—  |
+|
+
+
+Non-controlling interest impact of non-GAAP items
+|
+|
+|
+—  |
+|
+|
+|
+(6.0 |
+) |
+|
+|
+—  |
+|
+|
+|
+(6.0 |
+) |
+|
+|
+(12.3 |
+) |
+
+
+Tax impact of non-GAAP measures (8)
+|
+|
+|
+(38.9 |
+) |
+|
+|
+(61.3 |
+) |
+|
+|
+(18.1 |
+) |
+|
+|
+(193.5 |
+) |
+|
+|
+(119.9 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net earnings attributable to Coherent Corp. on non-GAAP
+basis
+|
+|
+$ |
+351.2 |
+|
+|
+$ |
+276.2 |
+|
+|
+$ |
+192.3 |
+|
+|
+$ |
+1,096.6 |
+|
+|
+$ |
+692.6 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Per share data:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Net earnings on GAAP basis
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Basic Earnings Per Share
+|
+|
+$ |
+1.23 |
+|
+|
+$ |
+1.01 |
+|
+|
+$ |
+(0.83 |
+) |
+|
+$ |
+4.34 |
+|
+|
+$ |
+(0.52 |
+) |
+
+
+Diluted Earnings Per Share
+|
+|
+$ |
+1.19 |
+|
+|
+$ |
+0.97 |
+|
+|
+$ |
+(0.83 |
+) |
+|
+$ |
+4.12 |
+|
+|
+$ |
+(0.52 |
+) |
+
+
+Net earnings on non-GAAP basis
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Basic Earnings Per Share
+|
+|
+$ |
+1.79 |
+|
+|
+$ |
+1.45 |
+|
+|
+$ |
+1.02 |
+|
+|
+$ |
+5.99 |
+|
+|
+$ |
+3.64 |
+|
+
+
+Diluted Earnings Per Share
+|
+|
+$ |
+1.74 |
+|
+|
+$ |
+1.41 |
+|
+|
+$ |
+1.00 |
+|
+|
+$ |
+5.61 |
+|
+|
+$ |
+3.53 |
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+(1) |
+During the second fiscal quarter of 2025, the Company refined its methodology to report non-GAAP measures. The change does not impact the Company’s financial position, cash flows, or GAAP consolidated results of operations. Prior period non-GAAP financial
+measures presented in this press release have been recast to conform to the current presentation.
+|
+
+
+
+(2) |
+Integration, site consolidation and other costs include retention and severance payments and other integration
+costs related to the acquisition of Coherent, Inc., implementation of common technology systems and costs related to business divestitures.
+|
+
+
+
+(3) |
+Financing fees include debt extinguishment costs and various fees related to closing the new Credit Agreement
+and repricing our Term Loan B as well as the conversion of Preferred Stock to Common Stock.
+|
+
+
+
+(4) |
+Restructuring charges include non-cash impairment charges for
+production assets and improvements on leased facilities, loss on sale of a facility, severance, contract termination costs and other costs related to the restructuring plans.
+|
+
+
+
+(5) |
+Impairment of assets
+held-for-sale relate to several entities classified as held-for-sale at June 30,
+2026, December 31, 2025, September 30, 2025 and/or June 30, 2025.
+|
+
+
+
+(6) |
+Gain on sale of business is due to the sale of our aerospace and defense and Munich tools businesses.
+
+|
+
+
+
+(7) |
+Gain on sale of investment is due to the sale of shares in an equity method investment.
+|
+
+
+
+(8) |
+The Company adopted a full-year, normalized tax rate for the computation of the
+non-GAAP income tax provision for fiscal year 2026. We believe this approach provides investors with a more consistent view of our underlying operating performance. In estimating the full-year non-GAAP normalized tax rate, the Company utilized a full-year financial projection that considers multiple factors such as changes to the Company’s current operating structure, expected reserve changes for
+the year, and other significant tax matters to the extent they are applicable to the full fiscal year financial projection. In addition to the adjustments described above, this normalized tax rate excludes the impact of share-based awards,
+amortization of acquisition-related intangible assets, integration and restructuring charges, foreign exchange gain/(loss), and certain tax valuation allowances.
+|
+
+For fiscal year 2026, the Company’s non-GAAP normalized tax rate is 19%. This projected
+normalized tax rate was be applied to each quarter of fiscal year 2026. The Company’s non-GAAP normalized tax rate on non-GAAP net income may be adjusted during
+the year to account for events or trends that the Company believes materially impact the original annual non-GAAP normalized tax rate including, but not limited to, significant changes resulting from tax
+legislation, acquisitions or dispositions, entity structures or operational changes and other significant events. These additional non-GAAP financial measures should not be considered substitutes for any
+measures derived in accordance with GAAP and may be inconsistent with similar measures presented by other companies.
+
+
+13
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 7
+GAAP Earnings Per Share Calculation*
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+|
+|
+THREE MONTHS ENDED |
+|
+|
+YEAR ENDED |
+|
+
+
+$ Millions, except per share amounts (unaudited)
+|
+|
+Jun 30,
+2026 |
+|
+|
+Mar 31,
+2026 |
+|
+|
+Jun 30,
+2025 |
+|
+|
+Jun 30,
+2026 |
+|
+|
+Jun 30,
+2025 (1) |
+|
+
+
+
+
+Numerator
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Net earnings (loss) attributable to Coherent Corp.
+|
+|
+$ |
+240.5 |
+|
+|
+$ |
+191.4 |
+|
+|
+$ |
+(95.6 |
+) |
+|
+$ |
+805.0 |
+|
+|
+$ |
+49.4 |
+|
+
+
+Deduct Series B redeemable preferred dividends
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+(33.1 |
+) |
+|
+|
+(35.1 |
+) |
+|
+|
+(129.9 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Basic earnings (loss) available to common shareholders
+|
+|
+$ |
+240.5 |
+|
+|
+$ |
+191.4 |
+|
+|
+$ |
+(128.8 |
+) |
+|
+$ |
+769.9 |
+|
+|
+$ |
+(80.6 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Effect of dilutive securities:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Add back Series B preferred dividends
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+35.1 |
+|
+|
+$ |
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted earnings (loss) available to common shareholders
+|
+|
+$ |
+240.5 |
+|
+|
+$ |
+191.4 |
+|
+|
+$ |
+(128.8 |
+) |
+|
+$ |
+805.0 |
+|
+|
+$ |
+(80.6 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Denominator
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Weighted average shares
+|
+|
+|
+195.7 |
+|
+|
+|
+190.2 |
+|
+|
+|
+155.5 |
+|
+|
+|
+177.3 |
+|
+|
+|
+154.8 |
+|
+
+
+Effect of dilutive securities:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Common stock equivalents
+|
+|
+|
+6.6 |
+|
+|
+|
+6.1 |
+|
+|
+|
+—  |
+|
+|
+|
+5.7 |
+|
+|
+|
+—  |
+|
+
+
+Series B Redeemable Preferred Stock
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+12.4 |
+|
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted weighted average common shares
+|
+|
+|
+202.2 |
+|
+|
+|
+196.4 |
+|
+|
+|
+155.5 |
+|
+|
+|
+195.4 |
+|
+|
+|
+154.8 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Basic earnings (loss) per common share
+|
+|
+$ |
+1.23 |
+|
+|
+$ |
+1.01 |
+|
+|
+$ |
+(0.83 |
+) |
+|
+$ |
+4.34 |
+|
+|
+$ |
+(0.52 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted earnings (loss) per common share
+|
+|
+$ |
+1.19 |
+|
+|
+$ |
+0.97 |
+|
+|
+$ |
+(0.83 |
+) |
+|
+$ |
+4.12 |
+|
+|
+$ |
+(0.52 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+14
+
+
+
+
+
+
+
+
+
+
+
+
+
+Table 8
+
+Non-GAAP Earnings Per Share Calculation*
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+|
+|
+THREE MONTHS ENDED |
+|
+|
+YEAR ENDED |
+|
+
+
+$ Millions, except per share amounts (unaudited)
+|
+|
+Jun 30,
+2026 |
+|
+|
+Mar 31,
+2026 |
+|
+|
+Jun 30,
+2025 |
+|
+|
+Jun 30,
+2026 |
+|
+|
+Jun 30,
+2025 (1) |
+|
+
+
+
+
+Numerator
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Net earnings attributable to Coherent Corp. on non-GAAP
+basis
+|
+|
+$ |
+351.2 |
+|
+|
+$ |
+276.2 |
+|
+|
+$ |
+192.3 |
+|
+|
+$ |
+1,096.6 |
+|
+|
+$ |
+692.6 |
+|
+
+
+Deduct Series B redeemable preferred dividends
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+(33.1 |
+) |
+|
+|
+(35.1 |
+) |
+|
+|
+(129.9 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Basic earnings available to common shareholders
+|
+|
+$ |
+351.2 |
+|
+|
+$ |
+276.2 |
+|
+|
+$ |
+159.1 |
+|
+|
+$ |
+1,061.5 |
+|
+|
+$ |
+562.6 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Effect of dilutive securities:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Add back Series B preferred dividends
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+—  |
+|
+|
+$ |
+35.1 |
+|
+|
+$ |
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted earnings available to common shareholders
+|
+|
+$ |
+351.2 |
+|
+|
+$ |
+276.2 |
+|
+|
+$ |
+159.1 |
+|
+|
+$ |
+1,096.6 |
+|
+|
+$ |
+562.6 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Denominator
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Weighted average shares
+|
+|
+|
+195.7 |
+|
+|
+|
+190.2 |
+|
+|
+|
+155.5 |
+|
+|
+|
+177.3 |
+|
+|
+|
+154.8 |
+|
+
+
+Effect of dilutive securities:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Common stock equivalents
+|
+|
+|
+6.6 |
+|
+|
+|
+6.1 |
+|
+|
+|
+3.7 |
+|
+|
+|
+5.7 |
+|
+|
+|
+4.5 |
+|
+
+
+Series B Redeemable Preferred Stock
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+—  |
+|
+|
+|
+12.4 |
+|
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted weighted average common shares
+|
+|
+|
+202.2 |
+|
+|
+|
+196.4 |
+|
+|
+|
+159.2 |
+|
+|
+|
+195.4 |
+|
+|
+|
+159.2 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Basic earnings per common share on non-GAAP
+basis
+|
+|
+$ |
+1.79 |
+|
+|
+$ |
+1.45 |
+|
+|
+$ |
+1.02 |
+|
+|
+$ |
+5.99 |
+|
+|
+$ |
+3.64 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Diluted earnings per common share on non-GAAP
+basis
+|
+|
+$ |
+1.74 |
+|
+|
+$ |
+1.41 |
+|
+|
+$ |
+1.00 |
+|
+|
+$ |
+5.61 |
+|
+|
+$ |
+3.53 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+
+
+
+
+
+* |
+Amounts may not recalculate due to rounding.
+|
+
+
+
+(1) |
+During the second fiscal quarter of 2025, the Company refined its methodology to report non-GAAP measures. The change does not impact the Company’s financial position, cash flows, or GAAP consolidated results of operations. Prior period non-GAAP financial
+measures presented in this press release have been recast to conform to the current presentation.
+|
+
+
+15\n

--- a/modules/test-fixtures/earnings-filings/csco.txt
+++ b/modules/test-fixtures/earnings-filings/csco.txt
@@ -1,0 +1,763 @@
+EX-99.1
+2
+exhibit991pressrelease-q4f.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+
+| | | | | | | | |
+Press Contact: | | Investor Relations Contact: |
+Robyn Blum | | Sami Badri |
+Cisco | | Cisco |
+1 (408) 930-8548 | | 1 (469) 420-4834 |
+rojenkin@cisco.com | | sambadri@cisco.com |
+
+CISCO REPORTS FOURTH QUARTER AND FISCAL YEAR 2026 EARNINGS
+
+
+News Summary :
+• Record top and bottom-line performance with double-digit growth in Q4 and FY 2026, exceeding the high end of guidance ranges
+• Exceptional FY 2026 operating margin results, demonstrating strong execution and operating efficiency
+• Broad-based, record high demand for Cisco technology with a networking supercycle underway
+◦ Q4 total product orders up 35% year over year; up 25% excluding hyperscalers, with double-digit growth across every geography and customer market
+◦ Networking product orders grew 40% year over year in Q4, marking the eighth consecutive quarter of double-digit growth
+• Significant momentum and raised expectations for AI infrastructure from hyperscalers
+◦ $4 billion of orders taken in Q4, bringing the total for FY 2026 to $9.3 billion
+◦ Delivered approximately $4 billion of revenue in FY 2026; $7.5 billion expected in FY 2027
+• Q4 FY 2026 Results:
+◦ Revenue: $17.3 billion
+▪ Increase of 18% year over year
+◦ Operating Margin: GAAP: 24.7%; Non-GAAP: 35.9%
+◦ Earnings per Share: GAAP: $0.97; Non-GAAP: $1.22
+▪ GAAP EPS increased 52% year over year
+▪ Non-GAAP EPS increased 23% year over year
+• FY 2026 Results:
+◦ Revenue: $63.3 billion
+▪ Increase of 12% year over year
+◦ Operating Margin: GAAP: 24.3%; Non-GAAP: 34.8%
+◦ Earnings per Share: GAAP: $3.33; Non-GAAP: $4.33
+▪ GAAP EPS increased 31% year over year
+▪ Non-GAAP EPS increased 14% year over year
+• Q1 FY 2027 Guidance:
+◦ Revenue: $18.0 billion to $18.2 billion
+◦ Earnings per Share: GAAP: $1.08 to $1.10; Non-GAAP: $1.32 to $1.34
+• FY 2027 Guidance:
+◦ Revenue: $72.2 billion to $73.4 billion
+◦ Earnings per Share: GAAP: $4.00 to $4.06; Non-GAAP: $5.05 to $5.11
+
+
+
+
+1
+
+
+
+
+
+SAN JOSE, Calif. -- August 12, 2026 -- Cisco (NASDAQ: CSCO) today reported fourth quarter and fiscal year results for the period ended July 25, 2026. Cisco reported fourth quarter revenue of $17.3 billion, net income on a generally accepted accounting principles (GAAP) basis of $3.9 billion or $0.97 per share, and non-GAAP net income of $4.9 billion or $1.22 per share.
+“We delivered a very strong close to fiscal 2026, marking another record year for Cisco. Our record performance is a testament to the accelerated pace of innovation and the excellent execution by our teams,” said Chuck Robbins, Chair and CEO of Cisco. “With the breadth and depth of our portfolio and our competitive differentiation in secure networking, Cisco is well positioned to support our customers however or wherever they decide to deploy AI.”
+“In Q4, we delivered record revenue, non-GAAP operating income and EPS, all exceeding the high end of our guidance ranges and demonstrating strong financial discipline and operating leverage,” said Mark Patterson, CFO of Cisco. “In fiscal 2026, Cisco achieved its highest productivity metrics in 30 years measured by revenue, non-GAAP operating margin, and earnings per employee. As we enter fiscal 2027, we remain focused on delivering durable growth, consistent profitability and continued capital returns as we make the strategic investments to capitalize on the significant growth opportunities we see ahead.”
+
+
+Q4 GAAP Results
+| | | | | | | | | | | | | | | | | | | | |
+| | Q4 FY 2026 | | Q4 FY 2025 | | Vs. Q4 FY 2025 |
+Revenue | | $ | 17.3 | billion | | $ | 14.7 | billion | | 18% |
+Net Income | | $ | 3.9 | billion | | $ | 2.6 | billion | | 51% |
+Diluted Earnings per Share (EPS) | | $ | 0.97 | | | $ | 0.64 | | | 52% |
+
+
+Q4 Non-GAAP Results
+| | | | | | | | | | | | | | | | | | | | |
+| | Q4 FY 2026 | | Q4 FY 2025 | | Vs. Q4 FY 2025 |
+Net Income | | $ | 4.9 | billion | | $ | 4.0 | billion | | 23% |
+EPS | | $ | 1.22 | | | $ | 0.99 | | | 23% |
+
+
+Fiscal Year GAAP Results
+| | | | | | | | | | | | | | | | | | | | |
+| | FY 2026 | | FY 2025 | | Vs. FY 2025 |
+Revenue | | $ | 63.3 | billion | | $ | 56.7 | billion | | 12% |
+Net Income | | $ | 13.3 | billion | | $ | 10.2 | billion | | 30% |
+EPS | | $ | 3.33 | | | $ | 2.55 | | | 31% |
+
+
+Fiscal Year Non-GAAP Results
+| | | | | | | | | | | | | | | | | | | | |
+| | FY 2026 | | FY 2025 | | Vs. FY 2025 |
+Net Income | | $ | 17.2 | billion | | $ | 15.2 | billion | | 13% |
+EPS | | $ | 4.33 | | | $ | 3.81 | | | 14% |
+
+Reconciliations between net income, EPS, and other measures on a GAAP and non-GAAP basis are provided in the tables located in the section entitled "Reconciliations of GAAP to non-GAAP Measures."
+Cisco Declares Quarterly Dividend
+Cisco has declared a quarterly dividend of $0.42 per common share to be paid on October 21, 2026, to all stockholders of record as of the close of business on October 2, 2026. Future dividends will be subject to Board approval.
+
+
+
+
+
+
+2
+
+
+
+
+
+
+Financial Summary
+All comparative percentages are on a year-over-year basis unless otherwise noted.
+Q4 FY 2026 Highlights
+Revenue -- Total revenue was $17.3 billion, up 18%, with product revenue up 24% and services revenue was flat.
+Revenue by geographic segment was: Americas up 18%, EMEA up 19%, and APJC up 14%. Product revenue performance reflected growth in Networking up 28%, Security up 14%, Collaboration up 12%, and Observability up 6%.
+Gross Margin -- On a GAAP basis, total gross margin, product gross margin, and services gross margin were 64.1%, 62.6%, and 69.4%, respectively, as compared with 63.2%, 61.5%, and 68.3%, respectively, in the fourth quarter of fiscal 2025.
+Total gross margins by geographic segment were: 64.5% for the Americas, 70.1% for EMEA and 67.3% for APJC.
+On a non-GAAP basis, total gross margin, product gross margin, and services gross margin were 66.3%, 64.8%, and 71.6%, respectively, as compared with 68.4%, 67.5%, and 70.8%, respectively, in the fourth quarter of fiscal 2025.
+Operating Expenses -- On a GAAP basis, operating expenses were $6.8 billion, up 10% year over year, and were 39.4% of revenue. Non-GAAP operating expenses were $5.2 billion, up 5%, and were 30.4% of revenue.
+Operating Income -- GAAP operating income was $4.3 billion, up 38%, with GAAP operating margin of 24.7%. Non-GAAP operating income was $6.2 billion, up 23%, with non-GAAP operating margin at 35.9%.
+Provision for Income Taxes -- The GAAP tax provision rate was 21.8%. The non-GAAP tax provision rate was 18.8%.
+Net Income and EPS -- On a GAAP basis, net income was $3.9 billion, an increase of 51%, and EPS was $0.97, an increase of 52%. On a non-GAAP basis, net income was $4.9 billion, an increase of 23%, and EPS was $1.22, an increase of 23%.
+Cash Flow from Operating Activities -- $5.4 billion for the fourth quarter of fiscal 2026, an increase of 27% compared with $4.2 billion for the fourth quarter of fiscal 2025.
+FY 2026 Highlights
+Revenue -- Total revenue was $63.3 billion, an increase of 12%.
+Operating Income -- GAAP operating income was $15.4 billion, up 31%, with GAAP operating margin of 24.3%. Non-GAAP operating income was $22.0 billion, up 13%, with non-GAAP operating margin at 34.8%.
+Net Income and EPS -- On a GAAP basis, net income was $13.3 billion, an increase of 30%, and EPS was $3.33, an increase of 31%. On a non-GAAP basis, net income was $17.2 billion, an increase of 13%, and EPS was $4.33, an increase of 14%.
+Cash Flow from Operating Activities -- $14.2 billion for fiscal 2026, flat compared with fiscal 2025.
+Balance Sheet and Other Financial Highlights
+Cash and Cash Equivalents and Investments -- $15.9 billion at the end of the fourth quarter of fiscal 2026, compared with $16.6 billion at the end of the third quarter of fiscal 2026, and compared with $16.1 billion at the end of fiscal 2025.
+Remaining Performance Obligations (RPO) -- $46.7 billion, up 7% in total. Product RPO was up 9% and services RPO was up 6%.
+Deferred Revenue -- $29.8 billion, up 3% in total, with deferred product revenue up 2%. Deferred services revenue up 4%.
+Capital Allocation -- In the fourth quarter of fiscal 2026, we returned $3.2 billion to stockholders through share buybacks and dividends. We declared and paid a cash dividend of $0.42 per common share, or $1.7 billion, and repurchased approximately 13 million shares of common stock under our stock repurchase program at an average price of $111.53 per share for an aggregate purchase price of $1.5 billion. The remaining authorized amount for stock repurchases under the program is $8.1 billion with no termination date.
+Acquisitions
+In the fourth quarter of fiscal 2026, we closed the following acquisitions:
+• Galileo Technologies, Inc. , a privately held observability company
+• Astrix Securities Ltd. , a privately held security company focused on Non-Human Identity (NHI) Security
+
+
+
+
+3
+
+
+
+
+
+
+Guidance
+Cisco expects to achieve the following results for the first quarter of fiscal 2027:
+| | | | | | | | |
+Q1 FY 2027 | | |
+Revenue | | $18.0 billion - $18.2 billion |
+Non-GAAP gross margin | | 65% - 66% |
+Non-GAAP operating margin | | 35.5% - 36.5% |
+Non-GAAP EPS | | $1.32 - $1.34 |
+
+Cisco estimates that GAAP EPS will be $1.08 to $1.10 for the first quarter of fiscal 2027.
+Cisco expects to achieve the following results for fiscal 2027:
+| | | | | | | | |
+FY 2027 | | |
+Revenue | | $72.2 billion - $73.4 billion |
+Non-GAAP EPS | | $5.05 - $5.11 |
+
+Cisco estimates that GAAP EPS will be $4.00 to $4.06 for fiscal 2027.
+Our Q1 FY 2027 guidance assumes an effective tax provision rate of approximately 15% for GAAP and approximately 18.5% for non-GAAP results. Our FY 2027 guidance assumes an effective tax provision rate of approximately 14.5% for GAAP and approximately 18.5% for non-GAAP results.
+A reconciliation between the guidance on a GAAP and non-GAAP basis is provided in the tables entitled "GAAP to non-GAAP Guidance" located in the section entitled "Reconciliations of GAAP to non-GAAP Measures."
+
+
+
+Editor's Notes:
+• Q4 fiscal year 2026 conference call to discuss Cisco's results along with its guidance will be held on Wednesday, August 12, 2026 at 1:30 p.m. Pacific Time. Conference call number is 1-888-848-6507 (United States) or 1-212-519-0847 (international).
+• Conference call replay will be available from 4:00 p.m. Pacific Time, August 12, 2026 to 10:00 p.m. Pacific Time, August 18, 2026 at 1-800-839-2232 (United States) or 1-203-369-3662 (international). The replay will also be available via webcast on the Cisco Investor Relations website at https://investor.cisco.com.
+• Additional information regarding Cisco's financials, as well as a webcast of the conference call with visuals designed to guide participants through the call, will be available at 1:30 p.m. Pacific Time, August 12, 2026. The conference call will also be livestreamed on YouTube at https://www.youtube.com/live/yYJFmYwIPeM, LinkedIn at https://www.linkedin.com/events/7490076339694387200 & X at https://x.com/i/broadcasts/1AxRnnDawDgxl. Text of the conference call's prepared remarks will be available within 24 hours of completion of the call. The webcast and livestreaming will include both the prepared remarks and the question-and-answer session. This information, along with the GAAP to non-GAAP reconciliation information, will be available on the Cisco Investor Relations website at https://investor.cisco.com.
+4
+
+
+
+
+
+
+CISCO SYSTEMS, INC.
+CONSOLIDATED STATEMENTS OF OPERATIONS
+(In millions, except per-share amounts)
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Fiscal Year Ended |
+| July 25,
+2026 | | July 26,
+2025 | | July 25,
+2026 | | July 26,
+2025 |
+REVENUE: | | | | | | | |
+Product | $ | 13,459 | | | $ | 10,886 | | | $ | 48,295 | | | $ | 41,608 | |
+Services | 3,793 | | | 3,787 | | | 15,030 | | | 15,046 | |
+Total revenue | 17,252 | | | 14,673 | | | 63,325 | | | 56,654 | |
+COST OF SALES: | | | | | | | |
+Product | 5,029 | | | 4,194 | | | 17,781 | | | 15,121 | |
+Services | 1,160 | | | 1,199 | | | 4,684 | | | 4,743 | |
+Total cost of sales | 6,189 | | | 5,393 | | | 22,465 | | | 19,864 | |
+GROSS MARGIN | 11,063 | | | 9,280 | | | 40,860 | | | 36,790 | |
+OPERATING EXPENSES: | | | | | | | |
+Research and development | 2,431 | | | 2,380 | | | 9,563 | | | 9,300 | |
+Sales and marketing | 2,952 | | | 2,818 | | | 11,559 | | | 10,966 | |
+General and administrative | 679 | | | 706 | | | 2,761 | | | 2,992 | |
+Amortization of purchased intangible assets | 226 | | | 254 | | | 916 | | | 1,028 | |
+Restructuring and other charges | 511 | | | 35 | | | 693 | | | 744 | |
+Total operating expenses | 6,799 | | | 6,193 | | | 25,492 | | | 25,030 | |
+OPERATING INCOME | 4,264 | | | 3,087 | | | 15,368 | | | 11,760 | |
+Interest income | 220 | | | 227 | | | 866 | | | 1,001 | |
+Interest expense | (373) | | | (368) | | | (1,470) | | | (1,593) | |
+Other income (loss), net | 822 | | | 53 | | | 1,245 | | | (68) | |
+Interest and other income (loss), net | 669 | | | (88) | | | 641 | | | (660) | |
+INCOME BEFORE PROVISION FOR INCOME TAXES | 4,933 | | | 2,999 | | | 16,009 | | | 11,100 | |
+Provision for income taxes | 1,074 | | | 449 | | | 2,742 | | | 920 | |
+NET INCOME | $ | 3,859 | | | $ | 2,550 | | | $ | 13,267 | | | $ | 10,180 | |
+| | | | | | | |
+Net income per share: | | | | | | | |
+Basic | $ | 0.98 | | | $ | 0.64 | | | $ | 3.36 | | | $ | 2.56 | |
+Diluted | $ | 0.97 | | | $ | 0.64 | | | $ | 3.33 | | | $ | 2.55 | |
+Shares used in per-share calculation: | | | | | | | |
+Basic | 3,949 | | | 3,960 | | | 3,953 | | | 3,976 | |
+Diluted | 3,984 | | | 3,992 | | | 3,987 | | | 3,998 | |
+
+
+
+
+
+
+
+
+
+
+
+5
+
+
+
+
+
+
+CISCO SYSTEMS, INC.
+REVENUE BY SEGMENT
+(In millions, except percentages)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | July 25, 2026 |
+| | Three Months Ended | | Fiscal Year Ended |
+| | Amount | | Y/Y% | | Amount | | Y/Y% |
+Revenue :
+| | | | | | | | |
+Americas | | $ | 10,396 | | | 18% | | $ | 37,799 | | | 12% |
+EMEA | | 4,350 | | | 19% | | 16,613 | | | 12% |
+APJC | | 2,506 | | | 14% | | 8,914 | | | 9% |
+Total | | $ | 17,252 | | | 18% | | $ | 63,325 | | | 12% |
+
+Amounts may not sum and percentages may not recalculate due to rounding.
+
+
+CISCO SYSTEMS, INC.
+GROSS MARGIN PERCENTAGE BY SEGMENT
+(In percentages)
+
+
+| | | | | | | | | | | | | | |
+| | July 25, 2026 |
+| | Three Months Ended | | Fiscal Year Ended |
+Gross Margin Percentage :
+| | | | |
+Americas | | 64.5% | | 65.1% |
+EMEA | | 70.1% | | 71.2% |
+APJC | | 67.3% | | 66.6% |
+
+
+
+
+
+CISCO SYSTEMS, INC.
+REVENUE FOR GROUPS OF SIMILAR PRODUCTS AND SERVICES
+(In millions, except percentages)
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | July 25, 2026 |
+| | Three Months Ended | | Fiscal Year Ended |
+| | Amount | | Y/Y % | | Amount | | Y/Y % |
+Revenue :
+| | | | | | | | |
+Networking | | $ | 9,791 | | | 28% | | $ | 34,668 | | | 22% |
+Security | | 2,226 | | | 14% | | 8,232 | | | 2% |
+Collaboration | | 1,167 | | | 12% | | 4,300 | | | 4% |
+Observability | | 275 | | | 6% | | 1,095 | | | 4% |
+Total Product | | 13,459 | | | 24% | | 48,295 | | | 16% |
+Services | | 3,793 | | | —% | | 15,030 | | | —% |
+Total | | $ | 17,252 | | | 18% | | $ | 63,325 | | | 12% |
+
+Amounts may not sum and percentages may not recalculate due to rounding.
+
+
+6
+
+
+
+
+
+
+CISCO SYSTEMS, INC.
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(In millions)
+(Unaudited)
+
+
+| | | | | | | | | | | |
+| July 25,
+2026 | | July 26,
+2025 |
+ASSETS | | | |
+Current assets: | | | |
+Cash and cash equivalents | $ | 7,218 | | | $ | 8,346 | |
+Investments | 8,700 | | | 7,764 | |
+Accounts receivable, net of allowance
+of $78 at July 25, 2026 and $69 at July 26, 2025
+| 7,470 | | | 6,701 | |
+Inventories | 5,694 | | | 3,164 | |
+Financing receivables, net | 3,392 | | | 3,061 | |
+Other current assets | 6,191 | | | 5,950 | |
+Total current assets | 38,665 | | | 34,986 | |
+Property and equipment, net | 2,760 | | | 2,113 | |
+Financing receivables, net | 4,940 | | | 3,466 | |
+Goodwill | 59,477 | | | 59,136 | |
+Purchased intangible assets, net | 7,557 | | | 9,175 | |
+Deferred tax assets | 7,109 | | | 7,356 | |
+Other assets | 9,129 | | | 6,059 | |
+TOTAL ASSETS | $ | 129,637 | | | $ | 122,291 | |
+LIABILITIES AND EQUITY | | | |
+Current liabilities: | | | |
+Short-term debt | $ | 10,161 | | | $ | 5,232 | |
+Accounts payable | 3,366 | | | 2,528 | |
+Income taxes payable | 190 | | | 1,857 | |
+Accrued compensation | 4,057 | | | 3,611 | |
+Deferred revenue | 16,988 | | | 16,416 | |
+Other current liabilities | 6,763 | | | 5,420 | |
+Total current liabilities | 41,525 | | | 35,064 | |
+Long-term debt | 19,372 | | | 22,861 | |
+Income taxes payable | 2,339 | | | 2,165 | |
+Deferred revenue | 12,793 | | | 12,363 | |
+Other long-term liabilities | 3,323 | | | 2,995 | |
+Total liabilities | 79,352 | | | 75,448 | |
+Total equity | 50,285 | | | 46,843 | |
+TOTAL LIABILITIES AND EQUITY | $ | 129,637 | | | $ | 122,291 | |
+
+
+
+
+
+
+
+
+
+7
+
+
+
+
+
+
+CISCO SYSTEMS, INC.
+CONSOLIDATED STATEMENTS OF CASH FLOWS
+(In millions)
+(Unaudited)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Fiscal Year Ended |
+| July 25,
+2026 | | July 26,
+2025 | | July 25,
+2026 | | July 26,
+2025 |
+Cash flows from operating activities: | | | | | | | |
+Net income | $ | 3,859 | | | $ | 2,550 | | | $ | 13,267 | | | $ | 10,180 | |
+Adjustments to reconcile net income to net cash provided by operating activities: | | | | | | | |
+Depreciation, amortization, and other | 638 | | | 635 | | | 2,540 | | | 2,811 | |
+Share-based compensation expense | 927 | | | 948 | | | 3,830 | | | 3,641 | |
+Provision for receivables | 12 | | | 7 | | | 23 | | | 24 | |
+Deferred income taxes | 443 | | | (341) | | | 226 | | | (1,133) | |
+(Gains) losses on divestitures, investments and other, net | (858) | | | (90) | | | (1,358) | | | (38) | |
+Change in operating assets and liabilities, net of effects of acquisitions and divestitures: | | | | | | | |
+Accounts receivable | (1,019) | | | (1,428) | | | (832) | | | (22) | |
+Inventories | (992) | | | (332) | | | (2,541) | | | 209 | |
+Financing receivables | (1,801) | | | (291) | | | (1,835) | | | 214 | |
+Other assets | (430) | | | 17 | | | (1,032) | | | (499) | |
+Accounts payable | 398 | | | 267 | | | 842 | | | 257 | |
+Income taxes, net | 38 | | | 163 | | | (2,304) | | | (1,839) | |
+Accrued compensation | 789 | | | 378 | | | 457 | | | (53) | |
+Deferred revenue | 1,266 | | | 772 | | | 1,125 | | | 248 | |
+Other liabilities | 2,116 | | | 979 | | | 1,769 | | | 193 | |
+Net cash provided by operating activities | 5,386 | | | 4,234 | | | 14,177 | | | 14,193 | |
+Cash flows from investing activities: | | | | | | | |
+Purchases of investments | (1,607) | | | (1,523) | | | (8,974) | | | (4,589) | |
+Proceeds from sales of investments | 129 | | | 415 | | | 2,013 | | | 2,643 | |
+Proceeds from maturities of investments | 2,294 | | | 958 | | | 6,105 | | | 4,943 | |
+Acquisitions, net of cash and cash equivalents acquired and divestitures | (470) | | | — | | | (516) | | | (291) | |
+Purchases of non-marketable equity securities | (247) | | | (118) | | | (946) | | | (383) | |
+Return of investments in non-marketable equity securities | 47 | | | 198 | | | 270 | | | 306 | |
+Acquisition of property and equipment | (390) | | | (217) | | | (1,410) | | | (905) | |
+Other | (20) | | | 14 | | | (26) | | | 9 | |
+Net cash provided by (used in) investing activities | (264) | | | (273) | | | (3,484) | | | 1,733 | |
+Cash flows from financing activities: | | | | | | | |
+Issuances of common stock | 451 | | | 416 | | | 805 | | | 736 | |
+Repurchases of common stock - repurchase program | (1,501) | | | (1,252) | | | (6,106) | | | (6,000) | |
+Shares repurchased for tax withholdings on vesting of restricted stock units | (511) | | | (312) | | | (1,873) | | | (1,222) | |
+Short-term borrowings, original maturities of 90 days or less, net | 204 | | | 448 | | | 616 | | | (31) | |
+Issuances of debt | 2,408 | | | 1,904 | | | 13,048 | | | 19,292 | |
+Repayments of debt | (4,397) | | | (3,528) | | | (12,251) | | | (22,073) | |
+Dividends paid | (1,659) | | | (1,625) | | | (6,553) | | | (6,437) | |
+Other | (1) | | | — | | | (33) | | | (80) | |
+Net cash used in financing activities | (5,006) | | | (3,949) | | | (12,347) | | | (15,815) | |
+Effect of foreign currency exchange rate changes on cash, cash equivalents, restricted cash and restricted cash equivalents | 28 | | | (20) | | | (29) | | | (43) | |
+Net increase (decrease) in cash, cash equivalents, restricted cash and restricted cash equivalents | 144 | | | (8) | | | (1,683) | | | 68 | |
+Cash, cash equivalents, restricted cash and restricted cash equivalents, beginning of period | 7,083 | | | 8,918 | | | 8,910 | | | 8,842 | |
+Cash, cash equivalents, restricted cash and restricted cash equivalents, end of period | $ | 7,227 | | | $ | 8,910 | | | $ | 7,227 | | | $ | 8,910 | |
+Supplemental cash flow information: | | | | | | | |
+Cash paid for interest | $ | 116 | | | $ | 130 | | | $ | 1,421 | | | $ | 1,500 | |
+Cash paid for income taxes, net | $ | 593 | | | $ | 627 | | | $ | 4,821 | | | $ | 3,892 | |
+
+8
+
+
+
+
+
+
+
+
+CISCO SYSTEMS, INC.
+REMAINING PERFORMANCE OBLIGATIONS
+(In millions, except percentages)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| July 25, 2026 | | April 25, 2026 | | July 26, 2025 |
+| Amount | | Y/Y % | | Amount | | Y/Y % | | Amount | | Y/Y % |
+Product | $ | 23,436 | | | 9 | % | | $ | 22,058 | | | 6 | % | | $ | 21,572 | | | 8 | % |
+Services | 23,298 | | | 6 | % | | 21,404 | | | 2 | % | | 21,961 | | | 5 | % |
+Total | $ | 46,734 | | | 7 | % | | $ | 43,462 | | | 4 | % | | $ | 43,533 | | | 6 | % |
+
+
+
+
+
+CISCO SYSTEMS, INC.
+DEFERRED REVENUE
+(In millions)
+| | | | | | | | | | | | | | | | | |
+| July 25,
+2026 | | April 25,
+2026 | | July 26,
+2025 |
+Deferred revenue: | | | | | |
+Product | $ | 13,817 | | | $ | 13,461 | | | $ | 13,490 | |
+Services | 15,964 | | | 15,138 | | | 15,289 | |
+Total | $ | 29,781 | | | $ | 28,599 | | | $ | 28,779 | |
+Reported as: | | | | | |
+Current | $ | 16,988 | | | $ | 16,446 | | | $ | 16,416 | |
+Noncurrent | 12,793 | | | 12,153 | | | 12,363 | |
+Total | $ | 29,781 | | | $ | 28,599 | | | $ | 28,779 | |
+
+
+
+CISCO SYSTEMS, INC.
+DIVIDENDS PAID AND REPURCHASES OF COMMON STOCK
+(In millions, except per-share amounts)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | DIVIDENDS | | STOCK REPURCHASE PROGRAM | | TOTAL |
+Quarter Ended | | Per Share | | Amount | | Shares | | Weighted-Average Price per Share | | Amount | | Amount |
+Fiscal 2026 | | | | | | | | | | | | |
+July 25, 2026 | | $ | 0.42 | | | $ | 1,659 | | | 13 | | | $ | 111.53 | | | $ | 1,502 | | | $ | 3,161 | |
+April 25, 2026 | | $ | 0.42 | | | $ | 1,660 | | | 16 | | | $ | 80.28 | | | $ | 1,252 | | | $ | 2,912 | |
+January 24, 2026 | | $ | 0.41 | | | $ | 1,617 | | | 18 | | | $ | 76.29 | | | $ | 1,351 | | | $ | 2,968 | |
+October 25, 2025 | | $ | 0.41 | | | $ | 1,617 | | | 29 | | | $ | 68.28 | | | $ | 2,001 | | | $ | 3,618 | |
+| | | | | | | | | | | | |
+Fiscal 2025 | | | | | | | | | | | | |
+July 26, 2025 | | $ | 0.41 | | | $ | 1,625 | | | 19 | | | $ | 64.65 | | | $ | 1,252 | | | $ | 2,877 | |
+April 26, 2025 | | $ | 0.41 | | | $ | 1,627 | | | 25 | | | $ | 59.78 | | | $ | 1,504 | | | $ | 3,131 | |
+January 25, 2025 | | $ | 0.40 | | | $ | 1,593 | | | 21 | | | $ | 58.58 | | | $ | 1,236 | | | $ | 2,829 | |
+October 26, 2024 | | $ | 0.40 | | | $ | 1,592 | | | 40 | | | $ | 49.56 | | | $ | 2,003 | | | $ | 3,595 | |
+
+
+
+
+
+
+
+
+
+9
+
+
+
+
+
+
+CISCO SYSTEMS, INC.
+RECONCILIATIONS OF GAAP TO NON-GAAP MEASURES
+
+
+GAAP TO NON-GAAP NET INCOME
+(In millions)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Fiscal Year Ended |
+| July 25,
+2026 | | July 26,
+2025 | | July 25,
+2026 | | July 26,
+2025 |
+GAAP net income | $ | 3,859 | | | $ | 2,550 | | | $ | 13,267 | | | $ | 10,180 | |
+Adjustments to cost of sales: | | | | | | | |
+Share-based compensation expense | 138 | | | 150 | | | 589 | | | 584 | |
+Amortization of acquisition-related intangible assets | 236 | | | 233 | | | 918 | | | 1,150 | |
+Acquisition/divestiture-related costs | 4 | | | 13 | | | 25 | | | 66 | |
+Legal and indemnification settlements/charges | — | | | 355 | | | — | | | 355 | |
+Supplier component remediation charge (adjustment) | — | | | — | | | — | | | (7) | |
+Total adjustments to GAAP cost of sales | 378 | | | 751 | | | 1,532 | | | 2,148 | |
+Adjustments to operating expenses: | | | | | | | |
+Share-based compensation expense | 751 | | | 797 | | | 3,181 | | | 3,019 | |
+Amortization of acquisition-related intangible assets | 226 | | | 255 | | | 916 | | | 1,029 | |
+Acquisition/divestiture-related costs | 68 | | | 104 | | | 350 | | | 791 | |
+Significant asset impairments and restructurings | 511 | | | 35 | | | 693 | | | 744 | |
+Total adjustments to GAAP operating expenses | 1,556 | | | 1,191 | | | 5,140 | | | 5,583 | |
+Adjustments to interest and other income (loss), net: | | | | | | | |
+(Gains) and losses on investments | (869) | | | (115) | | | (1,398) | | | (187) | |
+Total adjustments to GAAP interest and other income (loss), net | (869) | | | (115) | | | (1,398) | | | (187) | |
+Total adjustments to GAAP income before provision for income taxes | 1,065 | | | 1,827 | | | 5,274 | | | 7,544 | |
+Income tax effect of non-GAAP adjustments | (386) | | | (426) | | | (1,490) | | | (1,682) | |
+Significant tax matters | 330 | | | — | | | 198 | | | (829) | |
+Total adjustments to GAAP provision for income taxes | (56) | | | (426) | | | (1,292) | | | (2,511) | |
+Non-GAAP net income | $ | 4,868 | | | $ | 3,951 | | | $ | 17,249 | | | $ | 15,213 | |
+
+
+
+10
+
+
+
+
+
+CISCO SYSTEMS, INC.
+RECONCILIATIONS OF GAAP TO NON-GAAP MEASURES
+
+
+GAAP TO NON-GAAP EPS
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Fiscal Year Ended |
+| July 25,
+2026 | | July 26,
+2025 | | July 25,
+2026 | | July 26,
+2025 |
+GAAP EPS | $ | 0.97 | | | $ | 0.64 | | | $ | 3.33 | | | $ | 2.55 | |
+Adjustments to GAAP: | | | | | | | |
+Share-based compensation expense | 0.22 | | | 0.24 | | | 0.95 | | | 0.90 | |
+Amortization of acquisition-related intangible assets | 0.12 | | | 0.12 | | | 0.46 | | | 0.55 | |
+Acquisition/divestiture-related costs | 0.02 | | | 0.03 | | | 0.09 | | | 0.21 | |
+Legal and indemnification settlements/charges | — | | | 0.09 | | | — | | | 0.09 | |
+Significant asset impairments and restructurings | 0.13 | | | 0.01 | | | 0.17 | | | 0.19 | |
+(Gains) and losses on investments | (0.22) | | | (0.03) | | | (0.35) | | | (0.05) | |
+Income tax effect of non-GAAP adjustments | (0.10) | | | (0.11) | | | (0.37) | | | (0.42) | |
+Significant tax matters | 0.08 | | | — | | | 0.05 | | | (0.21) | |
+Non-GAAP EPS | $ | 1.22 | | | $ | 0.99 | | | $ | 4.33 | | | $ | 3.81 | |
+
+Amounts may not sum due to rounding .
+
+
+
+
+
+
+
+
+
+
+11
+
+
+
+
+
+CISCO SYSTEMS, INC.
+RECONCILIATIONS OF GAAP TO NON-GAAP MEASURES
+
+
+GROSS MARGINS, OPERATING EXPENSES, OPERATING MARGINS, INTEREST AND OTHER INCOME (LOSS), NET, AND NET INCOME
+(In millions, except percentages)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended |
+| July 25, 2026 |
+| Product Gross Margin | | Services Gross Margin | | Total Gross Margin | | Operating Expenses | | Y/Y | | Operating Income | | Y/Y | | Interest and other income (loss), net | | Net Income | | Y/Y |
+GAAP amount | $ | 8,430 | | | $ | 2,633 | | | $ | 11,063 | | | $ | 6,799 | | | 10% | | $ | 4,264 | | | 38% | | $ | 669 | | | $ | 3,859 | | | 51% |
+% of revenue | 62.6 | % | | 69.4 | % | | 64.1 | % | | 39.4 | % | | | | 24.7 | % | | | | 3.9 | % | | 22.4 | % | | |
+Adjustments to GAAP amounts: | | | | | | | | | | | | | | | | | | | |
+Share-based compensation expense | 59 | | | 79 | | | 138 | | | 751 | | | | | 889 | | | | | — | | | 889 | | | |
+Amortization of acquisition-related intangible assets | 236 | | | — | | | 236 | | | 226 | | | | | 462 | | | | | — | | | 462 | | | |
+Acquisition/divestiture-related costs | 1 | | | 3 | | | 4 | | | 68 | | | | | 72 | | | | | — | | | 72 | | | |
+Significant asset impairments and restructurings | — | | | — | | | — | | | 511 | | | | | 511 | | | | | — | | | 511 | | | |
+(Gains) and losses on investments | — | | | — | | | — | | | — | | | | | — | | | | | (869) | | | (869) | | | |
+Income tax effect/significant tax matters | — | | | — | | | — | | | — | | | | | — | | | | | — | | | (56) | | | |
+Non-GAAP amount | $ | 8,726 | | | $ | 2,715 | | | $ | 11,441 | | | $ | 5,243 | | | 5% | | $ | 6,198 | | | 23% | | $ | (200) | | | $ | 4,868 | | | 23% |
+% of revenue | 64.8 | % | | 71.6 | % | | 66.3 | % | | 30.4 | % | | | | 35.9 | % | | | | (1.2) | % | | 28.2 | % | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended |
+| July 26, 2025 |
+| Product Gross Margin | | Services Gross Margin | | Total Gross Margin | | Operating Expenses | | Operating
+Income | | Interest and other income (loss), net | | Net
+Income |
+GAAP amount | $ | 6,692 | | | $ | 2,588 | | | $ | 9,280 | | | $ | 6,193 | | | $ | 3,087 | | | $ | (88) | | | $ | 2,550 | |
+% of revenue | 61.5 | % | | 68.3 | % | | 63.2 | % | | 42.2 | % | | 21.0 | % | | (0.6) | % | | 17.4 | % |
+Adjustments to GAAP amounts: | | | | | | | | | | | | | |
+Share-based compensation expense | 66 | | | 84 | | | 150 | | | 797 | | | 947 | | | — | | | 947 | |
+Amortization of acquisition-related intangible assets | 233 | | | — | | | 233 | | | 255 | | | 488 | | | — | | | 488 | |
+Acquisition/divestiture-related costs | 2 | | | 11 | | | 13 | | | 104 | | | 117 | | | — | | | 117 | |
+Legal and indemnification settlements/charges | 355 | | | — | | | 355 | | | — | | | 355 | | | — | | | 355 | |
+Significant asset impairments and restructurings | — | | | — | | | — | | | 35 | | | 35 | | | — | | | 35 | |
+(Gains) and losses on investments | — | | | — | | | — | | | — | | | — | | | (115) | | | (115) | |
+Income tax effect/significant tax matters | — | | | — | | | — | | | — | | | — | | | — | | | (426) | |
+Non-GAAP amount | $ | 7,348 | | | $ | 2,683 | | | $ | 10,031 | | | $ | 5,002 | | | $ | 5,029 | | | $ | (203) | | | $ | 3,951 | |
+% of revenue | 67.5 | % | | 70.8 | % | | 68.4 | % | | 34.1 | % | | 34.3 | % | | (1.4) | % | | 26.9 | % |
+
+Amounts may not sum and percentages may not recalculate due to rounding.
+12
+
+
+
+
+
+CISCO SYSTEMS, INC.
+RECONCILIATIONS OF GAAP TO NON-GAAP MEASURES
+
+
+GROSS MARGINS, OPERATING EXPENSES, OPERATING MARGINS, INTEREST AND OTHER INCOME (LOSS), NET, AND NET INCOME
+(In millions, except percentages)
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Fiscal Year Ended |
+| July 25, 2026 |
+| Product Gross Margin | | Services Gross Margin | | Total Gross Margin | | Operating Expenses | | Y/Y | | Operating Income | | Y/Y | | Interest and other income (loss), net | | Net Income | | Y/Y |
+GAAP amount | $ | 30,514 | | | $ | 10,346 | | | $ | 40,860 | | | $ | 25,492 | | | 2% | | $ | 15,368 | | | 31% | | $ | 641 | | | $ | 13,267 | | | 30% |
+% of revenue | 63.2 | % | | 68.8 | % | | 64.5 | % | | 40.3 | % | | | | 24.3 | % | | | | 1.0 | % | | 21.0 | % | | |
+Adjustments to GAAP amounts: | | | | | | | | | | | | | | | | | | | |
+Share-based compensation expense | 254 | | | 335 | | | 589 | | | 3,181 | | | | | 3,770 | | | | | — | | | 3,770 | | | |
+Amortization of acquisition-related intangible assets | 918 | | | — | | | 918 | | | 916 | | | | | 1,834 | | | | | — | | | 1,834 | | | |
+Acquisition/divestiture-related costs | 7 | | | 18 | | | 25 | | | 350 | | | | | 375 | | | | | — | | | 375 | | | |
+Significant asset impairments and restructurings | — | | | — | | | — | | | 693 | | | | | 693 | | | | | — | | | 693 | | | |
+(Gains) and losses on investments | — | | | — | | | — | | | — | | | | | — | | | | | (1,398) | | | (1,398) | | | |
+Income tax effect/significant tax matters | — | | | — | | | — | | | — | | | | | — | | | | | — | | | (1,292) | | | |
+Non-GAAP amount | $ | 31,693 | | | $ | 10,699 | | | $ | 42,392 | | | $ | 20,352 | | | 5% | | $ | 22,040 | | | 13% | | $ | (757) | | | $ | 17,249 | | | 13% |
+% of revenue | 65.6 | % | | 71.2 | % | | 66.9 | % | | 32.1 | % | | | | 34.8 | % | | | | (1.2) | % | | 27.2 | % | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| Fiscal Year Ended |
+| July 26, 2025 |
+| Product Gross Margin | | Services Gross Margin | | Total Gross Margin | | Operating Expenses | | Operating
+Income | | Interest and other income (loss), net | | Net
+Income |
+GAAP amount | $ | 26,487 | | | $ | 10,303 | | | $ | 36,790 | | | $ | 25,030 | | | $ | 11,760 | | | $ | (660) | | | $ | 10,180 | |
+% of revenue | 63.7 | % | | 68.5 | % | | 64.9 | % | | 44.2 | % | | 20.8 | % | | (1.2) | % | | 18.0 | % |
+Adjustments to GAAP amounts: | | | | | | | | | | | | | |
+Share-based compensation expense | 255 | | | 329 | | | 584 | | | 3,019 | | | 3,603 | | | — | | | 3,603 | |
+Amortization of acquisition-related intangible assets | 1,150 | | | — | | | 1,150 | | | 1,029 | | | 2,179 | | | — | | | 2,179 | |
+Acquisition/divestiture-related costs | 14 | | | 52 | | | 66 | | | 791 | | | 857 | | | — | | | 857 | |
+Legal and indemnification settlements/charges | 355 | | | — | | | 355 | | | — | | | 355 | | | — | | | 355 | |
+Supplier component remediation charge (adjustment) | (7) | | | — | | | (7) | | | — | | | (7) | | | — | | | (7) | |
+Significant asset impairments and restructurings | — | | | — | | | — | | | 744 | | | 744 | | | — | | | 744 | |
+(Gains) and losses on investments | — | | | — | | | — | | | — | | | — | | | (187) | | | (187) | |
+Income tax effect/significant tax matters | — | | | — | | | — | | | — | | | — | | | — | | | (2,511) | |
+Non-GAAP amount | $ | 28,254 | | | $ | 10,684 | | | $ | 38,938 | | | $ | 19,447 | | | $ | 19,491 | | | $ | (847) | | | $ | 15,213 | |
+% of revenue | 67.9 | % | | 71.0 | % | | 68.7 | % | | 34.3 | % | | 34.4 | % | | (1.5) | % | | 26.9 | % |
+
+Amounts may not sum and percentages may not recalculate due to rounding.
+13
+
+
+
+
+
+CISCO SYSTEMS, INC.
+RECONCILIATIONS OF GAAP TO NON-GAAP MEASURES
+
+
+EFFECTIVE TAX RATE
+(In percentages)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Fiscal Year Ended |
+| July 25, 2026 | | July 26, 2025 | | July 25, 2026 | | July 26, 2025 |
+GAAP effective tax rate | 21.8 | % | | 15.0 | % | | 17.1 | % | | 8.3 | % |
+Total adjustments to GAAP provision for income taxes | (3.0) | % | | 3.1 | % | | 1.9 | % | | 10.1 | % |
+Non-GAAP effective tax rate | 18.8 | % | | 18.1 | % | | 19.0 | % | | 18.4 | % |
+
+
+
+
+
+
+
+
+
+
+
+
+GAAP TO NON-GAAP GUIDANCE
+| | | | | | | | | | | | | | | | | | | | |
+Q1 FY 2027 | | Gross Margin | | Operating Margin | | Earnings per Share (1)
+|
+GAAP | | 63% - 64% | | 28% - 29% | | $1.08 - $1.10 |
+Estimated adjustments for: | | | | | | |
+Share-based compensation expense | | 1.0% | | 4.5% | | $0.14 |
+Amortization of acquisition-related intangible assets and acquisition/divestiture-related costs | | 1.0% | | 2.5% | | $0.09 |
+Significant asset impairments and restructurings (2)
+| | — | | 0.5% | | $0.01 |
+Non-GAAP | | 65% - 66% | | 35.5% - 36.5% | | $1.32 - $1.34 |
+| | | | | | |
+
+| | | | | | | | |
+FY 2027 | | Earnings per Share (1)
+|
+GAAP | | $4.00 - $4.06 |
+Estimated adjustments for: | | |
+Share-based compensation expense | | $0.60 |
+Amortization of acquisition-related intangible assets and acquisition/divestiture-related costs | | $0.34 |
+Significant asset impairments and restructurings (2)
+| | $0.11 |
+Non-GAAP | | $5.05 - $5.11 |
+| | |
+
+(1) Estimated adjustments to GAAP earnings per share are shown after income tax effects.
+(2) Reflects charges related to a restructuring plan announced on May 13, 2026. We expect this plan to be substantially completed by the end of fiscal 2027.
+Except as noted above, this guidance does not include the effects of any future acquisitions/divestitures, significant asset impairments and restructurings, significant litigation settlements and other contingencies, gains and losses on investments, significant tax matters, or other items, which may or may not be significant.
+14
+
+
+
+
+
+
+Forward Looking Statements, Non-GAAP Information and Additional Information
+This release may be deemed to contain forward-looking statements, which are subject to the safe harbor provisions of the Private Securities Litigation Reform Act of 1995. These forward-looking statements include, among other things, statements regarding future events (such as being well positioned to support our customers however or wherever they decide to deploy AI, the significant momentum and raised expectations of AI infrastructure from hyperscalers, the broad-based high demand for Cisco technology, and the significant growth opportunities ahead) and the future financial performance of Cisco (including the guidance for Q1 FY 2027 and full year FY 2027) that involve risks and uncertainties, such as the actual impact of tariffs on our guidance for Q1 FY 2027 and full year FY 2027. Readers are cautioned that these forward-looking statements are only predictions and may differ materially from actual future events or results due to a variety of factors, including: business and economic conditions and growth trends in the networking industry, our customer markets and various geographic regions; global economic conditions and uncertainties in the geopolitical environment; our development and use of artificial intelligence; overall information technology spending; the growth and evolution of the Internet and levels of capital spending on Internet-based systems; variations in customer demand for products and services, including sales to the service provider market, cloud, enterprise and other customer markets; the return on our investments in certain key priority areas, and in certain geographical locations, as well as maintaining leadership in Networking and services; the timing of orders and manufacturing and customer lead times; supply constraints; changes in customer order patterns or customer mix; insufficient, excess or obsolete inventory; variability of component costs; variations in sales channels, product costs or mix of products sold; our ability to successfully acquire businesses and technologies and to successfully integrate and operate these acquired businesses and technologies; our ability to achieve expected benefits of our partnerships; increased competition in our product and services markets, including the data center market; dependence on the introduction and market acceptance of new product offerings and standards; rapid technological and market change; manufacturing and sourcing risks; product defects and returns; litigation involving patents, other intellectual property, antitrust, stockholder and other matters, and governmental investigations; our ability to achieve the benefits of restructurings and possible changes in the size and timing of related charges; cyber attacks, data breaches or other incidents; vulnerabilities and critical security defects; our ability to protect personal data; evolving regulatory uncertainty; terrorism; natural catastrophic events (including as a result of global climate change); any pandemic or epidemic; our ability to achieve the benefits anticipated from our investments in sales, engineering, service, marketing and manufacturing activities; our ability to recruit and retain key personnel; our ability to manage financial risk, and to manage expenses during economic downturns; risks related to the global nature of our operations, including our operations in emerging markets; currency fluctuations and other international factors; changes in provision for income taxes, including changes in tax laws and regulations or adverse outcomes resulting from examinations of our income tax returns; potential volatility in results of operations; and other factors listed in Cisco's most recent reports on Forms 10-Q and 10-K filed on May 19, 2026 and September 3, 2025, respectively. The financial information contained in this release should be read in conjunction with the consolidated financial statements and notes thereto included in Cisco's most recent reports on Forms 10-Q and 10-K as each may be amended from time to time. Cisco's results of operations for the three months and the year ended July 25, 2026 are not necessarily indicative of Cisco's results of operations for any future periods. Any projections in this release are based on limited information currently available to Cisco, which is subject to change. Although any such projections and the factors influencing them will likely change, Cisco will not necessarily update the information, since Cisco will only provide guidance at certain points during the year. Such information speaks only as of the date of this release.
+This release includes non-GAAP net income, non-GAAP gross margins, non-GAAP operating expenses, non-GAAP operating income and margin, non-GAAP effective tax rates, non-GAAP interest and other income (loss), net, and non-GAAP net income per share data for the periods presented. It also includes future estimated ranges for gross margin, operating margin, tax provision rate and EPS on a non-GAAP basis.
+These non-GAAP measures are not in accordance with, or an alternative for, measures prepared in accordance with generally accepted accounting principles (GAAP) and may be different from non-GAAP measures used by other companies. In addition, these non-GAAP measures are not based on any comprehensive set of accounting rules or principles. Cisco believes that non-GAAP measures have limitations in that they do not reflect all of the amounts associated with Cisco's results of operations as determined in accordance with GAAP and that these measures should only be used to evaluate Cisco's results of operations in conjunction with the corresponding GAAP measures.
+Cisco believes that the presentation of non-GAAP measures when shown in conjunction with the corresponding GAAP measures, provides useful information to investors and management regarding financial and business trends relating to its financial condition and its historical and projected results of operations.
+For its internal budgeting process, Cisco's management uses financial statements that do not include, when applicable, share-based compensation expense, amortization of acquisition-related intangible assets, acquisition/divestiture-related costs, significant asset impairments and restructurings, significant litigation settlements and other contingencies, gains and losses on investments, the income tax effects of the foregoing and significant tax matters. Cisco's management also uses the foregoing non-GAAP measures, in addition to the corresponding GAAP measures, in reviewing the financial results of Cisco. In prior periods, Cisco has excluded other items that it no longer excludes for purposes of its non-GAAP financial measures. From time to time in the future
+15
+
+
+
+
+
+there may be other items that Cisco may exclude for purposes of its internal budgeting process and in reviewing its financial results. For additional information on the items excluded by Cisco from one or more of its non-GAAP financial measures, refer to the Form 8-K regarding this release furnished today to the Securities and Exchange Commission.
+About Cisco
+Cisco (NASDAQ: CSCO) is the worldwide technology leader that is revolutionizing the way organizations connect and protect in the AI era. For more than 40 years, Cisco has securely connected the world. With its industry leading AI-powered solutions and services, Cisco enables its customers, partners and communities to unlock innovation, enhance productivity and strengthen digital resilience. With purpose at its core, Cisco remains committed to creating a more connected and inclusive future for all. Discover more on The Newsroom and follow us on X at @Cisco.
+Copyright © 2026 Cisco and/or its affiliates. All rights reserved. Cisco and the Cisco logo are trademarks or registered trademarks of Cisco and/or its affiliates in the U.S. and other countries. To view a list of Cisco trademarks, go to: www.cisco.com/go/trademarks. Third-party trademarks mentioned in this document are the property of their respective owners. The use of the word partner does not imply a partnership relationship between Cisco and any other company. This document is Cisco Public Information.
+RSS Feed for Cisco: https://newsroom.cisco.com/rss-feeds
+
+
+16\n

--- a/modules/test-fixtures/earnings-filings/envx.txt
+++ b/modules/test-fixtures/earnings-filings/envx.txt
@@ -1,0 +1,751 @@
+EX-99.1
+2
+envx8k-q22026x8122026ex991.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+Enovix Reports Second Quarter 2026 Results
+Second Quarter Revenue of $9.0 Million, Up 21% Year-over-Year, at High End of Guidance; First Half 2026 Revenue of $16.6 Million, Up 32% Year-over-Year
+Lead Smartphone Customer Confirms Passing More than 1,000 Cycles under the 0.2C Discharge Cycle Test 1 ; Final Accelerated Cycle-Life Test for Smartphone Qualification Underway, with Completion Expected in 2026
+
+
+
+
+FREMONT, Calif., August 12, 2026 -- Enovix Corporation (Nasdaq: ENVX) (“Enovix”), a developer and manufacturer of advanced lithium-ion batteries, including proprietary silicon-anode architectures, today reported financial results for the second quarter of 2026 .
+
+
+Second Quarter 2026 Highlights
+
+
+• Revenue of $9.0 million, up 21% year-over-year and 19% sequentially, at the high end of guidance — fifth consecutive quarter of year-over-year revenue growth; year-to-date revenue of $16.6 million, up 32% year-over-year.
+• Seventh consecutive quarter of positive gross profit, with GAAP gross margin of 14.4% and non-GAAP gross margin of 19.9%, down 11.6 and 10.9 percentage points, year-over-year, respectively, on a shift in battery product mix; year-to-date GAAP gross margin of 17.2% and non-GAAP gross margin of 22.8%, down 0.3 and up 1.5 percentage points year-over-year, respectively.
+• GAAP net loss per share of $0.20 and non-GAAP net loss per share of $0.13, compared to $0.22 and $0.13, respectively, in the prior-year quarter.
+• Lead smartphone customer confirms Enovix batteries passing more than 1,000 cycles under the 0.2C discharge cycle test 1 . Final accelerated cycle-life test for smartphone qualification is underway — built around a hybrid protocol defined in close collaboration with the customer and designed for silicon-anode cells.
+• Smart eyewear ramp underway: shipped approximately 2,100 AI-1 TM batteries, completed key international safety certifications, and recognized initial smart eyewear revenue; third quarter shipments expected to increase approximately 9x from the second quarter to approximately 19,000 packs against the 50,000-pack order.
+• Drone, defense, and industrial pipeline grew to $183 million, up approximately 41% from $130 million at the end of the first quarter, driven substantially by drone opportunities, which exceeded $100 million during the second quarter.
+• Third quarter 2026 outlook: revenue of $9.0 to $10.0 million, up approximately 13% to 25% year-over-year; full guidance detailed in the Financial Outlook section.
+
+1 Standard accelerated cycle-life testing condition based on a combination of 0.2C (2%) and 0.7C (98%) cycles used by customers as proxy for 0.2C cycle life. Blended average time per cycle ≈ 2.4 hours.
+1
+
+
+
+
+
+• Ended the quarter with approximately $552.1 million in cash, cash equivalents, and marketable securities, including restricted cash.
+
+
+“The second quarter showed momentum across all three of our target markets: our lead customer confirmed passing a defining smartphone qualification milestone. We have one final accelerated cycle-life test on the path to smartphone qualification, which we expect to complete this year. We also converted our smart eyewear ramp into initial revenue and substantially expanded our drone and defense pipeline,” said Dr. Raj Talluri, President and CEO of Enovix. “With revenue up 21% year-over-year at the high end of guidance and our fifth consecutive quarter of year-over-year growth, Enovix is executing the transition from technology validation to commercial scale.”
+
+
+Commercialization Progress: Smartphones
+
+
+Customer testing is now underway with the final accelerated cycle-life test, aligned through an iterative customer engagement process. This hybrid approach, which replaced the traditional 0.7C test used for legacy graphite batteries, consists of multiple test protocols across a range of charge and discharge conditions, with testing durations differing by variant mix. The lead customer is currently evaluating Enovix’s cells, including an enhanced design, across these multiple variants. The Company anticipates completing this final accelerated test in the fourth quarter of 2026, with targeted system-level field testing to follow.
+
+
+Enovix’s second smartphone OEM customer continues to progress toward alignment on a qualification framework, following a path parallel to that of the lead customer. The Company expects to begin sample deliveries in the fourth quarter of 2026.
+
+
+Commercialization Progress: Smart Eyewear
+
+
+“Our smart eyewear business recently marked several important milestones. We completed the international safety certifications required for commercial deployment, advanced our manufacturing ramp, and generated initial product revenue this quarter. Our next-generation AI-2 TM batteries are now in customers’ hands, and we expect them to be well received,” said Dr. Talluri. “We believe these milestones, achieved on a 100% silicon-anode battery in commercial production, further validate that our proprietary cell architecture can be manufactured, certified, and deployed at commercial scale.”
+
+
+Enovix’s smart eyewear ramp is well underway. Recently, Enovix completed key international safety certifications for its smart eyewear cells and battery packs, including UN 38.3 transportation testing, UL 2054, and KC 62133-2, and passed the full suite of customer reliability tests covering drop, tumble, thermal cycling, and extended heat soak.
+
+
+Following the start of commercial production in the first quarter, the Company shipped approximately 2,100 silicon-anode AI-1 batteries during the second quarter to support a leading smart eyewear reference platform and recognized initial smart eyewear product revenue. These shipments are being made under a customer order covering 50,000 battery packs for 2026 delivery. The customer has since issued delivery orders (specifying quantities and timing) under that same 50,000-pack order for approximately 19,000 packs to be delivered in the
+2
+
+
+
+
+
+third quarter — an approximately 9x increase over second-quarter shipments. The Company expects to fulfill the balance of the 50,000-pack order during the fourth quarter of 2026, with shipment volumes expected to grow in 2027 as downstream deployments are projected to expand.
+
+
+Commercialization Progress: Drones, Defense, and Industrial
+
+
+“Our defense and drone business delivered another quarter of strong growth and pipeline expansion,” said Dr. Talluri. “We are investing now to expand capacity so we can convert our growing pipeline into revenue as customer programs reach launch.”
+
+
+Demand across Enovix’s drone, defense, and industrial markets continued to expand in the second quarter. The Company’s global pipeline for products manufactured in South Korea increased 41% to approximately $183 million, up from $130 million at the end of the first quarter, with more than half of the growth driven by drone opportunities. Drone opportunities alone exceeded $100 million during the second quarter, with a substantial portion at stages where customers are actively evaluating and testing the Company’s cells or designing them into products. This pipeline represents the Company’s estimate of the peak annual production value of identified design opportunities.
+
+
+Enovix showcased the recently launched MX-1 TM at industry conferences across the U.S. and Europe during the quarter, with customer interest in the MX1-B01 TM drone cell continuing to grow. In particular, military customers are seeking products that satisfy various governmental requirements, and the Company is well-positioned to meet this demand. The product and transportation certifications necessary to support expanded customer sampling and initial deliveries are progressing well. Subsequent to quarter end, the Company commenced sampling to numerous customers in the third quarter and its drone battery passed UN 38.3 transportation testing, completing a key certification required for commercial shipment. Enovix believes demand for high-performance drone batteries that meet U.S. government sourcing requirements under the National Defense Authorization Act (NDAA) and the Trade Agreements Act (TAA) will materially exceed available supply through the end of the decade. Enovix’s South Korea manufacturing operations, with an established production history supporting defense customers, position the Company to be a scaled supplier able to address this gap, and the previously announced capacity expansion at the facility is underway, with the new capacity expected to come online in mid-2027. The expansion is expected to be capital-efficient, utilizing existing land and buildings the Company already owns and leveraging readily available production equipment.
+
+
+Technology Progress
+
+
+In the first quarter of 2026, Enovix produced the first engineering samples of AI-2, a next-generation smart eyewear battery expected to deliver approximately 20% higher volumetric energy density than AI-1. AI-2 leverages the EX-3M TM technology node, which reduces separator and current collector thickness, improves packaging efficiency, and increases cathode voltage. One tier 1 smart eyewear customer commenced sampling during the second quarter, and additional tier 1 customers are expected to receive samples in the third quarter. The same EX-3M innovations are also expected to support a step-function in performance gains for Enovix’s future smartphone batteries.
+
+
+3
+
+
+
+
+
+Enovix is also advancing the energy density of the silicon-blended graphite batteries produced at its South Korea facility. MX-2 TM , the next generation of the recently launched MX-1 drone cell, remains targeted for 2027, with a goal of reaching a gravimetric energy density of 400 Wh/kg — a significant advancement for this battery chemistry. Gravimetric energy density is especially critical in drone applications, where every gram of battery weight directly impacts flight time, range, payload capacity, and overall operational effectiveness.
+
+
+Manufacturing Readiness Progress
+
+
+Enovix continued to improve execution across Fab2 production zones. In smart eyewear battery production, all but one process step outside of Zone 1 delivered yields during the second quarter of 95% or greater, with individual steps as high as 99.6%. Zone 1 dicing — a key throughput driver across our smartphone and smart eyewear production lines — delivered step-level yield of approximately 84% in the second quarter, up from approximately 80% reported last quarter.
+
+
+To further improve throughput and cost efficiency, the Company has been implementing a hybrid dicing configuration that combines laser and mechanical dicing in Zone 1. This approach allows Enovix to apply the most effective technique at each step and is expected to reduce cell cost while increasing production rates to support early commercial demand as qualification progresses. The transition to mechanical dicing equipment is well underway, with multiple key dicing steps expected to come online at Fab2 around the end of the year.
+
+
+In parallel, Enovix is streamlining the manufacturing flow by eliminating select process steps, which is expected to further improve manufacturability, throughput, and yield while reducing capital intensity and unit costs. These initiatives reflect the Company’s ongoing focus on continuously improving efficiency and scalability across its manufacturing operations.
+
+
+Leadership
+
+
+As recently announced, Enovix appointed Michael Vyvoda to serve as its Chief Operating Officer to lead the Company’s next phase of global manufacturing execution. Mr. Vyvoda brings decades of operations leadership, including prior experience at Apple, and will oversee manufacturing, supply chain, quality, and customer delivery as Enovix scales production across multiple products, facilities, and end markets. His immediate focus is on scaling production to meet the Company’s second-half commitments: ramping smart eyewear output, preparing manufacturing for smartphone field-test builds, and driving the cost, yield and delivery initiatives underway across Enovix’s factories.
+
+
+Subsequent to quarter-end, Enovix also strengthened its commercial organization with a senior sales executive who spent nearly two decades at a leading global manufacturer of lithium-ion batteries for consumer devices, where he most recently headed its largest global sales region and built long-standing relationships across major smartphone OEMs.
+
+
+
+
+4
+
+
+
+
+
+Second Quarter and Year-to-Date 2026 Financial Results
+(in millions, except percentages)
+
+
+• Second quarter 2026 revenue of $9.0 million increased 21% year-over-year and rose 19% sequentially, at the high end of the Company’s guidance range and marking the fifth consecutive quarter of year-over-year revenue growth. Year-to-date, revenue of $16.6 million increased 32% from the first half of 2025. Growth in both periods primarily reflects continued strength in defense through Enovix’s South Korea operations, where the Company’s global pipeline grew to approximately $183 million during the period, driven substantially by new drone opportunities. Enovix also achieved commercial availability of its 100% silicon-anode smart eyewear battery during the second quarter and recognized initial smart eyewear product revenue — modest in amount, but an early proof point of contribution from AI-powered wearable devices.
+• GAAP gross profit was $1.3 million and non-GAAP gross profit was $1.8 million in 2Q26, marking the seventh consecutive quarter of positive gross profit on both a GAAP and non-GAAP basis and continued progression toward economically scalable production. GAAP gross margin was 14.4% and non-GAAP gross margin was 19.9%, down year-over-year primarily due to a shift in the mix of battery products sold through Enovix’s South Korea operations. Year-to-date, GAAP gross profit was $2.9 million and non-GAAP gross profit was $3.8 million, up from $2.2 million and $2.7 million in the first half of 2025, with non-GAAP gross margin improving to 22.8% from 21.3% on higher production volumes and operational execution improvements.
+• Net cash used in operating activities improved to $21.8 million in 2Q26 from $25.9 million in 2Q25. Free cash flow was an outflow of $31.4 million in 2Q26, compared to an outflow of $33.8 million in 2Q25. The modest year-over-year improvement primarily reflects favorable changes in working capital, partially offset by higher capital expenditures supporting manufacturing scale-up. For the first half of 2026, net cash used in operating activities was $54.9 million and free cash flow was an outflow of $67.7 million, compared to $42.8 million and $57.0 million, respectively, in the first half of 2025. The increase in year-to-date cash use primarily reflects greater working capital usage in the first quarter of 2026 and higher interest expense associated with the semi-annual interest payment of the Company’s convertible notes issued in the third quarter of 2025.
+• Cash, cash equivalents, and marketable securities, including restricted cash, totaled approximately $552.1 million at quarter-end, providing liquidity to support qualification completion and commercialization scale-up. Enovix continues to prioritize disciplined capital allocation as it advances manufacturing scale-up and commercialization, while maintaining flexibility to pursue select strategic opportunities. No shares were repurchased during the quarter under the Company’s previously authorized share repurchase program. The Company continues evaluating capital deployment alternatives under its existing authorization.
+
+
+
+
+
+5
+
+
+
+
+
+Second Quarter 2026 Financial Summary
+(unaudited, in millions, except per share data and percentages)
+Note: Amounts may not sum and percentages may not recompute due to rounding.
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| GAAP | | Non-GAAP |
+| Q2 2026 | | Q2 2025 | | YoY Δ | | Q2 2026 | | Q2 2025 | | YoY Δ |
+Revenue | $ | 9.0 | | $ | 7.5 | | $ | 1.5 | | $ | 9.0 | | $ | 7.5 | | $ | 1.5 |
+Gross profit | $ | 1.3 | | $ | 1.9 | | $ | (0.6) | | $ | 1.8 | | $ | 2.3 | | $ | (0.5) |
+Gross margin | 14.4 | % | | 26.0 | % | | (11.6)pts | | 19.9 | % | | 30.8 | % | | (10.9)pts |
+Operating expenses | $ | 44.6 | | $ | 45.7 | | $ | (1.1) | | $ | 30.6 | | $ | 28.8 | | $ | 1.8 |
+Loss from operations | $ | (43.3) | | $ | (43.7) | | $ | 0.4 | | $ | (28.8) | | $ | (26.5) | | $ | (2.3) |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+Net cash used in operating activities | $ | (21.8) | | $ | (25.9) | | $ | 4.1 | | $ | (21.8) | | $ | (25.9) | | $ | 4.1 |
+Capital expenditures (1)
+| $ | (9.6) | | $ | (8.0) | | $ | (1.6) | | $ | (9.6) | | $ | (8.0) | | $ | (1.6) |
+Free cash flow | N/A | | N/A | | N/A | | $ | (31.4) | | $ | (33.8) | | $ | 2.4 |
+Adjusted EBITDA | N/A | | N/A | | N/A | | $ | (18.9) | | $ | (20.1) | | $ | 1.2 |
+| | | | | | | | | | | |
+Net loss per share, basic (2)
+| $ | (0.20) | | $ | (0.22) | | $ | 0.02 | | $ | (0.13) | | $ | (0.13) | | $ | — |
+Weighted average shares, basic (3)
+| 218.5 | | 204.8 | | 13.7 | | 218.5 | | 204.8 | | 13.7 |
+Net loss per share, diluted (2)
+| $ | (0.20) | | $ | (0.22) | | $ | 0.02 | | $ | (0.13) | | $ | (0.13) | | $ | — |
+Weighted average shares, diluted (3)
+| 218.5 | | 204.8 | | 13.7 | | 218.5 | | 204.8 | | 13.7 |
+
+(1) Capital Expenditures reflects cash paid for property, equipment, and manufacturing assets and is a component of our free cash flow calculation. It excludes depreciation, accretion and amortization, and other non-cash investing items. It excludes one-time cash outflows related to business acquisitions. (2) Net loss per share attributable to Enovix. (3) Weighted average shares attributable to Enovix.
+
+
+
+
+2026 Year-to-Date Financial Summary
+(unaudited, in millions, except per share data and percentages)
+Note: Amounts may not sum and percentages may not recompute due to rounding.
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| GAAP | | Non-GAAP |
+| YTD 2026 | | YTD 2025 | | YoY Δ | | YTD 2026 | | YTD 2025 | | YoY Δ |
+Revenue | $ | 16.6 | | | $ | 12.6 | | | $ | 4.0 | | | $ | 16.6 | | | $ | 12.6 | | | $ | 4.0 | |
+Gross profit | $ | 2.9 | | | $ | 2.2 | | | $ | 0.7 | | | $ | 3.8 | | | $ | 2.7 | | | $ | 1.1 | |
+Gross margin | 17.2 | % | | 17.5 | % | | (0.3)pts | | 22.8 | % | | 21.3 | % | | 1.5pts |
+Operating expenses | $ | 90.0 | | | $ | 88.5 | | | $ | 1.5 | | | $ | 61.3 | | | $ | 57.1 | | | $ | 4.2 | |
+Loss from operations | $ | (87.2) | | | $ | (86.3) | | | $ | (0.9) | | | $ | (57.5) | | | $ | (54.5) | | | $ | (3.0) | |
+| | | | | | | | | | | |
+| | | | | | | | | | | |
+Net cash used in operating activities | $ | (54.9) | | | $ | (42.8) | | | $ | (12.1) | | | $ | (54.9) | | | $ | (42.8) | | | $ | (12.1) | |
+Capital expenditures (1)
+| $ | (12.8) | | | $ | (14.2) | | | $ | 1.4 | | | $ | (12.8) | | | $ | (14.2) | | | $ | 1.4 | |
+Free cash flow | N/A | | N/A | | N/A | | $ | (67.7) | | | $ | (57.0) | | | $ | (10.7) | |
+Adjusted EBITDA | N/A | | N/A | | N/A | | $ | (39.3) | | | $ | (40.9) | | | $ | 1.6 | |
+| | | | | | | | | | | |
+Net loss per share, basic (2)
+| $ | (0.37) | | | $ | (0.33) | | | $ | (0.04) | | | $ | (0.27) | | | $ | (0.26) | | | $ | (0.01) | |
+Weighted average shares, basic (3)
+| 217.9 | | | 204.1 | | | 13.8 | | | 217.9 | | | 204.1 | | | 13.8 | |
+Net loss per share, diluted (2)
+| $ | (0.37) | | | $ | (0.33) | | | $ | (0.04) | | | $ | (0.27) | | | $ | (0.26) | | | $ | (0.01) | |
+Weighted average shares, diluted (3)
+| 217.9 | | | 204.1 | | | 13.8 | | | 217.9 | | | 204.1 | | | 13.8 | |
+
+(1) Capital Expenditures reflects cash paid for property, equipment, and manufacturing assets and is a component of our free cash flow calculation. It excludes depreciation, accretion and amortization, and other non-cash investing items. It excludes one-time cash outflows related to business acquisitions. (2) Net loss per share attributable to Enovix. (3) Weighted average shares attributable to Enovix.
+.
+6
+
+
+
+
+
+
+
+
+Financial Outlook
+(unaudited, in millions, except per share data)
+
+
+| | | | | | | | | | | | | | | | | | | | |
+| | Q3 2026 Guidance (1)
+| | Q3 2025 Results | | Q2 2026 Results |
+Revenue | | $9.0 - 10.0 | | $8.0 | | $9.0 |
+Non-GAAP loss from operations (2)
+| | ($29.0 - 32.0) | | ($29.8) | | ($28.8) |
+Non-GAAP net loss per share (2),(3)
+| | ($0.13 - 0.17) | | ($0.14) | | ($0.13) |
+Capital expenditures (4)
+| | $8.0 - 12.0 | | $3.0 | | $9.6 |
+
+(1) Our outlook does not include provisions for proposed tax law changes or for the recently enacted tax reform legislation, future asset impairments or for pending legal matters, other than future legal amounts that are probable and estimable. Further, due to their nature, certain income and expense items, such as certain investments, derivative and foreign currency transaction gains or losses, cannot be accurately forecast. Accordingly, we only include such items in our financial outlook to the extent they are reasonably certain. Actual results may differ materially from the outlook; (2) See Appendix for definitions and reconciliations of non-GAAP Gross Profit (Loss), non-GAAP Gross Margin, non-GAAP Operating Loss, Adjusted EBITDA, and non-GAAP Net Loss Per Share Attributable to Enovix to their nearest comparable GAAP metrics for the historical periods presented. We are not presenting a quantitative reconciliation of our guidance for non-GAAP Operating Loss and non-GAAP Net Loss Per Share Attributable to Enovix to their GAAP equivalents, in reliance on the unreasonable efforts exception under Item 10(e)(1)(i)(B) of Regulation S-K. Further information is provided below under the heading "Non-GAAP Financial Measures"; (3) non-GAAP Net Loss Per Share represents non-GAAP Net Loss Per Share Attributable to Enovix; (4) Capital Expenditures reflects cash paid for property, equipment, and manufacturing assets and is a component of our free cash flow calculation. It excludes depreciation, accretion, amortization, and other non-cash investing items. It excludes one-time cash outflows related to business acquisitions.
+
+
+
+Conference Call Information
+
+
+The Company will host a live, audio-only webcast today at 5:00 PM ET / 2:00 PM PT to discuss the results and provide a business update. To register for the audio webcast, please visit: https://enovix-q2-2026.open-exchange.net/ .
+
+
+About Enovix
+
+
+Enovix develops and manufactures advanced lithium-ion batteries, including proprietary silicon-anode architectures for smartphones, smart eyewear, defense, industrial, and emerging edge-AI applications. Its proprietary silicon-anode battery architecture enables higher energy density and performance in space-constrained devices while maintaining safety and reliability, supporting commercialization across consumer and industrial markets.
+
+
+Enovix is headquartered in Silicon Valley with facilities in India, Korea, and Malaysia, serving customers globally. For more information visit https://enovix.com and follow us on LinkedIn.
+
+
+
+Non-GAAP Financial Measures
+This press release includes the use of non-GAAP financial measures, which are intended to provide supplemental information regarding our performance. These non-GAAP measures include non-GAAP cost of revenue, non-GAAP gross profit (loss), non-GAAP gross margin, non-GAAP research and development expense, non-GAAP selling, general and administrative expense, non-GAAP operating expenses, non-GAAP income (loss) from operations, EBITDA, adjusted EBITDA, non-GAAP net loss attributable to Enovix shareholders, non-GAAP earnings (loss) per share, free cash flow, and other non-GAAP measures that are included in this press release.
+
+
+We use these non-GAAP measures to supplement our financial reporting and to evaluate ongoing operations and results, facilitate internal planning and forecasting, and assess performance against prior periods, industry peers, and the broader market. These non-GAAP measures are not prepared in accordance with generally accepted accounting principles (GAAP) and should not be considered as an alternative to GAAP results. Industry peers and other companies may calculate similar non-GAAP measures differently. Non-GAAP financial measures have limitations, including but not limited to, that they exclude certain expenses that are required under GAAP, which adjustments reflect the exercise of judgment by management. We believe that these non-GAAP measures, when considered together with the GAAP results, provide investors with an
+7
+
+
+
+
+
+additional understanding of our operating performance. Reconciliations of each non-GAAP financial measure to the most directly comparable GAAP financial measure can be found in the tables at the end of this press release.
+
+
+While Enovix provides third quarter 2026 guidance for non-GAAP loss from operations, non-GAAP net loss per share and capital expenditures, we are unable to provide without unreasonable effort a GAAP to non-GAAP reconciliation of these projected non-GAAP measures, and we have not provided a quantitative reconciliation in reliance on the unreasonable efforts exception under Item 10(e)(1)(i)(B) of Regulation S-K. Such reconciliation to the corresponding GAAP financial measure cannot be provided without unreasonable effort because of the inherent difficulty in accurately forecasting the occurrence and financial impact of the various adjustments that have not yet occurred, are out of our control, or cannot be reasonably predicted, including but not limited to change in fair value of common stock, stock-based compensation and related tax effects, legal costs related to shareholder lawsuit, gain on bargain purchase of assets, acquisition-related costs, and restructuring costs. As a result, we are unable to assess the probable significance of the unavailable information, which could have a material impact on our future GAAP financial results.
+
+
+
+Forward-Looking Statements
+This press release contains forward-looking statements within the meaning of the Private Securities Litigation Reform Act of 1995. Forward-looking statements relate to future events or our future financial or operating performance and are identified by words such as anticipate, believe, could, estimate, expect, intend, may, might, plan, possible, potential, predict, project, should, will, would, and similar expressions. Forward-looking statements in this press release include, but are not limited to, statements regarding: our future operating results, financial position, growth opportunities, and guidance; expected performance, capabilities, and development of our battery products and technology roadmap; the timing, results and impact of customer testing, certification and qualification requirements; the timing and scale of sampling, product launches, production ramps, and customer programs; our ability to meet customer performance requirements and progress toward commercial deployment; our ability to scale and optimize manufacturing, including improvements in yield, throughput, dicing processes, performance, cost, timing and capital efficiency of our capacity expansion; our estimation of customer demand, adoption, growth and our ability to convert pipeline opportunities into revenue; our expectations regarding regulatory, certification and government sourcing requirements, including under the NDAA and TAA; and the sufficiency and use of our capital resources and our expectations regarding the benefits and use of our current balances of cash, cash equivalents, and marketable securities.
+
+
+Risks, uncertainties and assumptions that could cause actual results to differ materially from the results and events anticipated by such forward-looking statements include, but are not limited to: risks related to the outcome of customer testing and qualification activities, including the possibility that our products do not meet required performance thresholds or that such testing is delayed beyond expected time frames; our ability to successfully develop, manufacture and commercialize our battery products and transition to high-volume production; our ability to scale manufacturing operations and achieve expected production capacity and yields; the level and timing of customer demand, qualification and adoption of our products across end markets; our ability to enter into and expand commercial agreements, including securing design wins, purchase orders and production contracts; our ability to execute on our business strategy and build and scale our sales and commercial capabilities; lengthy and unpredictable customer qualification and sales cycles, safety considerations and contractual terms, particularly in defense and other regulated markets; risks related to battery performance, reliability and safety; customer concentration in the defense sector and certain consumer technology markets, such as smartphones and smart eyewear; challenges in forecasting demand, inventory and manufacturing requirements that may result in additional costs and production delays; our history of losses and expectation of continued losses; risks associated with the development and commercialization of products that remain under development and may not be successfully produced at commercial scale; our ability to effectively integrate and derive benefits from acquired businesses; fluctuations in foreign currency exchange rates and interest rates; operational and safety risks associated with manufacturing equipment; intense competition and our ability to keep up with rapid technological change and evolving standards in the battery industry; our ability to attract and retain qualified personnel; the outcome of litigation, regulatory investigations and other legal
+8
+
+
+
+
+
+matters, including the associated legal and other costs; liquidity constraints, capital availability and our ability to service existing debt; our ability to protect and enforce our intellectual property rights; volatility in the trading price of our common stock; changes in tax laws or regulations; the impact of cyber and other information technology or security related incidents on us, our customers or other parties; changes in the political, economic or regulatory environment generally and in the markets in which we operate; and other risks described in the disclosures contained in our filings with the Securities and Exchange Commission (“SEC”), including in the “Risk Factors” and “Management’s Discussion and Analysis of Financial Condition and Results of Operations” sections of our annual report on Form 10-K and quarterly reports on Form 10-Q and other documents that we have filed, or will file, with the SEC. These documents are available in the SEC Filings section of the Investor Relations page at https://ir.enovix.com and at www.sec.gov .
+
+
+Any forward-looking statements in this press release speak only as of the date on which they are made. We undertake no obligation to update or revise any forward-looking statements, whether as a result of new information, future events or otherwise.
+
+
+Note Regarding Customer Pipeline and Design Wins
+We may refer in this press release and other communications to our “customer pipeline” and “design wins.” Our customer pipeline represents our estimate of the peak annual production value of identified design opportunities for products manufactured in South Korea. A “design win” refers to an opportunity that has been awarded to Enovix but has not yet entered production. Customer pipeline and design win amounts do not represent customer orders, backlog or committed revenue and should not be viewed as forecasts of future revenue. Actual revenue, if any, will depend on a number of factors, including customer qualification, final program awards, production timing, capacity and volumes, and the successful launch and ramp of customer programs. These measures are forward-looking and are subject to the risks and uncertainties described above under “Forward-Looking Statements.”
+
+
+For media and investor inquiries, please contact:
+
+
+Investor Contact:
+Monica Gould
+ir@enovix.com
+
+
+
+
+
+9
+
+
+
+
+
+
+ENOVIX CORPORATION
+CONDENSED CONSOLIDATED BALANCE SHEETS
+(Unaudited, in thousands, except share and par value amounts)
+
+
+| | | | | | | | | | | |
+| As of July 5,
+2026 | | As of December 28,
+2025 |
+Assets | | | |
+Current assets: | | | |
+Cash and cash equivalents | $ | 33,741 | | | $ | 106,014 | |
+Short-term investments | 442,040 | | | 406,026 | |
+Accounts receivable, net | 3,097 | | | 4,421 | |
+Notes receivable, net | — | | | 4,012 | |
+Inventory | 17,520 | | | 13,617 | |
+Prepaid expenses and other current assets | 9,342 | | | 8,120 | |
+Total current assets | 505,740 | | | 542,210 | |
+Property and equipment, net | 165,155 | | | 170,263 | |
+Long-term investments | 74,430 | | | 106,810 | |
+Customer relationship intangibles and other intangibles, net | 29,168 | | | 31,638 | |
+Operating lease, right-of-use assets | 8,639 | | | 11,682 | |
+Goodwill | 12,217 | | | 12,217 | |
+Other assets, non-current | 4,270 | | | 4,155 | |
+Total assets | $ | 799,619 | | | $ | 878,975 | |
+Liabilities and Equity | | | |
+Current liabilities: | | | |
+Accounts payable | $ | 12,173 | | | $ | 17,818 | |
+Accrued expenses | 11,456 | | | 13,992 | |
+Accrued compensation | 7,560 | | | 6,219 | |
+Short-term debt | 10,593 | | | 9,865 | |
+Deferred revenue | 3,710 | | | 5,015 | |
+Warrant liability | — | | | 6,578 | |
+Other liabilities | 6,618 | | | 5,529 | |
+Total current liabilities | 52,110 | | | 65,016 | |
+Long-term debt, net | 520,994 | | | 519,271 | |
+| | | |
+Operating lease liabilities, non-current | 5,893 | | | 11,244 | |
+Deferred revenue, non-current | 300 | | | 300 | |
+Deferred tax liability | 8,320 | | | 9,119 | |
+Other liabilities, non-current | 13 | | | 14 | |
+Total liabilities | 587,630 | | | 604,964 | |
+| | | |
+Stockholders’ equity: | | | |
+Common stock, $0.0001 par value; authorized shares of 1,000,000,000; issued and outstanding shares of 219,195,932 and 216,556,238 as of July 5, 2026 and December 28, 2025, respectively
+| 23 | | | 22 | |
+Additional paid-in-capital | 1,328,872 | | | 1,307,912 | |
+Treasury stock, at cost | (58,385) | | | (58,385) | |
+Accumulated other comprehensive loss | (1,415) | | | (508) | |
+Accumulated deficit | (1,059,150) | | | (977,827) | |
+Total Enovix’s stockholders’ equity | 209,945 | | | 271,214 | |
+Non-controlling interest | 2,044 | | | 2,797 | |
+Total equity | 211,989 | | | 274,011 | |
+Total liabilities and equity | $ | 799,619 | | | $ | 878,975 | |
+
+
+
+
+
+
+
+
+
+ENOVIX CORPORATION
+CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS
+(Unaudited, in thousands, Except Share and per Share Amounts)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Fiscal Quarters Ended | | Fiscal Years-to-Date Ended |
+| July 5,
+2026 | | June 29,
+2025 | | July 5,
+2026 | | June 29,
+2025 |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+Revenue | $ | 9,024 | | | $ | 7,468 | | | $ | 16,624 | | | $ | 12,566 | |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+Cost of revenue | 7,722 | | | 5,526 | | | 13,770 | | | 10,363 | |
+Gross profit | 1,302 | | | 1,942 | | | 2,854 | | | 2,203 | |
+Operating expenses: | | | | | | | |
+Research and development | 24,444 | | | 28,148 | | | 50,972 | | | 54,077 | |
+Selling, general and administrative | 20,154 | | | 17,527 | | | 39,073 | | | 34,419 | |
+| | | | | | | |
+| | | | | | | |
+Total operating expenses | 44,598 | | | 45,675 | | | 90,045 | | | 88,496 | |
+Loss from operations | (43,296) | | | (43,733) | | | (87,191) | | | (86,293) | |
+Other income (expense): | | | | | | | |
+Change in fair value of common stock warrants | 181 | | | (5,885) | | | 6,578 | | | 9,911 | |
+| | | | | | | |
+| | | | | | | |
+Gain on bargain purchase of assets | — | | | 4,761 | | | — | | | 4,761 | |
+Interest income | 5,134 | | | 2,427 | | | 10,910 | | | 4,861 | |
+Interest expense | (6,521) | | | (1,705) | | | (13,529) | | | (3,421) | |
+Other income (expense), net | 984 | | | (992) | | | 1,327 | | | 1,361 | |
+Total other income (expense), net | (222) | | | (1,394) | | | 5,286 | | | 17,473 | |
+Loss before income tax benefit | (43,518) | | | (45,127) | | | (81,905) | | | (68,820) | |
+Income tax benefit | (441) | | | (861) | | | (570) | | | (1,023) | |
+Net loss | (43,077) | | | (44,266) | | | (81,335) | | | (67,797) | |
+Net gain (loss) attributable to non-controlling interest | (14) | | | 262 | | | (12) | | | 241 | |
+Net loss attributable to Enovix | $ | (43,063) | | | $ | (44,528) | | | $ | (81,323) | | | $ | (68,038) | |
+| | | | | | | |
+Net loss per share attributable to Enovix shareholders, basic and diluted (1)
+| $ | (0.20) | | | $ | (0.22) | | | $ | (0.37) | | | $ | (0.33) | |
+Weighted average number of common shares outstanding, basic and diluted (1)
+| 218,502,098 | | | 204,819,119 | | | 217,908,465 | | | 204,086,108 | |
+| | | | | | | |
+| | | | | | | |
+
+| | |
+|
+
+(1) As required by ASC 260, Earnings Per Share, the share and per share amounts presented in the above table for the fiscal quarter and fiscal year-to-date ended June 29, 2025 have been retroactively adjusted to reflect the warrant dividend issued in July 2025.
+
+
+
+
+
+
+
+
+ENOVIX CORPORATION
+CONDENSED CONSOLIDATED STATEMENTS OF CASH FLOWS
+(Unaudited, in thousands)
+
+
+| | | | | | | | | | | |
+| Fiscal Years-to-Date Ended |
+| July 5,
+2026 | | June 29,
+2025 |
+Cash flows used in operating activities: | | | |
+Net loss | $ | (81,335) | | | $ | (67,797) | |
+Adjustments to reconcile net loss to net cash used in operating activities | | | |
+Depreciation, accretion and amortization | 19,406 | | | 17,277 | |
+Stock-based compensation expense | 24,799 | | | 26,136 | |
+Change in fair value of common stock warrants | (6,578) | | | (9,911) | |
+Gain on bargain purchase of assets | — | | | (4,761) | |
+| | | |
+| | | |
+Others | (1,452) | | | 1,405 | |
+Changes in operating assets and liabilities: | | | |
+Accounts and notes receivables | 5,125 | | | (552) | |
+Inventory | (4,249) | | | (5,410) | |
+Prepaid expenses and other assets | (1,369) | | | 1,765 | |
+Accounts payable | (3,677) | | | 2,241 | |
+Accrued expenses and compensation | (1,660) | | | (5,001) | |
+Deferred revenue | (1,328) | | | 1,044 | |
+Deferred tax liability | (803) | | | (683) | |
+Other liabilities | (1,732) | | | 1,481 | |
+Net cash used in operating activities | (54,853) | | | (42,766) | |
+Cash flows from investing activities: | | | |
+Purchase of property and equipment | (12,844) | | | (14,243) | |
+Payment for business acquisition | — | | | (10,000) | |
+Purchases of investments | (230,074) | | | (85,473) | |
+Maturities of investments | 227,580 | | | 18,627 | |
+Net cash used in investing activities | (15,338) | | | (91,089) | |
+Cash flows from financing activities: | | | |
+| | | |
+| | | |
+| | | |
+| | | |
+Proceeds from loan borrowing | 1,300 | | | — | |
+| | | |
+| | | |
+Proceeds from issuance of common stock under employee stock purchase plan | 938 | | | 711 | |
+Payroll tax payments for shares withheld upon vesting of RSUs | (3,382) | | | (2,853) | |
+Purchase of Routejade shares from non-controlling interest | (740) | | | — | |
+Repayment of debt | (108) | | | (813) | |
+Proceeds from the exercise of stock options | — | | | 782 | |
+| | | |
+Payments of transaction costs related to common stock issuance | — | | | (512) | |
+Net cash used in financing activities | (1,992) | | | (2,685) | |
+Effect of exchange rate changes on cash, cash equivalents and restricted cash | (202) | | | (102) | |
+Change in cash, cash equivalents, and restricted cash | (72,385) | | | (136,642) | |
+Cash and cash equivalents and restricted cash, beginning of period | 107,979 | | | 274,691 | |
+Cash and cash equivalents and restricted cash, end of period | $ | 35,594 | | | $ | 138,049 | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+
+
+
+
+
+
+
+
+
+Net Loss Attributable to Enovix to Adjusted EBITDA Reconciliation
+“EBITDA” is defined as earnings (net loss) attributable to Enovix adjusted for interest income, interest expense, income tax benefit, depreciation, accretion and amortization expense. “Adjusted EBITDA” includes additional adjustments to EBITDA such as stock-based compensation expense, change in fair value of common stock warrants, impairment of equipment, warrant issuance cost, certain legal costs related to our defense of an ongoing securities class action complaint that is outside the ordinary course of business and that we do not consider representative of our performance, and other special items as determined by management which it does not believe to be indicative of its underlying business trends.
+These non-GAAP measures may differ from similarly titled measures used by other companies.
+
+
+Below is a reconciliation of net loss attributable to Enovix on a GAAP basis to the non-GAAP EBITDA and Adjusted EBITDA financial measures for the periods presented below (unaudited, in thousands):
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Fiscal Quarters Ended | | Fiscal Years-to-Date Ended |
+| July 5,
+2026 | | June 29,
+2025 | | July 5,
+2026 | | June 29,
+2025 |
+Net loss attributable to Enovix | $ | (43,063) | | | $ | (44,528) | | | $ | (81,323) | | | $ | (68,038) | |
+Interest expense (income), net | 1,387 | | | (722) | | | 2,619 | | | (1,440) | |
+Income tax benefit | (441) | | | (861) | | | (570) | | | (1,023) | |
+Depreciation, accretion and amortization | 10,036 | | | 8,829 | | | 19,406 | | | 17,277 | |
+EBITDA | (32,081) | | | (37,282) | | | (59,868) | | | (53,224) | |
+Stock-based compensation expense | 13,034 | | | 14,122 | | | 24,799 | | | 26,136 | |
+Change in fair value of common stock warrants | (181) | | | 5,885 | | | (6,578) | | | (9,911) | |
+| | | | | | | |
+| | | | | | | |
+Legal cost related to shareholder lawsuit (1)
+| 313 | | | 1,247 | | | 2,389 | | | 2,651 | |
+| | | | | | | |
+Acquisition cost | — | | | 664 | | | — | | | 664 | |
+Gain on bargain purchase of assets | — | | | (4,761) | | | — | | | (4,761) | |
+Import duty forgiveness | — | | | — | | | — | | | (2,431) | |
+Adjusted EBITDA | $ | (18,915) | | | $ | (20,125) | | | $ | (39,258) | | | $ | (40,876) | |
+
+| | |
+|
+
+(1) These amounts reflect litigation expenses related to the defense of an ongoing securities action.
+
+
+
+
+
+
+
+
+Reconciliation of Operating Loss to Non-GAAP Operating Loss and Adjusted EBITDA
+Additionally, below is a reconciliation of GAAP operating loss to non-GAAP operating loss and adjusted EBITDA for the periods presented (unaudited, in thousands).
+These non-GAAP measures may differ from similarly titled measures used by other companies.
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Fiscal Quarters Ended | | Fiscal Years-to-Date Ended |
+| | July 5,
+2026 | | June 29,
+2025 | | July 5,
+2026 | | June 29,
+2025 |
+GAAP loss from operations | | $ | (43,296) | | | $ | (43,733) | | | $ | (87,191) | | | $ | (86,293) | |
+Stock-based compensation expense | | 13,034 | | | 14,122 | | | 24,799 | | | 26,136 | |
+Amortization of intangible assets | | 1,190 | | | 1,188 | | | 2,471 | | | 2,378 | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Legal cost related to shareholder lawsuit (1)
+| | 313 | | | 1,247 | | | 2,389 | | | 2,651 | |
+| | | | | | | | |
+Acquisition cost | | — | | | 664 | | | — | | | 664 | |
+Non-GAAP loss from operations | | (28,759) | | | (26,512) | | | (57,532) | | | (54,464) | |
+Depreciation, accretion and amortization (excluding amortization of intangible assets) | | 8,846 | | | 7,641 | | | 16,935 | | | 14,899 | |
+Other income (loss), net (excluding import duty forgiveness) | | 984 | | | (992) | | | 1,327 | | | (1,070) | |
+Net gain (loss) attributable to non-controlling interest | | 14 | | | (262) | | | 12 | | | (241) | |
+Adjusted EBITDA | | $ | (18,915) | | | $ | (20,125) | | | $ | (39,258) | | | $ | (40,876) | |
+
+| | |
+|
+
+(1) These amounts reflect litigation expenses related to the defense of an ongoing securities action.
+
+
+
+
+
+
+
+
+Free Cash Flow Reconciliation
+We define “Free Cash Flow” as (i) net cash from operating activities less (ii) capital expenditures, net of proceeds from disposals of property and equipment, all of which are derived from our Consolidated Statements of Cash Flow. The presentation of non-GAAP Free Cash Flow is not intended as an alternative measure of cash flows from operations, as determined in accordance with GAAP.
+We believe Free Cash Flow is a useful measure for investors because it provides insight into the cash generated or used by our operations after funding capital expenditures, and it helps assess our ability to pursue strategic growth initiatives. We use Free Cash Flow internally to evaluate performance, support decision-making, and measure our progress toward profitability and cash flow breakeven.
+This non-GAAP measure may differ from similarly titled measures used by other companies.
+Below is a reconciliation of net cash used in operating activities to the Free Cash Flow financial measures for the periods presented below (unaudited, in thousands):
+| | | | | | | | | | | |
+| Fiscal Years-to-Date Ended |
+| July 5,
+2026 | | June 29,
+2025 |
+Net cash used in operating activities | $ | (54,853) | | | $ | (42,766) | |
+Capital expenditures | (12,844) | | | (14,243) | |
+Free cash flow | $ | (67,697) | | | $ | (57,009) | |
+
+
+
+
+
+
+
+
+
+
+
+Other Non-GAAP Financial Measures Reconciliation
+(Unaudited, in thousands, except share and per share amounts)
+These non-GAAP measures may differ from similarly titled measures used by other companies.
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Fiscal Quarters Ended | | Fiscal Years-to-Date Ended |
+| | July 5,
+2026 | | June 29,
+2025 | | July 5,
+2026 | | June 29,
+2025 |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Revenue | | $ | 9,024 | | | $ | 7,468 | | | $ | 16,624 | | | $ | 12,566 | |
+| | | | | | | | |
+Cost of revenue: | | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+GAAP cost of revenue | | $ | 7,722 | | | $ | 5,526 | | | $ | 13,770 | | | $ | 10,363 | |
+Stock-based compensation expense | | (490) | | | (356) | | | (935) | | | (477) | |
+| | | | | | | | |
+Non-GAAP cost of revenue | | $ | 7,232 | | | $ | 5,170 | | | $ | 12,835 | | | $ | 9,886 | |
+| | | | | | | | |
+GAAP gross profit | | $ | 1,302 | | | $ | 1,942 | | | $ | 2,854 | | | $ | 2,203 | |
+Stock-based compensation expense | | 490 | | | 356 | | | 935 | | | 477 | |
+| | | | | | | | |
+Non-GAAP gross profit | | $ | 1,792 | | | $ | 2,298 | | | $ | 3,789 | | | $ | 2,680 | |
+| | | | | | | | |
+GAAP research and development (R&D) expense | | $ | 24,444 | | | $ | 28,148 | | | $ | 50,972 | | | $ | 54,077 | |
+Stock-based compensation expense | | (4,620) | | | (6,941) | | | (9,690) | | | (13,296) | |
+Amortization of intangible assets | | (416) | | | (415) | | | (864) | | | (831) | |
+Non-GAAP R&D expense | | $ | 19,408 | | | $ | 20,792 | | | $ | 40,418 | | | $ | 39,950 | |
+| | | | | | | | |
+GAAP selling, general and administrative (SG&A) expense | | $ | 20,154 | | | $ | 17,527 | | | $ | 39,073 | | | $ | 34,419 | |
+Stock-based compensation expense | | (7,924) | | | (6,825) | | | (14,174) | | | (12,363) | |
+Amortization of intangible assets | | (774) | | | (773) | | | (1,607) | | | (1,547) | |
+Legal cost related to shareholder lawsuit (1)
+| | (313) | | | (1,247) | | | (2,389) | | | (2,651) | |
+| | | | | | | | |
+Acquisition cost | | — | | | (664) | | | — | | | (664) | |
+Non-GAAP SG&A expense | | $ | 11,143 | | | $ | 8,018 | | | $ | 20,903 | | | $ | 17,194 | |
+| | | | | | | | |
+GAAP operating expenses | | $ | 44,598 | | | $ | 45,675 | | | $ | 90,045 | | | $ | 88,496 | |
+Stock-based compensation expense included in R&D expense | | (4,620) | | | (6,941) | | | (9,690) | | | (13,296) | |
+Stock-based compensation expense included in SG&A expense | | (7,924) | | | (6,825) | | | (14,174) | | | (12,363) | |
+Amortization of intangible assets | | (1,190) | | | (1,188) | | | (2,471) | | | (2,378) | |
+| | | | | | | | |
+| | | | | | | | |
+Legal cost related to shareholder lawsuit (1)
+| | (313) | | | (1,247) | | | (2,389) | | | (2,651) | |
+| | | | | | | | |
+Acquisition cost | | — | | | (664) | | | — | | | (664) | |
+Non-GAAP operating expenses | | $ | 30,551 | | | $ | 28,810 | | | $ | 61,321 | | | $ | 57,144 | |
+| | | | | | | | |
+
+| | |
+|
+
+
+
+(1) These amounts reflect litigation expenses related to the defense of an ongoing securities action.
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | Fiscal Quarters Ended | | Fiscal Years-to-Date Ended |
+| | July 5,
+2026 | | June 29,
+2025 | | July 5,
+2026 | | June 29,
+2025 |
+GAAP loss from operations | | $ | (43,296) | | | $ | (43,733) | | | $ | (87,191) | | | $ | (86,293) | |
+Stock-based compensation expense | | 13,034 | | | 14,122 | | | 24,799 | | | 26,136 | |
+Amortization of intangible assets | | 1,190 | | | 1,188 | | | 2,471 | | | 2,378 | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Legal cost related to shareholder lawsuit (1)
+| | 313 | | | 1,247 | | | 2,389 | | | 2,651 | |
+| | | | | | | | |
+Acquisition cost | | — | | | 664 | | | — | | | 664 | |
+Non-GAAP loss from operations | | $ | (28,759) | | | $ | (26,512) | | | $ | (57,532) | | | $ | (54,464) | |
+| | | | | | | | |
+GAAP net loss attributable to Enovix | | $ | (43,063) | | | $ | (44,528) | | | $ | (81,323) | | | $ | (68,038) | |
+Stock-based compensation expense | | 13,034 | | | 14,122 | | | 24,799 | | | 26,136 | |
+Change in fair value of common stock warrants | | (181) | | | 5,885 | | | (6,578) | | | (9,911) | |
+| | | | | | | | |
+Amortization of intangible assets | | 1,190 | | | 1,188 | | | 2,471 | | | 2,378 | |
+| | | | | | | | |
+| | | | | | | | |
+Legal cost related to shareholder lawsuit (1)
+| | 313 | | | 1,247 | | | 2,389 | | | 2,651 | |
+| | | | | | | | |
+| | | | | | | | |
+Acquisition cost | | — | | | 664 | | | — | | | 664 | |
+| | | | | | | | |
+Gain on bargain purchase of assets | | — | | | (4,761) | | | — | | | (4,761) | |
+Import duty forgiveness | | — | | | — | | | — | | | (2,431) | |
+Non-GAAP net loss attributable to Enovix shareholders | | $ | (28,707) | | | $ | (26,183) | | | $ | (58,242) | | | $ | (53,312) | |
+| | | | | | | | |
+GAAP net loss per share attributable to Enovix, basic and diluted (2)
+| | $ | (0.20) | | | $ | (0.22) | | | $ | (0.37) | | | $ | (0.33) | |
+GAAP weighted average number of common shares outstanding, basic and diluted (2)
+| | 218,502,098 | | | 204,819,119 | | | 217,908,465 | | | 204,086,108 | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+Non-GAAP net loss per share attributable to Enovix, basic and diluted (2)
+| | $ | (0.13) | | | $ | (0.13) | | | $ | (0.27) | | | $ | (0.26) | |
+GAAP weighted average number of common shares outstanding, basic and diluted (2)
+| | 218,502,098 | | | 204,819,119 | | | 217,908,465 | | | 204,086,108 | |
+| | | | | | | | |
+| | | | | | | | |
+| | | | | | | | |
+
+| | |
+|
+
+(1) These amounts reflect litigation expenses related to the defense of an ongoing securities action.
+(2) As required by ASC 260, Earnings Per Share, the share and per share amounts presented in the above table for the fiscal quarter and fiscal year-to-date ended June 29, 2025 have been retroactively adjusted to reflect the warrant dividend issued in July 2025.\n

--- a/modules/test-fixtures/earnings-filings/infq.txt
+++ b/modules/test-fixtures/earnings-filings/infq.txt
@@ -1,0 +1,416 @@
+EX-99.1
+2
+infq-20260630xex991.htm
+EX-99.1
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+
+Infleqtion Reports Record Q2 Revenue, Raises 2026 Outlook as Quantum Commercialization Accelerates
+
+
+Rising government investment and customer demand are accelerating Infleqtion’s commercial progress across quantum computing and sensing
+
+
+• Record Revenue and Raised Outlook
+Q2 revenue of $12.6 million, up 116% year over year, 100% organic and entirely from quantum; 2026 revenue outlook raised to approximately $43 million
+
+
+• Strong Balance Sheet to Fund Growth
+Ended Q2 with $582 million in cash, cash equivalents, restricted cash and available-for-sale securities and no debt. Results included a $27.4 million temporary working-capital benefit from payroll taxes collected but not remitted on stock-option exercises. We expect to remit the $27.4 million in Q3.
+
+
+• Government Selection Validates Infleqtion’s Commercialization Path
+Commerce LOI provides for up to $100 million in proposed funding to advance commercialization following review of Infleqtion’s technology and roadmap
+
+
+• Advancing Toward Utility-Scale Quantum Computing
+On track for 30 logical qubits in 2026; Illinois quantum computer planned for 2027 with a new architecture designed to scale through modular upgrades to more than 50 logical qubits
+
+
+• Building the Quantum Computing Platform for Energy
+Eaton is using private-cloud access to Sqale for energy applications, while three DOE Genesis Mission projects span AI, nuclear applications and quantum sensing.
+
+
+
+
+LOUISVILLE, Colo.—(BUSINESS WIRE)--August 12, 2026— Infleqtion, Inc. (NYSE: INFQ) ("Infleqtion" or the "Company"), a global leader in quantum computing and quantum sensing powered by neutral-atom technology, today reported record second-quarter 2026 revenue of $12.6 million, up 116% year over year, and raised its full-year 2026 revenue outlook to approximately $43 million.
+
+
+“Q2 was a record quarter for Infleqtion, and the pace of quantum commercialization is accelerating,” said Matt Kinsella, Chief Executive Officer of Infleqtion. “Governments are putting dates and dollars behind quantum, and we are building applications with customers now as they prepare for the next generation of quantum systems. We delivered 116% revenue growth, all organic, raised our revenue outlook, and remain on track for 30 logical qubits this year. The quantum market is entering an execution phase, and Infleqtion has spent more than a decade preparing for it.”
+
+
+During and following the second quarter, Infleqtion advanced major programs across quantum computing and sensing, including proposed funding from the U.S. Department of Commerce, selection for three Department of Energy Genesis Mission projects, a contracted fault-tolerant quantum computing system for Illinois, and expanded application work with commercial customers.
+
+
+
+
+
+
+
+
+
+Second Quarter 2026 Financial Summary
+• Revenue: $12.6 million, up 116% year over year. Revenue growth was 100% organic and entirely from quantum
+
+
+• Operating Loss: GAAP operating loss was $30.6 million, compared with $10.1 million in Q2 2025. The increase primarily reflects higher operating expenses as we invest in our strategy, along with higher stock-based compensation. Non-GAAP operating loss was $17.0 million, compared with $7.3 million in Q2 2025.
+
+
+• Operating Cash Flow: Cash generated from operations was $13.2 million in Q2 2026. Results included a $27.4 million temporary working-capital benefit from payroll taxes collected but not remitted until after June 30, 2026, on stock-option exercises. Excluding this timing benefit, operating cash burn was approximately $14 million
+
+
+• Balance Sheet: Ended the quarter with $582 million in cash, cash equivalents, restricted cash and available-for-sale securities and no debt. Results included a $27.4 million temporary working-capital benefit from payroll taxes collected but not remitted on stock-option exercises. We expect to remit the $27.4 million in Q3.
+
+
+• 2026 Outlook: Raised full-year revenue outlook to approximately $43 million and reiterated the target of 30 logical qubits in 2026
+
+
+
+
+Second Quarter and Recent Business Highlights
+
+
+• U.S. Government Investment: The U.S. Department of Commerce selected Infleqtion for a Letter of Intent providing for up to $100 million in proposed funding to advance commercialization following a technical review of the Company’s technology and roadmap. The LOI also contemplates the U.S. Department of Commerce receiving Infleqtion common stock. The proposed funding remains subject to definitive agreements and government approvals.
+
+
+• 30 Logical Qubits: Infleqtion remains on track to reach 30 logical qubits in 2026 and has defined logical qubit circuits for customer workloads in finance, energy, and precision medicine.
+
+
+• Illinois Quantum Computer: Infleqtion is under contract to deploy a neutral-atom quantum computer at the Illinois Quantum & Microelectronics Park in 2027, with a new architecture designed to scale through modular upgrades to more than 50 logical qubits on the path to the system’s 100-logical-qubit goal.
+
+
+• Quantum Computing for Energy: Eaton is using private-cloud access to Sqale to explore quantum computing applications for complex energy problems. Infleqtion was also selected for three Department of Energy Genesis Mission projects spanning nuclear applications, quantum sensing, and fusion research.
+
+
+• Quantum Sensing: Execution on NASA’s Quantum Gravity Gradiometer program was a major driver of year-over-year revenue growth in Q2. Infleqtion is also selling its third-generation Tiqker optical atomic clock systems, supported by a global co-selling partnership with Safran.
+
+
+
+
+
+
+
+
+
+
+
+Conference Call Details
+
+
+The Company will host a conference call at 4:30 PM Eastern Time on August 12, 2026, to discuss financial results. The call will be webcast live on the Company’s Investor Relations website at https://ir.infleqtion.com/ in the News & Events section. An archived replay will be available shortly after the call.
+
+
+Live Call
+Domestic Dial-In: 1-877-869-3847
+International Dial-In: 1-201-689-8261
+
+
+Replay
+Domestic Dial-In: 1-877-660-6853
+International Dial-In: 1-201-612-7415
+Access ID: 13762062
+
+
+Webcast
+Event URL: https://event.webcasts.com/starthere.jsp?ei=1771468&tp_key=da7569203b
+
+
+The replay will be available approximately three hours after the conclusion of the conference call through August 26, 2026.
+
+
+
+
+Forward Looking Statements
+
+
+This press release contains forward-looking statements within the meaning of federal securities laws, including the “safe harbor” provisions of the Private Securities Litigation Reform Act of 1995. These statements may be identified by words such as “anticipates,” “believes,” “plans,” “seeks,” “will,” “on track” and variations of these words or similar expressions that are intended to identify forward-looking statements. All statements, other than statements of historical facts, including without limitation statements regarding the Company’s expected 2026 revenue, business outlook, customer demand, technology milestones, commercial opportunities, and market momentum are forward looking statements. These statements are based on Infleqtion’s current expectations, assumptions and projections as of the date of this release and are subject to risks and uncertainties that could cause actual results to differ materially and adversely. Readers are cautioned not to place undue reliance on these forward-looking statements, which speak only as of the date hereof. Such risks and uncertainties include, without limitation, those related to Infleqtion’s ability to recognize anticipated benefits of its business combination with Churchill Capital Corp X; the implementation, market acceptance, and success of Infleqtion’s business model, growth strategy, and opportunities, and its ability to commercialize its quantum computing technology; the expected benefits of and ability to maintain and enter into new contracts, awards, and other relationships, partnerships, or collaborations with governments or government entities; the potential for quantum computing technology to achieve quantum advantages; the ability of Infleqtion’s products to meet government counterparties’ and customers’ technical requirements and compliance and regulatory needs; Infleqtion’s ability to obtain and maintain intellectual property protection and not infringe on the rights of others; and other risks and uncertainties described in Infleqtion’s Annual Report on Form 10-K for the year ended December 31, 2025 and subsequent filings with the U.S. Securities and
+
+
+
+
+
+
+
+Exchange Commission. The Company undertakes no obligation to update these forward-looking statements except as required by law.
+
+
+Non-GAAP Financial Measures
+
+
+This press release includes certain non-GAAP financial measures. Infleqtion believes these measures provide investors with additional insight into the underlying performance of the business and, when considered together with the corresponding GAAP measures, assist investors in evaluating Infleqtion’s operating performance and comparing its results across reporting periods. These non-GAAP financial measures should not be considered in isolation or as substitutes for the comparable GAAP measures. In addition, these non-GAAP financial measures may not be computed in the same manner as similarly titled measures used by other companies.
+
+
+“Non-GAAP Cost of revenue” is defined as cost of revenue expense adjusted to add back, when applicable, stock-based compensation and acquisition and integration costs.
+
+
+“Non-GAAP R&D” is defined as research and development expense adjusted to add back, when applicable, stock-based compensation and acquisition and integration costs.
+
+
+“Non-GAAP SG&A” is defined as selling, general and administrative expense adjusted to add back, when applicable, stock-based compensation, acquisition and integration costs, go-public transaction expenses and former executive release payments.
+
+
+“Non-GAAP Loss from operations” is defined as loss from operations adjusted to add back, when applicable, stock-based compensation, go-public transaction expenses, acquisition and integration costs, former executive release payment and impairment of assets and goodwill.
+
+
+“Non-GAAP Net loss” is defined as net loss adjusted to add back, when applicable, stock-based compensation, go-public transaction expenses, acquisition and integration costs, change in fair value of contingent consideration, change in fair value of SAFE liabilities, former executive release payment and impairment of assets and goodwill.
+
+
+See “Reconciliation of Non-GAAP Financial Measures” in this press release for reconciliations of these non-GAAP measures to the most directly comparable GAAP measures. Management believes that Non-GAAP Cost of revenue, Non-GAAP R&D, Non-GAAP SG&A, Non-GAAP Loss from operations and Non-GAAP Net loss provide useful information to investors because they facilitate an evaluation of Infleqtion’s underlying operating performance and period-to-period comparability by excluding certain items that management believes do not directly reflect the Company’s core operations or may not be indicative of recurring operating results. Management uses these non-GAAP measures, together with the corresponding GAAP measures, to assess the operating performance of the business.
+
+
+About Infleqtion
+Infleqtion, Inc. (NYSE: INFQ) is a global leader in quantum technology, delivering neutral-atom solutions for quantum computing, networking, sensing, and security. With a product portfolio spanning quantum computers, quantum optical clocks, RF receivers, and inertial sensors, Infleqtion’s full-stack approach combines high-performance hardware with the company’s proprietary Superstaq quantum computing software platform. Infleqtion’s systems are already in use by the U.S.
+
+
+
+
+
+
+
+Department of War, NASA, the U.K. government, and in multiple collaborations with NVIDIA. Infleqtion, in collaboration with NVIDIA, published the world’s first demonstration of a materials science application using logical qubits. With operations in the U.S., Europe, and Asia, Infleqtion meets the demands of government and commercial customers across the space, defense, energy, finance and telecommunications sectors. For more information, visit Infleqtion.com or follow Infleqtion on LinkedIn, YouTube , and X .
+Investor Contact
+Marcus Kupferschmidt
+investors@infleqtion.com
+Media Contact
+Stephanie Knight
+Solebury Strategic Communications
+sknight@soleburystrat.com
+
+
+
+
+
+
+
+
+
+
+
+Infleqtion, Inc.
+Condensed Consolidated Statements of Operations and Comprehensive Loss
+(Unaudited; in thousands, except share and per share amounts)
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Total revenue | $ | 12,633 | | | $ | 5,837 | | | $ | 22,094 | | | $ | 14,140 | |
+Total cost of revenue | 11,244 | | | 4,820 | | | 18,714 | | | 9,746 | |
+Gross profit | 1,389 | | | 1,017 | | | 3,380 | | | 4,394 | |
+Research and development | 12,675 | | | 5,311 | | | 22,626 | | | 10,478 | |
+Selling, general and administrative | 19,818 | | | 6,250 | | | 46,138 | | | 12,034 | |
+Grant income | (468) | | | (471) | | | (1,173) | | | (1,095) | |
+Loss from operations | (30,636) | | | (10,073) | | | (64,211) | | | (17,023) | |
+Other income (expense): | | | | | | | |
+Interest income | 5,021 | | | 719 | | | 8,223 | | | 1,075 | |
+Other, net | 142 | | | 507 | | | 252 | | | 1,116 | |
+Total other income, net | 5,163 | | | 1,226 | | | 8,475 | | | 2,191 | |
+Loss before income taxes | (25,473) | | | (8,847) | | | (55,736) | | | (14,832) | |
+Income tax expense (benefit) | — | | | — | | | — | | | — | |
+Net loss | $ | (25,473) | | | $ | (8,847) | | | $ | (55,736) | | | $ | (14,832) | |
+Other comprehensive (loss) income: | | | | | | | |
+Unrealized loss on available-for-sale securities, net | (195) | | | — | | | (1,077) | | | — | |
+Foreign currency translation adjustment | (141) | | | (22) | | | (240) | | | 394 | |
+Total other comprehensive loss | (336) | | | (22) | | | (1,317) | | | 394 | |
+Comprehensive loss | $ | (25,809) | | | $ | (8,869) | | | $ | (57,053) | | | $ | (14,438) | |
+Net loss per share attributable to common stockholders - basic and diluted | $ | (0.12) | | | $ | (0.57) | | | $ | (0.33) | | | $ | (0.98) | |
+Weighted average shares used in computing net loss per share attributable to common stockholders – basic and diluted | 219,743,810 | | | 15,586,999 | | | 169,199,551 | | | 15,164,809 | |
+
+
+
+
+
+
+
+
+
+
+
+Infleqtion, Inc.
+Condensed Consolidated Balance Sheets
+(Unaudited; in thousands, except share and per share amounts)
+| | | | | | | | | | | |
+| As of |
+| June 30, 2026
+(Unaudited) | | December 31,
+2025 |
+ASSETS | | | |
+CURRENT ASSETS: | | | |
+Cash and cash equivalents | $ | 59,285 | | | $ | 11,694 | |
+Available-for-sale securities, current | 417,673 | | | 34,318 | |
+Accounts receivable | 5,413 | | | 9,543 | |
+Unbilled receivables | 4,147 | | | 4,734 | |
+Inventories | 5,834 | | | 4,299 | |
+Prepaid expenses and other current assets | 8,666 | | | 10,036 | |
+Total current assets | $ | 501,018 | | | $ | 74,624 | |
+Property and equipment, net | 8,684 | | | 8,674 | |
+Operating lease right-of-use assets | 13,709 | | | 4,923 | |
+Available-for-sale securities, non-current | 104,780 | | | 17,157 | |
+Goodwill | 9,315 | | | 9,315 | |
+Other assets | 4,617 | | | 620 | |
+TOTAL ASSETS | $ | 642,123 | | | $ | 115,313 | |
+LIABILITIES, CONVERTIBLE REDEEMABLE PREFERRED STOCK AND STOCKHOLDERS’ EQUITY (DEFICIT) | | | |
+CURRENT LIABILITIES: | | | |
+Accounts payable | 3,650 | | | $ | 5,644 | |
+Accrued liabilities | 45,964 | | | 8,610 | |
+Contract liabilities | 2,511 | | | 6,871 | |
+Current portion of operating lease liabilities | 1,002 | | | 1,076 | |
+Deferred consideration payable, current | — | | | 471 | |
+Total current liabilities | $ | 53,127 | | | $ | 22,672 | |
+Operating lease liabilities, net of current portion | 13,525 | | | 4,074 | |
+| | | |
+TOTAL LIABILITIES | $ | 66,652 | | | $ | 26,746 | |
+Convertible Redeemable Preferred Stock: | | | |
+Series Seed convertible redeemable preferred stock, $0.0001 par value per share | — | | | 6,526 | |
+Series Seed II convertible redeemable preferred stock; $0.0001 par value per share | — | | | 10,411 | |
+Series A convertible redeemable preferred stock, $0.0001 par value per share | — | | | 36,658 | |
+Series B convertible redeemable preferred stock; $0.0001 par value per share | — | | | 112,145 | |
+Series B-1 convertible redeemable preferred stock; $0.0001 par value per share | — | | | 32,990 | |
+Series C convertible redeemable preferred stock; $0.0001 par value per share | — | | | 71,733 | |
+Series C-1 convertible redeemable preferred stock; $0.0001 par value per share | — | | | 26,351 | |
+Total Convertible Redeemable Preferred Stock | $ | — | | | $ | 296,814 | |
+Commitments and contingencies (refer to note 9) | | | |
+Stockholders’ Equity (Deficit): | | | |
+Preferred stock: $0.0001 par value per share; 100,000,000 shares authorized; no shares issued and outstanding as of June 30, 2026 and December 31, 2025, respectively | — | | | — | |
+Common stock: $0.0001 par value per share; 1,400,000,000 shares authorized; 224,681,185 and 17,449,020 shares issued and outstanding as of June 30, 2026 and December 31, 2025, respectively | 23 | | | 2 | |
+Additional paid-in capital | 862,681 | | | 21,931 | |
+Accumulated deficit | (286,822) | | | (231,086) | |
+Accumulated other comprehensive income (loss) | (411) | | | 906 | |
+Total Stockholders' Equity (Deficit) | $ | 575,471 | | | $ | (208,247) | |
+Total Liabilities, Convertible Redeemable Preferred Stock and Stockholders’ Equity (Deficit) | $ | 642,123 | | | $ | 115,313 | |
+
+
+
+
+
+
+
+
+
+
+
+Infleqtion, Inc.
+Condensed Consolidated Statements of Cash Flows
+(Unaudited; in thousands)
+| | | | | | | | | | | |
+| Six Months Ended June 30, |
+| 2026 | | 2025 |
+Cash flows from operating activities | | | |
+Net loss | $ | (55,736) | | | $ | (14,832) | |
+Adjustments to reconcile net loss to net cash used in operating activities: | | | |
+Depreciation and amortization expense | 1,928 | | | 1,555 | |
+Stock-based compensation expense | 20,359 | | | 1,887 | |
+Change in fair value of contingent obligation | 1,472 | | | — | |
+Other non-cash operating adjustments | (2,429) | | | (807) | |
+Changes in operating assets and liabilities: | | | |
+Accounts receivable | 4,089 | | | 1,526 | |
+Unbilled receivables | 578 | | | (1,189) | |
+Inventories | (1,535) | | | (1,468) | |
+Prepaid expenses and other current assets | (3,845) | | | 671 | |
+Other assets | (75) | | | (37) | |
+Accounts payable | (1,986) | | | 4,507 | |
+Accrued liabilities | 35,205 | | | (2,237) | |
+Contract liabilities | (4,360) | | | 994 | |
+Operating lease right-of-use assets | 711 | | | 476 | |
+Operating lease liabilities | (350) | | | (773) | |
+Net cash used in operating activities | (5,974) | | | (9,727) | |
+Cash flows from investing activities | | | |
+Purchases of available-for-sale securities | (529,743) | | | — | |
+Maturities of available-for-sale securities | 60,200 | | | — | |
+Purchase of non-marketable equity investment | (3,000) | | | — | |
+Purchases of property and equipment | (1,702) | | | (1,098) | |
+Net cash used in investing activities | (474,245) | | | (1,098) | |
+Cash flows from financing activities | | | |
+Proceeds from issuance of Series C convertible redeemable preferred stock | — | | | 49,222 | |
+Proceeds from stock options and warrant exercises | 4,729 | | | 784 | |
+Payment of offering costs | (3,306) | | | — | |
+Proceeds from Business Combination, net of redemptions | 528,166 | | | — | |
+Payment of deferred cash consideration | (475) | | | (713) | |
+Net cash provided by financing activities | 529,114 | | | 49,293 | |
+Foreign currency translation | (370) | | | 1,187 | |
+Net increase in cash and cash equivalents and restricted cash | $ | 48,525 | | | $ | 39,655 | |
+Cash, cash equivalents and restricted cash at beginning of period | $ | 11,894 | | | $ | 48,142 | |
+Cash, cash equivalents and restricted cash at end of period | $ | 60,419 | | | $ | 87,797 | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+
+
+
+
+
+
+
+
+
+
+
+Infleqtion, Inc.
+Reconciliation of Non-GAAP Financial Measures
+(in thousands)
+The following is a reconciliation of non-GAAP measures of Infleqtion, Inc. for the three and six ended June 30, 2026 and 2025:
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Cost of revenue | $ | 11,244 | | | $ | 4,820 | | | $ | 18,714 | | | $ | 9,746 | |
+Adjustments: | | | | | | | |
+Stock-based compensation | 1,821 | | | 109 | | | 2,838 | | | 201 | |
+Acquisition and integration costs | — | | | — | | | — | | | — | |
+Non-GAAP Cost of revenue | $ | 9,423 | | | $ | 4,711 | | | $ | 15,876 | | | $ | 9,545 | |
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Research and development expense | $ | 12,675 | | | $ | 5,311 | | | $ | 22,626 | | | $ | 10,478 | |
+Adjustments: | | | | | | | |
+Stock-based compensation | 4,820 | | | 116 | | | 7,234 | | | 188 | |
+Acquisition and integration costs | — | | | — | | | — | | | — | |
+Non-GAAP R&D | $ | 7,855 | | | $ | 5,195 | | | $ | 15,392 | | | $ | 10,290 | |
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Selling, general and administrative expense | $ | 19,818 | | | $ | 6,250 | | | $ | 46,138 | | | $ | 12,034 | |
+Adjustments: | | | | | | | |
+Stock-based compensation | 5,425 | | | 544 | | | 10,287 | | | 1,498 | |
+Acquisition and integration costs | 841 | | | 2,000 | | | 1,472 | | | 2,000 | |
+Go-public transaction expenses | — | | | — | | | 11,466 | | | — | |
+Former executive release payment | 750 | | | — | | | 750 | | | — | |
+Non-GAAP SG&A | $ | 12,802 | | | $ | 3,706 | | | $ | 22,163 | | | $ | 8,536 | |
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Loss from operations | $ | (30,636) | | | $ | (10,073) | | | $ | (64,211) | | | $ | (17,023) | |
+Adjustments: | | | | | | | |
+Stock-based compensation | 12,066 | | | 769 | | | 20,359 | | | 1,887 | |
+Acquisition and integration costs | 841 | | | 2,000 | | | 1,472 | | | 2,000 | |
+Go-public transaction expenses | — | | | — | | | 11,466 | | | — | |
+Former executive release payment | 750 | | | — | | | 750 | | | — | |
+Non-GAAP Loss from operations | $ | (16,979) | | | $ | (7,304) | | | $ | (30,164) | | | $ | (13,136) | |
+
+
+
+
+
+
+
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended June 30, | | Six Months Ended June 30, |
+| 2026 | | 2025 | | 2026 | | 2025 |
+Net loss | $ | (25,473) | | | $ | (8,847) | | | $ | (55,736) | | | $ | (14,832) | |
+Adjustments: | | | | | | | |
+Stock-based compensation | 12,066 | | | 769 | | | 20,359 | | | 1,887 | |
+Acquisition and integration costs | 841 | | | 2,000 | | | 1,472 | | | 2,000 | |
+Go-public transaction expenses | — | | | — | | | 11,466 | | | — | |
+Former executive release payment | 750 | | | — | | | 750 | | | — | |
+Non-GAAP Net loss | $ | (11,816) | | | $ | (6,078) | | | $ | (21,689) | | | $ | (10,945) | |\n


### PR DESCRIPTION
Corrects result and outlook parsing for Cisco, Cerebras, Coherent, Allogene, Enovix, and Infleqtion. Adds focused mutation-tested coverage plus the complete audited SEC exhibits to the 70-filing regression corpus.\n\nValidation:\n- npm audit --audit-level=high\n- npm run lint\n- npm run test:coverage\n- npm run typecheck