### PR TITLE
Harden earnings parsing for Ascendis and Applied Materials

### DIFF
--- a/modules/earnings-results-corpus.test.ts
+++ b/modules/earnings-results-corpus.test.ts
@@ -1207,6 +1207,39 @@ const filingCorpus: {
     source: "1508478/000095010326012286/dp251668_6k.htm",
     ticker: "arco",
   },
+  {
+    // Legacy &#128; entities carry euros under HTML's Windows-1252 numeric-reference rules.
+    // Product and branded-drug revenue precede the consolidated total, while the prior-year
+    // net loss follows the current net profit in the same sentence.
+    company: "Ascendis Pharma",
+    metrics: [
+      ["gaap_eps", "€2.83"],
+      ["revenue", "€339M"],
+      ["net_income", "€207M"],
+    ],
+    outlook: [],
+    quarterLabel: "Q2 2026",
+    source: "1612042/000119312526348046/d31437dex991.htm",
+    ticker: "asnd",
+  },
+  {
+    // Guidance is expressed as midpoint +/- variance. The following explanatory sentence
+    // lists per-share exclusions that are adjustments, not the outlook itself.
+    company: "Applied Materials",
+    metrics: [
+      ["adjusted_eps", "$3.50"],
+      ["gaap_eps", "$3.17"],
+      ["revenue", "$9.12B"],
+      ["net_income", "$2.54B"],
+    ],
+    outlook: [
+      ["Revenue", "$9.75B to $10.75B"],
+      ["Adj EPS", "$3.82 to $4.22"],
+    ],
+    quarterLabel: "Q3 2026",
+    source: "6951/000162828026056699/exhibit991q32026earningsre.htm",
+    ticker: "amat",
+  },
 ];
 
 describe("earnings result filing corpus", () => {
@@ -1227,6 +1260,6 @@ describe("earnings result filing corpus", () => {
   }
 
   test("covers every stored fixture", () => {
-    expect(filingCorpus).toHaveLength(77);
+    expect(filingCorpus).toHaveLength(79);
   });
 });

--- a/modules/earnings-results-document.test.ts
+++ b/modules/earnings-results-document.test.ts
@@ -29,6 +29,11 @@ describe("earnings result document text", () => {
     );
   });
 
+  test("decodes legacy Windows-1252 numeric entities used by SEC exhibits", () => {
+    expect(decodeHtmlEntities("Revenue &#128;339 million &#x96; up year over year"))
+      .toBe("Revenue €339 million – up year over year");
+  });
+
   test("removes zero-width placeholders from otherwise-empty table cells", () => {
     expect(htmlToText("<tr><td>Loss per share</td><td>\u200B</td><td>$(0.10)</td></tr>"))
       .toBe("Loss per share | | $(0.10) |");

--- a/modules/earnings-results-document.ts
+++ b/modules/earnings-results-document.ts
@@ -50,9 +50,28 @@ export function decodeHtmlEntities(value: string): string {
     .replace(/&gt;/gi, ">")
     .replace(/&quot;/gi, "\"")
     .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_match, hexValue: string) => String.fromCodePoint(Number.parseInt(hexValue, 16)))
-    .replace(/&#([0-9]+);/g, (_match, numericValue: string) => String.fromCodePoint(Number.parseInt(numericValue, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_match, hexValue: string) => decodeNumericHtmlEntity(hexValue, 16))
+    .replace(/&#([0-9]+);/g, (_match, numericValue: string) => decodeNumericHtmlEntity(numericValue, 10))
     .replace(/&amp;/gi, "&");
+}
+
+// HTML numeric references in the C1 control range are decoded through Windows-1252,
+// even when the document itself is ASCII. Older SEC exhibits rely on that rule and emit
+// the euro sign as &#128;; converting it directly to Unicode U+0080 loses the currency.
+const windows1252CodePointByNumericReference = new Map<number, number>([
+  [0x80, 0x20AC], [0x82, 0x201A], [0x83, 0x0192], [0x84, 0x201E],
+  [0x85, 0x2026], [0x86, 0x2020], [0x87, 0x2021], [0x88, 0x02C6],
+  [0x89, 0x2030], [0x8A, 0x0160], [0x8B, 0x2039], [0x8C, 0x0152],
+  [0x8E, 0x017D], [0x91, 0x2018], [0x92, 0x2019], [0x93, 0x201C],
+  [0x94, 0x201D], [0x95, 0x2022], [0x96, 0x2013], [0x97, 0x2014],
+  [0x98, 0x02DC], [0x99, 0x2122], [0x9A, 0x0161], [0x9B, 0x203A],
+  [0x9C, 0x0153], [0x9E, 0x017E], [0x9F, 0x0178],
+]);
+
+function decodeNumericHtmlEntity(value: string, radix: number): string {
+  const numericReference = Number.parseInt(value, radix);
+  const codePoint = windows1252CodePointByNumericReference.get(numericReference) ?? numericReference;
+  return String.fromCodePoint(codePoint);
 }
 
 export function getMeaningfulLines(text: string): string[] {

--- a/modules/earnings-results-format-selection.ts
+++ b/modules/earnings-results-format-selection.ts
@@ -135,6 +135,11 @@ export function getMetricCandidateScore({
     } else if (/\btotal\s+revenues?\b/i.test(patternMatch?.[0] ?? "") &&
         2 <= revenueComponentKinds) {
       score += 100;
+    } else if (/\btotal\s+revenues?\s+for\s+(?:the\s+)?(?:q[1-4]|first|second|third|fourth|three[-\s]+months?)\b/i.test(metricLine)) {
+      // A current-period headline that explicitly says "Total revenue" is consolidated;
+      // individual products in the same release can each carry an equally specific quarter
+      // label and otherwise tie it on score merely because they appear first.
+      score += 40;
     } else if (/\b(?:net\s+)?product\s+sales\b|\bservice\s+revenues?\b/i.test(metricCaptionText)) {
       score -= 80;
     }

--- a/modules/earnings-results-metrics.ts
+++ b/modules/earnings-results-metrics.ts
@@ -130,6 +130,7 @@ export const earningsMetricDefinitions: MetricDefinition[] = [
       /\bnet\s+earnings(?!\s+per\s+(?:common\s+)?share)\b/i,
       /\bnet\s+\(loss(?:es)?\)\s+income\b/i,
       /\bnet\s+income\s*\/\s*\(loss(?:es)?\)(?!\s+per\s+(?:common\s+)?share)/i,
+      /\bnet\s+profit(?!\s+per\s+(?:common\s+)?share)\b/i,
       // Singular only: "net losses of a customer portfolio" is risk-factor prose, not the
       // income-statement row a loss-making filer labels "Net loss".
       /\bnet\s+loss(?!\s*(?:es\b|\s+per\s+(?:common\s+)?share))\b/i,

--- a/modules/earnings-results-outlook.test.ts
+++ b/modules/earnings-results-outlook.test.ts
@@ -566,6 +566,27 @@ describe("extractOutlookMetrics", () => {
     ]);
   });
 
+  test("converts midpoint-plus-minus rows to ranges and ignores adjustment footnotes", () => {
+    expect(extractOutlookMetrics([
+      "Business Outlook",
+      "Q4 FY2026",
+      "(In millions, except per share amounts)",
+      "Total revenue | | | $ | 10,250 | | +/- | $ | 500 | | | | | | | | | | | | | |",
+      "Non-GAAP diluted EPS | | | $ | 4.02 | | +/- | $ | 0.20 | | | | | | | | | | | | | |",
+      "This outlook for non-GAAP diluted EPS excludes known acquisition charges of $0.01 per share, includes a normalized tax benefit of $0.01 per share, and includes other tax benefits of $0.05 per share.",
+    ])).toEqual([
+      {key: "revenue", label: "Revenue", value: "$9.75B to $10.75B"},
+      {key: "adjusted_eps", label: "Adj EPS", value: "$3.82 to $4.22"},
+    ]);
+  });
+
+  test("does not publish per-share adjustments from an outlook explanation", () => {
+    expect(extractOutlookMetrics([
+      "Business Outlook",
+      "This outlook for non-GAAP diluted EPS excludes known acquisition charges of $0.01 per share, includes a normalized tax benefit of $0.01 per share, and includes other tax benefits of $0.05 per share.",
+    ])).toEqual([]);
+  });
+
   test("keeps core guidance separated across quarter and full-year sections", () => {
     expect(extractOutlookMetrics([
       "Third Quarter 2026 Financial Outlook",

--- a/modules/earnings-results-outlook.ts
+++ b/modules/earnings-results-outlook.ts
@@ -60,6 +60,7 @@ const moneyUnitPatternSource = String.raw`(?:trillions?|billions?|millions?|thou
 // token so the scale and negative sign survive range parsing.
 const moneyTokenPatternSource = String.raw`(?<![\d.])\(?\s*(?:(?:C\s*\$|[$€£¥])\s*|(?:(?:USD|CAD|EUR|GBP|JPY|CHF)\s+))?-?\d+(?:,\d{3})*(?:\.\d+)?\s*\)?\s*(?:${moneyUnitPatternSource})?\)?`;
 const moneyRangePattern = new RegExp(`(${moneyTokenPatternSource})\\s*(?:to|through|-|–|and)\\s*(${moneyTokenPatternSource})`, "gi");
+const moneyPlusMinusPattern = new RegExp(`(${moneyTokenPatternSource})\\s*(?:\\+\\s*\\/\\s*-|±|plus\\s+or\\s+minus)\\s*(${moneyTokenPatternSource})`, "i");
 const singleMoneyPattern = new RegExp(moneyTokenPatternSource, "gi");
 
 // Held separately because a plainly captioned per-share row is relabelled to it when the
@@ -679,6 +680,12 @@ function isHistoricalOutlookMetricLine(line: string): boolean {
 }
 
 function isNoisyOutlookLine(line: string): boolean {
+  // An explanatory footnote states the size of adjustments excluded from guidance. Its
+  // per-share amounts are not themselves the guided measure.
+  if (/^\s*(?:this\s+)?(?:outlook|guidance)\b.{0,160}\b(?:excludes?|includes?)\b.{0,160}\b(?:charges?|benefits?|expenses?|items?|tax)\b/i.test(line)) {
+    return true;
+  }
+
   const pipeCount = line.match(/\|/g)?.length ?? 0;
   // SEC inline-XBRL tables often render a two-column row with empty spacer cells:
   // "Adjusted EBITDA | | $181M to $191M | |". Count populated numeric cells rather
@@ -689,7 +696,10 @@ function isNoisyOutlookLine(line: string): boolean {
     .filter(cell => /\d/.test(cell))
     .length;
   const isSparseTwoColumnRow = 4 === pipeCount && 1 === populatedNumericCells;
-  return (pipeCount >= 4 && false === isSparseTwoColumnRow) ||
+  const isPlusMinusGuidanceRow = 4 <= pipeCount &&
+    2 === populatedNumericCells &&
+    /\+\s*\/\s*-|±|plus\s+or\s+minus/i.test(line);
+  return (pipeCount >= 4 && false === isSparseTwoColumnRow && false === isPlusMinusGuidanceRow) ||
     /\bpost[-\s]?20\d{2}\b.*\bcompound\s+annual\s+growth\s+rate\b/i.test(line);
 }
 
@@ -722,6 +732,7 @@ function extractOutlookValue(
     const value = ("tax_rate" === metricKey
       ? getBasisSpecificTaxRateValue(line, valueText)
       : null) ??
+      getPlusMinusOutlookValue(valueText, valueType, documentCurrencyCode, sectionMoneyUnit) ??
       ("eps" === valueType
         ? getOutlookRangeValue(valueText, valueType, documentCurrencyCode, sectionMoneyUnit)
         : null) ??
@@ -739,6 +750,62 @@ function extractOutlookValue(
   }
 
   return null;
+}
+
+function getPlusMinusOutlookValue(
+  value: string,
+  valueType: OutlookValueType,
+  documentCurrencyCode: string,
+  sectionMoneyUnit?: string,
+): string | null {
+  const flattenedValue = value.replace(/\s*\|\s*/g, " ").replace(/\s+/g, " ");
+  if ("percent" === valueType) {
+    const percentMatch = flattenedValue.match(
+      /(\(?-?\d+(?:\.\d+)?\s*%\)?)\s*(?:\+\s*\/\s*-|±|plus\s+or\s+minus)\s*(\(?-?\d+(?:\.\d+)?\s*%\)?)/i,
+    );
+    const midpoint = parseNumber(percentMatch?.[1]);
+    const variance = parseNumber(percentMatch?.[2]);
+    return null !== midpoint && null !== variance
+      ? `${formatPercent(midpoint - Math.abs(variance))} to ${formatPercent(midpoint + Math.abs(variance))}`
+      : null;
+  }
+
+  const plusMinusMatch = moneyPlusMinusPattern.exec(flattenedValue);
+  const midpointToken = plusMinusMatch?.[1];
+  const varianceToken = plusMinusMatch?.[2];
+  if (undefined === midpointToken || undefined === varianceToken) {
+    return null;
+  }
+
+  if ("eps" === valueType) {
+    const midpoint = parseNumber(midpointToken);
+    const variance = parseNumber(varianceToken);
+    return null !== midpoint && null !== variance
+      ? `${formatEps(midpoint - Math.abs(variance), documentCurrencyCode)} to ${formatEps(midpoint + Math.abs(variance), documentCurrencyCode)}`
+      : null;
+  }
+
+  if (false === ("money" === valueType || "text" === valueType)) {
+    return null;
+  }
+
+  const inferredUnit = getMoneyUnit(varianceToken) ??
+    getMoneyUnit(midpointToken) ??
+    sectionMoneyUnit;
+  if (undefined === inferredUnit &&
+      false === hasMoneyValueCue(midpointToken) &&
+      false === hasMoneyValueCue(varianceToken)) {
+    return null;
+  }
+
+  const inferredCurrencyCode = getCurrencyCodeFromText(varianceToken, documentCurrencyCode) ??
+    getCurrencyCodeFromText(midpointToken, documentCurrencyCode) ??
+    documentCurrencyCode;
+  const midpoint = parseMoneyWithOptionalUnit(midpointToken, inferredUnit, inferredCurrencyCode);
+  const variance = parseMoneyWithOptionalUnit(varianceToken, inferredUnit, inferredCurrencyCode);
+  return null !== midpoint && null !== variance
+    ? `${formatMoneyCompact(midpoint.value - Math.abs(variance.value), midpoint.currencyCode)} to ${formatMoneyCompact(midpoint.value + Math.abs(variance.value), midpoint.currencyCode)}`
+    : null;
 }
 
 function applyOutlookLossSign(

--- a/modules/test-fixtures/earnings-filings/amat.txt
+++ b/modules/test-fixtures/earnings-filings/amat.txt
@@ -1,0 +1,771 @@
+EX-99.1
+2
+exhibit991q32026earningsre.htm
+EX-99.1 EARNINGS RELEASE
+
+
+
+
+Document
+
+
+
+Exhibit 99.1
+
+
+
+Investor Relations Contact:
+Mike Sullivan (408) 986-7977
+mike_sullivan@amat.com
+
+
+Media Contact:
+Ricky Gradwohl (408) 235-4676
+ricky_gradwohl@amat.com
+
+
+
+
+
+
+APPLIED MATERIALS ANNOUNCES THIRD QUARTER 2026 RESULTS
+
+• Record revenue $9.12 billion, up 25 percent year over year
+• GAAP gross margin 50.3 percent and non-GAAP gross margin 50.4 percent
+• GAAP EPS $3.17 and record non-GAAP EPS $3.50, up 43 percent and 41 percent year over year, respectively
+• EPIC Center R&D partnerships expand to 11 engagements with leading chipmakers, universities and innovation partners
+SANTA CLARA, Calif., Aug. 13, 2026 — Applied Materials, Inc. (NASDAQ: AMAT) today reported results for its third quarter ended July 26, 2026.
+Third Quarter Results
+Applied generated record revenue of $9.12 billion. On a GAAP basis, the company reported gross margin of 50.3 percent, record operating income of $3.08 billion or 33.7 percent of revenue, and earnings per share (EPS) of $3.17.
+On a non-GAAP basis, the company reported gross margin of 50.4 percent, record operating income of $3.10 billion or 34.0 percent of revenue, and record EPS of $3.50.
+The company generated record cash from operations of $3.04 billion and distributed $860 million to shareholders through $440 million in share repurchases and $420 million in dividends.
+“Applied Materials delivered another record-breaking quarter, including the highest sequential revenue growth in the company’s history,” said Gary Dickerson, President and CEO. “As the rapid global adoption of AI drives unprecedented demand for our materials engineering solutions, we are further raising our Semiconductor Systems revenue expectations for calendar 2026 and are confident we will grow faster than the market this year. Based on the increased demand visibility we are receiving from our customers, we expect another strong growth year for Applied Materials in 2027.”
+“Applied Materials achieved its 13th consecutive quarter of year-over-year gross margin expansion, demonstrating the increasing value we create by enabling better chips, systems and fab returns,” said Brice Hill, Senior Vice President and CFO. “We expect continued strong revenue growth in the second half of the calendar year, particularly in DRAM as well as leading-edge foundry-logic and advanced packaging. Looking further ahead, we are making additional manufacturing capacity investments to support projected demand through the end of the decade.”
+
+
+
+
+Applied Materials, Inc.
+Page 2 of 14
+
+
+
+Results Summary
+| | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | |
+| Q3 FY2026 | | | | Q3 FY2025 | | | | | | Change |
+| | | | | | | | | | | | | | | |
+| (In millions, except per share amounts and percentages) |
+| | | | | | | | | | | | | | | |
+Revenue | $ | 9,115 | | | | | $ | 7,302 | | | | | | | 25% | | | | |
+| | | | | | | | | | | | | | | |
+Gross margin | 50.3 | % | | | | 48.8 | % | | | | | | 1.5 points | | | | |
+| | | | | | | | | | | | | | | |
+Operating margin | 33.7 | % | | | | 30.6 | % | | | | | | 3.1 points | | | | |
+Net income | $ | 2,538 | | | | | $ | 1,779 | | | | | | | 43% | | | | |
+Diluted earnings per share | $ | 3.17 | | | | | $ | 2.22 | | | | | | | 43% | | | | |
+Non-GAAP Results | | | | | | | | | | | | | | | |
+Non-GAAP gross margin | 50.4 | % | | | | 48.9 | % | | | | | | 1.5 points | | | | |
+Non-GAAP operating margin | 34.0 | % | | | | 30.7 | % | | | | | | 3.3 points | | | | |
+Non-GAAP net income | $ | 2,795 | | | | | $ | 1,989 | | | | | | | 41% | | | | |
+Non-GAAP diluted EPS | $ | 3.50 | | | | | $ | 2.48 | | | | | | | 41% | | | | |
+Non-GAAP free cash flow | $ | 2,330 | | | | | $ | 2,050 | | | | | | | 14% | | | | |
+
+A reconciliation of the GAAP and non-GAAP results is provided in the financial tables included in this release. See also “Use of Non-GAAP Financial Measures” section.
+
+Recent Highlights
+New Products and Technologies
+• Introduced six new chipmaking systems for DRAM and advanced packaging.
+• Enhanced Centura™ Prime™ Epi: selectively grows doped silicon germanium and silicon phosphorous in transistor source/drain regions, combining advanced strain engineering with precise doping control. The result is higher drive current and transistor efficiency, enabling faster, more power-efficient DRAM and high bandwidth memory (HBM).
+• Opta™ Quad CMP: engineered specifically for advanced packaging, the Opta Quad continuously monitors wafer conditions during polish and dynamically adjusts in real time, improving within-wafer uniformity and total thickness variation control, which is particularly critical for hybrid bonding.
+• Nokota™ VMax™ 2 ECD: high-precision copper plating across a broad range of applications for next-generation packaging, from TSV fill for 3D stacking to fine-pitch interconnects such as microbump formation. Nokota VMax 2 introduces Adaptive Pattern Tuning (APT), which dynamically shapes the electric field to correct for layout-driven variation and improve plating uniformity across the wafer.
+• Producer™ Avila™ 2 PECVD: improves the mechanical stability of ultra-thin DRAM dies by depositing stress-balanced dielectric films around TSVs, enabling reliable stacking of 12, 16 and future high-layer-count HBM designs.
+• VeritySEM™ 7AP Metrology: critical dimension eBeam metrology enables precise measurement of features on thick, heterogeneous and highly warped substrates common in HBM and chiplet architectures. VeritySEM AP systems automatically reconfigure to support a range of sizes and materials, while delivering sub-10nm sensitivity—orders of magnitude better than optical tools.
+• SEMVision™ G7AP Defect Analysis: extends Applied’s leadership in eBeam defect analysis into advanced packaging, enabling high-resolution defect review and automated classification across silicon, organic and glass substrates. The system can accelerate yield learning by helping customers quickly distinguish critical defects from nuisance signals.
+
+
+
+
+Applied Materials, Inc.
+Page 3 of 14
+
+• Introduced new deposition and etch systems that help chipmakers extend scaling in logic and memory to deliver higher performance, improved energy efficiency and better manufacturing yield for next-generation AI chips.
+• Centris™ Spectral™ SiN ALD: leverages innovative microwave plasma technology to deliver uniform silicon nitride deposition in challenging 3D structures.
+• Producer™ Selectra™ Mo Etch: selectively removes molybdenum for wordline separation to enable 3D NAND scaling.
+• Unveiled SENZ™, an integrated ambient visual platform that combines waveguide optics, light engine, sensing, vision correction and electronic dimming technology in a single system designed for AI-powered next-generation display smart glasses.
+Corporate Initiatives
+• Announced three additional EPIC Center partnerships. The EPIC Center is designed to dramatically reduce the time it takes to commercialize breakthrough technologies from early-stage research to full-scale manufacturing.
+• Broadcom Inc. will join EPIC as an innovation partner to accelerate development of advanced chip packaging technologies critical to next-generation AI systems.
+• The University of California, Berkeley will join the EPIC Center as a research collaborator. Working side by side with Applied’s scientists and engineers, UC Berkeley faculty and students will pursue high-impact research programs to accelerate the material and process innovations that are foundational to AI computing.
+• SCREEN Semiconductor Solutions Co., Ltd. (SCREEN SPE) will join the EPIC Center as an innovation partner, bringing together SCREEN SPE’s expertise in wafer cleaning technology with Applied's leadership in materials engineering to develop co-optimized process solutions for the world’s most advanced chips.
+• Expanded our manufacturing and R&D operations in Singapore to support the global build-out of AI infrastructure. The new US$500 million Tampines Campus more than doubles Applied’s advanced cleanroom capacity in Singapore and strengthens the company’s global manufacturing footprint.
+• Announced a long-term joint development agreement with EssilorLuxottica to accelerate the commercialization of next-generation intelligent optical systems for augmented reality and AI-powered smart eyewear.
+• Published our latest Impact Report highlighting how Applied is progressing toward its sustainability goals and helping reduce the resources required to manufacture the semiconductors and technologies that support more energy-efficient computing in use.
+
+
+
+
+
+Applied Materials, Inc.
+Page 4 of 14
+
+Business Outlook
+Applied’s total revenue and non-GAAP diluted EPS for the fourth quarter of fiscal 2026 are expected to be as follows:
+| | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+| | | Q4 FY2026 | | | | | | | | | | | | |
+(In millions, except per share amounts) | | | | | | | | | | | | | |
+Total revenue | | | $ | 10,250 | | +/- | $ | 500 | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Non-GAAP diluted EPS | | | $ | 4.02 | | +/- | $ | 0.20 | | | | | | | | | | | | | |
+
+This outlook for non-GAAP diluted EPS excludes known charges related to completed acquisitions of $0.01 per share, includes the normalized tax benefit of share-based compensation of $0.01 per share and includes a net income tax benefit related to intra-entity intangible asset transfers of $0.05 per share, but does not reflect any items that are unknown at this time, such as any additional charges related to acquisitions or other non-operational or unusual items, as well as other tax-related items, which we are not able to predict without unreasonable efforts due to their inherent uncertainty.
+
+Third Quarter Reportable Segment Information
+Effective in the first quarter of fiscal 2026, management moved our 200-millimeter equipment business to Semiconductor Systems. The business was previously included in Applied Global Services. Additionally, effective in the first quarter of fiscal 2026, management began fully allocating corporate support costs to our operating segments. Prior-period numbers have been recast to conform to the current-year presentation. Display operating segment financial results are included in the Other category balances below.
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+Semiconductor Systems | Q3 FY2026 | | | | Q3 FY2025 | | | | | | | | |
+(in millions, except percentages) | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Revenue | $ | 7,040 | | | | | $ | 5,564 | | | | | | | | | | | | | |
+Foundry, logic and other | 67 | % | | | | 69 | % | | | | | | | | | | | | |
+DRAM | 26 | % | | | | 22 | % | | | | | | | | | | | | |
+Flash memory | 7 | % | | | | 9 | % | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Gross margin | 55.3 | % | | | | 53.4 | % | | | | | | | | | | | | |
+Operating income | $ | 2,657 | | | | | $ | 1,837 | | | | | | | | | | | | | |
+Operating margin | 37.7 | % | | | | 33.0 | % | | | | | | | | | | | | |
+Non-GAAP Results | | | | | | | | | | | | | | | | |
+Non-GAAP gross margin | 55.4 | % | | | | 53.5 | % | | | | | | | | | | | | |
+Non-GAAP operating income | $ | 2,673 | | | | | $ | 1,849 | | | | | | | | | | | | | |
+Non-GAAP operating margin | 38.0 | % | | | | 33.2 | % | | | | | | | | | | | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+Applied Global Services | Q3 FY2026 | | | | Q3 FY2025 | | | | | | | | |
+(in millions, except percentages) | | | | | |
+| | | | | | | | | | | | | | | | | |
+Revenue | $ | 1,781 | | | | | $ | 1,463 | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | | | |
+Gross margin | 35.6 | % | | | | 33.8 | % | | | | | | | | | | | | |
+Operating income | $ | 536 | | | | | $ | 400 | | | | | | | | | | | | | |
+Operating margin | 30.1 | % | | | | 27.3 | % | | | | | | | | | | | | |
+Non-GAAP Results | | | | | | | | | | | | | | | | |
+Non-GAAP gross margin | 35.6 | % | | | | 33.8 | % | | | | | | | | | | | | |
+Non-GAAP operating income | $ | 536 | | | | | $ | 400 | | | | | | | | | | | | | |
+Non-GAAP operating margin | 30.1 | % | | | | 27.3 | % | | | | | | | | | | | | |
+
+| | | | | | | | | | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+Other | Q3 FY2026 | | | | Q3 FY2025 | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+(in millions) | | | | | | | | | | | | | | | |
+Revenue | $ | 294 | | | | | $ | 275 | | | | | | | | | | | |
+Cost of products sold and expenses | (412) | | | | | (279) | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+| | | | | | | | | | | | | | | |
+Operating income (loss) | $ | (118) | | | | | $ | (4) | | | | | | | | | | | |
+
+
+
+
+
+
+Applied Materials, Inc.
+Page 5 of 14
+
+Use of Non-GAAP Financial Measures
+Applied provides investors with certain non-GAAP financial measures, which are adjusted for the impact of certain costs, expenses, gains and losses, including, as applicable, certain items related to mergers and acquisitions; restructuring and severance charges and any associated adjustments; legal settlement charges; impairments of assets; gain or loss, dividends and impairments on strategic investments; certain income tax items; and other discrete adjustments. On a non-GAAP basis, the tax effect related to share-based compensation is recognized ratably over the fiscal year. Reconciliations of these non-GAAP measures to the most directly comparable financial measures calculated and presented in accordance with GAAP are provided in the financial tables included in this release.
+Management uses these non-GAAP financial measures to evaluate the company’s operating and financial performance and for planning purposes, and as performance measures in its executive compensation program. Applied believes these measures enhance an overall understanding of its performance and investors’ ability to review the company’s business from the same perspective as the company’s management, and facilitate comparisons of this period’s results with prior periods on a consistent basis by excluding items that management does not believe are indicative of Applied's ongoing operating performance. There are limitations in using non-GAAP financial measures because the non-GAAP financial measures are not prepared in accordance with generally accepted accounting principles, may be different from non-GAAP financial measures used by other companies, and may exclude certain items that may have a material impact upon our reported financial results. The presentation of this additional information is not meant to be considered in isolation or as a substitute for the directly comparable financial measures prepared in accordance with GAAP.
+Webcast Information
+Applied Materials will discuss these results during an earnings call that begins at 1:30 p.m. Pacific Time today. A live webcast and related slide presentation will be available at https://ir.appliedmaterials.com . A replay will be available on the website beginning at 5:00 p.m. Pacific Time today.
+
+
+
+
+
+Applied Materials, Inc.
+Page 6 of 14
+
+
+
+Forward-Looking Statements
+This press release contains forward-looking statements, including those regarding anticipated growth and trends in our businesses and markets, industry outlooks and demand drivers, technology transitions, our business and financial performance and market share positions, our capital allocation and cash deployment strategies, our investment and growth strategies, our development of new products and technologies, the plans and expectations for the EPIC Center, legal matters, our business outlook for the fourth quarter of fiscal 2026 and beyond, and other statements that are not historical facts. These statements and their underlying assumptions are subject to risks and uncertainties and are not guarantees of future performance. Factors that could cause actual results to differ materially from those expressed or implied by such statements include, without limitation: the level of demand for our products; global economic, political and industry conditions, including changes in interest rates and prices for goods and services; global trade issues, changes in trade and export regulations, license requirements, and their interpretation, and our ability to obtain licenses or authorizations on a timely basis, if at all; changes in tariffs, any retaliatory measures, and our ability to mitigate the impact of tariffs; the effects of geopolitical turmoil or conflicts; demand for semiconductor chips and electronic devices; customers’ technology and capacity requirements; the introduction of new and innovative technologies, and the timing of technology transitions; our ability to develop, deliver and support new products and technologies; our ability to meet customer demand, and our suppliers’ ability to meet our demand requirements; the concentrated nature of our customer base; our ability to expand our current markets, increase market share and develop new markets; market acceptance of existing and newly developed products; our ability to obtain and protect intellectual property rights in key technologies; cybersecurity incidents affecting us or our suppliers, customers or vendors; our ability to achieve the objectives of operational and strategic initiatives, align our resources and cost structure with business conditions, and attract, motivate and retain key employees; acquisitions, investments and divestitures; changes in income tax laws; the variability of operating expenses and results among products and segments, and our ability to accurately forecast future results, market conditions, customer requirements and business needs; our ability to ensure compliance with applicable law, rules and regulations; and other risks and uncertainties described in our filings with the Securities and Exchange Commission, including our most recent Forms 10-K, 10-Q and 8-K. All forward-looking statements are based on management’s current estimates, projections and assumptions, and we assume no obligation to update them.
+About Applied Materials
+Applied Materials, Inc. (Nasdaq: AMAT) is the leader in materials engineering solutions that are at the foundation of virtually every new semiconductor and advanced display in the world. The technology we create is essential to advancing AI and accelerating the commercialization of next-generation chips. At Applied, we push the boundaries of science and engineering to deliver material innovation that changes the world. Learn more at www.appliedmaterials.com .
+
+
+
+
+
+Applied Materials, Inc.
+Page 7 of 14
+
+
+
+
+APPLIED MATERIALS, INC.
+UNAUDITED CONSOLIDATED CONDENSED STATEMENTS OF OPERATIONS
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Nine Months Ended |
+(In millions, except per share amounts) | July 26,
+2026 | | | | July 27,
+2025 | | July 26,
+2026 | | July 27,
+2025 |
+Revenue | $ | 9,115 | | | | | $ | 7,302 | | | $ | 24,037 | | | $ | 21,568 | |
+Cost of products sold | 4,529 | | | | | 3,740 | | | 12,069 | | | 11,025 | |
+Gross profit | 4,586 | | | | | 3,562 | | | 11,968 | | | 10,543 | |
+Operating expenses: | | | | | | | | | |
+Research, development and engineering | 1,100 | | | | | 901 | | | 3,055 | | | 2,653 | |
+Marketing and selling | 249 | | | | | 224 | | | 704 | | | 646 | |
+General and administrative | 162 | | | | | 204 | | | 515 | | | 667 | |
+| | | | | | | | | |
+| | | | | | | | | |
+Legal settlement | — | | | | | — | | | 253 | | | — | |
+Restructuring charges | — | | | | | — | | | 12 | | | — | |
+| | | | | | | | | |
+Total operating expenses | 1,511 | | | | | 1,329 | | | 4,539 | | | 3,966 | |
+Income from operations | 3,075 | | | | | 2,233 | | | 7,429 | | | 6,577 | |
+| | | | | | | | | |
+Interest expense | 68 | | | | | 66 | | | 206 | | | 198 | |
+Interest and other income (expense), net | (100) | | | | | 396 | | | 1,237 | | | 625 | |
+Income before income taxes | 2,907 | | | | | 2,563 | | | 8,460 | | | 7,004 | |
+Provision for income taxes | 369 | | | | | 784 | | | 1,090 | | | 1,903 | |
+Net income | $ | 2,538 | | | | | $ | 1,779 | | | $ | 7,370 | | | $ | 5,101 | |
+Earnings per share: | | | | | | | | | |
+Basic | $ | 3.20 | | | | | $ | 2.23 | | | $ | 9.29 | | | $ | 6.32 | |
+Diluted | $ | 3.17 | | | | | $ | 2.22 | | | $ | 9.22 | | | $ | 6.29 | |
+Weighted average number of shares: | | | | | | | | | |
+Basic | 794 | | | | | 798 | | | 794 | | | 807 | |
+Diluted | 800 | | | | | 802 | | | 799 | | | 811 | |
+
+
+
+
+
+
+
+
+
+
+Applied Materials, Inc.
+Page 8 of 14
+
+
+
+APPLIED MATERIALS, INC.
+UNAUDITED CONSOLIDATED CONDENSED BALANCE SHEETS
+| | | | | | | | | | | | | |
+(In millions) | July 26,
+2026 | | | | October 26,
+2025 |
+ASSETS | | | | | |
+Current assets: | | | | | |
+Cash and cash equivalents | $ | 7,037 | | | | | $ | 7,241 | |
+Short-term investments | 2,196 | | | | | 1,332 | |
+Accounts receivable, net | 7,691 | | | | | 5,185 | |
+Inventories | 6,564 | | | | | 5,915 | |
+Other current assets | 1,607 | | | | | 1,208 | |
+| | | | | |
+Total current assets | 25,095 | | | | | 20,881 | |
+Long-term investments | 5,268 | | | | | 4,327 | |
+Property, plant and equipment, net | 5,606 | | | | | 4,610 | |
+Goodwill | 3,873 | | | | | 3,707 | |
+Purchased technology and other intangible assets, net | 315 | | | | | 226 | |
+Deferred income taxes and other assets | 3,365 | | | | | 2,548 | |
+Total assets | $ | 43,522 | | | | | $ | 36,299 | |
+LIABILITIES AND STOCKHOLDERS’ EQUITY | | | | | |
+Current liabilities: | | | | | |
+Short-term debt | $ | 1,299 | | | | | $ | 100 | |
+Accounts payable and accrued expenses | 5,787 | | | | | 5,333 | |
+Contract liabilities | 3,271 | | | | | 2,566 | |
+| | | | | |
+Total current liabilities | 10,357 | | | | | 7,999 | |
+Long-term debt | 5,245 | | | | | 6,455 | |
+Income taxes payable | 880 | | | | | 356 | |
+Other liabilities | 1,414 | | | | | 1,074 | |
+| | | | | |
+Total liabilities | 17,896 | | | | | 15,884 | |
+Total stockholders’ equity | 25,626 | | | | | 20,415 | |
+Total liabilities and stockholders’ equity | $ | 43,522 | | | | | $ | 36,299 | |
+
+
+
+
+
+
+
+
+
+
+
+
+Applied Materials, Inc.
+Page 9 of 14
+
+
+
+APPLIED MATERIALS, INC.
+UNAUDITED CONSOLIDATED CONDENSED STATEMENTS OF CASH FLOWS
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+(In millions) | Three Months Ended | | Nine Months Ended |
+July 26,
+2026 | | | | July 27,
+2025 | July 26,
+2026 | | July 27,
+2025 |
+Cash flows from operating activities: | | | | | | | | | |
+Net income | $ | 2,538 | | | | | $ | 1,779 | | | $ | 7,370 | | | $ | 5,101 | |
+Adjustments required to reconcile net income to cash provided by operating activities: | | | | | | | | | |
+Depreciation and amortization | 151 | | | | | 113 | | | 413 | | | 321 | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Restructuring charges | — | | | | | — | | | 12 | | | — | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+(Gain) / loss and impairment on investments | 229 | | | | | (294) | | | (909) | | | (270) | |
+| | | | | | | | | |
+Share-based compensation | 169 | | | | | 158 | | | 545 | | | 512 | |
+Deferred income taxes | (49) | | | | | 280 | | | 25 | | | 952 | |
+Other | (15) | | | | | 10 | | | (11) | | | (28) | |
+Net change in operating assets and liabilities | 14 | | | | | 588 | | | (1,877) | | | (1,458) | |
+Cash provided by operating activities | 3,037 | | | | | 2,634 | | | 5,568 | | | 5,130 | |
+Cash flows from investing activities: | | | | | | | | | |
+Capital expenditures | (707) | | | | | (584) | | | (1,988) | | | (1,475) | |
+Cash paid for acquisitions, net of cash acquired | (87) | | | | | — | | | (262) | | | (29) | |
+Proceeds from asset sale | — | | | | | — | | | 6 | | | 33 | |
+Proceeds from sales and maturities of investments | 1,351 | | | | | 793 | | | 4,585 | | | 3,937 | |
+Purchases of investments | (1,970) | | | | | (2,176) | | | (5,493) | | | (5,109) | |
+Cash provided by (used in) investing activities | (1,413) | | | | | (1,967) | | | (3,152) | | | (2,643) | |
+Cash flows from financing activities: | | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Proceeds from issuance of commercial paper | 99 | | | | | 100 | | | 399 | | | 400 | |
+Repayments of commercial paper | — | | | | | (100) | | | (400) | | | (400) | |
+Proceeds from common stock issuances | — | | | | | — | | | 131 | | | 129 | |
+Common stock repurchases | (440) | | | | | (1,056) | | | (1,177) | | | (4,044) | |
+| | | | | | | | | |
+Tax withholding payments for vested equity awards | (128) | | | | | (33) | | | (437) | | | (210) | |
+Payments of dividends to stockholders | (420) | | | | | (368) | | | (1,150) | | | (1,019) | |
+Payments of debt issuance costs | — | | | | | — | | | — | | | (2) | |
+| | | | | | | | | |
+Cash used in financing activities | (889) | | | | | (1,457) | | | (2,634) | | | (5,146) | |
+| | | | | | | | | |
+Increase (decrease) in cash, cash equivalents and restricted cash equivalents | 735 | | | | | (790) | | | (218) | | | (2,659) | |
+Cash, cash equivalents and restricted cash equivalents—beginning of period | 6,359 | | | | | 6,244 | | | 7,312 | | | 8,113 | |
+Cash, cash equivalents and restricted cash equivalents — end of period | $ | 7,094 | | | | | $ | 5,454 | | | $ | 7,094 | | | $ | 5,454 | |
+| | | | | | | | | |
+Reconciliation of cash, cash equivalents, and restricted cash equivalents | | | | | | | | | |
+Cash and cash equivalents | $ | 7,037 | | | | | $ | 5,384 | | | $ | 7,037 | | | $ | 5,384 | |
+Restricted cash equivalents included in deferred income taxes and other assets | 57 | | | | | 70 | | | 57 | | | 70 | |
+Total cash, cash equivalents, and restricted cash equivalents | $ | 7,094 | | | | | $ | 5,454 | | | $ | 7,094 | | | $ | 5,454 | |
+| | | | | | | | | |
+Supplemental cash flow information: | | | | | | | | | |
+Cash payments for income taxes | $ | 169 | | | | | $ | 436 | | | $ | 819 | | | $ | 1,269 | |
+Cash refunds from income taxes | $ | 6 | | | | | $ | 4 | | | $ | 22 | | | $ | 79 | |
+Cash payments for interest | $ | 73 | | | | | $ | 51 | | | $ | 192 | | | $ | 171 | |
+
+
+
+
+
+
+Applied Materials, Inc.
+Page 10 of 14
+
+Additional Information | | | | | | | | | | | | | | | | | |
+| Q3 FY2026 | | | | Q3 FY2025 | | | | |
+Revenue by Geography ( In millions )
+| | | | | |
+| | | | | | | | | |
+United States | $ | 1,367 | | | | | $ | 683 | | | | | |
+% of Total | 15 | % | | | | 9 | % | | | | |
+Europe | $ | 483 | | | | | $ | 160 | | | | | |
+% of Total | 5 | % | | | | 2 | % | | | | |
+Japan | $ | 839 | | | | | $ | 713 | | | | | |
+% of Total | 9 | % | | | | 10 | % | | | | |
+Korea | $ | 1,521 | | | | | $ | 1,160 | | | | | |
+% of Total | 17 | % | | | | 16 | % | | | | |
+Taiwan | $ | 2,025 | | | | | $ | 1,843 | | | | | |
+% of Total | 22 | % | | | | 25 | % | | | | |
+Southeast Asia | $ | 374 | | | | | $ | 195 | | | | | |
+% of Total | 4 | % | | | | 3 | % | | | | |
+China | $ | 2,506 | | | | | $ | 2,548 | | | | | |
+% of Total | 28 | % | | | | 35 | % | | | | |
+| | | | | | | | | |
+Employees (In thousands)
+| | | | | | | | | |
+Regular Full Time | 38.9 | | | | | 36.1 | | | | | |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Applied Materials, Inc.
+Page 11 of 14
+
+
+
+APPLIED MATERIALS, INC.
+UNAUDITED RECONCILIATION OF GAAP TO NON-GAAP RESULTS
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Nine Months Ended |
+(In millions, except percentages) | July 26,
+2026 | | | | July 27,
+2025 | | July 26,
+2026 | | July 27,
+2025 |
+Non-GAAP Gross Profit | | | | | | | | | |
+GAAP reported gross profit | $ | 4,586 | | | | | $ | 3,562 | | | $ | 11,968 | | | $ | 10,543 | |
+Certain items associated with acquisitions 1
+| 11 | | | | | 7 | | | 24 | | | 20 | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Non-GAAP gross profit | $ | 4,597 | | | | | $ | 3,569 | | | $ | 11,992 | | | $ | 10,563 | |
+Non-GAAP gross margin | 50.4 | % | | | | 48.9 | % | | 49.9 | % | | 49.0 | % |
+Non-GAAP Operating Income | | | | | | | | | |
+GAAP reported operating income | $ | 3,075 | | | | | $ | 2,233 | | | $ | 7,429 | | | $ | 6,577 | |
+Certain items associated with acquisitions 1
+| 16 | | | | | 11 | | | 37 | | | 34 | |
+Acquisition integration and deal costs | 5 | | | | | 1 | | | 8 | | | 4 | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Legal settlement 2
+| — | | | | | — | | | 253 | | | — | |
+Restructuring charges 3
+| — | | | | | — | | | 12 | | | — | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Non-GAAP operating income | $ | 3,096 | | | | | $ | 2,245 | | | $ | 7,739 | | | $ | 6,615 | |
+Non-GAAP operating margin | 34.0 | % | | | | 30.7 | % | | 32.2 | % | | 30.7 | % |
+Non-GAAP Net Income | | | | | | | | | |
+GAAP reported net income | $ | 2,538 | | | | | $ | 1,779 | | | $ | 7,370 | | | $ | 5,101 | |
+Certain items associated with acquisitions 1
+| 16 | | | | | 11 | | | 37 | | | 34 | |
+Acquisition integration and deal costs | 5 | | | | | 1 | | | 8 | | | 4 | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Legal settlement 2
+| — | | | | | — | | | 253 | | | — | |
+Restructuring charges 3
+| — | | | | | — | | | 12 | | | — | |
+| | | | | | | | | |
+| | | | | | | | | |
+Realized loss (gain), dividends and impairments on strategic investments, net | (7) | | | | | 16 | | | 22 | | | (11) | |
+Unrealized loss (gain) on strategic investments, net | 220 | | | | | (314) | | | (949) | | | (288) | |
+Foreign exchange loss (gain) related to purchase of strategic investment | — | | | | | — | | | — | | | 23 | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Loss (gain) on asset sale | — | | | | | — | | | — | | | (44) | |
+Income tax effect of share-based compensation 4
+| 10 | | | | | 7 | | | (4) | | | 1 | |
+| | | | | | | | | |
+Income tax effects related to intra-entity intangible asset transfers 5
+| 33 | | | | | 32 | | | 96 | | | 738 | |
+Resolution of prior years’ income tax filings and other tax items 6
+| (46) | | | | | 460 | | | 3 | | | 320 | |
+Income tax effect of non-GAAP adjustments 7
+| 26 | | | | | (3) | | | 132 | | | (3) | |
+Non-GAAP net income | $ | 2,795 | | | | | $ | 1,989 | | | $ | 6,980 | | | $ | 5,875 | |
+
+
+
+| | | | | |
+1 | These items are incremental charges attributable to completed acquisitions, consisting of amortization of purchased intangible assets. |
+| |
+| |
+| |
+2 | Charge of $253 million for settlement with the U.S. Commerce Department Bureau of Industry and Security to resolve a previously disclosed export controls compliance matter. |
+| |
+3 | The restructuring charges related to a workforce reduction plan announced in the fourth quarter of fiscal 2025. |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+4 | GAAP basis tax benefit related to share-based compensation is recognized ratably over the fiscal year on a non-GAAP basis. |
+| |
+| |
+| |
+5 | Amount for the nine months ended July 27, 2025, included changes to the income tax provision of $94 million from amortization of intangibles and a $644 million remeasurement of deferred tax assets resulting from new tax incentive agreements in Singapore in the first quarter of fiscal 2025. |
+| |
+6 | Amounts for the three and nine months ended July 27, 2025 included the impact of the recognition of a $410 million valuation allowance against deferred tax assets related to corporate alternative minimum tax credits. |
+| |
+| |
+| |
+7 | Adjustment to provision for income taxes related to non-GAAP adjustments reflected in income before income taxes. |
+| |
+| |
+
+
+
+
+
+
+
+Applied Materials, Inc.
+Page 12 of 14
+
+
+
+APPLIED MATERIALS, INC.
+UNAUDITED RECONCILIATION OF GAAP TO NON-GAAP RESULTS
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Nine Months Ended |
+(In millions, except per share amounts) | July 26,
+2026 | | | | July 27,
+2025 | | July 26,
+2026 | | July 27,
+2025 |
+Non-GAAP Earnings Per Diluted Share | | | | | | | | | |
+GAAP reported earnings per diluted share | $ | 3.17 | | | | | $ | 2.22 | | | $ | 9.22 | | | $ | 6.29 | |
+Certain items associated with acquisitions | 0.02 | | | | | 0.01 | | | 0.04 | | | 0.04 | |
+Acquisition integration and deal costs | 0.01 | | | | | — | | | 0.01 | | | — | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+Legal settlement | — | | | | | — | | | 0.32 | | | — | |
+Restructuring charges | — | | | | | — | | | 0.01 | | | — | |
+| | | | | | | | | |
+Realized loss (gain), dividends and impairments on strategic investments, net | (0.01) | | | | | 0.02 | | | 0.02 | | | (0.02) | |
+| | | | | | | | | |
+Unrealized loss (gain) on strategic investments, net | 0.31 | | | | | (0.39) | | | (1.01) | | | (0.36) | |
+Foreign exchange loss (gain) related to purchase of strategic investment | — | | | | | — | | | — | | | 0.03 | |
+Loss (gain) on asset sale | — | | | | | — | | | — | | | (0.04) | |
+| | | | | | | | | |
+| | | | | | | | | |
+Income tax effect of share-based compensation | 0.02 | | | | | 0.01 | | | — | | | — | |
+| | | | | | | | | |
+Income tax effects related to intra-entity intangible asset transfers 1
+| 0.04 | | | | | 0.04 | | | 0.12 | | | 0.91 | |
+Resolution of prior years’ income tax filings and other tax items 2
+| (0.06) | | | | | 0.57 | | | — | | | 0.40 | |
+| | | | | | | | | |
+| | | | | | | | | |
+Non-GAAP earnings per diluted share | $ | 3.50 | | | | | $ | 2.48 | | | $ | 8.73 | | | $ | 7.25 | |
+Weighted average number of diluted shares | 800 | | | | | 802 | | | 799 | | | 811 | |
+
+| | | | | |
+| |
+1 | Amount for the nine months ended July 27, 2025, included changes to the income tax provision of $0.12 per diluted share from amortization of intangibles and $0.79 per diluted share from a remeasurement of deferred tax assets resulting from new tax incentive agreements in Singapore in the first quarter of fiscal 2025. |
+| |
+2 | Amounts for the three and nine months ended July 27, 2025 included a $0.51 per diluted share impact of the recognition of a valuation allowance against deferred tax assets related to corporate alternative minimum tax credits. |
+| |
+| |
+| |
+| |
+| |
+
+
+
+
+
+
+
+
+
+
+Applied Materials, Inc.
+Page 13 of 14
+
+
+
+
+APPLIED MATERIALS, INC.
+UNAUDITED RECONCILIATION OF GAAP TO NON-GAAP RESULTS
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Nine Months Ended |
+(In millions, except percentages) | July 26,
+2026 | | | | July 27,
+2025 | | July 26,
+2026 | | July 27,
+2025 |
+Semiconductor Systems Non-GAAP Gross Profit | | | | | | | | | |
+GAAP reported gross profit | $ | 3,892 | | | | | $ | 2,970 | | | $ | 9,950 | | | $ | 8,845 | |
+Certain items associated with acquisitions 1
+| 11 | | | | | 7 | | | 24 | | | 20 | |
+Non-GAAP gross profit | $ | 3,903 | | | | | $ | 2,977 | | | $ | 9,974 | | | $ | 8,865 | |
+Non-GAAP gross margin | 55.4 | % | | | | 53.5 | % | | 55.0 | % | | 53.5 | % |
+Applied Global Services Non-GAAP Gross Profit | | | | | | | | | |
+GAAP reported gross profit | $ | 634 | | | | | $ | 494 | | | $ | 1,748 | | | $ | 1,407 | |
+| | | | | | | | | |
+Non-GAAP gross profit | $ | 634 | | | | | $ | 494 | | | $ | 1,748 | | | $ | 1,407 | |
+Non-GAAP gross margin | 35.6 | % | | | | 33.8 | % | | 34.9 | % | | 33.2 | % |
+Semiconductor Systems Non-GAAP Operating Income | | | | | | | | | |
+GAAP reported operating income | $ | 2,657 | | | | | $ | 1,837 | | | $ | 6,176 | | | $ | 5,479 | |
+Certain items associated with acquisitions 1
+| 16 | | | | | 11 | | | 37 | | | 34 | |
+Acquisition integration and deal costs | — | | | | | 1 | | | — | | | 3 | |
+Legal settlement 2
+| — | | | | | — | | | 253 | | | — | |
+| | | | | | | | | |
+| | | | | | | | | |
+Non-GAAP operating income | $ | 2,673 | | | | | $ | 1,849 | | | $ | 6,466 | | | $ | 5,516 | |
+Non-GAAP operating margin | 38.0 | % | | | | 33.2 | % | | 35.6 | % | | 33.3 | % |
+Applied Global Services Non-GAAP Operating Income | | | | | | | | | |
+GAAP reported operating income | $ | 536 | | | | | $ | 400 | | | $ | 1,461 | | | $ | 1,114 | |
+| | | | | | | | | |
+Acquisition integration and deal costs | — | | | | | — | | | — | | | 1 | |
+| | | | | | | | | |
+| | | | | | | | | |
+Non-GAAP operating income | $ | 536 | | | | | $ | 400 | | | $ | 1,461 | | | $ | 1,115 | |
+Non-GAAP operating margin | 30.1 | % | | | | 27.3 | % | | 29.2 | % | | 26.3 | % |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+| | | | | | | | | |
+
+| | | | | |
+1 | These items are incremental charges attributable to completed acquisitions, consisting of amortization of purchased intangible assets. |
+| |
+2 | Charge of $253 million for settlement with the U.S. Commerce Department Bureau of Industry and Security to resolve a previously disclosed export controls compliance matter. |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+| |
+
+
+
+Note: The reconciliation of GAAP and non-GAAP segment results above does not include certain revenues, costs of products sold and operating expenses that are reported within other and included in consolidated operating income.
+
+
+
+
+Applied Materials, Inc.
+Page 14 of 14
+
+
+
+
+
+
+
+
+APPLIED MATERIALS, INC.
+UNAUDITED RECONCILIATION OF GAAP TO NON-GAAP EFFECTIVE INCOME TAX RATE
+| | | | | |
+| Three Months Ended |
+(In millions, except percentages) | July 26, 2026 |
+| |
+GAAP provision for income taxes (a)
+| $ | 369 | |
+Income tax effect of share-based compensation | (10) | |
+| |
+Income tax effects related to intra-entity intangible asset transfers | (33) | |
+Resolutions of prior years’ income tax filings and other tax items | 46 | |
+Income tax effect of non-GAAP adjustments | (26) | |
+Non-GAAP provision for income taxes (b)
+| $ | 346 | |
+| |
+GAAP income before income taxes (c)
+| $ | 2,907 | |
+Certain items associated with acquisitions | 16 | |
+Acquisition integration and deal costs | 5 | |
+| |
+| |
+| |
+| |
+| |
+Realized loss (gain), dividends and impairments on strategic investments, net | (7) | |
+Unrealized loss (gain) on strategic investments, net | 220 | |
+| |
+| |
+| |
+| |
+| |
+Non-GAAP income before income taxes (d)
+| $ | 3,141 | |
+| |
+GAAP effective income tax rate (a/c)
+| 12.7 | % |
+| |
+Non-GAAP effective income tax rate (b/d)
+| 11.0 | % |
+
+
+
+
+
+
+
+
+UNAUDITED RECONCILIATION OF NON-GAAP FREE CASH FLOW
+
+
+| | | | | | | | | | | | | | | | | | | | | | | | | |
+| Three Months Ended | | Nine Months Ended |
+(In millions) | July 26,
+2026 | | | | July 27,
+2025 | | July 26,
+2026 | | July 27,
+2025 |
+| | | | | | | | | |
+Cash provided by operating activities | $ | 3,037 | | | | | $ | 2,634 | | | $ | 5,568 | | | $ | 5,130 | |
+Capital expenditures | (707) | | | | | (584) | | | (1,988) | | | (1,475) | |
+Non-GAAP free cash flow | $ | 2,330 | | | | | $ | 2,050 | | | $ | 3,580 | | | $ | 3,655 | |

--- a/modules/test-fixtures/earnings-filings/asnd.txt
+++ b/modules/test-fixtures/earnings-filings/asnd.txt
@@ -1,0 +1,4145 @@
+EX-99.1
+2
+d31437dex991.htm
+EX-99.1
+
+
+EX-99.1
+
+
+
+
+
+Exhibit 99.1
+
+
+
+
+
+
+
+PRESS RELEASE
+
+Ascendis Pharma Reports Second Quarter 2026 Financial Results
+
+
+
+
+
+|
+– |
+Q2 2026 product revenue of € 315 million (+105% Y/Y), comprising
+€ 252 million for YORVIPATH &reg; , € 55 million for SKYTROFA &reg; , and € 8 million for YUVIWEL &reg;
+|
+
+
+
+
+
+|
+– |
+Through July 31, more than 220 unique YUVIWEL patient enrollments in the U.S.
+
+|
+
+
+
+
+|
+– |
+Substantial pipeline updates: presented long-term Phase 2 & 3 YORVIPATH data, shared Week 78 COACH Trial
+data, and completed target enrollment for pivotal infant reACHin Trial
+|
+
+
+
+
+|
+– |
+Settled all convertible notes and Ascendis added to multiple Russell U.S. Indexes
+|
+
+
+
+
+
+|
+– |
+Conference call today at 8:00 am ET
+|
+
+COPENHAGEN, Denmark, August 13, 2026 (GLOBE NEWSWIRE) – Ascendis Pharma A/S (Nasdaq: ASND) today announced financial results
+for the second quarter ended June 30, 2026, and provided a business update.
+“Our patient focus has driven achievement of important milestones
+and strong demand for our TransCon products as Ascendis continues to transform into a leading biopharma company,” said Jan Mikkelsen, President and Chief Executive Officer of Ascendis Pharma. “This focus on addressing unmet medical needs
+continues to drive a growing pipeline of innovative TransCon programs, further positioning Ascendis for durable, long-term growth in rare endocrine diseases and new therapeutic areas.”
+
+Select Highlights & Anticipated 2026 Milestones
+
+
+
+
+|
+• |
+|
+YORVIPATH
+|
+
+(palopegteriparatide, developed as TransCon PTH)
+
+
+
+
+|
+• |
+|
+YORVIPATH revenue for the second quarter of 2026 totaled €252 million, reflecting consistent new
+patient demand in the U.S.
+|
+
+
+
+
+|
+• |
+|
+Outside of the U.S., consistent new patient demand and continued expansion of global commercial launches with
+full reimbursement. Now available commercially or through named patient programs in more than 35 countries.
+|
+
+
+
+
+|
+• |
+|
+Presented 5-year Phase 2 PaTH Forward data at ECE 2026 and 3.5-year Phase 3 PaTHway data at ENDO 2026 showing that long-term treatment with TransCon PTH demonstrated sustained efficacy and safety in adults with hypoparathyroidism.
+|
+
+
+
+
+
+|
+• |
+|
+Ongoing label expansion trials through PaTHway60 and PaTHway Adolescent.
+|
+
+
+
+
+
+|
+• |
+|
+SKYTROFA
+|
+
+(lonapegsomatropin, developed as TransCon hGH)
+
+
+
+
+|
+• |
+|
+SKYTROFA revenue for the second quarter of 2026 totaled €55 million.
+|
+
+
+Page 1 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|
+• |
+|
+More than 20,000 unique enrollments globally since launch.
+|
+
+
+
+
+
+|
+• |
+|
+Ongoing Phase 3 HighLiGHts basket trial across a range of established growth hormone indications: idiopathic
+short stature (ISS), SHOX deficiency, Turner syndrome, and small for gestational age (SGA).
+|
+
+
+
+
+|
+• |
+|
+YUVIWEL
+|
+
+(navepegritide, developed as TransCon CNP)
+
+
+
+
+|
+• |
+|
+YUVIWEL revenue for the second quarter of 2026 totaled €8 million.
+|
+
+
+
+
+
+|
+• |
+|
+More than 220 unique YUVIWEL patient enrollments by more than 100 prescribing healthcare providers, with more
+than 65% of enrollments approved for reimbursement in the U.S. through July 31, 2026.
+|
+
+
+
+
+|
+• |
+|
+Marketing Authorisation Application remains under review by the European Medicines Agency, with a decision
+anticipated in the fourth quarter of 2026.
+|
+
+
+
+
+|
+• |
+|
+Making YUVIWEL available in select International Markets countries through early access programs using U.S. FDA
+approval.
+|
+
+
+
+
+|
+• |
+|
+Completed target enrollment for pivotal reACHin Trial, supporting planned regulatory filings for infants 0 to
+
+
+
+
+|
+• |
+|
+Expect to initiate enrollment in Phase 3 trial in the second half of the year to investigate TransCon CNP
+monotherapy for the treatment of hypochondroplasia.
+|
+
+
+
+
+|
+• |
+|
+TransCon CNP + TransCon hGH Combination Therapy
+|
+
+(navepegritide plus lonapegsomatropin)
+
+
+
+
+|
+• |
+|
+Week 78 COACH Trial data showed sustained unprecedented efficacy over 78 weeks with no compromise to safety or
+tolerability.
+|
+
+
+
+
+|
+• |
+|
+To date, 100% of the 21 enrolled children completed 78 weeks of treatment and remain on therapy in the COACH
+Trial.
+|
+
+
+
+
+|
+• |
+|
+Expect to initiate enrollment in Phase 3 trial of TransCon CNP and TransCon hGH in pediatric achondroplasia in
+the fourth quarter of 2026.
+|
+Key Financial Highlights
+
+
+
+
+|
+• |
+|
+Total product revenue for the second quarter of 2026 increased to €315 million, reflecting
+year-over-year growth of +105%.
+|
+
+
+
+
+|
+• |
+|
+Total revenue for the second quarter of 2026 was €339 million.
+|
+
+
+
+
+
+|
+• |
+|
+Operating profit for the second quarter of 2026 totaled €220 million, reflecting a margin of 65%. On a non-IFRS basis, operating profit was €92 million*, reflecting a margin of 27%*.
+|
+
+
+
+
+|
+• |
+|
+Net profit for the second quarter of 2026 totaled €207 million, or €2.83 per diluted share. On a non-IFRS basis, net profit was €61 million*, or €0.90 per diluted share*.
+|
+
+
+
+
+|
+• |
+|
+As of June 30, 2026, Ascendis Pharma had cash and cash equivalents totaling €812 million, which
+includes the use of €56 million in the second quarter for our previously announced share repurchase program and the net settlement of certain Restricted Stock Units. As of December 31, 2025, cash and cash equivalents totaled
+€616 million.
+|
+
+
+Page 2 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|
+• |
+|
+During the second quarter, the Company closed the sale of its Rare Pediatric Disease Priority Review Voucher
+(PRV) to an undisclosed buyer with payment of €158 million in cash, net of transaction-related expenses. The PRV was awarded by the FDA upon approval of YUVIWEL in February 2026.
+|
+
+
+
+
+
+|
+• |
+|
+Effective May 6, 2026, the Company completed its previously announced optional redemption process with
+respect to all outstanding $575 million of 2.25% Convertible Senior Notes due 2028, resulting in the conversion of all outstanding notes. The conversions resulted in the settlement of the current liabilities of convertible notes to equity,
+comprising borrowings and derivative liabilities totaling €719 million as of the redemption date.
+|
+
+
+
+
+|
+• |
+|
+After the close of market on June 26, 2026, the Company was added to multiple Russell U.S. Indexes,
+including the Russell 3000, Russell 1000, Russell 2500 and Russell Midcap Indexes.
+|
+
+
+
+
+* |
+See “Non-IFRS Financial Measures” below for definitions
+of these non-IFRS measures and a reconciliation to the most directly comparable IFRS measures.
+|
+
+
+Page 3 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Second Quarter 2026 Financial Results
+
+Total revenue for the second quarter of 2026 was €339 million, compared to €158 million during the same period in 2025.
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+Total Revenue
+(In
+EUR’000s)
+|
+|
+Three Months Ended
+June 30, |
+|
+|
+Six Months Ended
+June 30, |
+|
+
+
+|
+|
+2026 |
+|
+|
+2025 |
+|
+|
+2026 |
+|
+|
+2025 |
+|
+
+
+
+
+Revenue
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Commercial products
+|
+|
+|
+314,910 |
+|
+|
+|
+153,663 |
+|
+|
+|
+555,763 |
+|
+|
+|
+249,690 |
+|
+
+
+Services and clinical supply
+|
+|
+|
+4,856 |
+|
+|
+|
+3,570 |
+|
+|
+|
+9,965 |
+|
+|
+|
+7,094 |
+|
+
+
+Licenses
+|
+|
+|
+2,473 |
+|
+|
+|
+812 |
+|
+|
+|
+3,112 |
+|
+|
+|
+2,214 |
+|
+
+
+Milestones
+|
+|
+|
+17,046 |
+|
+|
+|
+—  |
+|
+|
+|
+17,046 |
+|
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total revenue
+|
+|
+|
+339,285 |
+|
+|
+|
+158,045 |
+|
+|
+|
+585,886 |
+|
+|
+|
+258,998 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+Revenue from Commercial Products
+(In EUR’000s) |
+|
+Three Months Ended
+June 30, |
+|
+|
+Six Months Ended
+June 30, |
+|
+
+
+|
+|
+2026 |
+|
+|
+2025 |
+|
+|
+2026 |
+|
+|
+2025 |
+|
+
+
+
+
+Revenue from commercial products
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+YORVIPATH &reg;
+|
+|
+|
+252,114 |
+|
+|
+|
+102,957 |
+|
+|
+|
+449,010 |
+|
+|
+|
+147,646 |
+|
+
+
+SKYTROFA &reg;
+|
+|
+|
+55,214 |
+|
+|
+|
+50,706 |
+|
+|
+|
+99,171 |
+|
+|
+|
+102,044 |
+|
+
+
+YUVIWEL &reg;
+|
+|
+|
+7,582 |
+|
+|
+|
+—  |
+|
+|
+|
+7,582 |
+|
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total revenue from commercial products
+|
+|
+|
+314,910 |
+|
+|
+|
+153,663 |
+|
+|
+|
+555,763 |
+|
+|
+|
+249,690 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+Research and development expenses for the second quarter of 2026 were €76 million, compared to €72 million
+during the same period in 2025. The higher expenses were due to increased clinical trial activities within the Endocrinology Rare Disease pipeline, offset by reduced clinical trial activities within Oncology.
+
+Selling, general, and administrative expenses for the second quarter of 2026 were €173 million, compared to €108 million during the same
+period in 2025. The increase was primarily due to the continued impact from commercial expansion, including global launch activities.
+Total operating
+expenses for the second quarter of 2026 were €249 million compared to €180 million during the same period in 2025.
+Operating profit
+for the second quarter of 2026 was €220 million, compared to an operating loss of €53 million during the same period in 2025. The increase was primarily driven by growth in product revenue and sale of the PRV for
+€158 million in cash, net of transaction-related expenses.
+Net finance income for the second quarter of 2026 was €6 million, compared
+to €22 million in the same period in 2025. The change was primarily driven by non-cash items.
+For the
+second quarter of 2026, Ascendis Pharma reported a net profit of €207 million, or €3.22 per basic share and €2.83 per diluted share, compared to a net loss of €39 million, or €0.64 per basic share and €0.82
+per diluted share for the same period in 2025.
+Cash flows from operating activities for the six months ended June 30, 2026, were
+€274 million compared to €22 million used during the same period in 2025. The increase in cash flows from operating activities was primarily related to commercial revenue growth and sale of the PRV.
+
+
+Page 4 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+As of June 30, 2026, Ascendis Pharma had 66,189,926 ordinary shares outstanding, of which 516,642 were
+held as treasury shares.
+For the second quarter of 2026, non-IFRS operating profit was €92 million,
+compared to a non-IFRS operating loss of €23 million for the same period in 2025.
+For the second
+quarter of 2026, non-IFRS net profit was €61 million, or €0.90 earnings per diluted share, compared to a non-IFRS net profit of €4 million, or
+€0.07 earnings per diluted share, for the same period in 2025.
+Conference Call and Webcast Information
+
+Ascendis Pharma will host a conference call and webcast today at 8:00 am Eastern Time (ET) to discuss its second quarter 2026 financial results.
+
+Those who would like to participate may access the live webcast here , or register in advance for the teleconference here . The link to the live
+webcast will also be available on the Investors & News section of the Ascendis Pharma website at https://investors.ascendispharma.com . A replay of the webcast will be available in this section of the Ascendis Pharma website shortly
+after the conclusion of the event for 30 days.
+About Ascendis Pharma A/S
+
+Ascendis Pharma is a global biopharmaceutical company focused on applying our innovative TransCon technology platform to make a meaningful difference for
+patients. Guided by our core values of Patients, Science, and Passion, and following our algorithm for product innovation, we apply TransCon to develop new therapies that demonstrate
+best-in-class potential to address unmet medical needs. Ascendis is headquartered in Copenhagen, Denmark, and has additional facilities in Europe and the United States.
+Please visit ascendispharma.com to learn more.
+Forward-Looking Statements
+
+This press release contains forward-looking statements that involve substantial risks and uncertainties. All statements, other than statements of historical
+facts, included in this press release regarding Ascendis’ future operations, results, plans and objectives of management are forward-looking statements within the meaning of Section 27A of the Securities Act of 1933, as amended, and
+Section 21E of the Securities Exchange Act of 1934, as amended. Examples of such statements include, but are not limited to, statements relating to (i) anticipated timing of a regulatory decision from the European Medicines Agency,
+(ii) anticipated timing and plans of clinical trials and development activities, including expected timing of patient recruitment and trial initiation, (iii) Ascendis’ ability to apply its TransCon technology platform to make a
+meaningful difference for patients, (iv) Ascendis’ use of TransCon to create new and potentially best-in-class therapies, (v) plans for regulatory
+filings and label expansions, and (vi) expectations regarding continued patient demand, product uptake, reimbursement coverage, future growth and market positioning. Ascendis may not actually achieve the plans, carry out the intentions or meet
+the expectations or projections disclosed in the forward-looking statements and you should not place undue reliance on these forward-looking statements. Actual results or events could differ materially from the plans, intentions, expectations and
+projections disclosed in the forward-looking statements. Various important factors could cause actual results or events to differ materially from the forward-looking statements that Ascendis makes, including,
+
+
+
+Page 5 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+without limitation: dependence on third-party manufacturers, distributors, and service providers for Ascendis’ products and product candidates; risks
+related to regulatory review and approval, including the possibility of delays, requests for additional data or analyses, restrictions or limitations on use, approval with labeling that is more limited than expected, or failure to obtain approval
+in the United States, European Union, or other jurisdictions; clinical development risks, including that results from ongoing or future trials may not confirm earlier data; unforeseen safety or efficacy findings in development programs or on-market products; manufacturing, supply chain, quality, or logistics issues that could delay development or commercialization; unforeseen expenses related to commercialization of any approved Ascendis products;
+unforeseen research and development or selling, general and administrative expenses and other costs impacting Ascendis’ business generally; market acceptance, pricing, and reimbursement challenges, including payer coverage decisions and health
+technology assessments; competitive developments, including new or improved therapies; intellectual property protection, freedom-to-operate, and litigation risks;
+Ascendis’ ability to obtain additional funding, if needed, to support its business activities; cybersecurity, data privacy, and information technology disruptions; and the impact of international economic, political, legal, compliance, public
+health, and business factors, including tariffs, trade policies, currency fluctuations, and geopolitical events. For a further description of the risks and uncertainties that could cause actual results to differ from those expressed in these
+forward-looking statements, as well as risks relating to Ascendis’ business in general, see Ascendis’ Annual Report on Form 20-F filed with the U.S. Securities and Exchange Commission (SEC)
+on February 11, 2026, and Ascendis’ other future reports filed with, or submitted to, the SEC. Forward-looking statements do not reflect the potential impact of any future licensing, collaborations, acquisitions, mergers,
+dispositions, joint ventures, or investments that Ascendis may enter into or make. Ascendis does not assume any obligation to update any forward-looking statements, except as required by law.
+
+Ascendis, Ascendis Pharma, the Ascendis Pharma logo, the company logo, TransCon, SKYTROFA &reg; ,
+YORVIPATH &reg; , and YUVIWEL &reg; are trademarks owned by the Ascendis Pharma group. &copy;
+August 2026 Ascendis Pharma A/S.
+
+
+
+
+
+
+
+|
+
+|
+|
+
+
+Investor Contact:
+|
+|
+Media Contact:
+|
+
+
+
+
+Chad Fugere |
+|
+Melinda Baker |
+
+
+Ascendis Pharma |
+|
+Ascendis Pharma |
+
+
++1 (650) 519-7494 |
+|
++1 (650) 709-8875 |
+
+
+
+Page 6 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+FINANCIAL TABLES FOLLOW
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+Ascendis Pharma A/S
+Unaudited Condensed Consolidated
+
+Statements of Profit or (Loss) and
+Comprehensive Income /
+(Loss)
+(In EUR’000s, except per share data)
+|
+|
+Three Months Ended
+June 30, |
+|
+|
+Six Months Ended
+June 30, |
+|
+
+
+|
+|
+2026 |
+|
+|
+2025 |
+|
+|
+2026 |
+|
+|
+2025 |
+|
+
+
+
+
+Consolidated Statement of Profit or (Loss)
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Revenue
+|
+|
+|
+339,285 |
+|
+|
+|
+158,045 |
+|
+|
+|
+585,886 |
+|
+|
+|
+258,998 |
+|
+
+
+Cost of sales
+|
+|
+|
+(27,658 |
+) |
+|
+|
+(31,447 |
+) |
+|
+|
+(45,173 |
+) |
+|
+|
+(48,963 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Gross profit
+|
+|
+|
+311,627 |
+|
+|
+|
+126,598 |
+|
+|
+|
+540,713 |
+|
+|
+|
+210,035 |
+|
+
+
+Research and development expenses
+|
+|
+|
+(75,888 |
+) |
+|
+|
+(71,988 |
+) |
+|
+|
+(134,932 |
+) |
+|
+|
+(158,591 |
+) |
+
+
+Selling, general, and administrative expenses
+|
+|
+|
+(173,341 |
+) |
+|
+|
+(107,561 |
+) |
+|
+|
+(318,571 |
+) |
+|
+|
+(208,608 |
+) |
+
+
+Other operating income
+|
+|
+|
+158,067 |
+|
+|
+|
+—  |
+|
+|
+|
+158,067 |
+|
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Operating profit/(loss)
+|
+|
+|
+220,465 |
+|
+|
+|
+(52,951 |
+) |
+|
+|
+245,277 |
+|
+|
+|
+(157,164 |
+) |
+
+
+Share of profit/(loss) of associates
+|
+|
+|
+3,836 |
+|
+|
+|
+(4,097 |
+) |
+|
+|
+(6,415 |
+) |
+|
+|
+22,482 |
+|
+
+
+Finance income
+|
+|
+|
+19,965 |
+|
+|
+|
+55,059 |
+|
+|
+|
+9,347 |
+|
+|
+|
+83,912 |
+|
+
+
+Finance expenses
+|
+|
+|
+(14,173 |
+) |
+|
+|
+(33,018 |
+) |
+|
+|
+(66,292 |
+) |
+|
+|
+(77,803 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Profit/(loss) before tax
+|
+|
+|
+230,093 |
+|
+|
+|
+(35,007 |
+) |
+|
+|
+181,917 |
+|
+|
+|
+(128,573 |
+) |
+
+
+Income taxes (expenses)
+|
+|
+|
+(23,123 |
+) |
+|
+|
+(3,848 |
+) |
+|
+|
+654,393 |
+|
+|
+|
+(4,909 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net profit/(loss) for the period
+|
+|
+|
+206,970 |
+|
+|
+|
+(38,855 |
+) |
+|
+|
+836,310 |
+|
+|
+|
+(133,482 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Attributable to owners of the Company
+|
+|
+|
+206,970 |
+|
+|
+|
+(38,855 |
+) |
+|
+|
+836,310 |
+|
+|
+|
+(133,482 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Basic earnings/(loss) per share
+|
+|
+|
+3.22 |
+|
+|
+|
+(0.64 |
+) |
+|
+|
+13.27 |
+|
+|
+|
+(2.22 |
+) |
+
+
+Diluted earnings/(loss) per share
+|
+|
+|
+2.83 |
+|
+|
+|
+(0.82 |
+) |
+|
+|
+12.73 |
+|
+|
+|
+(2.22 |
+) |
+
+
+|
+|
+|
+|
+|
+
+
+Consolidated Statement of Comprehensive Income or (Loss)
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Net profit/(loss) for the period
+|
+|
+|
+206,970 |
+|
+|
+|
+(38,855 |
+) |
+|
+|
+836,310 |
+|
+|
+|
+(133,482 |
+) |
+
+
+Other comprehensive income/(loss)
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Items that may be reclassified subsequently to profit or (loss):
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Exchange differences on translating foreign operations
+|
+|
+|
+4,859 |
+|
+|
+|
+(1,399 |
+) |
+|
+|
+7,917 |
+|
+|
+|
+(1,474 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Other comprehensive income/(loss) for the period, net of tax
+|
+|
+|
+4,859 |
+|
+|
+|
+(1,399 |
+) |
+|
+|
+7,917 |
+|
+|
+|
+(1,474 |
+) |
+
+
+Total comprehensive income/(loss) for the period, net of tax
+|
+|
+|
+211,829 |
+|
+|
+|
+(40,254 |
+) |
+|
+|
+844,227 |
+|
+|
+|
+(134,956 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Attributable to owners of the Company
+|
+|
+|
+211,829 |
+|
+|
+|
+(40,254 |
+) |
+|
+|
+844,227 |
+|
+|
+|
+(134,956 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+Page 7 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+Ascendis Pharma A/S
+Unaudited Condensed Consolidated Statements of
+
+Financial Position
+(In EUR’000s)
+|
+|
+June 30,
+2026 |
+|
+|
+December 31,
+2025 |
+|
+
+
+
+
+Assets
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Non-current assets
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Intangible assets
+|
+|
+|
+3,680 |
+|
+|
+|
+3,710 |
+|
+
+
+Property, plant and equipment
+|
+|
+|
+135,685 |
+|
+|
+|
+146,479 |
+|
+
+
+Investments in associates
+|
+|
+|
+30,479 |
+|
+|
+|
+32,526 |
+|
+
+
+Other receivables
+|
+|
+|
+26,489 |
+|
+|
+|
+10,870 |
+|
+
+
+Deferred tax assets
+|
+|
+|
+699,276 |
+|
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+|
+|
+|
+895,609 |
+|
+|
+|
+193,585 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Current assets
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Inventories
+|
+|
+|
+310,576 |
+|
+|
+|
+301,533 |
+|
+
+
+Trade receivables
+|
+|
+|
+206,505 |
+|
+|
+|
+141,333 |
+|
+
+
+Income tax receivables
+|
+|
+|
+1,993 |
+|
+|
+|
+1,781 |
+|
+
+
+Other receivables
+|
+|
+|
+15,604 |
+|
+|
+|
+14,582 |
+|
+
+
+Prepayments
+|
+|
+|
+43,473 |
+|
+|
+|
+33,715 |
+|
+
+
+Cash and cash equivalents
+|
+|
+|
+812,260 |
+|
+|
+|
+616,041 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+|
+|
+|
+1,390,411 |
+|
+|
+|
+1,108,985 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total assets
+|
+|
+|
+2,286,020 |
+|
+|
+|
+1,302,570 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Equity and liabilities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Equity
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Share capital
+|
+|
+|
+8,885 |
+|
+|
+|
+8,322 |
+|
+
+
+Distributable equity
+|
+|
+|
+1,427,606 |
+|
+|
+|
+(171,143 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total equity
+|
+|
+|
+1,436,491 |
+|
+|
+|
+(162,821 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Non-current liabilities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Borrowings
+|
+|
+|
+384,642 |
+|
+|
+|
+385,254 |
+|
+
+
+Contract liabilities
+|
+|
+|
+—  |
+|
+|
+|
+1,123 |
+|
+
+
+Deferred tax liabilities
+|
+|
+|
+—  |
+|
+|
+|
+9,623 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+|
+|
+|
+384,642 |
+|
+|
+|
+396,000 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Current liabilities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Convertible notes
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Borrowings
+|
+|
+|
+—  |
+|
+|
+|
+429,391 |
+|
+
+
+Derivative liabilities
+|
+|
+|
+—  |
+|
+|
+|
+256,231 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+|
+|
+|
+—  |
+|
+|
+|
+685,622 |
+|
+
+
+Other current liabilities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Borrowings
+|
+|
+|
+65,432 |
+|
+|
+|
+57,141 |
+|
+
+
+Contract liabilities
+|
+|
+|
+2,776 |
+|
+|
+|
+4,944 |
+|
+
+
+Trade payables and accrued expenses
+|
+|
+|
+103,920 |
+|
+|
+|
+90,657 |
+|
+
+
+Other liabilities
+|
+|
+|
+58,690 |
+|
+|
+|
+58,204 |
+|
+
+
+Income tax payables
+|
+|
+|
+12,662 |
+|
+|
+|
+6,427 |
+|
+
+
+Provisions
+|
+|
+|
+221,407 |
+|
+|
+|
+166,396 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+|
+|
+|
+464,887 |
+|
+|
+|
+383,769 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+|
+|
+|
+464,887 |
+|
+|
+|
+1,069,391 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total liabilities
+|
+|
+|
+849,529 |
+|
+|
+|
+1,465,391 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total equity and liabilities
+|
+|
+|
+2,286,020 |
+|
+|
+|
+1,302,570 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+Page 8 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+Ascendis Pharma A/S
+Unaudited Condensed Consolidated Statements of Cash
+
+Flows
+(In EUR’000s)
+|
+|
+Six Months Ended
+June 30, |
+|
+
+
+|
+|
+2026 |
+|
+|
+2025 |
+|
+
+
+
+
+Operating activities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Net profit/(loss) for the period
+|
+|
+|
+836,310 |
+|
+|
+|
+(133,482 |
+) |
+
+
+Reversal of finance income
+|
+|
+|
+(9,347 |
+) |
+|
+|
+(83,912 |
+) |
+
+
+Reversal of finance expenses
+|
+|
+|
+66,292 |
+|
+|
+|
+77,803 |
+|
+
+
+Reversal of (gain)/loss on disposal of property, plant and equipment
+|
+|
+|
+21 |
+|
+|
+|
+—  |
+|
+
+
+Reversal of income taxes
+|
+|
+|
+(654,393 |
+) |
+|
+|
+4,909 |
+|
+
+
+Adjustments for non-cash items:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Non-cash consideration relating to revenue
+|
+|
+|
+(3,112 |
+) |
+|
+|
+(2,214 |
+) |
+
+
+Share of (profit)/loss of associates
+|
+|
+|
+6,415 |
+|
+|
+|
+(22,482 |
+) |
+
+
+Share-based payment
+|
+|
+|
+59,964 |
+|
+|
+|
+55,580 |
+|
+
+
+Depreciation and amortization
+|
+|
+|
+8,789 |
+|
+|
+|
+8,853 |
+|
+
+
+Impairment of property, plant and equipment
+|
+|
+|
+—  |
+|
+|
+|
+7,508 |
+|
+
+
+Changes in working capital:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Inventories
+|
+|
+|
+(9,044 |
+) |
+|
+|
+(7,772 |
+) |
+
+
+Receivables
+|
+|
+|
+(61,050 |
+) |
+|
+|
+50,047 |
+|
+
+
+Prepayments
+|
+|
+|
+(9,487 |
+) |
+|
+|
+(6,801 |
+) |
+
+
+Contract liabilities
+|
+|
+|
+(3,291 |
+) |
+|
+|
+(3,455 |
+) |
+
+
+Trade payables, accrued expenses and other liabilities
+|
+|
+|
+8,659 |
+|
+|
+|
+(25,558 |
+) |
+
+
+Provisions
+|
+|
+|
+50,369 |
+|
+|
+|
+65,536 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash flows generated from/(used in) operations
+|
+|
+|
+287,095 |
+|
+|
+|
+(15,440 |
+) |
+
+
+Finance income received
+|
+|
+|
+9,347 |
+|
+|
+|
+7,603 |
+|
+
+
+Finance expenses paid
+|
+|
+|
+(17,115 |
+) |
+|
+|
+(9,689 |
+) |
+
+
+Income taxes received/(paid)
+|
+|
+|
+(5,366 |
+) |
+|
+|
+(4,128 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash flows from/(used in) operating activities
+|
+|
+|
+273,961 |
+|
+|
+|
+(21,654 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Investing activities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Payments received under finance leases
+|
+|
+|
+1,341 |
+|
+|
+|
+—  |
+|
+
+
+Acquisition of intangible assets and property, plant and equipment
+|
+|
+|
+(10,948 |
+) |
+|
+|
+(5,041 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash flows from/(used in) investing activities
+|
+|
+|
+(9,607 |
+) |
+|
+|
+(5,041 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Financing activities
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+Repayment of borrowings
+|
+|
+|
+(16,720 |
+) |
+|
+|
+(8,553 |
+) |
+
+
+Proceeds from exercise of warrants
+|
+|
+|
+50,086 |
+|
+|
+|
+26,302 |
+|
+
+
+Costs of capital increase
+|
+|
+|
+(125 |
+) |
+|
+|
+—  |
+|
+
+
+Acquisition of treasury shares
+|
+|
+|
+(103,412 |
+) |
+|
+|
+(17,396 |
+) |
+
+
+Payment of withholding taxes under stock incentive programs
+|
+|
+|
+(12,781 |
+) |
+|
+|
+(11,396 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash flows from/(used in) financing activities
+|
+|
+|
+(82,952 |
+) |
+|
+|
+(11,043 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Increase/(decrease) in cash and cash equivalents
+|
+|
+|
+181,402 |
+|
+|
+|
+(37,738 |
+) |
+
+
+Cash and cash equivalents at January 1
+|
+|
+|
+616,041 |
+|
+|
+|
+559,543 |
+|
+
+
+Effect of exchange rate changes on balances held in foreign currencies
+|
+|
+|
+14,817 |
+|
+|
+|
+(27,759 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Cash and cash equivalents at June 30
+|
+|
+|
+812,260 |
+|
+|
+|
+494,046 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+
+Page 9 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Non-IFRS Financial Measures
+
+In addition to the financial information prepared in accordance with IFRS Accounting Standards (“IFRS”) as issued by the International Accounting
+Standards Board and as adopted by the European Union, this press release contains certain non-IFRS financial measures, including Non-IFRS Operating Profit/(Loss), Non-IFRS Net Profit/(Loss), Non-IFRS operating profit/(loss) margin, and Non-IFRS diluted earnings per share (“Non-IFRS Diluted EPS”). These non-IFRS measures are provided as supplemental information and should be considered in addition to, and not as a substitute for or
+superior to, the comparable measures prepared in accordance with IFRS. Management believes these non-IFRS measures support management’s, analysts’ and investors’ overall understanding of the
+Company’s underlying financial performance and trends and facilitate comparisons among current and past periods.
+Since non-IFRS measures do not have standardized definitions and meanings, they may differ from the non-IFRS measures used by other companies, which reduces their usefulness as
+comparative financial measures. Because of these limitations, you should consider these adjusted financial measures alongside other IFRS financial measures. Because these non-IFRS measures are not prepared in
+accordance with IFRS, they should not be viewed as superior to IFRS reported measures, nor should they be used on their own or as replacements for the IFRS financial information included in this press release. Additionally, our non-IFRS measures may differ from similarly labeled measures used by other companies due to variations in calculation methods or the size and nature of adjusted items. Investors should note that several of the items
+excluded from these non-IFRS measures have been recognized in prior periods and may continue to be recognized in future periods.
+
+The Company reports Non-IFRS Operating Profit/(Loss), Non-IFRS Net
+Profit/(Loss), Non-IFRS operating profit/(loss) margin and Non-IFRS Diluted EPS as non-IFRS measures, which exclude the following
+specified items:
+(i) Share-based compensation costs. Although share-based compensation is a recurring expense, the Company excludes it from non-IFRS measures because the amount and timing of recognition depend on the value of the underlying equity instruments, which can fluctuate based on factors unrelated to the Company’s operating performance
+during the period.
+(ii) Other operating income from sale of PRV. The Company excludes income recognized from the sale of its PRV because it does not
+reflect the Company’s ongoing operating activities.
+(iii) Share of (profit)/loss of associates. The Company excludes its share of the profit or loss
+of equity-method investees because these amounts are not within the control of the Company and do not reflect the Company’s core operating performance.
+
+(iv) Remeasurement (gain)/loss of derivative liabilities. The Company excludes the fair-value remeasurement of derivative liabilities associated with its
+convertible notes because these amounts depend on movements in the Company’s share price and other market inputs and are not indicative of the Company’s underlying operating performance.
+
+(v) Remeasurement (gain)/loss of royalty funding liabilities. The Company excludes gains and losses arising from the remeasurement of royalty funding
+liabilities as these amounts are driven by changes in estimates of future royalty payment obligations under the Company’s royalty funding agreements and do not reflect the Company’s underlying operating performance.
+
+(vi) Recognition of previously unrecognized deferred tax assets. The Company excludes the one-time recognition of
+previously unrecognized deferred tax assets because this item reflects a reassessment of the recoverability of historical tax attributes rather than the Company’s current period operating performance.
+
+
+Page 10 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Income taxes related to the foregoing items are adjusted accordingly, considering the individual impact of
+each item, the relevant tax jurisdiction, applicable tax rates, and the deductibility of the item.
+For further details regarding valuation of derivative
+liabilities, and the recognition of previously unrecognized deferred tax assets, please refer to “Note 3 – Significant Accounting Judgements and Estimates,” contained in our Interim Report on Form
+6-K, for the period ended June 30, 2026 and “Note 3 – Significant Accounting Judgements and Estimates,” contained in our Annual Report on Form
+20-F, for the year ended December 31, 2025.
+The following table provides a reconciliation of the most
+directly comparable IFRS measures to Non-IFRS Operating Profit/(Loss), Non-IFRS Net Profit/(Loss) and Non-IFRS Diluted EPS.
+
+
+Page 11 of 12
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+PRESS RELEASE
+
+Reconciliation of unaudited IFRS to Non-IFRS Financial Information
+
+(in EUR’000s, except number of shares and per share data)
+
+
+
+
+
+
+
+
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+
+|
+|
+Three Months Ended
+June 30, |
+|
+|
+Six Months Ended
+June 30, |
+|
+
+
+|
+|
+2026 |
+|
+|
+2025 |
+|
+|
+2026 |
+|
+|
+2025 |
+|
+
+
+
+
+IFRS operating profit/(loss)
+|
+|
+|
+220,465 |
+|
+|
+|
+(52,951 |
+) |
+|
+|
+245,277 |
+|
+|
+|
+(157,164 |
+) |
+
+
+Share-based compensation costs
+|
+|
+|
+29,608 |
+|
+|
+|
+30,022 |
+|
+|
+|
+59,964 |
+|
+|
+|
+55,580 |
+|
+
+
+Other operating income from sale of PRV
+|
+|
+|
+(158,067 |
+) |
+|
+|
+—  |
+|
+|
+|
+(158,067 |
+) |
+|
+|
+—  |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total non-IFRS adjustments to operating
+profit/(loss)
+|
+|
+|
+(128,459 |
+) |
+|
+|
+30,022 |
+|
+|
+|
+(98,103 |
+) |
+|
+|
+55,580 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Non-IFRS operating profit/(loss)
+|
+|
+|
+92,006 |
+|
+|
+|
+(22,929 |
+) |
+|
+|
+147,174 |
+|
+|
+|
+(101,584 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+IFRS operating profit/(loss) margin
+(%)
+|
+|
+|
+65.0 |
+% |
+|
+|
+(33.5 |
+%) |
+|
+|
+41.9 |
+% |
+|
+|
+(60.7 |
+%) |
+
+
+Non-IFRS operating profit/(loss) margin (%)
+|
+|
+|
+27.1 |
+% |
+|
+|
+(14.5 |
+%) |
+|
+|
+25.1 |
+% |
+|
+|
+(39.2 |
+%) |
+
+
+IFRS Net profit/(loss)
+|
+|
+|
+206,970 |
+|
+|
+|
+(38,855 |
+) |
+|
+|
+836,310 |
+|
+|
+|
+(133,482 |
+) |
+
+
+Share-based compensation costs
+|
+|
+|
+29,608 |
+|
+|
+|
+30,022 |
+|
+|
+|
+59,964 |
+|
+|
+|
+55,580 |
+|
+
+
+Other operating income from sale of PRV
+|
+|
+|
+(158,067 |
+) |
+|
+|
+—  |
+|
+|
+|
+(158,067 |
+) |
+|
+|
+—  |
+|
+
+
+Share of (profit)/loss of associates
+|
+|
+|
+(3,836 |
+) |
+|
+|
+4,097 |
+|
+|
+|
+6,415 |
+|
+|
+|
+(22,482 |
+) |
+
+
+Remeasurement (gain)/loss of derivative liabilities
+|
+|
+|
+(8,313 |
+) |
+|
+|
+11,998 |
+|
+|
+|
+25,938 |
+|
+|
+|
+35,909 |
+|
+
+
+Remeasurement (gain)/loss of royalty funding liabilities
+|
+|
+|
+—  |
+|
+|
+|
+(1,399 |
+) |
+|
+|
+—  |
+|
+|
+|
+(1,399 |
+) |
+
+
+Recognition of previously unrecognized deferred tax assets
+|
+|
+|
+(24,622 |
+) |
+|
+|
+—  |
+|
+|
+|
+(704,209 |
+) |
+|
+|
+—  |
+|
+
+
+Tax effects of adjustments
+|
+|
+|
+19,524 |
+|
+|
+|
+(1,641 |
+) |
+|
+|
+11,901 |
+|
+|
+|
+(3,281 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Total non-IFRS adjustments to net profit/(loss)
+|
+|
+|
+(145,706 |
+) |
+|
+|
+43,077 |
+|
+|
+|
+(758,058 |
+) |
+|
+|
+64,327 |
+|
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Non-IFRS net profit/(loss)
+|
+|
+|
+61,264 |
+|
+|
+|
+4,222 |
+|
+|
+|
+78,252 |
+|
+|
+|
+(69,155 |
+) |
+
+
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+|
+
+|
+
+|
+|
+
+
+Net profit/(loss) per diluted share:
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+
+IFRS adjusted for dilution effects (as
+reported)
+|
+|
+|
+2.83 |
+|
+|
+|
+(0.82 |
+) |
+|
+|
+12.73 |
+|
+|
+|
+(2.22 |
+) |
+
+
+IFRS excluding dilution effects
+|
+|
+|
+3.03 |
+|
+|
+|
+(0.61 |
+) |
+|
+|
+12.73 |
+|
+|
+|
+(2.22 |
+) |
+
+
+Diluted per share impact of total non-IFRS
+adjustments
+|
+|
+|
+(2.13 |
+) |
+|
+|
+0.67 |
+|
+|
+|
+(11.54 |
+) |
+|
+|
+1.07 |
+|
+
+
+Non-IFRS
+|
+|
+|
+0.90 |
+|
+|
+|
+0.07 |
+|
+|
+|
+1.19 |
+|
+|
+|
+(1.15 |
+) |
+
+
+Shares used in diluted per share calculation (IFRS and
+non-IFRS):
+|
+|
+|
+68,320,412 |
+|
+|
+|
+63,911,374 |
+|
+|
+|
+65,678,245 |
+|
+|
+|
+60,237,774 |
+|
+
+
+
+
+
+|
+Defined as either IFRS or non-IFRS operating profit/(loss) divided by
+total revenue
+|
+
+
+
+|
+Dilutive effects relate to impact from convertible notes (interests, foreign exchange gain/(loss), and fair
+value adjustments on derivative liabilities, net of tax) of €13.8 million and €13.5 million for the three months ended June 30, 2026 and 2025, respectively. There were no dilution impact for the six months ended
+June 30, 2026 and 2025.
+|
+
+
+Page 12 of 12


### PR DESCRIPTION
## Summary
- decode legacy SEC Windows-1252 numeric entities so euro-denominated results retain their currency
- prefer current-period total revenue and recognize net profit as the net-income metric
- parse midpoint-plus-minus guidance and reject per-share adjustment footnotes
- add full Ascendis Pharma and Applied Materials SEC filing fixtures

## Verification
- npm audit --audit-level=high
- npm run lint
- npm run test:coverage
- npm run typecheck
- mutation checks for currency, revenue, net profit, guidance ranges, and footnote rejection